### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ The Helix CLI tool can be used to check, compile and deploy Helix locally.
 3. Write queries
 
    Open your newly created `.hx` files and start writing your schema and queries.
-   Head over to [our docs](https://docs.helix-db.com/introduction/cookbook/basic) for more information about writing queries
+   Head over to [our docs](https://docs.helix-db.com/documentation/getting-started/intro) for more information about writing queries
+
+
 
    ```js
    QUERY addUser(name: String, age: I64) =>


### PR DESCRIPTION
## Description

Fix broken link

## Related Issues

Closes #

## Checklist when merging to main

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-02 16:42:44 UTC

<h3>Summary</h3>
This PR fixes a broken documentation link in the README.md file. The change updates the URL from `https://docs.helix-db.com/introduction/cookbook/basic` to `https://docs.helix-db.com/documentation/getting-started/intro`. This is a simple but important documentation maintenance fix that ensures users can successfully access the getting started documentation when following the README instructions.

The change appears to be necessitated by a restructuring of the HelixDB documentation website, where the old URL path structure (`introduction/cookbook/basic`) was replaced with a new structure (`documentation/getting-started/intro`). This type of link maintenance is common when documentation sites are reorganized or updated.

Two additional blank lines were also added after the link, which appears to be either incidental formatting or to improve consistency with the surrounding content. This change integrates seamlessly with the existing README structure and doesn't affect any code functionality.

**PR Description Notes:**
- The "Related Issues" section shows "Closes #" without specifying an issue number, suggesting this was either a quick fix or the issue reference was accidentally omitted.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| README.md | 5/5 | Fixed broken documentation link from old URL structure to current valid path |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant "GitHub PR System"
    participant "Repository"
    
    User->>User: "Identify broken link in README.md"
    User->>"GitHub PR System": "Create branch 'patch-1'"
    User->>"GitHub PR System": "Edit README.md file"
    Note over User, "GitHub PR System": Fix broken link
    User->>"GitHub PR System": "Commit changes to patch-1"
    User->>"GitHub PR System": "Create pull request"
    Note over "GitHub PR System": PR: "Update README.md" - Fix broken link
    "GitHub PR System"->>"Repository": "Request merge patch-1 -> main"
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->