### PR TITLE
Properly use cargo chef in generated Dockerfile

### DIFF
--- a/helix-cli/src/docker.rs
+++ b/helix-cli/src/docker.rs
@@ -174,20 +174,14 @@ COPY helix-container/ ./helix-container/
 
 FROM chef AS planner
 # Generate the recipe file for dependency caching
-RUN cargo chef prepare --recipe-path recipe.json
+RUN cargo chef prepare --recipe-path recipe.json --bin helix-container
 
 FROM chef AS builder
 # Copy the recipe file
 COPY --from=planner /build/recipe.json recipe.json
 
-# Install system dependencies again for builder stage
-RUN apt-get update && apt-get install -y \
-    pkg-config \
-    libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
-
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook {build_flag} --recipe-path recipe.json --package helix-container
+RUN cargo chef cook {build_flag} --recipe-path recipe.json --bin helix-container
 
 # Copy source code and build the application
 COPY helix-repo-copy/ ./
@@ -244,7 +238,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      {platform} 
+      {platform}
     image: {image_name}
     container_name: {container_name}
     ports:


### PR DESCRIPTION
## Description
Updates the cargo-chef commands in the generated Dockerfile for proper usage of chef in a monorepo. Specifies --bin in both prepare and cook to cache workspace deps appropriately.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-02 19:14:12 UTC

<h3>Summary</h3>
This PR optimizes the Docker build process for HelixDB by improving cargo-chef usage in the generated Dockerfile template. The changes specifically address proper dependency caching in a monorepo environment by adding the `--bin helix-container` flag to both the `prepare` and `cook` commands. This ensures that cargo-chef only processes dependencies relevant to the helix-container binary rather than attempting to handle all workspace dependencies, which improves build performance and reliability.

The changes are made to the `helix-cli/src/docker.rs` file, which appears to contain templates for generating Dockerfiles. In a monorepo with multiple binary targets like HelixDB, specifying the exact binary target is crucial for cargo-chef to function correctly. Without this specification, the build process could be inefficient or fail entirely due to cargo-chef trying to cache dependencies for all workspace members.

Additionally, the PR removes redundant system dependency installation from the builder stage since these are already installed in the chef base stage, making the Dockerfile more efficient. A minor formatting fix removing a trailing space is also included.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| helix-cli/src/docker.rs | 5/5 | Improves cargo-chef usage by adding `--bin helix-container` flags to prepare and cook commands, removes redundant system dependency installation, and includes minor formatting fixes |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as "Helix CLI"
    participant DockerManager as "Docker Manager"
    participant Docker as "Docker Engine"
    participant CargoChef as "Cargo Chef"

    User->>CLI: "helix build <instance>"
    CLI->>DockerManager: "build_image(instance_name)"
    DockerManager->>DockerManager: "generate_dockerfile()"
    Note over DockerManager: Generate Dockerfile with cargo-chef stages
    
    DockerManager->>Docker: "docker-compose build"
    Docker->>CargoChef: "FROM lukemathwalker/cargo-chef:latest-rust-1.88"
    CargoChef-->>Docker: Base image ready
    
    Docker->>Docker: "COPY helix-repo-copy/ ./"
    Docker->>Docker: "COPY helix-container/ ./helix-container/"
    
    Note over Docker,CargoChef: Planner stage
    Docker->>CargoChef: "cargo chef prepare --recipe-path recipe.json --bin helix-container"
    CargoChef-->>Docker: Recipe file generated
    
    Note over Docker,CargoChef: Builder stage - cook dependencies
    Docker->>CargoChef: "cargo chef cook {build_flag} --recipe-path recipe.json --bin helix-container"
    CargoChef-->>Docker: Dependencies cached and built
    
    Docker->>Docker: "COPY source code again"
    Docker->>CargoChef: "cargo build {build_flag} --package helix-container"
    CargoChef-->>Docker: Binary built
    
    Note over Docker: Runtime stage
    Docker->>Docker: "FROM debian:bookworm-slim"
    Docker->>Docker: "COPY --from=builder /build/target/{build_mode}/helix-container"
    
    Docker-->>DockerManager: Image built successfully
    DockerManager-->>CLI: Build complete
    CLI-->>User: "Image built successfully"
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->