### PR TITLE
Start of Python and TypeScript DSL

### DIFF
--- a/examples/bookstore.py
+++ b/examples/bookstore.py
@@ -67,9 +67,9 @@ class SubChapter(db.Node):
     title: helix.String
     content: helix.String
 
-    embedding: EmbeddingVector
+    embedding: SubChapterEmbedding
 
-class EmbeddingVector(db.Vector(dimensions=1536, hnsw=helix.cosine)):
+class SubChapterEmbedding(db.Vector(dimensions=1536, hnsw=helix.cosine)):
     pass
 
 class Contains(db.Edge[Chapter, SubChapter]):
@@ -93,7 +93,7 @@ def loaddocs_rag(chapters: helix.List[ArgChapter]) -> str:
             sc_node = db.add_node(SubChapter(
                 title=sc.title,
                 content=sc.content,
-                embedding=EmbeddingVector(sc.chunk)
+                embedding=SubChapterEmbedding(sc.chunk)
             ))
             
             db.add_edge(Contains(from=c_node, to=sc_node))

--- a/examples/bookstore.py
+++ b/examples/bookstore.py
@@ -85,7 +85,7 @@ class ArgSubchapter(helix.Struct):
     chunk: helix.Vector
 
 @db.query
-def loaddocs_rag(chapters: helix.List[ArgChapter]) -> str:
+def loaddocs_rag(chapters: helix.List[ArgChapter]) -> helix.String:
     for c in chapters:
         c_node = db.add_node(Chapter(index=c.id))
 
@@ -101,7 +101,7 @@ def loaddocs_rag(chapters: helix.List[ArgChapter]) -> str:
     return "Success"
 
 @db.query
-def searchdocs_rag(query: helix.Vector, k: helix.I32) -> helix.Iterator[dict[str, helix.Value]]:
+def searchdocs_rag(query: helix.Vector, k: helix.I32) -> helix.Iterator[helix.Map[helix.String, helix.Value]]:
     # TODO
     vecs = db.search_vector(query, k)
     chapters = vecs.incoming_nodes[Contains]

--- a/examples/bookstore.py
+++ b/examples/bookstore.py
@@ -59,8 +59,9 @@ import helix
 db = helix.Db()
 
 class Chapter(db.Node):
-    @index
     index: helix.I64
+
+db.index(Chapter.index, unique=True)
 
 class SubChapter(db.Node):
     title: helix.String

--- a/examples/bookstore.py
+++ b/examples/bookstore.py
@@ -1,0 +1,115 @@
+# N::Chapter {
+#     chapter_index: I64
+# }
+# 
+# N::SubChapter {
+#     title: String,
+#     content: String
+# }
+# 
+# E::Contains {
+#     From: Chapter,
+#     To: SubChapter,
+#     Properties: {
+#     }
+# }
+# 
+# V::Embedding {
+#     chunk: String
+# }
+# 
+# E::EmbeddingOf {
+#     From: SubChapter,
+#     To: Embedding,
+#     Properties: {
+#         chunk: String
+#     }
+# }
+
+# QUERY loaddocs_rag(chapters: [{ id: I64, subchapters: [{ title: String, content: String, chunks: [{chunk: String, vector: [F64]}]}] }]) =>
+#     FOR {id, subchapters} IN chapters {
+#         chapter_node <- AddN<Chapter>({ chapter_index: id })
+#         FOR {title, content, chunks} IN subchapters {
+#             subchapter_node <- AddN<SubChapter>({ title: title, content: content })
+#             AddE<Contains>::From(chapter_node)::To(subchapter_node)
+#             FOR {chunk, vector} IN chunks {
+#                 vec <- AddV<Embedding>(vector)
+#                 AddE<EmbeddingOf>({chunk: chunk})::From(subchapter_node)::To(vec)
+#             }
+#         }
+#     }
+#     RETURN "Success"
+
+# QUERY searchdocs_rag(query: [F64], k: I32) =>
+#     vecs <- SearchV<Embedding>(query, k)
+#     subchapters <- vecs::In<EmbeddingOf>
+#     RETURN subchapters::{title, content}
+
+# QUERY edge_node() => 
+#     e <- N<Chapter>::OutE<Contains>
+#     RETURN e
+
+# QUERY edge_node_id(id: ID) => 
+#     e <- N<Chapter>::OutE<Contains>(id)
+#     RETURN e
+# 
+
+import helix
+
+db = helix.Db()
+
+class Chapter(db.Node):
+    @index
+    index: helix.I64
+
+class SubChapter(db.Node):
+    title: helix.String
+    content: helix.String
+
+    embedding: EmbeddingVector
+
+class EmbeddingVector(db.Vector(dimensions=1536, hnsw=helix.cosine)):
+    pass
+
+class Contains(db.Edge[Chapter, SubChapter]):
+    pass
+
+class ArgChapter(helix.Struct):
+    id: helix.I64
+    subchapters: helix.List[ArgSubchapter]
+
+class ArgSubchapter(helix.Struct):
+    title: helix.String
+    content: helix.String
+    chunk: helix.Vector
+
+@db.query
+def loaddocs_rag(chapters: helix.List[ArgChapter]) -> str:
+    for c in chapters:
+        c_node = db.add_node(Chapter(index=c.id))
+
+        for sc in c.subchapters:
+            sc_node = db.add_node(SubChapter(
+                title=sc.title,
+                content=sc.content,
+                embedding=EmbeddingVector(sc.chunk)
+            ))
+            
+            db.add_edge(Contains(from=c_node, to=sc_node))
+
+    return "Success"
+
+@db.query
+def searchdocs_rag(query: helix.Vector, k: helix.I32) -> helix.Iterator[dict[str, helix.Value]]:
+    # TODO
+    vecs = db.search_vector(query, k)
+    chapters = vecs.incoming_nodes[Contains]
+    return chapters.map(lambda c: {"index": c.index})
+
+@db.query
+def edge_node() -> helix.Iterator[Contains]:
+    return db.nodes[Chapter].outgoing_edges[Contains]
+
+@db.query
+def edge_node_id(id: helix.Id[Chapter]) -> helix.Iterator[Contains]:
+    return db.nodes[Chapter](id=id).outgoing_edges[Contains]

