### PR TITLE
Fix panic on empty schema by adding validation check

### DIFF
--- a/helix-cli/src/utils.rs
+++ b/helix-cli/src/utils.rs
@@ -486,6 +486,10 @@ fn parse_content(content: &Content) -> Result<Source, String> {
 /// Runs the static analyzer on the parsed source to catch errors and generate diagnostics if any.
 /// Otherwise returns the generated source object which is an IR used to transpile the queries to rust.
 fn analyze_source(source: Source) -> Result<GeneratedSource, String> {
+    if source.schema.is_empty() {
+        return Err("No schema definitions provided".to_string());
+    }
+
     let (diagnostics, source) = analyze(&source);
     if !diagnostics.is_empty() {
         for diag in diagnostics {


### PR DESCRIPTION
## Description

Before this change, running commands like `helix compile`, `helix check`, or `helix deploy` with an empty or comment-only `schema.hx` file would cause a panic:

```
thread 'main' panicked at helix-db/src/helixc/parser/helix_parser.rs:70:9:
assertion failed: latest_schema.is_some()
```

This PR adds a validation step in `analyze_source` to gracefully handle this case.
If the schema is empty, Helix now returns a clear error message instead of panicking:

```
Failed to generate queries
└── No schema definitions provided
```

This improves developer experience and prevents crashes during query compilation when no schema definitions are present.

## Related Issues

### None

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes

### None