### PR TITLE
perf: maintain only edge_id instead of edge object in tracing HashMap

### DIFF
--- a/helix-db/src/helix_engine/traversal_core/ops/util/paths.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/util/paths.rs
@@ -42,11 +42,11 @@ impl<'a, I: Iterator<Item = Result<TraversalValue, GraphError>>> Iterator
 
                 let mut queue = VecDeque::with_capacity(32);
                 let mut visited = HashSet::with_capacity(64);
-                let mut parent: HashMap<u128, (u128, Edge)> = HashMap::with_capacity(32);
+                let mut parent: HashMap<u128, (u128, u128)> = HashMap::with_capacity(32);
                 queue.push_back(from);
                 visited.insert(from);
 
-                let reconstruct_path = |parent: &HashMap<u128, (u128, Edge)>,
+                let reconstruct_path = |parent: &HashMap<u128, (u128, u128)>,
                                         start_id: &u128,
                                         end_id: &u128|
                  -> Result<TraversalValue, GraphError> {
@@ -59,7 +59,7 @@ impl<'a, I: Iterator<Item = Result<TraversalValue, GraphError>>> Iterator
                         nodes.push(self.storage.get_node(self.txn, current)?);
 
                         let (prev_node, edge) = &parent[current];
-                        edges.push(edge.clone());
+                        edges.push(self.storage.get_edge(self.txn, edge)?);
                         current = prev_node;
                     }
 
@@ -93,8 +93,7 @@ impl<'a, I: Iterator<Item = Result<TraversalValue, GraphError>>> Iterator
 
                         if !visited.contains(&to_node) {
                             visited.insert(to_node);
-                            let edge = self.storage.get_edge(self.txn, &edge_id).unwrap(); // TODO: handle error
-                            parent.insert(to_node, (current_id, edge));
+                            parent.insert(to_node, (current_id, edge_id));
 
                             if to_node == to {
                                 return Some(reconstruct_path(&parent, &from, &to));


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [ x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ x All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [x] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers --> 