--- a/examples/bookstore.ts
+++ b/examples/bookstore.ts
@@ -1,0 +1,72 @@
+import hx from "helix";
+
+const schema = hx.schema();
+
+const Chapter = schema.defineNode({
+  index: I64,
+});
+
+schema.index(Chapter.index, { unique: true });
+
+const SubChapter = schema.defineNode({
+  title: hx.String,
+  content: hx.String,
+
+  embedding: SubChapterEmbedding,
+});
+
+const SubChapterEmbedding = schema.defineVector({
+  dimensions: 1536,
+  hnsw: hx.cosine,
+});
+
+const Contains = schema.defineEdge({ from: Chapter, to: SubChapter });
+
+const ArgChapter = hx.Struct({
+  id: hx.I64,
+  subchapters: hx.List(ArgSubchapter),
+});
+
+const ArgSubChapter = hx.Struct({
+  title: hx.String,
+  content: hx.String,
+  chunk: hx.Vector,
+});
+
+const loadDocsRag = schema.query({
+  name: "loaddocs_rag",
+  arguments: [hx.List(ArgChapter)],
+  returns: hx.String,
+}, (db, [chapters]) => {
+  chapters.forEach((c) => {
+    const cNode = db.addNode(Chapter({ index: c.id }));
+
+    c.subchapters.forEach((sc) => {
+      const scNode = db.addNode(SubChapter({
+        title: sc.title,
+        content: sc.content,
+        embedding: SubChapterEmbedding(sc.chunk),
+      }));
+
+      db.addEdge(Contains({ from: cNode, to: scNode }));
+    });
+  });
+
+  return "Success";
+});
+
+const edgeNode = schema.query({
+  name: "edge_node",
+  arguments: [],
+  returns: hx.Iterator(Contains),
+}, (db, []) => {
+  return db.nodes[Chapter].outgoingEdges[Contains];
+});
+
+const edgeNodeId = schema.query({
+  name: "edge_node_id",
+  arguments: [hx.Id(Chapter)],
+  returns: hx.Iterator(Contains),
+}, (db, [id]) => {
+  return db.nodes[Chapter]({ id }).outgoingEdges[Contains];
+});

--- a/examples/bookstore.ts
+++ b/examples/bookstore.ts
@@ -2,25 +2,28 @@ import hx from "helix";
 
 const schema = hx.schema();
 
