### PR TITLE
bug/244 bug comparison of u64 values

### DIFF
--- a/helix-container/src/queries.rs
+++ b/helix-container/src/queries.rs
@@ -1,1 +1,103 @@
+use chrono::{DateTime, Utc};
+use heed3::RoTxn;
+use helix_db::{
+    embed, exclude_field, field_remapping,
+    helix_engine::{
+        graph_core::ops::{
+            bm25::search_bm25::SearchBM25Adapter,
+            g::G,
+            in_::{in_::InAdapter, in_e::InEdgesAdapter, to_n::ToNAdapter, to_v::ToVAdapter},
+            out::{
+                from_n::FromNAdapter, from_v::FromVAdapter, out::OutAdapter, out_e::OutEdgesAdapter,
+            },
+            source::{
+                add_e::{AddEAdapter, EdgeType},
+                add_n::AddNAdapter,
+                e_from_id::EFromIdAdapter,
+                e_from_type::EFromTypeAdapter,
+                n_from_id::NFromIdAdapter,
+                n_from_index::NFromIndexAdapter,
+                n_from_type::NFromTypeAdapter,
+            },
+            tr_val::{Traversable, TraversalVal},
+            util::{
+                dedup::DedupAdapter, drop::Drop, exist::Exist, filter_mut::FilterMut,
+                filter_ref::FilterRefAdapter, map::MapAdapter, paths::ShortestPathAdapter,
+                props::PropsAdapter, range::RangeAdapter, update::UpdateAdapter,
+            },
+            vectors::{
+                brute_force_search::BruteForceSearchVAdapter, insert::InsertVAdapter,
+                search::SearchVAdapter,
+            },
+        },
+        types::GraphError,
+        vector_core::vector::HVector,
+    },
+    helix_gateway::{
+        embedding_providers::embedding_providers::{EmbeddingModel, get_embedding_model},
+        mcp::mcp::{MCPHandler, MCPHandlerSubmission, MCPToolInput},
+        router::router::HandlerInput,
+    },
+    identifier_remapping, node_matches, props,
+    protocol::{
+        format::Format,
+        remapping::{Remapping, RemappingMap, ResponseRemapping},
+        response::Response,
+        return_values::ReturnValue,
+        value::Value,
+    },
+    traversal_remapping,
+    utils::{
+        count::Count,
+        filterable::Filterable,
+        id::ID,
+        items::{Edge, Node},
+    },
+    value_remapping,
+};
+use helix_macros::{handler, mcp_handler, tool_call};
+use sonic_rs::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Instant;
 
