### PR TITLE
fixing cli to work with embeddings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs 6.0.0",
+ "dotenvy",
  "futures-util",
  "helix-db",
  "indicatif",

--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -24,6 +24,7 @@ webbrowser = "1.0"
 tokio-tungstenite = "0.27.0"
 futures-util = "0.3.31"
 anyhow = "1.0.98"
+dotenvy = "0.15.7"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61.1", features = [

--- a/helix-cli/src/args.rs
+++ b/helix-cli/src/args.rs
@@ -64,6 +64,10 @@ pub enum CommandType {
 #[derive(Debug, Args)]
 #[clap(name = "deploy", about = "Deploy a Helix project")]
 pub struct DeployCommand {
+
+    #[clap(long, help = "Build in release mode (default is dev)")]
+    pub release: bool,
+
     #[clap(short, long, help = "Redeploy a remote instance of HelixDB")]
     pub remote: bool,
 

--- a/helix-cli/src/instance_manager.rs
+++ b/helix-cli/src/instance_manager.rs
@@ -58,6 +58,7 @@ impl InstanceManager {
         source_binary: &Path,
         port: u16,
         endpoints: Vec<String>,
+        openai_key: Option<String>,
     ) -> io::Result<InstanceInfo> {
         let instance_id = Uuid::new_v4().to_string();
         let cached_binary = self.cache_dir.join(&instance_id);
@@ -89,6 +90,7 @@ impl InstanceManager {
             .env("HELIX_DAEMON", "1")
             .env("HELIX_DATA_DIR", data_dir.to_str().unwrap())
             .env("HELIX_PORT", port.to_string())
+            .env("OPENAI_API_KEY", openai_key.unwrap_or_default())
             .stdout(Stdio::from(log_file))
             .stderr(Stdio::from(error_log_file));
 
@@ -113,7 +115,7 @@ impl InstanceManager {
     }
 
     /// instance_id can either be u16 or uuid here (same for the others)
-    pub fn start_instance(&self, instance_id: &str, endpoints: Option<Vec<String>>) -> Result<InstanceInfo, String> {
+    pub fn start_instance(&self, instance_id: &str, endpoints: Option<Vec<String>>, openai_key: Option<String>) -> Result<InstanceInfo, String> {
         let instance_id = match instance_id.parse() {
             Ok(n) => match self.id_from_short_id(n) {
                 Ok(n) => n.id,
@@ -166,6 +168,7 @@ impl InstanceManager {
             .env("HELIX_DAEMON", "1")
             .env("HELIX_DATA_DIR", data_dir.to_str().unwrap())
             .env("HELIX_PORT", instance.port.to_string())
+            .env("OPENAI_API_KEY", openai_key.unwrap_or_default())
             .stdout(Stdio::from(log_file.try_clone().map_err(|e| {
                 format!("Failed to clone log file: {e}")
             })?))

--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -63,8 +63,8 @@ async fn main() -> ExitCode {
             {
                 let instance_manager = InstanceManager::new().unwrap();
                 let mut sp = Spinner::new(Spinners::Dots9, "Starting Helix instance".into());
-
-                match instance_manager.start_instance(&command.cluster.unwrap(), None) {
+                let openai_key = get_openai_key();  
+                match instance_manager.start_instance(&command.cluster.unwrap(), None, openai_key) {
                     Ok(instance) => {
                         sp.stop_with_message(
                             "Successfully started Helix instance"
@@ -102,7 +102,7 @@ async fn main() -> ExitCode {
             };
 
             if !command.remote {
-                let code = match compile_and_build_helix(path, &output, files) {
+                let code = match compile_and_build_helix(path, &output, files, command.release) {
                     Ok(code) => code,
                     Err(_) => return ExitCode::FAILURE,
                 };

--- a/helix-db/src/helix_gateway/embedding_providers/embedding_providers.rs
+++ b/helix-db/src/helix_gateway/embedding_providers/embedding_providers.rs
@@ -43,6 +43,9 @@ impl EmbeddingModelImpl {
 #[cfg(feature = "embed_openai")]
 impl EmbeddingModel for EmbeddingModelImpl {
     fn fetch_embedding(&self, text: &str) -> Result<Vec<f64>, GraphError> {
+        if self.api_key.is_empty() {
+            return Err(GraphError::from("OPENAI_API_KEY not set"));
+        }
         let response = self
             .client
             .post("https://api.openai.com/v1/embeddings")
@@ -58,7 +61,6 @@ impl EmbeddingModel for EmbeddingModelImpl {
             .map_err(|e| GraphError::from(format!("Failed to parse response: {e}")))?;
         let response = sonic_rs::from_str::<sonic_rs::Value>(&text)
             .map_err(|e| GraphError::from(format!("Failed to parse response: {e}")))?;
-
         let embedding = response["data"][0]["embedding"]
             .as_array()
             .ok_or_else(|| GraphError::from("Invalid embedding format"))?

--- a/hql-tests/file1/file1.hx
+++ b/hql-tests/file1/file1.hx
@@ -1,5 +1,5 @@
 N::File1 {
-    name: String,
+    INDEX name: String,
     age: I32,
 }
 

--- a/hql-tests/file56/file56.hx
+++ b/hql-tests/file56/file56.hx
@@ -1,0 +1,19 @@
+QUERY CreateUserBioEmbedding(userId: String, bioText: String, lastUpdated: String) =>
+    embedding <- AddV<UserEmbedding>(Embed(bioText), {
+        userId: userId,
+        dataType: "bio",
+        metadata: "{}",
+        lastUpdated: lastUpdated
+    })
+    RETURN embedding
+
+QUERY SearchSimilarUsers(queryText: String, k: I64, dataType: String) =>
+    search_results <- SearchV<UserEmbedding>(Embed(queryText), k)
+    RETURN search_results
+
+V::UserEmbedding {
+    userId: String,
+    dataType: String,
+    metadata: String DEFAULT "{}",
+    lastUpdated: String
+}


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
fixing cli to work with embeddings

CLI was not reading OPENAI_API_KEY from .env or shell env and then passing it to spawned child processes in the daemon. Now correctly parses the key and passes it to child process as env var. 

Also added building local binaries in dev mode by default

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`
- [ ] Lines are kept under 100 characters where possible
- [ ] Code is good

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers --> 