### PR TITLE
feat(hql + core): f32 and f16 vector precision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1120,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "serde",
+]
+
+[[package]]
 name = "halfbrown"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1246,7 @@ dependencies = [
  "chrono",
  "dirs 5.0.1",
  "dotenvy",
+ "half",
  "heed3",
  "helix-db",
  "helix-macros",
@@ -1253,6 +1271,7 @@ dependencies = [
  "chrono",
  "core_affinity",
  "flume",
+ "half",
  "heed3",
  "helix-macros",
  "helix-metrics",

--- a/helix-container/Cargo.toml
+++ b/helix-container/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = "0.1"
 tracing-subscriber = "0.3.20"
 tracing = "0.1.41"
 dotenvy = "0.15.7"
+half = { version = "2.6.0", features = ["std"] }
 
 [features]
 dev = ["helix-db/dev-instance"]

--- a/helix-db/Cargo.toml
+++ b/helix-db/Cargo.toml
@@ -29,6 +29,7 @@ tempfile = "3.20.0"
 paste = "1.0.15"
 rayon = "1.11.0"
 mimalloc = "0.1.48"
+half = { version = "2.4.1", features = ["serde", "std"] }
 
 # compiler dependencies
 pest = { version = "2.7", optional = true }

--- a/helix-db/src/grammar.pest
+++ b/helix-db/src/grammar.pest
@@ -8,9 +8,14 @@ source = { SOI ~ (schema_def | migration_def | query_def)* ~ EOI }
 // Schema definitions
 // ---------------------------------------------------------------------
 schema_def = {( schema_version ~ "{" ~ (vector_def | node_def | edge_def)* ~ "}") | (vector_def | node_def | edge_def) }
-vector_def = { "V::" ~ identifier_upper ~ node_body? }
+vector_def = { "V::" ~ identifier_upper ~ precision? ~ node_body? }
 node_def   = { "N::" ~ identifier_upper ~ node_body? }
 edge_def   = { "E::" ~ identifier_upper ~ edge_body }
+precision = { "<" ~ (f64 | f32 | f16) ~ ">" }
+f64 = { "F64" }
+f32 = { "F32" }
+f16 = { "F16" }
+
 
 node_body  = { "{" ~ field_defs ~ "}" }
 edge_body  = { "{" ~ "From:" ~ identifier_upper ~ "," ~ ("To:" ~ identifier_upper ~ "," ~ properties ~ "}" | "To:" ~ identifier_upper ~ ","? ~ "}") }
@@ -264,7 +269,7 @@ id_arg    = { (identifier | string_literal) }
 id_args   = { (id_arg) ~ ("," ~ id_arg)* }
 array            = { "[" ~ param_type ~ "]" }
 object           = { "{" ~ field_defs ~ "}" }
-named_type       = { "String" | "Boolean" | "F32" | "F64" | "I8" | "I16" | "I32" | "I64" | "U8" | "U16" | "U32" | "U64" | "U128" }
+named_type       = { "String" | "Boolean" | "F16" | "F32" | "F64" | "I8" | "I16" | "I32" | "I64" | "U8" | "U16" | "U32" | "U64" | "U128" }
 ID_TYPE          = { "ID" }
 date_type       = { "Date" }
 param_type       = { named_type | date_type | ID_TYPE | array | object | identifier  }

--- a/helix-db/src/helix_engine/bm25/bm25.rs
+++ b/helix-db/src/helix_engine/bm25/bm25.rs
@@ -1,14 +1,14 @@
 use crate::{
+    debug_println,
     helix_engine::{
         storage_core::HelixGraphStorage,
         types::GraphError,
-        vector_core::{hnsw::HNSW, vector::HVector},
+        vector_core::{VectorData, hnsw::HNSW, vector::HVector},
     },
     protocol::value::Value,
-    debug_println,
 };
 
-use heed3::{types::*, Database, Env, RoTxn, RwTxn};
+use heed3::{Database, Env, RoTxn, RwTxn, types::*};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tokio::task;
@@ -82,10 +82,10 @@ impl HBM25Config {
 
         let doc_lengths_db: Database<U128<heed3::byteorder::BE>, U32<heed3::byteorder::BE>> =
             graph_env
-            .database_options()
-            .types::<U128<heed3::byteorder::BE>, U32<heed3::byteorder::BE>>()
-            .name(DB_BM25_DOC_LENGTHS)
-            .create(wtxn)?;
+                .database_options()
+                .types::<U128<heed3::byteorder::BE>, U32<heed3::byteorder::BE>>()
+                .name(DB_BM25_DOC_LENGTHS)
+                .create(wtxn)?;
 
         let term_frequencies_db: Database<Bytes, U32<heed3::byteorder::BE>> = graph_env
             .database_options()
@@ -110,7 +110,11 @@ impl HBM25Config {
         })
     }
 
-    pub fn new_temp(graph_env: &Env, wtxn: &mut RwTxn, uuid: &str) -> Result<HBM25Config, GraphError> {
+    pub fn new_temp(
+        graph_env: &Env,
+        wtxn: &mut RwTxn,
+        uuid: &str,
+    ) -> Result<HBM25Config, GraphError> {
         let inverted_index_db: Database<Bytes, Bytes> = graph_env
             .database_options()
             .types::<Bytes, Bytes>()
@@ -120,10 +124,10 @@ impl HBM25Config {
 
         let doc_lengths_db: Database<U128<heed3::byteorder::BE>, U32<heed3::byteorder::BE>> =
             graph_env
-            .database_options()
-            .types::<U128<heed3::byteorder::BE>, U32<heed3::byteorder::BE>>()
-            .name(format!("{DB_BM25_DOC_LENGTHS}_{uuid}").as_str())
-            .create(wtxn)?;
+                .database_options()
+                .types::<U128<heed3::byteorder::BE>, U32<heed3::byteorder::BE>>()
+                .name(format!("{DB_BM25_DOC_LENGTHS}_{uuid}").as_str())
+                .create(wtxn)?;
 
         let term_frequencies_db: Database<Bytes, U32<heed3::byteorder::BE>> = graph_env
             .database_options()
@@ -188,7 +192,7 @@ impl BM25 for HBM25Config {
             let current_df = self.term_frequencies_db.get(txn, term_bytes)?.unwrap_or(0);
             self.term_frequencies_db
                 .put(txn, term_bytes, &(current_df + 1))?;
-            }
+        }
 
         let mut metadata = if let Some(data) = self.metadata_db.get(txn, METADATA_KEY)? {
             bincode::deserialize::<BM25Metadata>(data)?
@@ -400,7 +404,7 @@ impl HybridSearch for HelixGraphStorage {
         limit: usize,
     ) -> Result<Vec<(u128, f32)>, GraphError> {
         let query_owned = query.to_string();
-        let query_vector_owned = query_vector.to_vec();
+        let query_vector_owned = VectorData::from_f64_slice(query_vector);
 
         let graph_env_bm25 = self.graph_env.clone();
         let graph_env_vector = self.graph_env.clone();
@@ -413,18 +417,19 @@ impl HybridSearch for HelixGraphStorage {
             }
         });
 
-        let vector_handle = task::spawn_blocking(move || -> Result<Option<Vec<HVector>>, GraphError> {
-            let txn = graph_env_vector.read_txn()?;
-            let results = self.vectors.search::<fn(&HVector, &RoTxn) -> bool>(
-                &txn,
-                &query_vector_owned,
-                limit * 2,
-                "vector",
-                None,
-                false,
-            )?;
-            Ok(Some(results))
-        });
+        let vector_handle =
+            task::spawn_blocking(move || -> Result<Option<Vec<HVector>>, GraphError> {
+                let txn = graph_env_vector.read_txn()?;
+                let results = self.vectors.search::<fn(&HVector, &RoTxn) -> bool>(
+                    &txn,
+                    &query_vector_owned,
+                    limit * 2,
+                    "vector",
+                    None,
+                    false,
+                )?;
+                Ok(Some(results))
+            });
 
         let (bm25_results, vector_results) = match tokio::try_join!(bm25_handle, vector_handle) {
             Ok((a, b)) => (a, b),
@@ -447,7 +452,7 @@ impl HybridSearch for HelixGraphStorage {
                     .entry(doc_id)
                     .and_modify(|existing_score| *existing_score += (1.0 - alpha) * similarity)
                     .or_insert((1.0 - alpha) * similarity); // correction made here from score as f32 to similarity
-                }
+            }
         }
 
         let mut results = combined_scores.into_iter().collect::<Vec<(u128, f32)>>();
@@ -475,4 +480,3 @@ impl BM25Flatten for HashMap<String, Value> {
             })
     }
 }
-

--- a/helix-db/src/helix_engine/bm25/bm25_tests.rs
+++ b/helix-db/src/helix_engine/bm25/bm25_tests.rs
@@ -7,7 +7,7 @@ mod tests {
             },
             storage_core::{HelixGraphStorage, version_info::VersionInfo},
             traversal_core::config::Config,
-            vector_core::{hnsw::HNSW, vector::HVector},
+            vector_core::{VectorData, hnsw::HNSW, vector::HVector},
         },
         protocol::value::Value,
     };
@@ -1424,9 +1424,11 @@ mod tests {
         let mut wtxn = storage.graph_env.write_txn().unwrap();
         let vectors = generate_random_vectors(800, 650);
         for vec in vectors {
-            let _ = storage
-                .vectors
-                .insert::<fn(&HVector, &RoTxn) -> bool>(&mut wtxn, &vec, None);
+            let _ = storage.vectors.insert::<fn(&HVector, &RoTxn) -> bool>(
+                &mut wtxn,
+                VectorData::F64(vec),
+                None,
+            );
         }
         wtxn.commit().unwrap();
 
@@ -1466,9 +1468,11 @@ mod tests {
         let mut wtxn = storage.graph_env.write_txn().unwrap();
         let vectors = generate_random_vectors(800, 650);
         for vec in vectors {
-            let _ = storage
-                .vectors
-                .insert::<fn(&HVector, &RoTxn) -> bool>(&mut wtxn, &vec, None);
+            let _ = storage.vectors.insert::<fn(&HVector, &RoTxn) -> bool>(
+                &mut wtxn,
+                VectorData::F64(vec),
+                None,
+            );
         }
         wtxn.commit().unwrap();
 
@@ -1509,9 +1513,11 @@ mod tests {
         let mut wtxn = storage.graph_env.write_txn().unwrap();
         let vectors = generate_random_vectors(800, 650);
         for vec in vectors {
-            let _ = storage
-                .vectors
-                .insert::<fn(&HVector, &RoTxn) -> bool>(&mut wtxn, &vec, None);
+            let _ = storage.vectors.insert::<fn(&HVector, &RoTxn) -> bool>(
+                &mut wtxn,
+                VectorData::F64(vec),
+                None,
+            );
         }
         wtxn.commit().unwrap();
 

--- a/helix-db/src/helix_engine/tests/hnsw_tests.rs
+++ b/helix-db/src/helix_engine/tests/hnsw_tests.rs
@@ -1,18 +1,14 @@
 // MAKE SURE TO --release
-use crate::{
-    helix_engine::vector_core::{
-        hnsw::HNSW,
-        vector::HVector,
-        vector_core::{HNSWConfig, VectorCore},
-    },
+use crate::helix_engine::vector_core::{
+    VectorData,
+    hnsw::HNSW,
+    vector::HVector,
+    vector_core::{HNSWConfig, VectorCore},
 };
 use heed3::{Env, EnvOpenOptions, RoTxn};
-use rand::{
-    seq::SliceRandom,
-    Rng,
-};
+use rand::{Rng, seq::SliceRandom};
 use std::{
-    collections::{HashSet, HashMap},
+    collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
     thread,
 };
@@ -53,7 +49,7 @@ fn calc_ground_truths(
                 let local_results: HashMap<usize, Vec<u128>> = chunk
                     .into_iter()
                     .map(|(query_id, query_vec)| {
-                        let query_hvector = HVector::from_slice(0, query_vec);
+                        let query_hvector = HVector::from_slice(0, VectorData::F64(query_vec));
 
                         let mut distances: Vec<(u128, f64)> = base_vectors
                             .iter()
@@ -63,26 +59,23 @@ fn calc_ground_truths(
                                     .map(|dist| (base_vec.id.clone(), dist))
                                     .ok()
                             })
-                        .collect();
+                            .collect();
 
                         distances.sort_by(|a, b| {
                             a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal)
                         });
 
-                        let top_k_ids: Vec<u128> = distances
-                            .into_iter()
-                            .take(k)
-                            .map(|(id, _)| id)
-                            .collect();
+                        let top_k_ids: Vec<u128> =
+                            distances.into_iter().take(k).map(|(id, _)| id).collect();
 
                         (query_id, top_k_ids)
                     })
-                .collect();
+                    .collect();
 
                 results.lock().unwrap().extend(local_results);
             })
         })
