### PR TITLE
Fix vis and cli check update

### DIFF
--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-cli"
-version = "1.0.108"
+version = "1.0.109"
 edition = "2024"
 
 [dependencies]

--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -10,8 +10,8 @@ use sonic_rs::json;
 use spinners::{Spinner, Spinners};
 use std::{
     fmt::Write,
-    fs::{self, File, OpenOptions, read_to_string},
-    io::{Read, Write as iWrite},
+    fs::{self, OpenOptions, read_to_string},
+    io::{Write as iWrite},
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };

--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -24,6 +24,8 @@ mod utils;
 async fn main() {
     let args = HelixCLI::parse();
 
+    check_helix_version().await;
+
     match args.command {
         CommandType::Demo => {
             println!("{}", "Demoing Helix".green().bold());

--- a/helix-container/src/graphvis.rs
+++ b/helix-container/src/graphvis.rs
@@ -24,7 +24,7 @@ pub fn graphvis(input: &HandlerInput, response: &mut Response) -> Result<(), Gra
     };
     let json_ne_m = modify_graph_json(&json_ne).unwrap();
 
-    let db_counts: String = match db.get_db_stats_json() {
+    let db_counts: String = match db.get_db_stats_json(&txn) {
         Ok(value) => value,
         Err(e) => {
             println!("error with json: {:?}", e);

--- a/helixdb/Cargo.toml
+++ b/helixdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helixdb"
-version = "1.0.108"
+version = "1.0.109"
 edition = "2024"
 description = "HelixDB is a multi-model database built for performance and simplicity."
 license = "AGPL-3.0"

--- a/helixdb/src/helix_engine/storage_core/storage_core.rs
+++ b/helixdb/src/helix_engine/storage_core/storage_core.rs
@@ -24,7 +24,7 @@ use heed3::{
     RoTxn, RwTxn,
     byteorder::BE,
     RoIter,
-    
+
 };
 use std::{
     cmp::Ordering,
@@ -546,9 +546,7 @@ impl HelixGraphStorage {
     }
 
     /// Get number of nodes, edges, and vectors from lmdb
-    pub fn get_db_stats_json(&self) -> Result<String, GraphError> {
-        let txn = self.graph_env.read_txn().unwrap();
-
+    pub fn get_db_stats_json(&self, txn: &RoTxn) -> Result<String, GraphError> {
         let result = json!({
             "num_nodes":   self.nodes_db.len(&txn).unwrap_or(0),
             "num_edges":   self.edges_db.len(&txn).unwrap_or(0),


### PR DESCRIPTION
## Description
- was getting an extra txn on graphvis that was crashing. fixed now.
- helix version also checked on every cli run
- v1.0.109

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`
- [ ] Lines are kept under 100 characters where possible
- [ ] Code is good

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers --> 