### PR TITLE
fix: remove unnecessary whitespace from generated config

### DIFF
--- a/helix-db/src/helix_engine/graph_core/config.rs
+++ b/helix-db/src/helix_engine/graph_core/config.rs
@@ -86,23 +86,21 @@ impl Config {
     }
 
     pub fn init_config() -> String {
-        r#"
-    {
-        "vector_config": {
-            "m": 16,
-            "ef_construction": 128,
-            "ef_search": 768
-        },
-        "graph_config": {
-            "secondary_indices": []
-        },
-        "db_max_size_gb": 10,
-        "mcp": true,
-        "bm25": true,
-        "embedding_model": "text-embedding-ada-002",
-        "graphvis_node_label": ""
-    }
-    "#
+        r#"{
+    "vector_config": {
+        "m": 16,
+        "ef_construction": 128,
+        "ef_search": 768
+    },
+    "graph_config": {
+        "secondary_indices": []
+    },
+    "db_max_size_gb": 10,
+    "mcp": true,
+    "bm25": true,
+    "embedding_model": "text-embedding-ada-002",
+    "graphvis_node_label": ""
+}"#
         .to_string()
     }
 


### PR DESCRIPTION
## Description
The `helix init` command was adding unintended padding to the generated `config.hx.json` file. this fix ensures cleaner output.

## Checklist when merging to main

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`
- [x] Lines are kept under 100 characters where possible
- [x] Code is good