### PR TITLE
fix (hql): fixing updating, removing asserts

### DIFF
--- a/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
+++ b/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
@@ -964,7 +964,9 @@ pub(crate) fn infer_expr_type<'a>(
                     );
                     // Where/boolean ops don't change the element type,
                     // so `cur_ty` stays the same.
-                    assert!(stmt.is_some());
+                    if stmt.is_none() {
+                        return (Type::Vector(sv.vector_type.clone()), None);
+                    }
                     let stmt = stmt.unwrap();
                     let mut gen_traversal = GeneratedTraversal {
                         traversal_type: TraversalType::NestedFrom(GenRef::Std("v".to_string())),
@@ -1134,7 +1136,9 @@ pub(crate) fn infer_expr_type<'a>(
         Exists(expr) => {
             let (_, stmt) =
                 infer_expr_type(ctx, &expr.expr, scope, original_query, parent_ty, gen_query);
-            assert!(stmt.is_some());
+            if stmt.is_none() {
+                return (Type::Boolean, None);
+            }
             assert!(matches!(stmt, Some(GeneratedStatement::Traversal(_))));
             let traversal = match stmt.unwrap() {
                 GeneratedStatement::Traversal(mut tr) => {

--- a/helix-db/src/helixc/analyzer/methods/query_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/query_validation.rs
@@ -77,7 +77,7 @@ pub(crate) fn validate_query<'a>(ctx: &mut Ctx<'a>, original_query: &'a Query) {
             query.statements.push(s);
         } else {
             // given all erroneous statements are caught by the analyzer, this should never happen
-            unreachable!()
+            return;
         }
     }
 
@@ -132,6 +132,10 @@ fn analyze_return_expr<'a>(
     match ret {
         ReturnType::Expression(expr) => {
             let (_, stmt) = infer_expr_type(ctx, expr, scope, original_query, None, query);
+
+            if stmt.is_none() {
+                return;
+            }
 
             match stmt.unwrap() {
                 GeneratedStatement::Traversal(traversal) => {

--- a/helix-db/src/helixc/analyzer/methods/statement_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/statement_validation.rs
@@ -60,7 +60,10 @@ pub(crate) fn validate_statements<'a>(
                 infer_expr_type(ctx, &assign.value, scope, original_query, None, query);
             
             scope.insert(assign.variable.as_str(), rhs_ty);
-            assert!(stmt.is_some(), "Assignment statement should be generated");
+
+            if stmt.is_none() {
+                return None;
+            }
 
             let assignment = GeneratedStatement::Assignment(GeneratedAssignment {
                 variable: GenRef::Std(assign.variable.clone()),
@@ -71,7 +74,9 @@ pub(crate) fn validate_statements<'a>(
 
         Drop(expr) => {
             let (_, stmt) = infer_expr_type(ctx, expr, scope, original_query, None, query);
-            assert!(stmt.is_some());
+            if stmt.is_none() {
+                return None;
+            }
             query.is_mut = true;
             if let Some(GeneratedStatement::Traversal(tr)) = stmt {
                 Some(GeneratedStatement::Drop(GeneratedDrop { expression: tr }))

--- a/helix-db/src/helixc/analyzer/methods/statement_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/statement_validation.rs
@@ -61,9 +61,7 @@ pub(crate) fn validate_statements<'a>(
             
             scope.insert(assign.variable.as_str(), rhs_ty);
 
-            if stmt.is_none() {
-                return None;
-            }
+            stmt.as_ref()?;
 
             let assignment = GeneratedStatement::Assignment(GeneratedAssignment {
                 variable: GenRef::Std(assign.variable.clone()),
@@ -74,9 +72,8 @@ pub(crate) fn validate_statements<'a>(
 
         Drop(expr) => {
             let (_, stmt) = infer_expr_type(ctx, expr, scope, original_query, None, query);
-            if stmt.is_none() {
-                return None;
-            }
+            stmt.as_ref()?;
+
             query.is_mut = true;
             if let Some(GeneratedStatement::Traversal(tr)) = stmt {
                 Some(GeneratedStatement::Drop(GeneratedDrop { expression: tr }))


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-03 08:36:04 UTC

<h3>Summary</h3>
This PR improves error handling robustness in the HelixQL (Helix Query Language) compiler by replacing panic-inducing `assert!()` and `unreachable!()` statements with graceful error handling. The changes span four critical analyzer modules that handle type inference, traversal validation, statement validation, and query validation.

**Key Changes:**
- **Type inference**: Replaces `assert!` statements with early returns providing sensible fallback types (`Type::Vector` and `Type::Boolean`) when statement inference fails for `SearchVector` and `Exists` expressions
- **Traversal validation**: Removes assertions that could panic and replaces them with early returns using the current type, plus simplifies Update operation validation
- **Statement validation**: Converts panicky assertions to proper `None` returns when `Assignment` and `Drop` statement validation fails
- **Query validation**: Changes `unreachable!()` to graceful `return` and adds defensive null checks

These changes align with Rust's philosophy of explicit error handling and make the compiler more resilient when processing malformed or edge-case HQL queries. The compiler can now continue processing or fail gracefully rather than crashing the entire application.

**PR Description Notes:**
- The PR description is essentially empty with only template placeholders
- No issue reference or detailed description of the changes is provided
- The checklist items are not marked as completed

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|--------|----------|
| helix-db/src/helixc/analyzer/methods/infer_expr_type.rs | 4/5 | Replaces two `assert!` statements with graceful early returns, providing fallback types for SearchVector and Exists expressions when statement inference fails |
| helix-db/src/helixc/analyzer/methods/traversal_validation.rs | 4/5 | Removes panic-inducing assertions and simplifies Update operation validation, but may mask underlying issues that assertions previously caught |
| helix-db/src/helixc/analyzer/methods/statement_validation.rs | 5/5 | Clean conversion of assertion panics to proper `None` returns for Assignment and Drop statement validation failures |
| helix-db/src/helixc/analyzer/methods/query_validation.rs | 4/5 | Replaces `unreachable!()` with graceful return and adds defensive null checking to prevent unwrap panics |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant QueryValidator as Query Validator
    participant ExprInferrer as Expression Type Inferrer
    participant TraversalValidator as Traversal Validator
    participant StatementValidator as Statement Validator
    participant CodeGenerator as Code Generator

    User->>QueryValidator: "Submit HQL Query"
    QueryValidator->>QueryValidator: "Parse parameters and built-in macros"
    QueryValidator->>StatementValidator: "Validate each statement"
    
    loop For each statement
        StatementValidator->>ExprInferrer: "Infer expression type"
        ExprInferrer->>ExprInferrer: "Match expression type (Identifier, Literal, Traversal, etc.)"
        
        alt Expression is Traversal
            ExprInferrer->>TraversalValidator: "Validate traversal steps"
            TraversalValidator->>TraversalValidator: "Process start node (Node/Edge/Vector/Identifier)"
            
            loop For each step in traversal
                TraversalValidator->>TraversalValidator: "Apply graph step validation"
                alt Step is Update
                    TraversalValidator->>TraversalValidator: "Set traversal type to Update"
                    TraversalValidator->>CodeGenerator: "Mark query as mutating"
                end
                alt Step is Where/BooleanOperation
                    TraversalValidator->>ExprInferrer: "Infer boolean expression type"
                    ExprInferrer-->>TraversalValidator: "Return boolean expression"
                end
            end
            
            TraversalValidator-->>ExprInferrer: "Return final traversal type"
        end
        
        ExprInferrer-->>StatementValidator: "Return (Type, GeneratedStatement)"
        StatementValidator-->>QueryValidator: "Return validated statement"
    end
    
    QueryValidator->>QueryValidator: "Validate RETURN expressions"
    QueryValidator->>ExprInferrer: "Process return values"
    ExprInferrer-->>QueryValidator: "Return validated return expressions"
    
    QueryValidator->>CodeGenerator: "Add query to output"
    CodeGenerator-->>User: "Generated Rust code"
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->