### PR TITLE
chore(docker): migrate from docker-compose to docker compose

### DIFF
--- a/helix-cli/src/docker.rs
+++ b/helix-cli/src/docker.rs
@@ -96,7 +96,8 @@ impl<'a> DockerManager<'a> {
         let mut full_args = vec!["--project-name", &project_name];
         full_args.extend(args);
 
-        let output = Command::new("docker compose")
+        let output = Command::new("docker")
+            .arg("compose")
             .args(&full_args)
             .current_dir(&workspace)
             .output()

--- a/helix-cli/src/docker.rs
+++ b/helix-cli/src/docker.rs
@@ -88,7 +88,7 @@ impl<'a> DockerManager<'a> {
         Ok(output)
     }
 
-    /// Run a docker-compose command with proper project naming
+    /// Run a docker compose command with proper project naming
     fn run_compose_command(&self, instance_name: &str, args: Vec<&str>) -> Result<Output> {
         let workspace = self.project.instance_workspace(instance_name);
         let project_name = self.compose_project_name(instance_name);
@@ -96,11 +96,11 @@ impl<'a> DockerManager<'a> {
         let mut full_args = vec!["--project-name", &project_name];
         full_args.extend(args);
 
-        let output = Command::new("docker-compose")
+        let output = Command::new("docker compose")
             .args(&full_args)
             .current_dir(&workspace)
             .output()
-            .map_err(|e| eyre!("Failed to run docker-compose {}: {e}", full_args.join(" ")))?;
+            .map_err(|e| eyre!("Failed to run docker compose {}: {e}", full_args.join(" ")))?;
         Ok(output)
     }
 
@@ -274,7 +274,7 @@ networks:
         Ok(())
     }
 
-    /// Start instance using docker-compose
+    /// Start instance using docker compose
     pub fn start_instance(&self, instance_name: &str) -> Result<()> {
         print_status("DOCKER", &format!("Starting instance '{instance_name}'..."));
 
@@ -292,7 +292,7 @@ networks:
         Ok(())
     }
 
-    /// Stop instance using docker-compose
+    /// Stop instance using docker compose
     pub fn stop_instance(&self, instance_name: &str) -> Result<()> {
         print_status("DOCKER", &format!("Stopping instance '{instance_name}'..."));
 


### PR DESCRIPTION
## Description

Replaced all docker-compose commands with the docker compose CLI.
The old standalone binary is deprecated and no longer required.
This makes Docker usage simpler and aligns with current best practices.

## Related Issues
None


## Checklist when merging to main

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
None

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-06 15:41:01 UTC

<h3>Summary</h3>
This PR modernizes the HelixDB codebase by migrating from the deprecated standalone `docker-compose` binary to the `docker compose` CLI subcommand. The changes are minimal and focused entirely on the `helix-cli/src/docker.rs` file, where the command invocations and related documentation have been updated to use the new syntax.

The migration is part of Docker's evolution where the standalone `docker-compose` binary has been deprecated in favor of `docker compose` as a subcommand of the main Docker CLI. This change ensures the codebase stays current with Docker best practices and maintains compatibility with newer Docker installations where the standalone binary may not be available.

From a functional perspective, this change has zero impact on the behavior of the application - it simply updates the command being executed from `docker-compose` to `docker compose`. The HelixDB CLI will continue to work exactly as before, but now uses the modern Docker tooling approach.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| helix-cli/src/docker.rs | 5/5 | Updated command invocation from `docker-compose` to `docker compose` and updated related comments/documentation |

</details>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->