### PR TITLE
Wsl docker fixes

### DIFF
--- a/helix-cli/src/docker.rs
+++ b/helix-cli/src/docker.rs
@@ -71,14 +71,6 @@ impl<'a> DockerManager<'a> {
         format!("{project_name}_app")
     }
 
-    /// Get the data volume name for an instance
-    pub(crate) fn data_volume_name(&self, instance_name: &str) -> String {
-        format!(
-            "{}_data",
-            // has to replace all `-` with `_` because fly requires underscores in volume names
-            self.compose_project_name(instance_name).replace("-", "_")
-        )
-    }
 
     /// Get the network name for an instance
     fn network_name(&self, instance_name: &str) -> String {
@@ -232,7 +224,6 @@ CMD ["helix-container"]
         let service_name = Self::service_name();
         let image_name = self.image_name(instance_name, instance_config.build_mode());
         let container_name = self.container_name(instance_name);
-        let data_volume_name = self.data_volume_name(instance_name);
         let network_name = self.network_name(instance_name);
 
         let compose = format!(
@@ -248,7 +239,7 @@ services:
     ports:
       - "{port}:{port}"
     volumes:
-      - {data_volume_name}:/data
+      - ../.volumes/{instance_name}:/data
     environment:
       - HELIX_PORT={port}
       - HELIX_DATA_DIR={data_dir}
@@ -257,14 +248,6 @@ services:
     restart: unless-stopped
     networks:
       - {network_name}
-
-volumes:
-  {data_volume_name}:
-    driver: local
-    driver_opts:
-      type: bind
-      device: ../.volumes/{instance_name}
-      o: bind
 
 networks:
   {network_name}:
@@ -452,6 +435,20 @@ networks:
                 "DOCKER",
                 &format!("Instance '{instance_name}' pruned successfully"),
             );
+        }
+
+        // Clean up orphaned named volumes from old CLI versions
+        // Old volume naming pattern: helix_{project_name}_{instance_name}_data
+        if remove_volumes {
+            let old_volume_name = format!(
+                "helix_{}_{}",
+                self.project.config.project.name.replace("-", "_"),
+                instance_name.replace("-", "_")
+            );
+
+            // Try to remove old-style named volume (ignore errors if it doesn't exist)
+            let volume_to_remove = format!("{}_data", old_volume_name);
+            let _ = self.run_docker_command(&["volume", "rm", &volume_to_remove]);
         }
 
         Ok(())

--- a/helix-cli/src/docker.rs
+++ b/helix-cli/src/docker.rs
@@ -71,7 +71,6 @@ impl<'a> DockerManager<'a> {
         format!("{project_name}_app")
     }
 
-
     /// Get the network name for an instance
     fn network_name(&self, instance_name: &str) -> String {
         let project_name = self.compose_project_name(instance_name);
@@ -447,7 +446,7 @@ networks:
             );
 
             // Try to remove old-style named volume (ignore errors if it doesn't exist)
-            let volume_to_remove = format!("{}_data", old_volume_name);
+            let volume_to_remove = format!("{old_volume_name}_data");
             let _ = self.run_docker_command(&["volume", "rm", &volume_to_remove]);
         }
 


### PR DESCRIPTION
Let docker handle the volumes and just use a bind mount. Hopefully the last fix needed for WSL.

Changes delete and prune commands so that it keeps what it currently does to prevent old CLI volumes orphaning, on top of manually handling the new bind folders.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 09:31:27 UTC

<h3>Summary</h3>
This PR migrates HelixDB's Docker data persistence from named volumes to bind mounts to resolve Windows Subsystem for Linux (WSL) compatibility issues. The core change involves modifying the docker-compose template generation in `helix-cli/src/docker.rs` to use direct filesystem bind mounts (`../.volumes/{instance_name}:/data`) instead of Docker managed named volumes.

The migration addresses a fundamental issue where Docker's named volume system with bind mount drivers can be unreliable in WSL environments due to how Windows filesystem paths are handled. By switching to direct bind mounts, Docker bypasses its internal volume management and directly mounts the host filesystem path, providing more reliable cross-platform behavior.

The change includes backward compatibility measures by adding cleanup logic that removes orphaned named volumes from previous CLI versions during delete and prune operations. This ensures users upgrading from the old system won't accumulate unused Docker volumes.

This fits into the broader HelixDB codebase as part of the CLI's Docker orchestration functionality, which manages containerized database instances through generated docker-compose configurations. The change maintains the same external behavior while improving reliability on Windows development environments.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| helix-cli/src/docker.rs | 4/5 | Migrates Docker data persistence from named volumes to bind mounts for WSL compatibility, removes volume configuration methods, and adds cleanup for orphaned volumes |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant DockerManager
    participant DockerCompose
    participant Docker
    participant FileSystem

    User->>CLI: "helix start <instance>"
    CLI->>DockerManager: "start_instance(instance_name)"
    DockerManager->>DockerManager: "compose_project_name(instance_name)"
    DockerManager->>DockerManager: "project.instance_workspace(instance_name)"
    DockerManager->>DockerCompose: "docker-compose up -d"
    DockerCompose->>Docker: "create/start containers"
    Docker->>FileSystem: "mount bind volume ../.volumes/{instance}:/data"
    Docker-->>DockerCompose: "container started"
    DockerCompose-->>DockerManager: "success/error output"
    DockerManager-->>CLI: "Result<()>"
    CLI-->>User: "Instance started successfully"

    User->>CLI: "helix build <instance>"
    CLI->>DockerManager: "build_image(instance_name)"
    DockerManager->>DockerManager: "compose_project_name(instance_name)"
    DockerManager->>DockerCompose: "docker-compose build"
    DockerCompose->>Docker: "build image with Dockerfile"
    Docker-->>DockerCompose: "build complete"
    DockerCompose-->>DockerManager: "success/error output"
    DockerManager-->>CLI: "Result<()>"
    CLI-->>User: "Image built successfully"

    User->>CLI: "helix stop <instance>"
    CLI->>DockerManager: "stop_instance(instance_name)"
    DockerManager->>DockerCompose: "docker-compose down"
    DockerCompose->>Docker: "stop containers"
    Docker-->>DockerCompose: "containers stopped"
    DockerCompose-->>DockerManager: "success/error output"
    DockerManager-->>CLI: "Result<()>"
    CLI-->>User: "Instance stopped successfully"

    User->>CLI: "helix prune <instance>"
    CLI->>DockerManager: "prune_instance(instance_name, remove_volumes)"
    DockerManager->>FileSystem: "check workspace exists"
    FileSystem-->>DockerManager: "workspace found"
    DockerManager->>DockerCompose: "docker-compose down --volumes --remove-orphans"
    DockerCompose->>Docker: "remove containers and volumes"
    Docker-->>DockerCompose: "cleanup complete"
    DockerManager->>Docker: "docker volume rm old_volume_name"
    Docker-->>DockerManager: "old volume removed"
    DockerManager-->>CLI: "Result<()>"
    CLI-->>User: "Instance pruned successfully"
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->