### PR TITLE
feat(hql): Enable vector start nodes in Helix queries (V<...>(...))

### DIFF
--- a/helix-db/src/helixc/generator/utils.rs
+++ b/helix-db/src/helixc/generator/utils.rs
@@ -391,6 +391,8 @@ use helix_db::{
                     n_from_id::NFromIdAdapter,
                     n_from_index::NFromIndexAdapter,
                     n_from_type::NFromTypeAdapter,
+                    v_from_id::VFromIdAdapter,
+                    v_from_type::VFromTypeAdapter
                 },
                 util::{
                     dedup::DedupAdapter, drop::Drop, exist::Exist, filter_mut::FilterMut,


### PR DESCRIPTION
## Description

This PR adds full support for vector start nodes in Helix queries, allowing traversals to begin from specific vectors using `V<type>(id)` syntax. Previously, this syntax was unhandled, so it defaulted to anonymous traversals. The validator then panicked on parent_ty.unwrap() since anonymous traversals expect a parent context (which doesn't exist for top-level queries).

## Changes
- **Parser**:  Adds a new case in parse_start_node() to recognize Rule::start_vector (matching the grammar rule V<...>(...)), parsing it into StartNode::Vector with the vector type and IDs.
- This fixes the panic on `parent_ty.unwrap()` for top-level vector queries.

- **Code Generator**: Added `VFromIdAdapter` and `VFromTypeAdapter` imports to `write_headers()` to ensure the traits are available in generated query code.
- This resolves the "no method named `v_from_id` compilation error when helix deploy.

## Testing
- Verified 
```js
QUERY get_vector(vector_id: ID) =>
    vector <- V<Embedding>(vector_id) 
    RETURN vector
``` 
now parses, validates, and compiles successfully.
- Confirmed vector lookups work correctly in the traversal engine and via the SDK client.


## Related Issues

Closes None

## Checklist when merging to main


- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
