### PR TITLE
Fix panic on unknown node type during query validation

### DIFF
--- a/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
+++ b/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
@@ -124,6 +124,7 @@ pub(crate) fn infer_expr_type<'a>(
             if let Some(ref ty) = add.node_type {
                 if !ctx.node_set.contains(ty.as_str()) {
                     generate_error!(ctx, original_query, add.loc.clone(), E101, ty.as_str());
+                    return (Type::Node(None), None);
                 }
                 let label = GenRef::Literal(ty.clone());
 

--- a/helix-db/src/helixc/analyzer/methods/query_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/query_validation.rs
@@ -71,12 +71,9 @@ pub(crate) fn validate_query<'a>(ctx: &mut Ctx<'a>, original_query: &'a Query) {
         );
     }
     for stmt in &original_query.statements {
-        let statement = validate_statements(ctx, &mut scope, original_query, &mut query, stmt);
-        if let Some(s) = statement {
-            query.statements.push(s);
-        } else {
-            // given all erroneous statements are caught by the analyzer, this should never happen
-            unreachable!()
+        match validate_statements(ctx, &mut scope, original_query, &mut query, stmt) {
+            Some(s) => query.statements.push(s),
+            None => return,
         }
     }
 

--- a/helix-db/src/helixc/analyzer/methods/statement_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/statement_validation.rs
@@ -57,8 +57,10 @@ pub(crate) fn validate_statements<'a>(
 
             let (rhs_ty, stmt) =
                 infer_expr_type(ctx, &assign.value, scope, original_query, None, query);
+
+            stmt.as_ref()?;
+
             scope.insert(assign.variable.as_str(), rhs_ty);
-            assert!(stmt.is_some(), "Assignment statement should be generated");
 
             let assignment = GeneratedStatement::Assignment(GeneratedAssignment {
                 variable: GenRef::Std(assign.variable.clone()),


### PR DESCRIPTION
## Description
This PR fixes a panic that occurred when running `helix check` on queries referencing unknown node types. Instead of crashing with `Assignment statement should be generated`, Helix now properly reports a diagnostic error (E101) and halts query generation gracefully.

## Related Issues

Closes #364 

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [x] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`
- [x] Lines are kept under 100 characters where possible
- [x] Code is good

## Additional Notes
* The analyzer now returns `(Type::Node(None), None)` for undefined node types.
* `validate_statements` gracefully handles missing statements instead of panicking.
* This allows diagnostics to surface the intended error message instead of aborting.
