### PR TITLE
implementing reading and initializing the secondary indices from the config

### DIFF
--- a/helix-db/src/helix_engine/graph_core/config.rs
+++ b/helix-db/src/helix_engine/graph_core/config.rs
@@ -1,4 +1,7 @@
-use crate::{helix_engine::types::GraphError, helixc::analyzer::analyzer::INTROSPECTION_DATA};
+use crate::{
+    helix_engine::types::GraphError,
+    helixc::analyzer::analyzer::{INTROSPECTION_DATA, SECONDARY_INDICES},
+};
 use serde::{Deserialize, Serialize};
 use std::{fmt, path::PathBuf};
 
@@ -193,20 +196,10 @@ impl fmt::Display for Config {
         writeln!(
             f,
             "secondary_indices: {},",
-            match &self
-                .graph_config
-                .as_ref()
-                .unwrap_or(&GraphConfig::default())
-                .secondary_indices
-            {
-                Some(indices) => format!(
-                    "Some(vec![{}])",
-                    indices
-                        .iter()
-                        .map(|s| format!("\"{s}\".to_string()"))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ),
+            match SECONDARY_INDICES.get() {
+                Some(indices) => {
+                    format!("Some(vec![{}]", indices.join(".to_string(),"))
+                }
                 None => "None".to_string(),
             }
         )?;

--- a/helix-db/src/helixc/analyzer/analyzer.rs
+++ b/helix-db/src/helixc/analyzer/analyzer.rs
@@ -41,6 +41,7 @@ pub(crate) struct Ctx<'a> {
 }
 
 pub static INTROSPECTION_DATA: OnceLock<IntrospectionData> = OnceLock::new();
+pub static SECONDARY_INDICES: OnceLock<Vec<String>> = OnceLock::new();
 
 impl<'a> Ctx<'a> {
     pub(super) fn new(src: &'a Source) -> Self {
@@ -72,6 +73,21 @@ impl<'a> Ctx<'a> {
             .set(IntrospectionData::from_schema(&out))
             .ok();
 
+        SECONDARY_INDICES
+            .set(
+                src.node_schemas
+                    .iter()
+                    .map(|schema| {
+                        schema
+                            .fields
+                            .iter()
+                            .filter(|f| f.is_indexed())
+                            .map(|f| f.name.clone())
+                    })
+                    .flatten()
+                    .collect(),
+            )
+            .ok();
         out
     }
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
implementing reading and initializing the secondary indices from the config

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`
- [ ] Lines are kept under 100 characters where possible
- [ ] Code is good

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers --> 