-    .collect();
+        .collect();
 
     for handle in handles {
         handle.join().unwrap();
@@ -116,22 +109,14 @@ fn tests_hnsw_config_build() {
     let env = setup_temp_env();
     let mut txn = env.write_txn().unwrap();
 
-    let config = HNSWConfig::new(
-        Some(32),
-        Some(256),
-        Some(256),
-    );
+    let config = HNSWConfig::new(Some(32), Some(256), Some(256));
 
     let index = VectorCore::new(&env, &mut txn, config).unwrap();
     assert_eq!(index.config.m, 32);
     assert_eq!(index.config.ef_construct, 256);
     assert_eq!(index.config.ef, 256);
 
-    let config = HNSWConfig::new(
-        Some(6969),
-        Some(6969),
-        Some(6969),
-    );
+    let config = HNSWConfig::new(Some(6969), Some(6969), Some(6969));
     assert_eq!(config.m, 48);
     assert_eq!(config.ef_construct, 512);
     assert_eq!(config.ef, 512);
@@ -148,8 +133,10 @@ fn test_hnsw_insert() {
     let vectors = gen_sim_vecs(n_base, dims, 0.8);
 
     for data in vectors {
-        let vec = index.insert::<Filter>(&mut txn, &data, None).unwrap();
-        assert_eq!(vec.data, data);
+        let vec = index
+            .insert::<Filter>(&mut txn, VectorData::F64(data.to_vec()), None)
+            .unwrap();
+        assert_eq!(vec.data, VectorData::F64(data));
         assert!(vec.properties.is_none());
     }
 
@@ -169,7 +156,11 @@ fn test_get_vector() {
 
     let mut all_vectors: Vec<HVector> = Vec::with_capacity(n_base);
     for data in vectors {
-        all_vectors.push(index.insert::<Filter>(&mut txn, &data, None).unwrap());
+        all_vectors.push(
+            index
+                .insert::<Filter>(&mut txn, VectorData::F64(data), None)
+                .unwrap(),
+        );
     }
 
     for inserted_vec in all_vectors {
@@ -210,8 +201,12 @@ fn test_hnsw_search() {
     let index = VectorCore::new(&env, &mut txn, HNSWConfig::new(None, None, None)).unwrap();
 
     let mut base_all_vectors: Vec<HVector> = Vec::new();
-    for data in base_vectors.iter() {
-        base_all_vectors.push(index.insert::<Filter>(&mut txn, &data, None).unwrap());
+    for data in base_vectors.into_iter() {
+        base_all_vectors.push(
+            index
+                .insert::<Filter>(&mut txn, VectorData::F64(data.to_vec()), None)
+                .unwrap(),
+        );
     }
     txn.commit().unwrap();
 
@@ -225,7 +220,16 @@ fn test_hnsw_search() {
     let mut total_recall = 0.0;
     let mut total_precision = 0.0;
     for (qid, query) in query_vectors {
-        let results = index.search::<Filter>(&txn, &query, k, "vector", None, false).unwrap();
+        let results = index
+            .search::<Filter>(
+                &txn,
+                &VectorData::F64(query.to_vec()),
+                k,
+                "vector",
+                None,
+                false,
+            )
+            .unwrap();
 
         let result_indices = results
             .into_iter()
@@ -256,18 +260,14 @@ fn test_hnsw_search() {
         total_recall, total_precision
     );
     assert!(total_recall >= 0.8, "recall not high enough!");
-    assert!(total_precision>= 0.8, "precision not high enough!");
+    assert!(total_precision >= 0.8, "precision not high enough!");
 }
 
 #[test]
-fn test_hnsw_search_property_ordering() {
-}
+fn test_hnsw_search_property_ordering() {}
 
 #[test]
-fn test_hnsw_search_filter_ordering() {
-}
+fn test_hnsw_search_filter_ordering() {}
 
 #[test]
-fn test_hnsw_delete() {
-}
-
+fn test_hnsw_delete() {}

--- a/helix-db/src/helix_engine/tests/traversal_tests/drop_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/drop_tests.rs
@@ -21,7 +21,7 @@ use crate::{
             },
             traversal_value::{Traversable, TraversalValue},
         },
-        vector_core::vector::HVector,
+        vector_core::{vector::HVector, VectorData},
     },
     props,
     utils::filterable::Filterable,
@@ -359,7 +359,7 @@ fn test_vector_deletion_in_existing_graph() {
     for _ in 0..10 {
         let other_vector = G::new_mut(Arc::clone(&storage), &mut txn)
             .insert_v::<fn(&HVector, &RoTxn) -> bool>(
-                &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
                 "vector",
                 None,
             )
@@ -368,7 +368,11 @@ fn test_vector_deletion_in_existing_graph() {
     }
 
     let vector = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<fn(&HVector, &RoTxn) -> bool>(&[1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "vector", None)
+        .insert_v::<fn(&HVector, &RoTxn) -> bool>(
+            VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+            "vector",
+            None,
+        )
         .collect_to_obj();
 
     for other_vector in &other_vectors {

--- a/helix-db/src/helix_engine/tests/traversal_tests/edge_traversal_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/edge_traversal_tests.rs
@@ -20,7 +20,7 @@ use crate::{
             },
             traversal_value::{Traversable, TraversalValue},
         },
-        vector_core::vector::HVector,
+        vector_core::{vector::HVector, VectorData},
     },
     props,
     utils::filterable::Filterable,
@@ -408,7 +408,11 @@ fn test_add_e_between_node_and_vector() {
         .collect_to_obj();
 
     let vector = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<fn(&HVector, &RoTxn) -> bool>(&[1.0, 2.0, 3.0], "vector", None)
+        .insert_v::<fn(&HVector, &RoTxn) -> bool>(
+            VectorData::F64(vec![1.0, 2.0, 3.0]),
+            "vector",
+            None,
+        )
         .collect_to_obj();
 
     let _ = G::new_mut(Arc::clone(&storage), &mut txn)
@@ -435,7 +439,12 @@ fn test_add_e_between_node_and_vector() {
     println!(
         "vectors: {:?}",
         G::new(Arc::clone(&storage), &txn)
-            .search_v::<fn(&HVector, &RoTxn) -> bool, _>(&[1.0, 2.0, 3.0], 10, "vector", None)
+            .search_v::<fn(&HVector, &RoTxn) -> bool, _>(
+                VectorData::F64(vec![1.0, 2.0, 3.0]),
+                10,
+                "vector",
+                None
+            )
             .collect_to::<Vec<_>>()
     );
 

--- a/helix-db/src/helix_engine/tests/traversal_tests/util_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/util_tests.rs
@@ -17,7 +17,7 @@ use crate::{
             },
             traversal_value::Traversable,
         },
-        vector_core::vector::HVector,
+        vector_core::{VectorData, vector::HVector},
     },
     props,
 };
@@ -212,22 +212,34 @@ fn test_order_vector_by_asc() {
     type FnTy = fn(&HVector, &RoTxn) -> bool;
 
     let vector = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<FnTy>(&[1.0, 2.0, 3.0], "vector", Some(props! { "age" => 30 }))
+        .insert_v::<FnTy>(
+            VectorData::F64(vec![1.0, 2.0, 3.0]),
+            "vector",
+            Some(props! { "age" => 30 }),
+        )
         .collect_to_obj();
 
     let vector2 = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<FnTy>(&[1.0, 2.0, 3.0], "vector", Some(props! { "age" => 20 }))
+        .insert_v::<FnTy>(
+            VectorData::F64(vec![1.0, 2.0, 3.0]),
+            "vector",
+            Some(props! { "age" => 20 }),
+        )
         .collect_to_obj();
 
     let vector3 = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<FnTy>(&[1.0, 2.0, 3.0], "vector", Some(props! { "age" => 10 }))
+        .insert_v::<FnTy>(
+            VectorData::F64(vec![1.0, 2.0, 3.0]),
+            "vector",
+            Some(props! { "age" => 10 }),
+        )
         .collect_to_obj();
 
     txn.commit().unwrap();
 
     let txn = storage.graph_env.read_txn().unwrap();
     let traversal = G::new(Arc::clone(&storage), &txn)
-        .search_v::<FnTy, _>(&[1.0, 2.0, 3.0], 10, "vector", None)
+        .search_v::<FnTy, _>(VectorData::F64(vec![1.0, 2.0, 3.0]), 10, "vector", None)
         .order_by_asc("age")
         .collect_to::<Vec<_>>();
 
@@ -244,22 +256,34 @@ fn test_order_vector_by_desc() {
     type FnTy = fn(&HVector, &RoTxn) -> bool;
 
     let vector = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<FnTy>(&[1.0, 2.0, 3.0], "vector", Some(props! { "age" => 30 }))
+        .insert_v::<FnTy>(
+            VectorData::F64(vec![1.0, 2.0, 3.0]),
+            "vector",
+            Some(props! { "age" => 30 }),
+        )
         .collect_to_obj();
 
     let vector2 = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<FnTy>(&[1.0, 2.0, 3.0], "vector", Some(props! { "age" => 20 }))
+        .insert_v::<FnTy>(
+            VectorData::F64(vec![1.0, 2.0, 3.0]),
+            "vector",
+            Some(props! { "age" => 20 }),
+        )
         .collect_to_obj();
 
     let vector3 = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<FnTy>(&[1.0, 2.0, 3.0], "vector", Some(props! { "age" => 10 }))
+        .insert_v::<FnTy>(
+            VectorData::F64(vec![1.0, 2.0, 3.0]),
+            "vector",
+            Some(props! { "age" => 10 }),
+        )
         .collect_to_obj();
 
     txn.commit().unwrap();
 
     let txn = storage.graph_env.read_txn().unwrap();
     let traversal = G::new(Arc::clone(&storage), &txn)
-        .search_v::<FnTy, _>(&[1.0, 2.0, 3.0], 10, "vector", None)
+        .search_v::<FnTy, _>(VectorData::F64(vec![1.0, 2.0, 3.0]), 10, "vector", None)
         .order_by_desc("age")
         .collect_to::<Vec<_>>();
 

--- a/helix-db/src/helix_engine/tests/traversal_tests/vector_traversal_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/vector_traversal_tests.rs
@@ -23,7 +23,7 @@ use crate::{
             },
             traversal_value::{Traversable, TraversalValue},
         },
-        vector_core::vector::HVector,
+        vector_core::{VectorData, vector::HVector},
     },
     props,
 };
@@ -55,7 +55,11 @@ fn test_from_v() {
         .collect_to_obj();
 
     let vector = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<fn(&HVector, &RoTxn) -> bool>(&[1.0, 2.0, 3.0], "vector", None)
+        .insert_v::<fn(&HVector, &RoTxn) -> bool>(
+            VectorData::F64(vec![1.0, 2.0, 3.0]),
+            "vector",
+            None,
+        )
         .collect_to_obj();
 
     let _ = G::new_mut(Arc::clone(&storage), &mut txn)
@@ -86,7 +90,11 @@ fn test_to_v() {
         .collect_to_obj();
 
     let vector = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<fn(&HVector, &RoTxn) -> bool>(&[1.0, 2.0, 3.0], "vector", None)
+        .insert_v::<fn(&HVector, &RoTxn) -> bool>(
+            VectorData::F64(vec![1.0, 2.0, 3.0]),
+            "vector",
+            None,
+        )
         .collect_to_obj();
 
     let _ = G::new_mut(Arc::clone(&storage), &mut txn)
@@ -127,7 +135,7 @@ fn test_brute_force_vector_search() {
     let mut vector_ids = Vec::new();
     for vector in vectors {
         let vector_id = G::new_mut(Arc::clone(&storage), &mut txn)
-            .insert_v::<fn(&HVector, &RoTxn) -> bool>(&vector, "vector", None)
+            .insert_v::<fn(&HVector, &RoTxn) -> bool>(VectorData::F64(vector), "vector", None)
             .collect_to_obj()
             .id();
         let _ = G::new_mut(Arc::clone(&storage), &mut txn)
@@ -213,7 +221,11 @@ fn test_vector_search() {
             rng.random::<f64>(),
         ];
         let _ = G::new_mut(Arc::clone(&storage), &mut txn)
-            .insert_v::<fn(&HVector, &RoTxn) -> bool>(&random_vector, "vector", None)
+            .insert_v::<fn(&HVector, &RoTxn) -> bool>(
+                VectorData::F64(random_vector),
+                "vector",
+                None,
+            )
             .collect_to_obj();
         println!("inserted vector: {i:?}");
         i += 1;
@@ -234,7 +246,7 @@ fn test_vector_search() {
 
     for vector in vectors {
         let node = G::new_mut(Arc::clone(&storage), &mut txn)
-            .insert_v::<fn(&HVector, &RoTxn) -> bool>(&vector, "vector", None)
+            .insert_v::<fn(&HVector, &RoTxn) -> bool>(VectorData::F64(vector), "vector", None)
             .collect_to_obj();
         inserted_vectors.push(node.id());
         println!("inserted vector: {i:?}");
@@ -246,7 +258,7 @@ fn test_vector_search() {
     let txn = storage.graph_env.read_txn().unwrap();
     let traversal = G::new(Arc::clone(&storage), &txn)
         .search_v::<fn(&HVector, &RoTxn) -> bool, _>(
-            &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
             2000,
             "vector",
             None,
@@ -268,7 +280,11 @@ fn test_delete_vector() {
     let mut txn = storage.graph_env.write_txn().unwrap();
 
     let vector = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<fn(&HVector, &RoTxn) -> bool>(&[1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "vector", None)
+        .insert_v::<fn(&HVector, &RoTxn) -> bool>(
+            VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+            "vector",
+            None,
+        )
         .collect_to_obj();
     let node = G::new_mut(Arc::clone(&storage), &mut txn)
         .add_n("person", None, None)
@@ -282,7 +298,7 @@ fn test_delete_vector() {
     let txn = storage.graph_env.read_txn().unwrap();
     let traversal = G::new(Arc::clone(&storage), &txn)
         .search_v::<fn(&HVector, &RoTxn) -> bool, usize>(
-            &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
             2000,
             "vector",
             None,
@@ -298,7 +314,7 @@ fn test_delete_vector() {
     Drop::drop_traversal(
         G::new(Arc::clone(&storage), &txn)
             .search_v::<fn(&HVector, &RoTxn) -> bool, _>(
-                &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
                 2000,
                 "vector",
                 None,
@@ -314,7 +330,7 @@ fn test_delete_vector() {
     let txn = storage.graph_env.read_txn().unwrap();
     let traversal = G::new(Arc::clone(&storage), &txn)
         .search_v::<fn(&HVector, &RoTxn) -> bool, usize>(
-            &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
             2000,
             "vector",
             None,
@@ -352,7 +368,11 @@ fn test_drop_vectors_then_add_them_back() {
         .collect_to_obj();
 
     let embedding = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<fn(&HVector, &RoTxn) -> bool>(&[1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "vector", None)
+        .insert_v::<fn(&HVector, &RoTxn) -> bool>(
+            VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+            "vector",
+            None,
+        )
         .collect_to_obj();
 
     let _ = G::new_mut(Arc::clone(&storage), &mut txn)
@@ -409,7 +429,7 @@ fn test_drop_vectors_then_add_them_back() {
 
     let embedding = G::new_mut(Arc::clone(&storage), &mut txn)
         .insert_v::<fn(&HVector, &RoTxn) -> bool>(
-            &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
             "Entity_Embedding",
             Some(props! { "name_embedding" => [1.0, 1.0, 1.0, 1.0, 1.0, 1.0].to_vec() }),
         )
@@ -430,7 +450,7 @@ fn test_drop_vectors_then_add_them_back() {
     let txn = storage.graph_env.read_txn().unwrap();
     let traversal = G::new(Arc::clone(&storage), &txn)
         .search_v::<fn(&HVector, &RoTxn) -> bool, usize>(
-            &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
             2000,
             "Entity_Embedding",
             None,
@@ -450,7 +470,11 @@ fn test_drop_vectors_then_add_them_back() {
     let mut txn = storage.graph_env.write_txn().unwrap();
 
     let embedding = G::new_mut(Arc::clone(&storage), &mut txn)
-        .insert_v::<fn(&HVector, &RoTxn) -> bool>(&[1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "vector", None)
+        .insert_v::<fn(&HVector, &RoTxn) -> bool>(
+            VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+            "vector",
+            None,
+        )
         .collect_to_obj();
 
     let _ = G::new_mut(Arc::clone(&storage), &mut txn)
@@ -487,7 +511,7 @@ fn test_drop_vectors_then_add_them_back() {
 
     let embedding = G::new_mut(Arc::clone(&storage), &mut txn)
         .insert_v::<fn(&HVector, &RoTxn) -> bool>(
-            &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
             "Entity_Embedding",
             Some(props! { "name_embedding" => [1.0, 1.0, 1.0, 1.0, 1.0, 1.0].to_vec() }),
         )
@@ -508,7 +532,7 @@ fn test_drop_vectors_then_add_them_back() {
     let txn = storage.graph_env.read_txn().unwrap();
     let traversal = G::new(Arc::clone(&storage), &txn)
         .search_v::<fn(&HVector, &RoTxn) -> bool, usize>(
-            &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            VectorData::F64(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
             2000,
             "Entity_Embedding",
             None,

--- a/helix-db/src/helix_engine/tests/vector_tests.rs
+++ b/helix-db/src/helix_engine/tests/vector_tests.rs
@@ -1,48 +1,49 @@
 use crate::helix_engine::vector_core::vector_distance::{MAX_DISTANCE, MIN_DISTANCE, ORTHOGONAL};
 
+use crate::helix_engine::vector_core::VectorData;
 use crate::helix_engine::vector_core::vector::HVector;
 
 #[test]
 fn test_hvector_new() {
     let data: Vec<f64> = vec![1.0, 2.0, 3.0];
-    let vector = HVector::new(data);
-    assert_eq!(vector.get_data(), &[1.0, 2.0, 3.0]);
+    let vector = HVector::new(VectorData::F64(data));
+    assert_eq!(vector.get_data(), &VectorData::F64(vec![1.0, 2.0, 3.0]));
 }
 
 #[test]
 fn test_hvector_from_slice() {
     let data: Vec<f64> = vec![1.0, 2.0, 3.0];
-    let vector = HVector::from_slice(0, data);
-    assert_eq!(vector.get_data(), &[1.0, 2.0, 3.0]);
+    let vector = HVector::from_slice(0, VectorData::F64(data));
+    assert_eq!(vector.get_data(), &VectorData::F64(vec![1.0, 2.0, 3.0]));
 }
 
 #[test]
 fn test_hvector_distance_orthogonal() {
-    let v1 = HVector::new(vec![1.0, 0.0]);
-    let v2 = HVector::new(vec![0.0, 1.0]);
+    let v1 = HVector::new(VectorData::F64(vec![1.0, 0.0]));
+    let v2 = HVector::new(VectorData::F64(vec![0.0, 1.0]));
     let distance = v1.distance_to(&v2).unwrap();
     assert!(distance == ORTHOGONAL);
 }
 
 #[test]
 fn test_hvector_distance_min() {
-    let v1 = HVector::new(vec![1.0, 2.0, 3.0]);
-    let v2 = HVector::new(vec![1.0, 2.0, 3.0]);
+    let v1 = HVector::new(VectorData::F64(vec![1.0, 2.0, 3.0]));
+    let v2 = HVector::new(VectorData::F64(vec![1.0, 2.0, 3.0]));
     let distance = v2.distance_to(&v1).unwrap();
     assert!(distance.abs() == MIN_DISTANCE);
 }
 
 #[test]
 fn test_hvector_distance_max() {
-    let v1 = HVector::new(vec![0.0, 0.0]);
-    let v2 = HVector::new(vec![3.0, 4.0]);
+    let v1 = HVector::new(VectorData::F64(vec![0.0, 0.0]));
+    let v2 = HVector::new(VectorData::F64(vec![3.0, 4.0]));
     let distance = v1.distance_to(&v2).unwrap();
     assert!(distance == MAX_DISTANCE);
 }
 
 #[test]
 fn test_bytes_roundtrip() {
-    let original = HVector::new(vec![1.0, 2.0, 3.0]);
+    let original = HVector::new(VectorData::F64(vec![1.0, 2.0, 3.0]));
     let bytes = original.to_bytes();
     let reconstructed = HVector::from_bytes(original.get_id(), 0, &bytes).unwrap();
     assert_eq!(original.get_data(), reconstructed.get_data());
@@ -51,14 +52,14 @@ fn test_bytes_roundtrip() {
 #[test]
 fn test_hvector_len() {
     let data = vec![1.0, 2.0, 3.0, 4.0];
-    let vector = HVector::new(data);
+    let vector = HVector::new(VectorData::F64(data));
     assert_eq!(vector.len(), 4);
 }
 
 #[test]
 fn test_hvector_is_empty() {
-    let empty_vector = HVector::new(vec![]);
-    let non_empty_vector = HVector::new(vec![1.0, 2.0]);
+    let empty_vector = HVector::new(VectorData::F64(vec![]));
+    let non_empty_vector = HVector::new(VectorData::F64(vec![1.0, 2.0]));
 
     assert!(empty_vector.is_empty());
     assert!(!non_empty_vector.is_empty());
@@ -67,8 +68,8 @@ fn test_hvector_is_empty() {
 #[test]
 #[should_panic]
 fn test_hvector_distance_different_dimensions() {
-    let v1 = HVector::new(vec![1.0, 2.0, 3.0]);
-    let v2 = HVector::new(vec![1.0, 2.0, 3.0, 4.0]);
+    let v1 = HVector::new(VectorData::F64(vec![1.0, 2.0, 3.0]));
+    let v2 = HVector::new(VectorData::F64(vec![1.0, 2.0, 3.0, 4.0]));
     let distance = v1.distance_to(&v2).unwrap();
     println!("distance: {distance}");
     assert!(distance.is_finite());
@@ -76,16 +77,16 @@ fn test_hvector_distance_different_dimensions() {
 
 #[test]
 fn test_hvector_large_values() {
-    let v1 = HVector::new(vec![1e6, 2e6]);
-    let v2 = HVector::new(vec![1e6, 2e6]);
+    let v1 = HVector::new(VectorData::F64(vec![1e6, 2e6]));
+    let v2 = HVector::new(VectorData::F64(vec![1e6, 2e6]));
     let distance = v1.distance_to(&v2).unwrap();
     assert!(distance.abs() < 1e-10);
 }
 
 #[test]
 fn test_hvector_negative_values() {
-    let v1 = HVector::new(vec![-1.0, -2.0]);
-    let v2 = HVector::new(vec![1.0, 2.0]);
+    let v1 = HVector::new(VectorData::F64(vec![-1.0, -2.0]));
+    let v2 = HVector::new(VectorData::F64(vec![1.0, 2.0]));
     let distance = v1.distance_to(&v2).unwrap();
     // used round to avoid floating point precision issues
     assert!(distance.round() == MAX_DISTANCE);
@@ -93,8 +94,8 @@ fn test_hvector_negative_values() {
 
 #[test]
 fn test_hvector_cosine_similarity() {
-    let v1 = HVector::new(vec![1.0, 2.0, 3.0]);
-    let v2 = HVector::new(vec![4.0, 5.0, 6.0]);
+    let v1 = HVector::new(VectorData::F64(vec![1.0, 2.0, 3.0]));
+    let v2 = HVector::new(VectorData::F64(vec![4.0, 5.0, 6.0]));
     let similarity = v1.distance_to(&v2).unwrap();
     assert!(similarity == 1.0 - 0.9746318461970762);
 }

--- a/helix-db/src/helix_engine/traversal_core/ops/vectors/brute_force_search.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/vectors/brute_force_search.rs
@@ -5,7 +5,7 @@ use crate::{
     helix_engine::{
         traversal_core::{traversal_iter::RoTraversalIterator, traversal_value::TraversalValue},
         types::GraphError,
-        vector_core::vector_distance::cosine_similarity,
+        vector_core::{vector_data::VectorData, vector_distance::cosine_similarity_mixed},
     },
     protocol::value::Value,
     utils::filterable::Filterable,
@@ -59,7 +59,9 @@ impl<'a, I: Iterator<Item = Result<TraversalValue, GraphError>> + 'a> BruteForce
             .inner
             .filter_map(|v| match v {
                 Ok(TraversalValue::Vector(mut v)) => {
-                    let d = cosine_similarity(v.get_data(), query).unwrap();
+                    let v_data = v.get_data();
+                    let d =
+                        cosine_similarity_mixed(v_data, &VectorData::F64(query.to_vec())).unwrap();
                     v.set_distance(d);
                     Some(v)
                 }

--- a/helix-db/src/helix_engine/traversal_core/ops/vectors/insert.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/vectors/insert.rs
@@ -4,7 +4,7 @@ use crate::{
     helix_engine::{
         traversal_core::{traversal_iter::RwTraversalIterator, traversal_value::TraversalValue},
         types::GraphError,
-        vector_core::{hnsw::HNSW, vector::HVector},
+        vector_core::{VectorData, hnsw::HNSW, vector::HVector},
     },
     protocol::value::Value,
 };
@@ -24,7 +24,7 @@ impl Iterator for InsertVIterator {
 pub trait InsertVAdapter<'a, 'b>: Iterator<Item = Result<TraversalValue, GraphError>> {
     fn insert_v<F>(
         self,
-        query: &[f64],
+        query: VectorData,
         label: &str,
         fields: Option<Vec<(String, Value)>>,
     ) -> RwTraversalIterator<'a, 'b, impl Iterator<Item = Result<TraversalValue, GraphError>>>
@@ -37,7 +37,7 @@ impl<'a, 'b, I: Iterator<Item = Result<TraversalValue, GraphError>>> InsertVAdap
 {
     fn insert_v<F>(
         self,
-        query: &[f64],
+        query: VectorData,
         label: &str,
         fields: Option<Vec<(String, Value)>>,
     ) -> RwTraversalIterator<'a, 'b, impl Iterator<Item = Result<TraversalValue, GraphError>>>
@@ -55,7 +55,10 @@ impl<'a, 'b, I: Iterator<Item = Result<TraversalValue, GraphError>>> InsertVAdap
                 (String::from("is_deleted"), Value::Boolean(false)),
             ]),
         };
-        let vector = self.storage.vectors.insert::<F>(self.txn, query, fields);
+        let vector =
+            self.storage
+                .vectors
+                .insert::<F>(self.txn, query, fields);
 
         let result = match vector {
             Ok(vector) => Ok(TraversalValue::Vector(vector)),

--- a/helix-db/src/helix_engine/vector_core/hnsw.rs
+++ b/helix-db/src/helix_engine/vector_core/hnsw.rs
@@ -1,5 +1,6 @@
 use crate::{helix_engine::types::VectorError, protocol::value::Value};
 use crate::helix_engine::vector_core::vector::HVector;
+use crate::helix_engine::vector_core::vector_data::VectorData;
 use heed3::{RoTxn, RwTxn};
 
 pub trait HNSW
@@ -9,7 +10,7 @@ pub trait HNSW
     /// # Arguments
     ///
     /// * `txn` - The transaction to use
-    /// * `query` - The query vector
+    /// * `query` - The query vector data
     /// * `k` - The number of nearest neighbors to search for
     ///
     /// # Returns
@@ -18,7 +19,7 @@ pub trait HNSW
     fn search<F>(
         &self,
         txn: &RoTxn,
-        query: &[f64],
+        query: &VectorData,
         k: usize,
         label: &str,
         filter: Option<&[F]>,
@@ -40,7 +41,7 @@ pub trait HNSW
     fn insert<F>(
         &self,
         txn: &mut RwTxn,
-        data: &[f64],
+        data: VectorData,
         fields: Option<Vec<(String, Value)>>,
     ) -> Result<HVector, VectorError>
     where

--- a/helix-db/src/helix_engine/vector_core/mod.rs
+++ b/helix-db/src/helix_engine/vector_core/mod.rs
@@ -2,6 +2,9 @@ pub mod hnsw;
 pub mod utils;
 pub mod vector;
 pub mod vector_core;
+pub mod vector_data;
 pub mod vector_distance;
 
-
+// Re-export commonly used types
+pub use vector::HVector;
+pub use vector_data::VectorData;

--- a/helix-db/src/helix_engine/vector_core/vector.rs
+++ b/helix-db/src/helix_engine/vector_core/vector.rs
@@ -1,7 +1,7 @@
 use crate::{
     helix_engine::{
         types::{GraphError, VectorError},
-        vector_core::vector_distance::DistanceCalc,
+        vector_core::{vector_data::VectorData, vector_distance::DistanceCalc},
     },
     protocol::{return_values::ReturnValue, value::Value},
     utils::{
@@ -10,12 +10,16 @@ use crate::{
     },
 };
 use core::fmt;
+use half::f16;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, cmp::Ordering, collections::HashMap, fmt::Debug};
 
-// TODO: make this generic over the type of encoding (f32, f64, etc)
+// Type markers for serialization
+const F64_MARKER: u8 = 0x01;
+const F32_MARKER: u8 = 0x02;
+const F16_MARKER: u8 = 0x03;
+
 // TODO: use const param to set dimension
-// TODO: set level as u8
 
 #[repr(C, align(16))] // TODO: see performance impact of repr(C) and align(16)
 #[derive(Clone, Serialize, Deserialize, PartialEq)]
@@ -30,9 +34,9 @@ pub struct HVector {
     /// The distance of the HVector
     #[serde(default)]
     pub distance: Option<f64>,
-    /// The actual vector
+    /// The actual vector data with precision support
     #[serde(default)]
-    pub data: Vec<f64>,
+    pub data: VectorData,
     /// The properties of the HVector
     #[serde(default)]
     pub properties: Option<HashMap<String, Value>>,
@@ -40,6 +44,12 @@ pub struct HVector {
     /// the version of the vector
     #[serde(default)]
     pub version: u8,
+}
+
+impl Default for VectorData {
+    fn default() -> Self {
+        VectorData::F64(Vec::new())
+    }
 }
 
 impl Eq for HVector {}
@@ -61,11 +71,12 @@ impl Debug for HVector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{{ \nid: {},\nlevel: {},\ndistance: {:?},\ndata: {:?},\nproperties: {:#?} }}",
+            "{{ \nid: {},\nlevel: {},\ndistance: {:?},\nprecision: {},\ndata: {:?},\nproperties: {:#?} }}",
             uuid::Uuid::from_u128(self.id),
             // self.is_deleted,
             self.level,
             self.distance,
+            self.data.precision(),
             self.data,
             self.properties
         )
@@ -74,7 +85,7 @@ impl Debug for HVector {
 
 impl HVector {
     #[inline(always)]
-    pub fn new(data: Vec<f64>) -> Self {
+    pub fn new(data: VectorData) -> Self {
         let id = v6_uuid();
         HVector {
             id,
@@ -88,7 +99,7 @@ impl HVector {
     }
 
     #[inline(always)]
-    pub fn from_slice(level: usize, data: Vec<f64>) -> Self {
+    pub fn from_slice(level: usize, data: VectorData) -> Self {
         let id = v6_uuid();
         HVector {
             id,
@@ -99,6 +110,12 @@ impl HVector {
             distance: None,
             properties: None,
         }
+    }
+
+    /// Create HVector from f64 slice (backwards compatibility)
+    #[inline(always)]
+    pub fn from_f64_slice(level: usize, data: Vec<f64>) -> Self {
+        Self::from_slice(level, VectorData::F64(data))
     }
 
     #[inline(always)]
@@ -112,9 +129,19 @@ impl HVector {
         Ok(vector)
     }
 
-    /// Returns the data of the HVector
+    /// Returns the data of the HVector as f64 vec (for calculations)
     #[inline(always)]
-    pub fn get_data(&self) -> &[f64] {
+    pub fn get_data_f64(&self) -> Vec<f64> {
+        match &self.data {
+            VectorData::F64(v) => v.clone(),
+            VectorData::F32(v) => v.iter().map(|&f| f as f64).collect(),
+            VectorData::F16(v) => v.iter().map(|&f| f.to_f32() as f64).collect(),
+        }
+    }
+
+    /// Returns a reference to the VectorData
+    #[inline(always)]
+    pub fn get_data(&self) -> &VectorData {
         &self.data
     }
 
@@ -130,36 +157,96 @@ impl HVector {
         self.level
     }
 
-    /// Converts the HVector to an vec of bytes by accessing the data field directly
-    /// and converting each f64 to a byte slice
+    /// Converts the HVector to a vec of bytes with type marker
+    /// Format: [type_marker: 1 byte][data: n bytes]
     pub fn to_bytes(&self) -> Vec<u8> {
-        let size = self.data.len() * std::mem::size_of::<f64>();
+        let (marker, element_size) = match &self.data {
+            VectorData::F64(_) => (F64_MARKER, std::mem::size_of::<f64>()),
+            VectorData::F32(_) => (F32_MARKER, std::mem::size_of::<f32>()),
+            VectorData::F16(_) => (F16_MARKER, std::mem::size_of::<u16>()),
+        };
+
+        let size = 1 + self.data.len() * element_size;
         let mut bytes = Vec::with_capacity(size);
-        for &value in &self.data {
-            bytes.extend_from_slice(&value.to_be_bytes());
+        bytes.push(marker);
+
+        match &self.data {
+            VectorData::F64(vec) => {
+                for &value in vec {
+                    bytes.extend_from_slice(&value.to_be_bytes());
+                }
+            }
+            VectorData::F32(vec) => {
+                for &value in vec {
+                    bytes.extend_from_slice(&value.to_be_bytes());
+                }
+            }
+            VectorData::F16(vec) => {
+                for &value in vec {
+                    bytes.extend_from_slice(&value.to_bits().to_be_bytes());
+                }
+            }
         }
+
         bytes
     }
 
-    // will make to use const param for type of encoding (f32, f64, etc)
-    /// Converts a byte array into a HVector by chunking the bytes into f64 values
+    /// Converts a byte array into a HVector, detecting precision from type marker
+    /// Format: [type_marker: 1 byte][data: n bytes]
+    /// For backwards compatibility, assumes F64 if no marker present
     pub fn from_bytes(id: u128, level: usize, bytes: &[u8]) -> Result<Self, VectorError> {
-        if !bytes.len().is_multiple_of(std::mem::size_of::<f64>()){
+        if bytes.is_empty() {
             return Err(VectorError::InvalidVectorData);
         }
 
-        let mut data = Vec::with_capacity(bytes.len() / std::mem::size_of::<f64>());
-        let chunks = bytes.chunks_exact(std::mem::size_of::<f64>());
+        // Check if this is a new format with type marker
+        let (type_marker, data_bytes) =
+            if bytes[0] == F64_MARKER || bytes[0] == F32_MARKER || bytes[0] == F16_MARKER {
+                (bytes[0], &bytes[1..])
+            } else {
+                // Backwards compatibility: no marker means F64
+                (F64_MARKER, bytes)
+            };
 
-        for chunk in chunks {
-            // panic here because panic means corruption of some sort
-            let value = f64::from_be_bytes(chunk.try_into().expect("Invalid chunk"));
-            data.push(value);
-        }
+        let data = match type_marker {
+            F64_MARKER => {
+                if !data_bytes.len().is_multiple_of(std::mem::size_of::<f64>()) {
+                    return Err(VectorError::InvalidVectorData);
+                }
+                let mut vec = Vec::with_capacity(data_bytes.len() / std::mem::size_of::<f64>());
+                for chunk in data_bytes.chunks_exact(std::mem::size_of::<f64>()) {
+                    let value = f64::from_be_bytes(chunk.try_into().expect("Invalid chunk"));
+                    vec.push(value);
+                }
+                VectorData::F64(vec)
+            }
+            F32_MARKER => {
+                if !data_bytes.len().is_multiple_of(std::mem::size_of::<f32>()) {
+                    return Err(VectorError::InvalidVectorData);
+                }
+                let mut vec = Vec::with_capacity(data_bytes.len() / std::mem::size_of::<f32>());
+                for chunk in data_bytes.chunks_exact(std::mem::size_of::<f32>()) {
+                    let value = f32::from_be_bytes(chunk.try_into().expect("Invalid chunk"));
+                    vec.push(value);
+                }
+                VectorData::F32(vec)
+            }
+            F16_MARKER => {
+                if !data_bytes.len().is_multiple_of(std::mem::size_of::<u16>()) {
+                    return Err(VectorError::InvalidVectorData);
+                }
+                let mut vec = Vec::with_capacity(data_bytes.len() / std::mem::size_of::<u16>());
+                for chunk in data_bytes.chunks_exact(std::mem::size_of::<u16>()) {
+                    let bits = u16::from_be_bytes(chunk.try_into().expect("Invalid chunk"));
+                    vec.push(f16::from_bits(bits));
+                }
+                VectorData::F16(vec)
+            }
+            _ => return Err(VectorError::InvalidVectorData),
+        };
 
         Ok(HVector {
             id,
-            // is_deleted: false,
             level,
             version: 1,
             data,
@@ -176,6 +263,11 @@ impl HVector {
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
+    }
+
+    /// Returns the precision of the vector data
+    pub fn precision(&self) -> &'static str {
+        self.data.precision()
     }
 
     #[inline(always)]
@@ -197,8 +289,8 @@ impl HVector {
     pub fn get_label(&self) -> Option<&Value> {
         match &self.properties {
             Some(p) => p.get("label"),
-            None => None
-        } 
+            None => None,
+        }
     }
 }
 
@@ -248,15 +340,24 @@ impl Filterable for HVector {
 
     fn properties(self) -> Option<HashMap<String, Value>> {
         let mut properties = self.properties.unwrap_or_default();
-        properties.insert(
-            "data".to_string(),
-            Value::Array(self.data.iter().map(|f| Value::F64(*f)).collect()),
-        );
+        let vec_values = match &self.data {
+            VectorData::F64(v) => v.iter().map(|&f| Value::F64(f)).collect(),
+            VectorData::F32(v) => v.iter().map(|&f| Value::F32(f)).collect(),
+            VectorData::F16(v) => v.iter().map(|&f| Value::F32(f.to_f32())).collect(),
+        };
+        properties.insert("data".to_string(), Value::Array(vec_values));
         Some(properties)
     }
 
     fn vector_data(&self) -> &[f64] {
-        &self.data
+        // For backwards compatibility, we need to return &[f64]
+        // This is a temporary workaround - ideally this method should be updated
+        // For now, we'll need to convert on the fly
+        // Note: This is inefficient and should be refactored later
+        match &self.data {
+            VectorData::F64(v) => v.as_slice(),
+            _ => &[], // Return empty slice for non-f64 data
+        }
     }
 
     fn score(&self) -> f64 {
@@ -275,9 +376,14 @@ impl Filterable for HVector {
         match key {
             "id" => Ok(Cow::Owned(Value::from(self.uuid()))),
             "label" => Ok(Cow::Owned(Value::from(self.label().to_string()))),
-            "data" => Ok(Cow::Owned(Value::Array(
-                self.data.iter().map(|f| Value::F64(*f)).collect(),
-            ))),
+            "data" => {
+                let vec_values = match &self.data {
+                    VectorData::F64(v) => v.iter().map(|&f| Value::F64(f)).collect(),
+                    VectorData::F32(v) => v.iter().map(|&f| Value::F32(f)).collect(),
+                    VectorData::F16(v) => v.iter().map(|&f| Value::F32(f.to_f32())).collect(),
+                };
+                Ok(Cow::Owned(Value::Array(vec_values)))
+            }
             "score" => Ok(Cow::Owned(Value::F64(self.score()))),
             _ => match &self.properties {
                 Some(properties) => properties

--- a/helix-db/src/helix_engine/vector_core/vector_core.rs
+++ b/helix-db/src/helix_engine/vector_core/vector_core.rs
@@ -6,6 +6,7 @@ use crate::{
             hnsw::HNSW,
             utils::{Candidate, HeapOps, VectorFilter},
             vector::HVector,
+            vector_data::VectorData,
         },
     },
     protocol::value::Value,
@@ -399,7 +400,7 @@ impl HNSW for VectorCore {
     fn search<F>(
         &self,
         txn: &RoTxn,
-        query: &[f64],
+        query: &VectorData,
         k: usize,
         label: &str,
         filter: Option<&[F]>,
@@ -408,7 +409,7 @@ impl HNSW for VectorCore {
     where
         F: Fn(&HVector, &RoTxn) -> bool,
     {
-        let query = HVector::from_slice(0, query.to_vec());
+        let query = HVector::from_slice(0, query.clone());
 
         let mut entry_point = self.get_entry_point(txn)?;
 
@@ -455,7 +456,7 @@ impl HNSW for VectorCore {
     fn insert<F>(
         &self,
         txn: &mut RwTxn,
-        data: &[f64],
+        data: VectorData,
         fields: Option<Vec<(String, Value)>>,
     ) -> Result<HVector, VectorError>
     where
@@ -463,7 +464,7 @@ impl HNSW for VectorCore {
     {
         let new_level = self.get_new_level();
 
-        let mut query = HVector::from_slice(0, data.to_vec());
+        let mut query = HVector::from_slice(0, data);
         self.put_vector(txn, &query)?;
         query.level = new_level;
         if new_level > 0 {

--- a/helix-db/src/helix_engine/vector_core/vector_data.rs
+++ b/helix-db/src/helix_engine/vector_core/vector_data.rs
@@ -1,0 +1,66 @@
+use half::f16;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Represents vector data with different floating-point precisions
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub enum VectorData {
+    F64(Vec<f64>),
+    F32(Vec<f32>),
+    F16(Vec<f16>),
+}
+
+impl VectorData {
+    /// Returns the number of elements in the vector
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        match self {
+            VectorData::F64(v) => v.len(),
+            VectorData::F32(v) => v.len(),
+            VectorData::F16(v) => v.len(),
+        }
+    }
+
+    /// Returns true if the vector is empty
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the precision type as a string
+    pub fn precision(&self) -> &'static str {
+        match self {
+            VectorData::F64(_) => "f64",
+            VectorData::F32(_) => "f32",
+            VectorData::F16(_) => "f16",
+        }
+    }
+
+    /// Creates VectorData from f64 slice
+    #[inline(always)]
+    pub fn from_f64_slice(data: &[f64]) -> Self {
+        VectorData::F64(data.to_vec())
+    }
+
+    /// Creates VectorData from f32 slice
+    #[inline(always)]
+    pub fn from_f32_slice(data: &[f32]) -> Self {
+        VectorData::F32(data.to_vec())
+    }
+
+    /// Creates VectorData from f16 slice
+    #[inline(always)]
+    pub fn from_f16_slice(data: &[f16]) -> Self {
+        VectorData::F16(data.to_vec())
+    }
+}
+
+impl fmt::Debug for VectorData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VectorData::F64(v) => write!(f, "f64({v:?})"),
+            VectorData::F32(v) => write!(f, "f32({v:?})"),
+            VectorData::F16(v) => write!(f, "f16({v:?})"),
+        }
+    }
+}

--- a/helix-db/src/helix_gateway/mcp/tools.rs
+++ b/helix-db/src/helix_gateway/mcp/tools.rs
@@ -22,7 +22,7 @@ use crate::{
             traversal_value::{Traversable, TraversalValue},
         },
         types::GraphError,
-        vector_core::vector::HVector,
+        vector_core::{VectorData, vector::HVector},
     },
     helix_gateway::{
         embedding_providers::embedding_providers::{EmbeddingModel, get_embedding_model},
@@ -511,7 +511,12 @@ impl<'a> McpTools<'a> for McpBackend {
         let embedding = result?;
 
         let res = G::new(db, txn)
-            .search_v::<fn(&HVector, &RoTxn) -> bool, _>(&embedding, k.unwrap_or(5), &label, None)
+            .search_v::<fn(&HVector, &RoTxn) -> bool, _>(
+                VectorData::F64(embedding),
+                k.unwrap_or(5),
+                &label,
+                None,
+            )
             .collect_to::<Vec<_>>();
 
         debug_println!("result: {res:?}");

--- a/helix-db/src/helix_gateway/mcp/tools_tests.rs
+++ b/helix-db/src/helix_gateway/mcp/tools_tests.rs
@@ -5,7 +5,7 @@ use tempfile::TempDir;
 
 use crate::{
     helix_engine::{
-        storage_core::{version_info::VersionInfo},
+        storage_core::version_info::VersionInfo,
         traversal_core::{
             HelixGraphEngine, HelixGraphEngineOpts,
             config::Config,
@@ -19,7 +19,7 @@ use crate::{
             },
             traversal_value::{Traversable, TraversalValue},
         },
-        vector_core::vector::HVector,
+        vector_core::{VectorData, vector::HVector},
     },
     helix_gateway::mcp::{mcp::MCPConnection, tools::McpTools},
 };
@@ -66,7 +66,6 @@ fn test_mcp_tool_search_vector_text() {}
 
 use rand::prelude::SliceRandom;
 
-
 #[test]
 fn test_mcp_tool_search_vector() {
     let (engine, _temp_dir) = setup_test_db();
@@ -94,7 +93,7 @@ fn test_mcp_tool_search_vector() {
 
     for vector in vectors {
         let vector = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-            .insert_v::<fn(&HVector, &RoTxn) -> bool>(&vector, "vector", None)
+            .insert_v::<fn(&HVector, &RoTxn) -> bool>(VectorData::F64(vector), "vector", None)
             .collect_to_obj();
 
         let _ = G::new_mut(Arc::clone(&engine.storage), &mut txn)
@@ -132,7 +131,7 @@ fn test_mcp_tool_search_vector() {
 
     // checks that the first vector is correct
     if let TraversalValue::Vector(v) = res[0].clone() {
-        assert_eq!(v.get_data(), &[1.0, 1.0, 1.0]);
+        assert_eq!(v.get_data(), &VectorData::F64(vec![1.0, 1.0, 1.0]));
     } else {
         panic!("Expected vector");
     }

--- a/helix-db/src/helixc/analyzer/methods/graph_step_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/graph_step_validation.rs
@@ -1,7 +1,7 @@
 //! Semantic analyzer for Helix‑QL.
 use crate::helixc::analyzer::error_codes::ErrorCode;
 use crate::helixc::analyzer::utils::type_in_scope;
-use crate::helixc::generator::utils::EmbedData;
+use crate::helixc::generator::utils::{EmbedData, Precision as GeneratedPrecision};
 use crate::{
     generate_error,
     helix_engine::traversal_core::ops::source::add_e::EdgeType,
@@ -271,7 +271,7 @@ pub(crate) fn apply_graph_step<'a>(
             match cur_ty {
                 Type::Edges(_) => traversal.should_collect = ShouldCollect::ToVec,
                 Type::Edge(_) => traversal.should_collect = ShouldCollect::ToObj,
-                _ => {},
+                _ => {}
             }
             new_ty
         }
@@ -294,7 +294,7 @@ pub(crate) fn apply_graph_step<'a>(
             match cur_ty {
                 Type::Edges(_) => traversal.should_collect = ShouldCollect::ToVec,
                 Type::Edge(_) => traversal.should_collect = ShouldCollect::ToObj,
-                _ => {},
+                _ => {}
             }
             new_ty
         }
@@ -320,7 +320,7 @@ pub(crate) fn apply_graph_step<'a>(
             match cur_ty {
                 Type::Edges(_) => traversal.should_collect = ShouldCollect::ToVec,
                 Type::Edge(_) => traversal.should_collect = ShouldCollect::ToObj,
-                _ => {},
+                _ => {}
             }
             new_ty
         }
@@ -344,7 +344,7 @@ pub(crate) fn apply_graph_step<'a>(
             match cur_ty {
                 Type::Edges(_) => traversal.should_collect = ShouldCollect::ToVec,
                 Type::Edge(_) => traversal.should_collect = ShouldCollect::ToObj,
-                _ => {},
+                _ => {}
             }
             new_ty
         }
@@ -648,6 +648,21 @@ pub(crate) fn apply_graph_step<'a>(
                 }
             };
 
+            let vector_in_schema = ctx
+                .src
+                .get_latest_schema()
+                .unwrap()
+                .vector_schemas
+                .iter()
+                .find(|v| &v.name == sv.vector_type.as_ref().unwrap())
+                .cloned()
+                .unwrap();
+
+               let vec = match vector_in_schema.precision {
+                Precision::F64 => GenRef::Std(GeneratedPrecision::F64(vec)),
+                Precision::F32 => GenRef::Std(GeneratedPrecision::F32(vec)),
+                Precision::F16 => GenRef::Std(GeneratedPrecision::F16(vec)),
+            };
             // Search returns nodes that contain the vectors
 
             // Some(GeneratedStatement::Traversal(GeneratedTraversal {

--- a/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
+++ b/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
@@ -799,10 +799,9 @@ pub(crate) fn infer_expr_type<'a>(
                                     let data = gen_identifier_or_param(
                                         original_query,
                                         i.as_str(),
-                                        false,
+                                        true,
                                         false,
                                     );
-                                    scope.remove(i.as_str());
                                     EmbedData {
                                         data,
                                         model_name: gen_query.embedding_model_to_use.clone(),
@@ -901,8 +900,7 @@ pub(crate) fn infer_expr_type<'a>(
                     let embed_data = match &e.value {
                         EvaluatesToString::Identifier(i) => {
                             let data =
-                                gen_identifier_or_param(original_query, i.as_str(), false, false);
-                            scope.remove(i.as_str());
+                                gen_identifier_or_param(original_query, i.as_str(), true, false);
                             EmbedData {
                                 data,
                                 model_name: gen_query.embedding_model_to_use.clone(),

--- a/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
+++ b/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
@@ -1,7 +1,7 @@
 //! Semantic analyzer for Helix‑QL.
 use crate::helixc::analyzer::error_codes::ErrorCode;
 use crate::helixc::analyzer::utils::{DEFAULT_VAR_NAME, is_in_scope};
-use crate::helixc::generator::utils::EmbedData;
+use crate::helixc::generator::utils::{EmbedData, Precision as GeneratedPrecision};
 use crate::{
     generate_error,
     helixc::{
@@ -789,22 +789,27 @@ pub(crate) fn infer_expr_type<'a>(
                         VectorData::Identifier(i) => {
                             is_valid_identifier(ctx, original_query, add.loc.clone(), i.as_str());
                             let id =
-                                gen_identifier_or_param(original_query, i.as_str(), true, false);
+                                gen_identifier_or_param(original_query, i.as_str(), false, false);
+                            scope.remove(i.as_str());
                             VecData::Standard(id)
                         }
                         VectorData::Embed(e) => {
                             let embed_data = match &e.value {
-                                EvaluatesToString::Identifier(i) => EmbedData {
-                                    data: gen_identifier_or_param(
+                                EvaluatesToString::Identifier(i) => {
+                                    let data = gen_identifier_or_param(
                                         original_query,
                                         i.as_str(),
-                                        true,
                                         false,
-                                    ),
-                                    model_name: gen_query.embedding_model_to_use.clone(),
-                                },
+                                        false,
+                                    );
+                                    scope.remove(i.as_str());
+                                    EmbedData {
+                                        data,
+                                        model_name: gen_query.embedding_model_to_use.clone(),
+                                    }
+                                }
                                 EvaluatesToString::StringLiteral(s) => EmbedData {
-                                    data: GeneratedValue::Literal(GenRef::Ref(s.clone())),
+                                    data: GeneratedValue::Literal(GenRef::Std(s.clone())),
                                     model_name: gen_query.embedding_model_to_use.clone(),
                                 },
                             };
@@ -812,6 +817,23 @@ pub(crate) fn infer_expr_type<'a>(
                             VecData::Hoisted(gen_query.add_hoisted_embed(embed_data))
                         }
                     };
+
+                    let vector_in_schema = ctx
+                        .src
+                        .get_latest_schema()
+                        .unwrap()
+                        .vector_schemas
+                        .iter()
+                        .find(|v| &v.name == add.vector_type.as_ref().unwrap())
+                        .cloned()
+                        .unwrap();
+
+                    let vec = match vector_in_schema.precision {
+                        Precision::F64 => GenRef::Std(GeneratedPrecision::F64(vec)),
+                        Precision::F32 => GenRef::Std(GeneratedPrecision::F32(vec)),
+                        Precision::F16 => GenRef::Std(GeneratedPrecision::F16(vec)),
+                    };
+
                     let add_v = AddV {
                         vec,
                         label,
@@ -870,19 +892,22 @@ pub(crate) fn infer_expr_type<'a>(
                     is_valid_identifier(ctx, original_query, sv.loc.clone(), i.as_str());
                     // if is in params then use data.
                     let _ = type_in_scope(ctx, original_query, sv.loc.clone(), scope, i.as_str());
-                    VecData::Standard(gen_identifier_or_param(
-                        original_query,
-                        i.as_str(),
-                        true,
-                        false,
-                    ))
+                    let identifier =
+                        gen_identifier_or_param(original_query, i.as_str(), false, false);
+                    scope.remove(i.as_str());
+                    VecData::Standard(identifier)
                 }
                 Some(VectorData::Embed(e)) => {
                     let embed_data = match &e.value {
-                        EvaluatesToString::Identifier(i) => EmbedData {
-                            data: gen_identifier_or_param(original_query, i.as_str(), true, false),
-                            model_name: gen_query.embedding_model_to_use.clone(),
-                        },
+                        EvaluatesToString::Identifier(i) => {
+                            let data =
+                                gen_identifier_or_param(original_query, i.as_str(), false, false);
+                            scope.remove(i.as_str());
+                            EmbedData {
+                                data,
+                                model_name: gen_query.embedding_model_to_use.clone(),
+                            }
+                        }
                         EvaluatesToString::StringLiteral(s) => EmbedData {
                             data: GeneratedValue::Literal(GenRef::Ref(s.clone())),
                             model_name: gen_query.embedding_model_to_use.clone(),
@@ -1007,6 +1032,21 @@ pub(crate) fn infer_expr_type<'a>(
                 None => None,
             };
 
+            let vector_in_schema = ctx
+                .src
+                .get_latest_schema()
+                .unwrap()
+                .vector_schemas
+                .iter()
+                .find(|v| &v.name == sv.vector_type.as_ref().unwrap())
+                .cloned()
+                .unwrap();
+
+            let vec = match vector_in_schema.precision {
+                Precision::F64 => GenRef::Std(GeneratedPrecision::F64(vec)),
+                Precision::F32 => GenRef::Std(GeneratedPrecision::F32(vec)),
+                Precision::F16 => GenRef::Std(GeneratedPrecision::F16(vec)),
+            };
             // Search returns nodes that contain the vectors
             (
                 Type::Vectors(sv.vector_type.clone()),

--- a/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
@@ -422,8 +422,7 @@ pub(crate) fn validate_traversal<'a>(
                     let embed_data = match &e.value {
                         EvaluatesToString::Identifier(i) => {
                             let data =
-                                gen_identifier_or_param(original_query, i.as_str(), false, false);
-                            scope.remove(i.as_str());
+                                gen_identifier_or_param(original_query, i.as_str(), true, false);
                             EmbedData {
                                 data,
                                 model_name: gen_query.embedding_model_to_use.clone(),

--- a/helix-db/src/helixc/analyzer/types.rs
+++ b/helix-db/src/helixc/analyzer/types.rs
@@ -175,6 +175,7 @@ impl From<FieldType> for GeneratedType {
     fn from(generated: FieldType) -> Self {
         match generated {
             FieldType::String => GeneratedType::RustType(GeneratedRustType::String),
+            FieldType::F16 => GeneratedType::RustType(GeneratedRustType::F16),
             FieldType::F32 => GeneratedType::RustType(GeneratedRustType::F32),
             FieldType::F64 => GeneratedType::RustType(GeneratedRustType::F64),
             FieldType::I8 => GeneratedType::RustType(GeneratedRustType::I8),
@@ -210,6 +211,7 @@ impl From<DefaultValue> for GeneratedValue {
     fn from(generated: DefaultValue) -> Self {
         match generated {
             DefaultValue::String(s) => GeneratedValue::Primitive(GenRef::Std(s)),
+            DefaultValue::F16(f) => GeneratedValue::Primitive(GenRef::Std(f.to_string())),
             DefaultValue::F32(f) => GeneratedValue::Primitive(GenRef::Std(f.to_string())),
             DefaultValue::F64(f) => GeneratedValue::Primitive(GenRef::Std(f.to_string())),
             DefaultValue::I8(i) => GeneratedValue::Primitive(GenRef::Std(i.to_string())),
@@ -387,23 +389,31 @@ impl From<FieldType> for Type {
     fn from(ft: FieldType) -> Self {
         use FieldType::*;
         match ft {
-            String | Boolean | F32 | F64 | I8 | I16 | I32 | I64 | U8 | U16 | U32 | U64 | U128
+            String | Boolean | F16 | F32 | F64 | I8 | I16 | I32 | I64 | U8 | U16 | U32 | U64 | U128
             | Uuid | Date => Type::Scalar(ft.clone()),
             Array(inner_ft) => Type::Array(Box::new(Type::from(*inner_ft))),
-            Object(obj) => Type::Object(obj.into_iter().map(|(k, v)| (k, Type::from(v))).collect()),
+            Object(obj) => Type::Object(
+                obj.into_iter()
+                    .map(|(k, v)| (k, Type::from(v)))
+                    .collect(),
+            ),
             Identifier(id) => Type::Scalar(FieldType::Identifier(id)),
         }
-    }
+}
 }
 
 impl From<&FieldType> for Type {
     fn from(ft: &FieldType) -> Self {
         use FieldType::*;
         match ft {
-            String | Boolean | F32 | F64 | I8 | I16 | I32 | I64 | U8 | U16 | U32 | U64 | U128
+            String | Boolean | F16 | F32 | F64 | I8 | I16 | I32 | I64 | U8 | U16 | U32 | U64 | U128
             | Uuid | Date => Type::Scalar(ft.clone()),
             Array(inner_ft) => Type::Array(Box::new(Type::from(*inner_ft.clone()))),
-            Object(obj) => Type::Object(obj.iter().map(|(k, v)| (k.clone(), Type::from(v))).collect()),
+            Object(obj) => Type::Object(
+                obj.iter()
+                    .map(|(k, v)| (k.clone(), Type::from(v)))
+                    .collect(),
+            ),
             Identifier(id) => Type::Scalar(FieldType::Identifier(id.clone())),
         }
     }

--- a/helix-db/src/helixc/generator/source_steps.rs
+++ b/helix-db/src/helixc/generator/source_steps.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 use std::fmt::Display;
 
-use crate::helixc::generator::utils::{write_properties, write_secondary_indices, VecData};
+use crate::helixc::generator::utils::{write_properties, write_secondary_indices, Precision, VecData};
 
 use super::{
     bool_ops::BoExp,
@@ -88,7 +88,7 @@ impl Display for AddE {
 #[derive(Clone)]
 pub struct AddV {
     /// Vector to add
-    pub vec: VecData,
+    pub vec: GenRef<Precision<VecData>>,
     /// Label of vector
     pub label: GenRef<String>,
     /// Properties of vector
@@ -231,7 +231,7 @@ pub struct SearchVector {
     /// Label of vector to search for
     pub label: GenRef<String>,
     /// Vector to search for
-    pub vec: VecData,
+    pub vec: GenRef<Precision<VecData>>,
     /// Number of results to return
     pub k: GeneratedValue,
     /// Pre-filter to apply to the search - currently not implemented in grammar

--- a/helix-db/src/helixc/generator/traversal_steps.rs
+++ b/helix-db/src/helixc/generator/traversal_steps.rs
@@ -1,4 +1,4 @@
-use crate::helixc::generator::utils::{VecData, write_properties};
+use crate::helixc::generator::utils::{Precision, VecData, write_properties};
 
 use super::{
     bool_ops::{BoExp, BoolOp},
@@ -52,7 +52,7 @@ pub enum ShouldCollect {
     ToObj,
     No,
     Try,
-    ToValue
+    ToValue,
 }
 impl Display for ShouldCollect {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -209,7 +209,9 @@ impl Display for Step {
             Step::BoolOp(bool_op) => write!(f, "{bool_op}"),
             Step::Remapping(remapping) => write!(f, "{remapping}"),
             Step::ShortestPath(shortest_path) => write!(f, "{shortest_path}"),
-            Step::ShortestPathDijkstras(shortest_path_dijkstras) => write!(f, "{shortest_path_dijkstras}"),
+            Step::ShortestPathDijkstras(shortest_path_dijkstras) => {
+                write!(f, "{shortest_path_dijkstras}")
+            }
             Step::ShortestPathBFS(shortest_path_bfs) => write!(f, "{shortest_path_bfs}"),
             Step::SearchVector(search_vector) => write!(f, "{search_vector}"),
             Step::GroupBy(group_by) => write!(f, "{group_by}"),
@@ -351,7 +353,16 @@ pub struct GroupBy {
 }
 impl Display for GroupBy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "group_by(&[{}], {})", self.properties.iter().map(|s|s.to_string()).collect::<Vec<_>>().join(","), self.should_count)
+        write!(
+            f,
+            "group_by(&[{}], {})",
+            self.properties
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+                .join(","),
+            self.should_count
+        )
     }
 }
 
@@ -362,10 +373,18 @@ pub struct AggregateBy {
 }
 impl Display for AggregateBy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "aggregate_by(&[{}], {})", self.properties.iter().map(|s|s.to_string()).collect::<Vec<_>>().join(","), self.should_count)
+        write!(
+            f,
+            "aggregate_by(&[{}], {})",
+            self.properties
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+                .join(","),
+            self.should_count
+        )
     }
 }
-
 
 #[derive(Clone)]
 pub struct ShortestPath {
@@ -486,7 +505,7 @@ impl Display for ShortestPathBFS {
 
 #[derive(Clone)]
 pub struct SearchVectorStep {
-    pub vec: VecData,
+    pub vec: GenRef<Precision<VecData>>,
     pub k: GeneratedValue,
 }
 impl Display for SearchVectorStep {

--- a/helix-db/src/helixc/generator/utils.rs
+++ b/helix-db/src/helixc/generator/utils.rs
@@ -60,12 +60,16 @@ where
             GenRef::Unknown => {
                 // This should have been caught during analysis
                 // For now, panic with a descriptive message
-                panic!("Code generation error: Unknown reference type encountered. This indicates a bug in the analyzer.")
+                panic!(
+                    "Code generation error: Unknown reference type encountered. This indicates a bug in the analyzer."
+                )
             }
             GenRef::Std(t) => t,
             GenRef::Id(_) => {
                 // Id doesn't have an inner T, it's just a String identifier
-                panic!("Code generation error: Cannot get inner value of Id type. Use the identifier directly.")
+                panic!(
+                    "Code generation error: Cannot get inner value of Id type. Use the identifier directly."
+                )
             }
         }
     }
@@ -97,7 +101,7 @@ impl From<GenRef<String>> for String {
             GenRef::Literal(s) => format!("\"{s}\""),
             GenRef::Std(s) => format!("\"{s}\""),
             GenRef::Ref(s) => format!("\"{s}\""),
-            GenRef::Id(s) => s,  // Identifiers don't need quotes
+            GenRef::Id(s) => s, // Identifiers don't need quotes
             GenRef::Unknown => {
                 // Generate a compile error in the output code
                 "compile_error!(\"Unknown value in code generation\")".to_string()
@@ -239,11 +243,15 @@ impl GeneratedValue {
             GeneratedValue::Traversal(_) => {
                 // This should not be called for traversals
                 // The caller should handle traversals specially
-                panic!("Code generation error: Cannot get inner value of Traversal. Traversals should be handled specially.")
+                panic!(
+                    "Code generation error: Cannot get inner value of Traversal. Traversals should be handled specially."
+                )
             }
             GeneratedValue::Unknown => {
                 // This indicates a bug in the analyzer
-                panic!("Code generation error: Unknown GeneratedValue encountered. This indicates incomplete type inference in the analyzer.")
+                panic!(
+                    "Code generation error: Unknown GeneratedValue encountered. This indicates incomplete type inference in the analyzer."
+                )
             }
         }
     }
@@ -309,6 +317,7 @@ pub enum RustType {
     U32,
     U64,
     U128,
+    F16,
     F32,
     F64,
     Bool,
@@ -328,6 +337,7 @@ impl Display for RustType {
             RustType::U32 => write!(f, "u32"),
             RustType::U64 => write!(f, "u64"),
             RustType::U128 => write!(f, "u128"),
+            RustType::F16 => write!(f, "f16"),
             RustType::F32 => write!(f, "f32"),
             RustType::F64 => write!(f, "f64"),
             RustType::Bool => write!(f, "bool"),
@@ -349,11 +359,12 @@ impl RustType {
             RustType::U32 => "number",
             RustType::U64 => "number",
             RustType::U128 => "number",
+            RustType::F16 => "number",
             RustType::F32 => "number",
             RustType::F64 => "number",
             RustType::Bool => "boolean",
-            RustType::Uuid => "string", // do thee
-            RustType::Date => "Date",   // do thee
+            RustType::Uuid => "string",
+            RustType::Date => "Date",
         };
         s.to_string()
     }
@@ -438,7 +449,7 @@ use helix_db::{
             traversal_value::{Traversable, TraversalValue},
         },
         types::GraphError,
-        vector_core::vector::HVector,
+        vector_core::{vector::HVector, VectorData},
     },
     helix_gateway::{
         embedding_providers::embedding_providers::{EmbeddingModel, get_embedding_model},
@@ -468,6 +479,24 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
 use chrono::{DateTime, Utc};
+use half::f16;
     "#
     .to_string()
+}
+
+#[derive(Clone)]
+pub enum Precision<T: Display> {
+    F64(T),
+    F32(T),
+    F16(T),
+}
+
+impl<T: Display> Display for Precision<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Precision::F64(v) => write!(f, "VectorData::F64({v})"),
+            Precision::F32(v) => write!(f, "VectorData::F32({v})"),
+            Precision::F16(v) => write!(f, "VectorData::F16({v})"),
+        }
+    }
 }

--- a/helix-db/src/helixc/parser/utils.rs
+++ b/helix-db/src/helixc/parser/utils.rs
@@ -96,6 +96,9 @@ pub trait PairsTools<'a> {
 
     /// Equivalent to next().into_inner()
     fn try_next_inner(&mut self) -> Result<Pairs<'a, Rule>, ParserError>;
+
+    /// equivalent to peek() then if some get next 
+    fn try_peek_matches(&mut self, rule: Rule) -> Option<Pair<'a, Rule>>;
 }
 use std::panic::Location;
 impl<'a> PairTools<'a> for Pair<'a, Rule> {
@@ -136,6 +139,20 @@ impl<'a> PairsTools<'a> for Pairs<'a, Rule> {
             None => Err(ParserError::from("Expected next inner")),
         }
     }
+
+    fn try_peek_matches(&mut self, rule: Rule) -> Option<Pair<'a, Rule>> {
+        match self.peek() {
+            Some(pair) => {
+                if pair.as_rule() == rule {
+                    self.next();
+                    Some(pair)
+                } else {
+                    None
+                }
+            }
+            None => None,
+        }
+    }
 }
 
 impl<'a> PairsTools<'a> for Result<Pairs<'a, Rule>, ParserError> {
@@ -150,6 +167,13 @@ impl<'a> PairsTools<'a> for Result<Pairs<'a, Rule>, ParserError> {
         match self {
             Ok(pairs) => pairs.try_next_inner(),
             Err(e) => Err(e.clone()),
+        }
+    }
+
+    fn try_peek_matches(&mut self, rule: Rule) -> Option<Pair<'a, Rule>> {
+        match self {
+            Ok(pairs) => pairs.try_peek_matches(rule),
+            Err(_) => None,
         }
     }
 }

--- a/helix-db/src/protocol/value.rs
+++ b/helix-db/src/protocol/value.rs
@@ -1459,6 +1459,7 @@ pub mod casting {
                 FieldType::U32 => CastType::U32,
                 FieldType::U64 => CastType::U64,
                 FieldType::U128 => CastType::U128,
+
                 FieldType::F32 => CastType::F32,
                 FieldType::F64 => CastType::F64,
                 FieldType::Date => CastType::Date,

--- a/hql-tests/tests/vector_precision/config.hx.json
+++ b/hql-tests/tests/vector_precision/config.hx.json
@@ -1,0 +1,14 @@
+{
+    "vector_config": {
+        "m": 16,
+        "ef_construction": 128,
+        "ef_search": 768,
+        "db_max_size": 20
+    },
+    "graph_config": {
+        "secondary_indices": []
+    },
+    "db_max_size_gb": 20,
+    "mcp": true,
+    "bm25": true
+}

--- a/hql-tests/tests/vector_precision/helix.toml
+++ b/hql-tests/tests/vector_precision/helix.toml
@@ -1,0 +1,9 @@
+[project]
+name = "vector_precision"
+queries = "."
+
+[local.dev]
+port = 6969
+build_mode = "debug"
+
+[cloud]

--- a/hql-tests/tests/vector_precision/queries.hx
+++ b/hql-tests/tests/vector_precision/queries.hx
@@ -1,0 +1,25 @@
+V::Embedding1<F16> {
+    content: String
+}
+
+V::Embedding2<F32> {
+    content: String
+}
+
+V::Embedding3<F64> {
+    content: String
+}
+
+V::Embedding4 {
+    content: String
+}
+
+QUERY add_embedding(content: String, vector: [F16]) =>
+    embedding <- AddV<Embedding1>(vector, {content: content})
+    RETURN embedding
+
+QUERY search_embedding(content: String, vector: [F16]) =>
+    embedding <- SearchV<Embedding1>(vector, 10)
+    RETURN embedding
+
+

--- a/hql-tests/tests/vector_precision/schema.hx
+++ b/hql-tests/tests/vector_precision/schema.hx
@@ -1,0 +1,32 @@
+// N::Doc {
+//     content: String
+// }
+//     
+// V::Embedding {
+//     chunk: String
+// }
+// 
+// N::Chunk {
+//     content: String
+// }
+// 
+// E::EmbeddingOf {
+//     From: Doc,
+//     To: Embedding, 
+//     Properties: {
+//     }
+// }
+
+// N::User {
+//     name: String,
+//     age: I32
+// }
+// 
+// E::Knows {
+//     From: User,
+//     To: User,
+//     Properties: {
+//         since: I32,
+//     }
+// }
+


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #650 

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-08 17:38:49 UTC

<h3>Summary</h3>
This PR implements comprehensive support for multiple floating-point precisions (f16, f32, f64) in HelixDB's vector operations, addressing issue #650. The changes introduce a new `VectorData` enum that wraps different precision types, enabling more memory-efficient vector storage and operations while maintaining backward compatibility with existing f64 vectors.

Key architectural changes include:
- **New `VectorData` enum**: Provides type-safe abstraction over f64, f32, and f16 vectors with proper serialization support
- **Grammar extensions**: HQL now supports precision specifications like `V::MyVector<F32>` for vector definitions
- **Vector core updates**: HNSW search, distance calculations, and storage operations now handle multiple precisions natively
- **Compiler enhancements**: Parser, analyzer, and code generator updated to support precision-aware vector operations
- **Test coverage**: Comprehensive test suite validates functionality across all precision types

The implementation follows a systematic approach, updating every layer from the grammar parser through to the storage engine. The `VectorData` enum serves as the central abstraction, allowing the same APIs to work with different precision types while enabling precision-specific optimizations for distance calculations.

**PR Description Notes:**
- The PR description is quite minimal and lacks detail about the significant architectural changes being made
- No mention of the new `VectorData` enum or the comprehensive nature of the changes across multiple system layers

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `helix-db/src/helix_engine/vector_core/vector_data.rs` | 4/5 | New core VectorData enum implementation supporting f64/f32/f16 precision types with serialization |
| `helix-db/src/helix_engine/vector_core/vector.rs` | 4/5 | Major refactor replacing Vec<f64> with VectorData enum, includes backwards compatibility for existing vectors |
| `helix-db/src/helix_engine/vector_core/vector_distance.rs` | 4/5 | Implements native precision distance calculations and mixed-precision comparisons with SIMD optimizations |
| `helix-db/src/grammar.pest` | 5/5 | Extends HQL grammar to support vector precision specifications like V::MyVector<F32> |
| `helix-db/src/helixc/parser/types.rs` | 4/5 | Adds Precision enum and F16 field type support throughout the type system |
| `helix-db/src/helixc/analyzer/methods/traversal_validation.rs` | 4/5 | Updates validation logic to handle precision-aware vector operations with proper scope management |
| `helix-db/src/helixc/generator/utils.rs` | 4/5 | Adds code generation support for F16 type and Precision enum with TypeScript mappings |
| `helix-db/src/helix_engine/vector_core/hnsw.rs` | 4/5 | Updates HNSW trait signatures to accept VectorData instead of raw f64 slices |
| `helix-db/src/helix_engine/vector_core/vector_core.rs` | 5/5 | Core HNSW implementation updated to work with VectorData enum for multi-precision support |
| `helix-db/src/helix_engine/traversal_core/ops/vectors/search.rs` | 5/5 | Vector search operations updated to accept VectorData instead of f64 arrays |
| `helix-db/src/helix_engine/traversal_core/ops/vectors/insert.rs` | 5/5 | Vector insertion API updated to handle VectorData enum with proper type safety |
| `helix-db/src/helixc/parser/schema_parse_methods.rs` | 4/5 | Parser support for vector precision specifications in schema definitions |
| `helix-db/src/helixc/analyzer/types.rs` | 3/5 | Adds F16 type support but missing F16 in is_numeric() method - potential validation bug |
| `helix-db/Cargo.toml` | 5/5 | Adds half crate dependency for f16 support with appropriate features |
| `helix-container/Cargo.toml` | 5/5 | Consistent half crate dependency addition for container component |
| `hql-tests/tests/vector_precision/schema.hx` | 2/5 | Test schema file with all definitions commented out - appears incomplete |
| `hql-tests/tests/vector_precision/queries.hx` | 4/5 | Comprehensive test queries demonstrating F16/F32/F64 vector operations |
| `hql-tests/tests/vector_precision/config.hx.json` | 5/5 | Well-structured test configuration for validating vector precision features |
| `hql-tests/tests/vector_precision/helix.toml` | 5/5 | Standard test project configuration for vector precision validation |
| `helix-db/src/helix_gateway/mcp/tools.rs` | 5/5 | MCP tools updated to wrap embeddings in VectorData::F64 for compatibility |
| `helix-db/src/helix_engine/tests/traversal_tests/util_tests.rs` | 5/5 | Test updates to use VectorData enum while maintaining test functionality |
| `helix-db/src/protocol/value.rs` | 5/5 | Minor formatting improvement in type casting module |
| `helix-db/src/helix_engine/bm25/bm25.rs` | 4/5 | BM25 hybrid search updated to use VectorData::from_f64_slice for compatibility |
| `helix-db/src/helixc/parser/utils.rs` | 4/5 | New try_peek_matches utility method for parsing optional precision specifiers |
| `helix-db/src/helix_engine/tests/traversal_tests/edge_traversal_tests.rs` | 5/5 | Vector operations wrapped in VectorData::F64 to maintain test compatibility |
| `helix-db/src/helix_engine/tests/traversal_tests/drop_tests.rs` | 5/5 | Drop functionality tests updated for new VectorData enum structure |
| `helix-db/src/helix_engine/tests/traversal_tests/vector_traversal_tests.rs` | 5/5 | Comprehensive vector traversal test updates using VectorData wrappers |
| `helix-db/src/helix_engine/bm25/bm25_tests.rs` | 5/5 | BM25 test suite updated to wrap vector data in VectorData::F64 enum |
| `helix-db/src/helix_gateway/mcp/tools_tests.rs` | 4/5 | MCP tools tests updated to support VectorData enum with proper assertions |
| `helix-db/src/helixc/generator/traversal_steps.rs` | 4/5 | SearchVectorStep updated to use precision-wrapped vector data |
| `helix-db/src/helix_engine/tests/hnsw_tests.rs` | 5/5 | HNSW tests adapted to new VectorData API while preserving functionality |
| `helix-db/src/helix_engine/tests/vector_tests.rs` | 4/5 | Core vector tests updated to use VectorData enum for all operations |
| `helix-db/src/helixc/analyzer/methods/infer_expr_type.rs` | 4/5 | Expression type inference updated with precision-aware vector handling |
| `helix-db/src/helixc/analyzer/methods/graph_step_validation.rs` | 4/5 | Graph step validation enhanced with vector precision support |
| `helix-db/benches/hnsw_benches.rs` | 4/5 | Benchmark code updated to use VectorData while maintaining performance testing |
| `helix-db/src/helixc/generator/source_steps.rs` | 5/5 | Code generator updated to handle precision-wrapped vector data in operations |
| `helix-db/src/helix_engine/vector_core/mod.rs` | 5/5 | Module exports updated to include VectorData and related types |
| `helix-db/src/helix_engine/traversal_core/ops/vectors/brute_force_search.rs` | 4/5 | Brute force search updated for mixed-precision vector comparisons |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Parser as "HQL Parser"
    participant Analyzer as "Semantic Analyzer" 
    participant Generator as "Code Generator"
    participant VectorCore as "Vector Core"
    participant Storage as "HNSW Storage"

    User->>Parser: "V::Embedding<F16> { content: String }"
    Parser->>Parser: "Parse precision specification"
    Parser->>Analyzer: "VectorSchema with Precision::F16"
    
    Analyzer->>Analyzer: "Validate precision type"
    Analyzer->>Generator: "Generate VectorData::F16 operations"
    
    User->>Parser: "AddV<Embedding>(vector, {content: content})"
    Parser->>Analyzer: "Vector creation with F16 data"
    Analyzer->>Generator: "Generate F16-specific VectorData"
    Generator->>VectorCore: "VectorData::F16(vec)"
    
    VectorCore->>VectorCore: "Create HVector with F16 precision"
    VectorCore->>Storage: "Store vector with type marker"
    Storage-->>VectorCore: "Vector stored with F16 metadata"
    
    User->>Parser: "SearchV<Embedding>(query_vector, 10)"
    Parser->>Analyzer: "Vector search operation"
    Analyzer->>Generator: "Generate F16 search operation"
    Generator->>VectorCore: "search() with VectorData::F16"
    
    VectorCore->>VectorCore: "Perform cosine similarity with F16"
    Note over VectorCore: "Uses native F16 arithmetic or converts to F32 for calculations"
    VectorCore->>Storage: "Query HNSW index"
    Storage-->>VectorCore: "Return matching F16 vectors"
    VectorCore-->>Generator: "Search results"
    Generator-->>User: "Vector search results"
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->