### PR TITLE
fix: remove Label since it's in RESERVED_FIELD_NAMES

### DIFF
--- a/helix-cli/src/utils.rs
+++ b/helix-cli/src/utils.rs
@@ -65,7 +65,6 @@ pub const DEFAULT_SCHEMA: &str = r#"// Start building your schema here.
 //
 // N::User {
 //     Name: String,
-//     Label: String,
 //     Age: Integer,
 //     IsAdmin: Boolean,
 // }

--- a/hql-tests/tests/negating_exists/schema.hx
+++ b/hql-tests/tests/negating_exists/schema.hx
@@ -16,7 +16,6 @@
 //
 // N::User {
 //     Name: String,
-//     Label: String,
 //     Age: Integer,
 //     IsAdmin: Boolean,
 // }


### PR DESCRIPTION
## Description

Remove Label field name from the DEFAULT_SCHEMA and test files, since leabel is in RESERVED_FIELD_NAMES it's invalid to have Label as a field name.

## Related Issues
### None

Closes #

## Checklist when merging to main

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
### None