### PR TITLE
Feat/helix init command json output

### DIFF
--- a/helix-db/src/helix_engine/traversal_core/config.rs
+++ b/helix-db/src/helix_engine/traversal_core/config.rs
@@ -199,7 +199,14 @@ impl fmt::Display for Config {
             "secondary_indices: {},",
             match SECONDARY_INDICES.get() {
                 Some(indices) => {
-                    format!("Some(vec![{}])", indices.iter().map(|i| format!("\"{i}\".to_string()")).collect::<Vec<_>>().join(", "))
+                    format!(
+                        "Some(vec![{}])",
+                        indices
+                            .iter()
+                            .map(|i| format!("\"{i}\".to_string()"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
                 }
                 None => "None".to_string(),
             }

--- a/helix-db/src/helix_engine/traversal_core/config.rs
+++ b/helix-db/src/helix_engine/traversal_core/config.rs
@@ -90,22 +90,23 @@ impl Config {
 
     pub fn init_config() -> String {
         r#"
-    {
-        "vector_config": {
-            "m": 16,
-            "ef_construction": 128,
-            "ef_search": 768
-        },
-        "graph_config": {
-            "secondary_indices": []
-        },
-        "db_max_size_gb": 10,
-        "mcp": true,
-        "bm25": true,
-        "embedding_model": "text-embedding-ada-002",
-        "graphvis_node_label": ""
-    }
-    "#
+{
+	"vector_config": {
+		"m": 16,
+		"ef_construction": 128,
+		"ef_search": 768
+	},
+	"graph_config": {
+		"secondary_indices": []
+	},
+	"db_max_size_gb": 10,
+	"mcp": true,
+	"bm25": true,
+	"embedding_model": "text-embedding-ada-002",
+	"graphvis_node_label": ""
+}
+        "#
+        .trim()
         .to_string()
     }
 


### PR DESCRIPTION
## Description

Quick DX improvement for the init command!

Clean up the JSON config file generated by the `helix init` command.

When users run `helix init` the generated config file had unnecessary leading/trailing whitespace that made the output look messy.

## Related Issues
### None

## Checklist when merging to main

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`
- [x] Lines are kept under 100 characters where possible
- [x] Code is good

## Additional Notes
### None