### PR TITLE
resolving issue with helix compilation when using literal return valu…

### DIFF
--- a/helix-container/src/queries.rs
+++ b/helix-container/src/queries.rs
@@ -1,0 +1,121 @@
+use chrono::{DateTime, Utc};
+use heed3::RoTxn;
+use helix_db::{
+    embed, exclude_field, field_remapping,
+    helix_engine::{
+        graph_core::ops::{
+            bm25::search_bm25::SearchBM25Adapter,
+            g::G,
+            in_::{in_::InAdapter, in_e::InEdgesAdapter, to_n::ToNAdapter, to_v::ToVAdapter},
+            out::{
+                from_n::FromNAdapter, from_v::FromVAdapter, out::OutAdapter, out_e::OutEdgesAdapter,
+            },
+            source::{
+                add_e::{AddEAdapter, EdgeType},
+                add_n::AddNAdapter,
+                e_from_id::EFromIdAdapter,
+                e_from_type::EFromTypeAdapter,
+                n_from_id::NFromIdAdapter,
+                n_from_index::NFromIndexAdapter,
+                n_from_type::NFromTypeAdapter,
+            },
+            tr_val::{Traversable, TraversalVal},
+            util::{
+                dedup::DedupAdapter, drop::Drop, exist::Exist, filter_mut::FilterMut,
+                filter_ref::FilterRefAdapter, map::MapAdapter, paths::ShortestPathAdapter,
+                props::PropsAdapter, range::RangeAdapter, update::UpdateAdapter,
+            },
+            vectors::{
+                brute_force_search::BruteForceSearchVAdapter, insert::InsertVAdapter,
+                search::SearchVAdapter,
+            },
+        },
+        types::GraphError,
+        vector_core::vector::HVector,
+    },
+    helix_gateway::{
+        embedding_providers::embedding_providers::{EmbeddingModel, get_embedding_model},
+        mcp::mcp::{MCPHandler, MCPHandlerSubmission, MCPToolInput},
+        router::router::HandlerInput,
+    },
+    identifier_remapping, node_matches, props,
+    protocol::{
+        format::Format,
+        remapping::{Remapping, RemappingMap, ResponseRemapping},
+        response::Response,
+        return_values::ReturnValue,
+        value::Value,
+    },
+    traversal_remapping,
+    utils::{
+        count::Count,
+        filterable::Filterable,
+        id::ID,
+        items::{Edge, Node},
+    },
+    value_remapping,
+};
+use helix_macros::{handler, mcp_handler, tool_call};
+use sonic_rs::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Instant;
+
+pub struct Continent {
+    pub name: String,
+}
+
+pub struct Country {
+    pub name: String,
+    pub currency: String,
+    pub population: i64,
+    pub gdp: f64,
+}
+
+pub struct City {
+    pub name: String,
+    pub description: String,
+    pub zip_codes: Vec<String>,
+}
+
+pub struct Continent_to_Country {
+    pub from: Continent,
+    pub to: Country,
+}
+
+pub struct Country_to_City {
+    pub from: Country,
+    pub to: City,
+}
+
+pub struct Country_to_Capital {
+    pub from: Country,
+    pub to: City,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct countCapitalsInput {}
+#[handler(with_read)]
+pub fn countCapitals(input: &HandlerInput, response: &mut Response) -> Result<(), GraphError> {
+    {
+        let num_capital = G::new(Arc::clone(&db), &txn)
+            .n_from_type("City")
+            .filter_ref(|val, txn| {
+                if let Ok(val) = val {
+                    Ok(Exist::exists(
+                        &mut G::new_from(Arc::clone(&db), &txn, vec![val.clone()])
+                            .in_("Country_to_Capital", &EdgeType::Node),
+                    ))
+                } else {
+                    Ok(false)
+                }
+            })
+            .count_to_val();
+        let mut return_vals: HashMap<String, ReturnValue> = HashMap::new();
+        return_vals.insert(
+            "num_capital".to_string(),
+            ReturnValue::from(Value::from(num_capital.clone())),
+        );
+    }
+    Ok(())
+}

--- a/helix-db/src/helixc/generator/generator_types.rs
+++ b/helix-db/src/helixc/generator/generator_types.rs
@@ -487,7 +487,7 @@ impl Display for ReturnValue {
             ReturnType::NamedLiteral(name) => {
                 write!(
                     f,
-                    "    return_vals.insert(\"{}\".to_string(), ReturnValue::from(Value::from({})));\n",
+                    "    return_vals.insert({}.to_string(), ReturnValue::from(Value::from({})));\n",
                     name, self.value
                 )
             }

--- a/hql-tests/file48/file48.hx
+++ b/hql-tests/file48/file48.hx
@@ -1,0 +1,3 @@
+QUERY countCapitals () =>
+    num_capital <- N<City>::WHERE(EXISTS(_::In<Country_to_Capital>))::COUNT
+    RETURN num_capital

--- a/hql-tests/file48/schema.hx
+++ b/hql-tests/file48/schema.hx
@@ -1,32 +1,37 @@
-// N::Doc {
-//     content: String
-// }
-//     
-// V::Embedding {
-//     chunk: String
-// }
-// 
-// N::Chunk {
-//     content: String
-// }
-// 
-// E::EmbeddingOf {
-//     From: Doc,
-//     To: Embedding, 
-//     Properties: {
-//     }
-// }
+N::Continent {
+    name: String
+}
 
-// N::User {
-//     name: String,
-//     age: I32
-// }
-// 
-// E::Knows {
-//     From: User,
-//     To: User,
-//     Properties: {
-//         since: I32,
-//     }
-// }
+N::Country {
+    name: String,
+    currency: String,
+    population: I64,
+    gdp: F64
+}
 
+N::City {
+    name: String,
+    description: String,
+    zip_codes: [String]
+}
+
+E::Continent_to_Country {
+    From: Continent,
+    To: Country,
+    Properties: {
+    }
+}
+
+E::Country_to_City {
+    From: Country,
+    To: City,
+    Properties: {
+    }
+}
+
+E::Country_to_Capital {
+    From: Country,
+    To: City,
+    Properties: {
+    }
+}


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
resolving issue with helix compilation when using literal return values e.g. a named return value that is a number. ReturnType::NamedLiteral was double quoting strings.

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #249 

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`
- [ ] Lines are kept under 100 characters where possible
- [ ] Code is good

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers --> 