### PR TITLE
feat(hql): add schema field type validation

### DIFF
--- a/helix-db/src/helixc/analyzer/methods/schema_methods.rs
+++ b/helix-db/src/helixc/analyzer/methods/schema_methods.rs
@@ -158,6 +158,15 @@ pub(crate) fn check_schema(ctx: &mut Ctx) {
                         Some("rename the field".to_string()),
                     );
                 }
+                if !is_valid_schema_field_type(&f.field_type) {
+                    push_schema_err(
+                        ctx,
+                        f.loc.clone(),
+                        ErrorCode::E209,
+                        format!("invalid type in schema field: `{}`", f.name),
+                        Some("use built-in types only (String, U32, etc.)".to_string()),
+                    );
+                }
             })
         }
         ctx.output.edges.push(edge.clone().into());
@@ -171,6 +180,15 @@ pub(crate) fn check_schema(ctx: &mut Ctx) {
                     ErrorCode::E204,
                     format!("field `{}` is a reserved field name", f.name),
                     Some("rename the field".to_string()),
+                );
+            }
+            if !is_valid_schema_field_type(&f.field_type) {
+                push_schema_err(
+                    ctx,
+                    f.loc.clone(),
+                    ErrorCode::E209,
+                    format!("invalid type in schema field: `{}`", f.name),
+                    Some("use built-in types only (String, U32, etc.)".to_string()),
                 );
             }
         });
@@ -187,8 +205,26 @@ pub(crate) fn check_schema(ctx: &mut Ctx) {
                     Some("rename the field".to_string()),
                 );
             }
+            if !is_valid_schema_field_type(&f.field_type) {
+                push_schema_err(
+                    ctx,
+                    f.loc.clone(),
+                    ErrorCode::E209,
+                    format!("invalid type in schema field: `{}`", f.name),
+                    Some("use built-in types only (String, U32, etc.)".to_string()),
+                );
+            }
         });
         ctx.output.vectors.push(vector.clone().into());
+    }
+}
+
+fn is_valid_schema_field_type(ft: &FieldType) -> bool {
+    match ft {
+        FieldType::Identifier(_) => false,
+        FieldType::Object(_) => false,
+        FieldType::Array(inner) => is_valid_schema_field_type(inner),
+        _ => true,
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds validation for field types in schema definitions to prevent the use of unknown or custom types (identifiers) in node, vector, and edge fields. It enforces the use of built-in types only.

Previously, invalid type definitions could still pass the Helix check

## Related Issues
### None

## Checklist when merging to main

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
### None
