### PR TITLE
CLI: extend default-to-current-directory behavior to `init` and `compile` commands

### DIFF
--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -597,13 +597,18 @@ async fn run() -> ExitCode {
         CommandType::Init(command) => {
             println!("{}", "Initialising Helix project...".bold());
 
-            let path = match command.path {
-                Some(path) => PathBuf::from(path),
-                None => PathBuf::from(DB_DIR),
+            let path_str = match get_path_or_cwd(command.path.as_ref()) {
+                Ok(path) => path,
+                Err(e) => {
+                    println!("{}", "Error: failed to get path".red().bold());
+                    println!("└── {e}");
+                    return ExitCode::FAILURE;
+                }
             };
-            let path_str = path.to_str().unwrap();
 
-            match check_and_read_files(path_str) {
+            let path = PathBuf::from(&path_str);
+
+            match check_and_read_files(&path_str) {
                 Ok(files) if !files.is_empty() => {
                     println!(
                         "{} {}",

--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -14,7 +14,6 @@ use serde::Deserialize;
 use sonic_rs::json;
 use spinners::{Spinner, Spinners};
 use std::{
-    env,
     fmt::Write,
     fs::{self, File, OpenOptions, read_to_string},
     io::{Read, Write as iWrite},
@@ -455,23 +454,18 @@ async fn run() -> ExitCode {
         }
 
         CommandType::Check(command) => {
-            let path = match &command.path {
-                Some(path) => PathBuf::from(path),
-                None => env::current_dir().expect("Failed to get current working directory"),
-            };
-
-            let mut sp = Spinner::new(Spinners::Dots9, "Checking Helix queries".into());
-
-            let path_str = match path.to_str() {
-                Some(s) => s,
-                None => {
-                    sp.stop_with_message("Invalid path encoding".red().bold().to_string());
-                    println!("└── Path contains invalid UTF-8 characters: {path:?}");
+            let path = match get_path_or_cwd(command.path.as_ref()) {
+                Ok(path) => path,
+                Err(e) => {
+                    println!("{}", "Error: failed to get path".red().bold());
+                    println!("└── {e}");
                     return ExitCode::FAILURE;
                 }
             };
 
-            let files = match check_and_read_files(path_str) {
+            let mut sp = Spinner::new(Spinners::Dots9, "Checking Helix queries".into());
+
+            let files = match check_and_read_files(&path) {
                 Ok(files) => files,
                 Err(e) => {
                     sp.stop_with_message("Error checking files".red().bold().to_string());
@@ -490,7 +484,7 @@ async fn run() -> ExitCode {
                 return ExitCode::FAILURE;
             }
 
-            match generate(&files, path_str) {
+            match generate(&files, &path) {
                 Ok(_) => {}
                 Err(e) => {
                     sp.stop_with_message("Failed to generate queries".red().bold().to_string());
@@ -604,6 +598,7 @@ async fn run() -> ExitCode {
 
         CommandType::Init(command) => {
             println!("{}", "Initialising Helix project...".bold());
+
             let path = match command.path {
                 Some(path) => PathBuf::from(path),
                 None => PathBuf::from(DB_DIR),

--- a/helix-cli/src/utils.rs
+++ b/helix-cli/src/utils.rs
@@ -399,6 +399,19 @@ pub fn get_n_helix_cli() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// Returns the path or the current working directory if no path is provided
+pub fn get_path_or_cwd(path: Option<&String>) -> Result<String, Box<dyn Error>> {
+    match path {
+        Some(p) => Ok(p.to_string()),
+        None => {
+            let cwd = env::current_dir()?;
+            cwd.to_str()
+                .map(|s| s.to_string())
+                .ok_or_else(|| format!("Path contains invalid UTF-8 characters: {cwd:?}").into())
+        }
+    }
+}
+
 /// Checks if the path contains a schema.hx and config.hx.json file
 /// Returns a vector of DirEntry objects for all .hx files in the path
 pub fn check_and_read_files(path: &str) -> Result<Vec<DirEntry>, String> {


### PR DESCRIPTION
## Description

This PR continues the improvement introduced in [#355](https://github.com/HelixDB/helix-db/pull/355), where the `helix check` command was updated to default to the current working directory when no path is provided.

Just like `cargo init` or `cargo build` can be run without explicitly passing a path (defaulting to `.`), the `helix` CLI now behaves the same way for `init` and `compile`.


### Changes

* Updated **`helix init`** to use the current working directory when no path is specified.
* Updated **`helix compile`** to use the current working directory when no path is specified.
* Refactored path resolution into a shared helper function `get_path_or_cwd` to avoid duplication.


## Related Issues

None

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`
- [x] Lines are kept under 100 characters where possible
- [x] Code is good

## Additional Notes

To keep reviews focused and easy to follow, this PR only covers `init` and `compile`. A follow-up PR will extend the same default-to-current-directory behavior to the `deploy` command.