+pub struct Country {
+    pub name: String,
+    pub currency: String,
+    pub population: u64,
+    pub gdp: f64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct getCountriesByPopulationInput {
+    pub max_population: u64,
+}
+#[handler(with_read)]
+pub fn getCountriesByPopulation(
+    input: &HandlerInput,
+    response: &mut Response,
+) -> Result<(), GraphError> {
+    {
+        let countries = G::new(Arc::clone(&db), &txn)
+            .n_from_type("Country")
+            .filter_ref(|val, txn| {
+                if let Ok(val) = val {
+                    Ok(G::new_from(Arc::clone(&db), &txn, val.clone())
+                        .check_property("population")
+                        .map_value_or(false, |v| *v < data.max_population.clone())?)
+                } else {
+                    Ok(false)
+                }
+            })
+            .collect_to::<Vec<_>>();
+        let mut return_vals: HashMap<String, ReturnValue> = HashMap::new();
+        return_vals.insert(
+            "countries".to_string(),
+            ReturnValue::from_traversal_value_array_with_mixin(
+                countries.clone().clone(),
+                remapping_vals.borrow_mut(),
+            ),
+        );
+    }
+    Ok(())
+}

--- a/helix-db/src/protocol/value.rs
+++ b/helix-db/src/protocol/value.rs
@@ -144,6 +144,62 @@ impl PartialOrd for Value {
 
 impl Eq for Value {}
 
+impl PartialEq<u8> for Value {
+    fn eq(&self, other: &u8) -> bool {
+        match self {
+            Value::U8(u) => u == other,
+            _ => false,
+        }
+    }
+}
+impl PartialEq<u16> for Value {
+    fn eq(&self, other: &u16) -> bool {
+        match self {
+            Value::U16(u) => u == other,
+            _ => false,
+        }
+    }
+}
+impl PartialEq<u32> for Value {
+    fn eq(&self, other: &u32) -> bool {
+        match self {
+            Value::U32(u) => u == other,
+            _ => false,
+        }
+    }
+}
+impl PartialEq<u64> for Value {
+    fn eq(&self, other: &u64) -> bool {
+        match self {
+            Value::U64(u) => u == other,
+            _ => false,
+        }
+    }
+}
+impl PartialEq<u128> for Value {
+    fn eq(&self, other: &u128) -> bool {
+        match self {
+            Value::U128(u) => u == other,
+            _ => false,
+        }
+    }
+}
+impl PartialEq<i8> for Value {
+    fn eq(&self, other: &i8) -> bool {
+        match self {
+            Value::I8(i) => i == other,
+            _ => false,
+        }
+    }
+}
+impl PartialEq<i16> for Value {
+    fn eq(&self, other: &i16) -> bool {
+        match self {
+            Value::I16(i) => i == other,
+            _ => false,
+        }
+    }
+}
 impl PartialEq<i32> for Value {
     fn eq(&self, other: &i32) -> bool {
         match self {
@@ -161,6 +217,14 @@ impl PartialEq<i64> for Value {
     }
 }
 
+impl PartialEq<f32> for Value {
+    fn eq(&self, other: &f32) -> bool {
+        match self {
+            Value::F32(f) => f == other,
+            _ => false,
+        }
+    }
+}
 impl PartialEq<f64> for Value {
     fn eq(&self, other: &f64) -> bool {
         match self {
@@ -188,15 +252,6 @@ impl PartialEq<bool> for Value {
     }
 }
 
-impl PartialEq<f32> for Value {
-    fn eq(&self, other: &f32) -> bool {
-        match self {
-            Value::F32(f) => f == other,
-            _ => false,
-        }
-    }
-}
-
 impl PartialEq<&str> for Value {
     fn eq(&self, other: &&str) -> bool {
         match self {
@@ -206,6 +261,30 @@ impl PartialEq<&str> for Value {
     }
 }
 
+impl PartialOrd<i8> for Value {
+    fn partial_cmp(&self, other: &i8) -> Option<Ordering> {
+        match self {
+            Value::I8(i) => i.partial_cmp(other),
+            _ => None,
+        }
+    }
+}
+impl PartialOrd<i16> for Value {
+    fn partial_cmp(&self, other: &i16) -> Option<Ordering> {
+        match self {
+            Value::I16(i) => i.partial_cmp(other),
+            _ => None,
+        }
+    }
+}
+impl PartialOrd<i32> for Value {
+    fn partial_cmp(&self, other: &i32) -> Option<Ordering> {
+        match self {
+            Value::I32(i) => i.partial_cmp(other),
+            _ => None,
+        }
+    }
+}
 impl PartialOrd<i64> for Value {
     fn partial_cmp(&self, other: &i64) -> Option<Ordering> {
         match self {
@@ -214,11 +293,10 @@ impl PartialOrd<i64> for Value {
         }
     }
 }
-
-impl PartialOrd<i32> for Value {
-    fn partial_cmp(&self, other: &i32) -> Option<Ordering> {
+impl PartialOrd<f32> for Value {
+    fn partial_cmp(&self, other: &f32) -> Option<Ordering> {
         match self {
-            Value::I32(i) => i.partial_cmp(other),
+            Value::F32(f) => f.partial_cmp(other),
             _ => None,
         }
     }
@@ -231,7 +309,46 @@ impl PartialOrd<f64> for Value {
         }
     }
 }
-
+impl PartialOrd<u8> for Value {
+    fn partial_cmp(&self, other: &u8) -> Option<Ordering> {
+        match self {
+            Value::U8(u) => u.partial_cmp(other),
+            _ => None,
+        }
+    }
+}
+impl PartialOrd<u16> for Value {
+    fn partial_cmp(&self, other: &u16) -> Option<Ordering> {
+        match self {
+            Value::U16(u) => u.partial_cmp(other),
+            _ => None,
+        }
+    }
+}
+impl PartialOrd<u32> for Value {
+    fn partial_cmp(&self, other: &u32) -> Option<Ordering> {
+        match self {
+            Value::U32(u) => u.partial_cmp(other),
+            _ => None,
+        }
+    }
+}
+impl PartialOrd<u64> for Value {
+    fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+        match self {
+            Value::U64(u) => u.partial_cmp(other),
+            _ => None,
+        }
+    }
+}
+impl PartialOrd<u128> for Value {
+    fn partial_cmp(&self, other: &u128) -> Option<Ordering> {
+        match self {
+            Value::U128(u) => u.partial_cmp(other),
+            _ => None,
+        }
+    }
+}
 /// Custom serialisation implementation for Value that removes enum variant names in JSON
 /// whilst preserving them for binary formats like bincode.
 impl Serialize for Value {

--- a/hql-tests/file45/file45.hx
+++ b/hql-tests/file45/file45.hx
@@ -1,0 +1,10 @@
+N::Country {
+    name: String,
+    currency: String,
+    population: U64,
+    gdp: F64
+}
+
+QUERY getCountriesByPopulation (max_population: U64) =>
+    countries <- N<Country>::WHERE(_::{population}::LT(max_population))
+    RETURN countries


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
PartialEq and PartialOrd was unimplemented for a number of rust primitives leading to these bugs.
## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`
- [ ] Lines are kept under 100 characters where possible
- [ ] Code is good

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers --> 