### PR TITLE
docs: clean up CONTRIBUTORS.md by removing duplicate header section

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,19 +4,6 @@
 HelixDB is a high-performance graph-vector database built in Rust, optimized for RAG and AI applications. It combines graph traversals, vector similarity search, and full-text search in a single database.
 
 ## Project Structure
-Expand
-message.txt
-5 KB
-﻿
-George
-georgecurtis
- 
-# HelixDB Contributors Guide
-
-## Overview
-HelixDB is a high-performance graph-vector database built in Rust, optimized for RAG and AI applications. It combines graph traversals, vector similarity search, and full-text search in a single database.
-
-## Project Structure
 
 ### Core Components
 


### PR DESCRIPTION
## Description

This PR cleans up the `CONTRIBUTORS.md` file by removing an unintended duplicate header and overview section.
The file now contains only the actual contributors guide, improving clarity and maintaining a clean documentation structure.

## Related Issues

N/A

Closes #

## Checklist when merging to main

* [x] No compiler warnings (not applicable — docs only)
* [x] Code is formatted with `rustfmt` (not applicable — docs only)
* [x] No useless or dead code (not applicable — docs only)
* [x] Code is easy to understand
* [x] Doc comments are used for all functions, enums, structs, and fields (not applicable — docs only)
* [x] All tests pass (not applicable — docs only)
* [x] Performance has not regressed (not applicable — docs only)
* [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml` (not applicable — docs only)
* [x] Lines are kept under 100 characters where possible
* [x] Code is good

## Additional Notes

This is a documentation-only change; no functional or code-level modifications are included.