-const Chapter = schema.defineNode({
+const Chapter = schema.defineNode("Chapter", {
   index: I64,
 });
 
 schema.index(Chapter.index, { unique: true });
 
-const SubChapter = schema.defineNode({
+const SubChapter = schema.defineNode("SubChapter", {
   title: hx.String,
   content: hx.String,
 
   embedding: SubChapterEmbedding,
 });
 
-const SubChapterEmbedding = schema.defineVector({
+const SubChapterEmbedding = schema.defineVector("SubChapterEmbedding", {
   dimensions: 1536,
   hnsw: hx.cosine,
 });
 
-const Contains = schema.defineEdge({ from: Chapter, to: SubChapter });
+const Contains = schema.defineEdge("Contains", {
+  from: Chapter,
+  to: SubChapter,
+});
 
 const ArgChapter = hx.Struct({
   id: hx.I64,
@@ -33,8 +36,7 @@ const ArgSubChapter = hx.Struct({
   chunk: hx.Vector,
 });
 
-const loadDocsRag = schema.query({
-  name: "loaddocs_rag",
+const loadDocsRag = schema.query("loaddocs_rag", {
   arguments: [hx.List(ArgChapter)],
   returns: hx.String,
 }, (db, [chapters]) => {
@@ -55,16 +57,14 @@ const loadDocsRag = schema.query({
   return "Success";
 });
 
-const edgeNode = schema.query({
-  name: "edge_node",
+const edgeNode = schema.query("edge_node", {
   arguments: [],
   returns: hx.Iterator(Contains),
 }, (db, []) => {
   return db.nodes[Chapter].outgoingEdges[Contains];
 });
 
-const edgeNodeId = schema.query({
-  name: "edge_node_id",
+const edgeNodeId = schema.query("edge_node_id", {
   arguments: [hx.Id(Chapter)],
   returns: hx.Iterator(Contains),
 }, (db, [id]) => {

--- a/helix-ts/deno.json
+++ b/helix-ts/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "dev": "deno run --watch main.ts"
+  }
+}

--- a/helix-ts/ir.ts
+++ b/helix-ts/ir.ts
@@ -1,0 +1,79 @@
+export const ExprKindString = { kind: "String" as const };
+export const ExprKindI64 = { kind: "I64" as const };
+export const ExprKindF64 = { kind: "F64" as const };
+export const ExprKindBoolean = { kind: "Boolean" as const };
+export const ExprKindVector = { kind: "Vector" as const };
+export const ExprKindList = (item: ExprKind) => ({
+  kind: "List" as const,
+  item,
+});
+export const ExprKindStruct = (fields: Record<string, ExprKind>) => ({
+  kind: "Struct" as const,
+  fields,
+});
+
+export type ExprKind =
+  | typeof ExprKindString
+  | typeof ExprKindI64
+  | typeof ExprKindF64
+  | typeof ExprKindBoolean
+  | typeof ExprKindVector
+  | { kind: "List"; item: ExprKind }
+  | { kind: "Struct"; fields: Record<string, ExprKind> };
+
+export type Expr = {
+  kind: ExprKind;
+  expr:
+    | { expr: "Argument"; index: number }
+    | { expr: "PropAccess"; target: Expr; field: string }
+    | { expr: "Literal"; value: any }
+    | { expr: "BinaryOp"; op: string; left: Expr; right: Expr }
+    | { expr: "Call"; func: string; args: Expr[] };
+};
+
+export type Statement =
+  | { stmt: "Expr"; expr: Expr }
+  | { stmt: "Return"; value: Expr };
+
+export type Block = Statement[];
+
+export type Query = {
+  name: string;
+  arguments: ExprKind[];
+  returns: ExprKind;
+  body: Block;
+};
+
+export type NodeName = `node_${number}`;
+export type Node = {
+  id: typeof ExprKindI64;
+  [_: string]: ExprKind;
+};
+
+export type EdgeName = `edge_${number}`;
+export type Edge = {
+  id: typeof ExprKindI64;
+  from: NodeName;
+  to: NodeName;
+};
+
+export const GlobalVectorspaceName = `vectorspace_global` as const;
+export type GlobalVectorspaceName = typeof GlobalVectorspaceName;
+export type GlobalVectorspace = symbol;
+
+export type VectorspaceName = `vectorspace_${number}`;
+export type Vectorspace = {
+  dimensions: number;
+  hnsw: any; // TODO
+};
+
+export type Schema = {
+  nodes: Record<NodeName, Node>;
+  indices: [{ on: NodeName; field: string; unique: boolean }];
+
+  edges: Record<EdgeName, Edge>;
+
+  vectorspaces:
+    & Record<GlobalVectorspaceName, GlobalVectorspace>
+    & Record<VectorspaceName, Vectorspace>;
+};

--- a/helix-ts/ir.ts
+++ b/helix-ts/ir.ts
@@ -13,13 +13,16 @@ export const ExprKindStruct = (fields: Record<string, ExprKind>) => ({
 });
 
 export type ExprKind =
-  | typeof ExprKindString
-  | typeof ExprKindI64
-  | typeof ExprKindF64
-  | typeof ExprKindBoolean
-  | typeof ExprKindVector
-  | { kind: "List"; item: ExprKind }
-  | { kind: "Struct"; fields: Record<string, ExprKind> };
+  & MaybeNamed
+  & (
+    | typeof ExprKindString
+    | typeof ExprKindI64
+    | typeof ExprKindF64
+    | typeof ExprKindBoolean
+    | typeof ExprKindVector
+    | { kind: "List"; item: ExprKind }
+    | { kind: "Struct"; fields: Record<string, ExprKind> }
+  );
 
 export type Expr = {
   kind: ExprKind;
@@ -37,21 +40,24 @@ export type Statement =
 
 export type Block = Statement[];
 
-export type Query = {
-  name: string;
+export type Named = { name: string };
+export type MaybeNamed = Partial<Named>;
+
+export type QueryName = string;
+export type Query = Named & {
   arguments: ExprKind[];
   returns: ExprKind;
   body: Block;
 };
 
-export type NodeName = `node_${number}`;
-export type Node = {
+export type NodeName = string;
+export type Node = Named & {
   id: typeof ExprKindI64;
   [_: string]: ExprKind;
 };
 
-export type EdgeName = `edge_${number}`;
-export type Edge = {
+export type EdgeName = string;
+export type Edge = Named & {
   id: typeof ExprKindI64;
   from: NodeName;
   to: NodeName;
@@ -61,8 +67,8 @@ export const GlobalVectorspaceName = `vectorspace_global` as const;
 export type GlobalVectorspaceName = typeof GlobalVectorspaceName;
 export type GlobalVectorspace = symbol;
 
-export type VectorspaceName = `vectorspace_${number}`;
-export type Vectorspace = {
+export type VectorspaceName = string;
+export type Vectorspace = Named & {
   dimensions: number;
   hnsw: any; // TODO
 };
@@ -73,7 +79,7 @@ export type Schema = {
 
   edges: Record<EdgeName, Edge>;
 
-  vectorspaces:
-    & Record<GlobalVectorspaceName, GlobalVectorspace>
-    & Record<VectorspaceName, Vectorspace>;
+  vectorspaces: Record<GlobalVectorspaceName | VectorspaceName, Vectorspace>;
+
+  queries: Record<QueryName, Query>;
 };

--- a/helix-ts/main.ts
+++ b/helix-ts/main.ts
@@ -1,0 +1,3 @@
+if (import.meta.main) {
+  console.log("it runs!");
+}


### PR DESCRIPTION
Renamed the branch name of https://github.com/HelixDB/helix-db/pull/698, so I had to re-create a PR. More changes & a better description coming soon (consult the original one for now)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Introduces Python and TypeScript DSL examples for HelixDB, demonstrating how to define schemas and queries programmatically as an alternative to HelixQL.

**Major changes:**
- Added `examples/bookstore.py` with Python DSL showing nodes, vectors, edges, and query definitions
- Added `examples/bookstore.ts` with equivalent TypeScript DSL implementation
- Both examples include RAG use case with chapters, subchapters, and vector embeddings

**Issues found:**
- Python file has 3 syntax errors that will prevent execution (forward reference, typo, missing prefix)
- Python `searchdocs_rag` has logic bug - traverses wrong edge type
- TypeScript has 1 syntax error (undefined variable)

The PR provides a promising foundation for language-native DSLs, but the examples need syntax fixes before they can serve as working references.

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| examples/bookstore.py | 2/5 | Python DSL example with syntax errors (forward reference, typo) and logic bug in searchdocs_rag |
| examples/bookstore.ts | 3/5 | TypeScript DSL example with syntax error (missing hx. prefix on I64) |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant DSL as Python/TS DSL
    participant Schema as Schema Definition
    participant DB as HelixDB
    
    User->>DSL: Define Schema (Chapter, SubChapter nodes)
    DSL->>Schema: Register Node Types
    Schema->>DB: Create Node Type Definitions
    
    User->>DSL: Define Vector (SubChapterEmbedding)
    DSL->>Schema: Register Vector Type (1536 dims, cosine)
    Schema->>DB: Create Vector Index
    
    User->>DSL: Define Edge (Contains)
    DSL->>Schema: Register Edge Type (Chapter → SubChapter)
    Schema->>DB: Create Edge Type Definition
    
    User->>DSL: Call loaddocs_rag(chapters)
    DSL->>DB: AddN<Chapter>(index)
    DB-->>DSL: chapter_node
    
    loop For each subchapter
        DSL->>DB: AddN<SubChapter>(title, content, embedding)
        DB-->>DSL: subchapter_node
        DSL->>DB: AddE<Contains>(chapter → subchapter)
    end
    
    DSL-->>User: "Success"
    
    User->>DSL: Call searchdocs_rag(query, k)
    DSL->>DB: SearchV<Embedding>(query, k)
    DB-->>DSL: vectors
    DSL->>DB: Traverse edges (vectors → subchapters)
    DB-->>DSL: subchapter nodes
    DSL-->>User: {title, content} objects
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->