### PR TITLE
A bunch of cli fixes and better workflow

### DIFF
--- a/helix-cli/src/args.rs
+++ b/helix-cli/src/args.rs
@@ -57,9 +57,6 @@ pub struct DeployCommand {
     #[clap(short, long, help = "The output path")]
     pub output: Option<String>,
 
-    #[clap(short, long, help = "Should build for local machine")]
-    pub local: bool,
-
     #[clap(short, long, help = "Port to run the instance on")]
     pub port: Option<u16>,
 }
@@ -72,9 +69,6 @@ pub struct CompileCommand {
 
     #[clap(short, long, help = "The output path")]
     pub output: Option<String>,
-
-    #[clap(short, long, help = "Should generate python bindings")]
-    pub gen_py: bool,
 
     // #[clap(short, long, help = "The target platform")]
     // pub target: Option<String>,


### PR DESCRIPTION
## Description

## Crits
- [ ] `helix start <id>` doesn't work because stopping instances removes it from the instances.json
- [ ] `helix instances` show stopped instances as well
- [ ] in confix.hx.json con't put db_max_size under vector config. rename to db_max_size_gb.
- [ ] add a `helix save` command to just take the `.mdb` file with you
- [X] also going to remove `--local` from `helix deploy` flag since we are no longer providing a managed service (BREAKING CHANGE FOR DEMOS)
- [ ] introduce a `helix remove <instance_id>` to delete an instance fully AND it's data
- [ ] introduce a `helix label <instance_id>` to give an instance a short description if needed