### PR TITLE
feat: Add RebuildHNSWIndex command for index maintenance

### DIFF
--- a/helix-db/src/helix_engine/vector_core/hnsw.rs
+++ b/helix-db/src/helix_engine/vector_core/hnsw.rs
@@ -60,4 +60,23 @@ pub trait HNSW {
     /// * `txn` - The transaction to use
     /// * `id` - The id of the vector
     fn delete(&self, txn: &mut RwTxn, id: u128, arena: &bumpalo::Bump) -> Result<(), VectorError>;
+
+    /// Reconnect an existing vector to the HNSW graph without changing its ID.
+    /// Used for index rebuilding after deletions cause graph fragmentation.
+    ///
+    /// # Arguments
+    ///
+    /// * `txn` - The write transaction to use
+    /// * `vector` - The vector to reconnect (with existing ID and level)
+    /// * `arena` - The bump allocator for temporary allocations
+    fn reconnect_vector<'db, 'arena, 'txn, F>(
+        &'db self,
+        txn: &'txn mut RwTxn<'db>,
+        vector: &HVector<'arena>,
+        arena: &'arena bumpalo::Bump,
+    ) -> Result<(), VectorError>
+    where
+        F: Fn(&HVector<'arena>, &RoTxn<'db>) -> bool,
+        'db: 'arena,
+        'arena: 'txn;
 }

--- a/helix-db/src/helix_engine/vector_core/vector_core.rs
+++ b/helix-db/src/helix_engine/vector_core/vector_core.rs
@@ -723,9 +723,9 @@ impl HNSW for VectorCore {
                 arena,
             )?;
 
-            if let Some(closest) = nearest.peek() {
-                curr_ep = *closest;
-            }
+            curr_ep = *nearest.peek().ok_or(VectorError::VectorCoreError(
+                "empty search result".to_string(),
+            ))?;
 
             let neighbors =
                 self.select_neighbors::<F>(txn, label, vector, nearest, level, true, None, arena)?;

--- a/helix-db/src/helix_engine/vector_core/vector_core.rs
+++ b/helix-db/src/helix_engine/vector_core/vector_core.rs
@@ -705,9 +705,9 @@ impl HNSW for VectorCore {
         for level in (new_level + 1..=l).rev() {
             let mut nearest =
                 self.search_level::<F>(txn, label, vector, &mut curr_ep, 1, level, None, arena)?;
-            if let Some(closest) = nearest.pop() {
-                curr_ep = closest;
-            }
+            curr_ep = nearest.pop().ok_or(VectorError::VectorCoreError(
+                "empty search result".to_string(),
+            ))?;
         }
 
         // Connect at each level

--- a/helix-db/src/helix_gateway/builtin/mod.rs
+++ b/helix-db/src/helix_gateway/builtin/mod.rs
@@ -2,3 +2,4 @@ pub mod all_nodes_and_edges;
 pub mod node_by_id;
 pub mod node_connections;
 pub mod nodes_by_label;
+pub mod rebuild_hnsw_index;

--- a/helix-db/src/helix_gateway/builtin/rebuild_hnsw_index.rs
+++ b/helix-db/src/helix_gateway/builtin/rebuild_hnsw_index.rs
@@ -8,7 +8,7 @@ use crate::helix_engine::vector_core::vector_core::ENTRY_POINT_KEY;
 use crate::helix_gateway::router::router::{Handler, HandlerInput, HandlerSubmission};
 use crate::protocol;
 
-const BATCH_SIZE: usize = 50;
+const BATCH_SIZE: usize = 5;
 
 /// Rebuild the HNSW index by reconnecting all vectors.
 /// This fixes graph fragmentation caused by deletions and re-insertions.
@@ -18,16 +18,13 @@ pub fn rebuild_hnsw_index_inner(input: HandlerInput) -> Result<protocol::Respons
 
     let db = Arc::clone(&input.graph.storage);
 
-    // Step 1: Get vector IDs only (to avoid loading all vector data at once)
-    eprintln!("[RebuildHNSWIndex] Counting vectors...");
+    // Step 1: Get vector IDs only (memory-efficient, doesn't load vector data)
+    eprintln!("[RebuildHNSWIndex] Collecting vector IDs...");
     let vector_ids: Vec<u128> = {
         let txn = db.graph_env.read_txn().map_err(GraphError::from)?;
-        let arena = bumpalo::Bump::new();
-        let vectors = db
-            .vectors
-            .get_all_vectors(&txn, None, &arena)
-            .map_err(|e| GraphError::New(format!("Failed to get vectors: {}", e)))?;
-        vectors.iter().map(|v| v.id).collect()
+        db.vectors
+            .get_all_vector_ids(&txn)
+            .map_err(|e| GraphError::New(format!("Failed to get vector IDs: {}", e)))?
     };
     let vector_count = vector_ids.len();
     eprintln!("[RebuildHNSWIndex] Found {} vectors", vector_count);
@@ -58,27 +55,30 @@ pub fn rebuild_hnsw_index_inner(input: HandlerInput) -> Result<protocol::Respons
         txn.commit().map_err(GraphError::from)?;
     }
 
-    // Step 3: Reconnect vectors one at a time (fresh arena each to control memory)
-    eprintln!("[RebuildHNSWIndex] Reconnecting {} vectors...", vector_count);
+    // Step 3: Reconnect vectors in batches (fresh arena per batch to control memory)
+    eprintln!("[RebuildHNSWIndex] Reconnecting {} vectors in batches of {}...", vector_count, BATCH_SIZE);
 
-    for (i, &vector_id) in vector_ids.iter().enumerate() {
-        if i % 500 == 0 {
+    for (batch_idx, chunk) in vector_ids.chunks(BATCH_SIZE).enumerate() {
+        let processed = batch_idx * BATCH_SIZE;
+        if processed % 500 == 0 {
             eprintln!("[RebuildHNSWIndex] Progress: {}/{} ({:.1}%)",
-                i, vector_count, (i as f64 / vector_count as f64) * 100.0);
+                processed, vector_count, (processed as f64 / vector_count as f64) * 100.0);
         }
 
-        // Fresh arena for each vector to prevent memory growth
+        // Fresh arena for each batch to prevent memory growth
         let arena = bumpalo::Bump::new();
         let mut txn = db.graph_env.write_txn().map_err(GraphError::from)?;
 
-        match db.vectors.get_full_vector(&txn, vector_id, &arena) {
-            Ok(v) => {
-                db.vectors
-                    .reconnect_vector::<fn(&_, &_) -> bool>(&mut txn, &v, &arena)
-                    .map_err(|e| GraphError::New(format!("Failed to reconnect vector {}: {}", vector_id, e)))?;
-            }
-            Err(e) => {
-                eprintln!("[RebuildHNSWIndex] Warning: skipping vector {}: {}", vector_id, e);
+        for &vector_id in chunk {
+            match db.vectors.get_full_vector(&txn, vector_id, &arena) {
+                Ok(v) => {
+                    db.vectors
+                        .reconnect_vector::<fn(&_, &_) -> bool>(&mut txn, &v, &arena)
+                        .map_err(|e| GraphError::New(format!("Failed to reconnect vector {}: {}", vector_id, e)))?;
+                }
+                Err(e) => {
+                    eprintln!("[RebuildHNSWIndex] Warning: skipping vector {}: {}", vector_id, e);
+                }
             }
         }
 

--- a/helix-db/src/helix_gateway/builtin/rebuild_hnsw_index.rs
+++ b/helix-db/src/helix_gateway/builtin/rebuild_hnsw_index.rs
@@ -1,0 +1,104 @@
+use std::sync::Arc;
+
+use sonic_rs::json;
+
+use crate::helix_engine::types::GraphError;
+use crate::helix_engine::vector_core::hnsw::HNSW;
+use crate::helix_engine::vector_core::vector_core::ENTRY_POINT_KEY;
+use crate::helix_gateway::router::router::{Handler, HandlerInput, HandlerSubmission};
+use crate::protocol;
+
+const BATCH_SIZE: usize = 50;
+
+/// Rebuild the HNSW index by reconnecting all vectors.
+/// This fixes graph fragmentation caused by deletions and re-insertions.
+/// Processes in batches to avoid OOM.
+pub fn rebuild_hnsw_index_inner(input: HandlerInput) -> Result<protocol::Response, GraphError> {
+    eprintln!("[RebuildHNSWIndex] Starting rebuild...");
+
+    let db = Arc::clone(&input.graph.storage);
+
+    // Step 1: Get vector IDs only (to avoid loading all vector data at once)
+    eprintln!("[RebuildHNSWIndex] Counting vectors...");
+    let vector_ids: Vec<u128> = {
+        let txn = db.graph_env.read_txn().map_err(GraphError::from)?;
+        let arena = bumpalo::Bump::new();
+        let vectors = db
+            .vectors
+            .get_all_vectors(&txn, None, &arena)
+            .map_err(|e| GraphError::New(format!("Failed to get vectors: {}", e)))?;
+        vectors.iter().map(|v| v.id).collect()
+    };
+    let vector_count = vector_ids.len();
+    eprintln!("[RebuildHNSWIndex] Found {} vectors", vector_count);
+
+    if vector_count == 0 {
+        return Ok(protocol::Response {
+            body: sonic_rs::to_vec(&json!({
+                "status": "success",
+                "message": "No vectors to rebuild",
+                "vectors_rebuilt": 0
+            }))
+            .map_err(|e| GraphError::New(e.to_string()))?,
+            fmt: Default::default(),
+        });
+    }
+
+    // Step 2: Clear all HNSW edges
+    {
+        let mut txn = db.graph_env.write_txn().map_err(GraphError::from)?;
+        eprintln!("[RebuildHNSWIndex] Clearing HNSW edges...");
+        db.vectors
+            .edges_db
+            .clear(&mut txn)
+            .map_err(|e| GraphError::New(format!("Failed to clear edges: {}", e)))?;
+
+        eprintln!("[RebuildHNSWIndex] Clearing entry point...");
+        let _ = db.vectors.vectors_db.delete(&mut txn, ENTRY_POINT_KEY);
+        txn.commit().map_err(GraphError::from)?;
+    }
+
+    // Step 3: Reconnect vectors one at a time (fresh arena each to control memory)
+    eprintln!("[RebuildHNSWIndex] Reconnecting {} vectors...", vector_count);
+
+    for (i, &vector_id) in vector_ids.iter().enumerate() {
+        if i % 500 == 0 {
+            eprintln!("[RebuildHNSWIndex] Progress: {}/{} ({:.1}%)",
+                i, vector_count, (i as f64 / vector_count as f64) * 100.0);
+        }
+
+        // Fresh arena for each vector to prevent memory growth
+        let arena = bumpalo::Bump::new();
+        let mut txn = db.graph_env.write_txn().map_err(GraphError::from)?;
+
+        match db.vectors.get_full_vector(&txn, vector_id, &arena) {
+            Ok(v) => {
+                db.vectors
+                    .reconnect_vector::<fn(&_, &_) -> bool>(&mut txn, &v, &arena)
+                    .map_err(|e| GraphError::New(format!("Failed to reconnect vector {}: {}", vector_id, e)))?;
+            }
+            Err(e) => {
+                eprintln!("[RebuildHNSWIndex] Warning: skipping vector {}: {}", vector_id, e);
+            }
+        }
+
+        txn.commit().map_err(GraphError::from)?;
+        // Arena dropped here, memory freed
+    }
+
+    eprintln!("[RebuildHNSWIndex] Rebuild complete! {} vectors reconnected", vector_count);
+    Ok(protocol::Response {
+        body: sonic_rs::to_vec(&json!({
+            "status": "success",
+            "vectors_rebuilt": vector_count
+        }))
+        .map_err(|e| GraphError::New(e.to_string()))?,
+        fmt: Default::default(),
+    })
+}
+
+inventory::submit! {
+    HandlerSubmission(
+        Handler::new("RebuildHNSWIndex", rebuild_hnsw_index_inner, true)
+    )
+}


### PR DESCRIPTION
## Summary

Adds a new built-in command `RebuildHNSWIndex` that rebuilds HNSW graph edges, fixing fragmentation caused by vector deletions and re-insertions.

### Problem

When vectors are deleted and re-added to an HNSW index, the graph becomes fragmented. The entry point only connects to vectors inserted after it, leaving older vectors unreachable via search. This causes search quality degradation over time.

### Solution

The `RebuildHNSWIndex` command:
1. Reads all existing vector IDs efficiently (without loading full vector data)
2. Clears all HNSW edges and entry point
3. Reconnects all vectors in configurable batches to rebuild a fully connected graph

### Changes

| File | Change |
|------|--------|
| `helix-db/src/helix_engine/vector_core/hnsw.rs` | Added `reconnect_vector` method to HNSW trait |
| `helix-db/src/helix_engine/vector_core/vector_core.rs` | Implemented `reconnect_vector` + added `get_all_vector_ids` for memory-efficient ID iteration |
| `helix-db/src/helix_gateway/builtin/rebuild_hnsw_index.rs` | **NEW** - Handler for RebuildHNSWIndex endpoint |
| `helix-db/src/helix_gateway/builtin/mod.rs` | Added module export |

### Usage

```bash
# Default batch size (5)
curl -X POST http://localhost:6969/RebuildHNSWIndex \
  -H "Content-Type: application/json" -d '{}'

# Custom batch size for performance tuning
curl -X POST http://localhost:6969/RebuildHNSWIndex \
  -H "Content-Type: application/json" -d '{"batch_size": 10}'
```

Returns:
```json
{"status": "success", "vectors_rebuilt": 97862, "batch_size": 5}
```

### Performance Notes

- **batch_size parameter**: Controls vectors per transaction. Higher values reduce transaction overhead but increase memory usage per batch. Default of 5 balances speed and memory.
- **Memory efficient**: Uses `get_all_vector_ids()` to iterate over keys without loading full vector data
- Progress logged every 500 vectors

### What It Does NOT Do

- Does NOT re-generate embeddings (preserves existing vectors)
- Does NOT change vector IDs
- Only rebuilds the HNSW graph edges (navigation structure)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds `RebuildHNSWIndex` command to fix graph fragmentation caused by vector deletions and re-insertions. The implementation properly reconnects all vectors in memory-efficient batches.

**Key changes:**
- Added `reconnect_vector()` trait method and implementation to rebuild HNSW edges while preserving vector IDs and levels
- Added `get_all_vector_ids()` for memory-efficient ID iteration without loading full vector data
- Created `/RebuildHNSWIndex` HTTP endpoint with configurable `batch_size` parameter
- Uses fresh arena per batch to prevent memory growth during rebuild operations
- Fixed error handling in reconnection loops to match `insert` method behavior (returns errors instead of silently continuing)

**Quality:**
- All previously identified issues have been addressed in the latest commits
- Proper error handling throughout the reconnection process
- Memory-efficient batch processing with progress logging
- Clear API documentation and usage examples

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/src/helix_engine/vector_core/hnsw.rs | Added `reconnect_vector` trait method for index rebuilding - well-documented and properly integrated |
| helix-db/src/helix_engine/vector_core/vector_core.rs | Implemented `reconnect_vector` with proper error handling and added memory-efficient `get_all_vector_ids` method |
| helix-db/src/helix_gateway/builtin/rebuild_hnsw_index.rs | New handler for rebuilding HNSW index with proper batch processing and memory management |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as RebuildHNSWIndex Handler
    participant DB as Database
    participant VectorCore
    participant HNSW as HNSW Graph

    Client->>Handler: POST /RebuildHNSWIndex {batch_size: 10}
    Handler->>Handler: Parse batch_size (default: 5)
    
    Note over Handler,DB: Step 1: Collect Vector IDs
    Handler->>DB: read_txn()
    Handler->>VectorCore: get_all_vector_ids()
    VectorCore->>DB: prefix_iter(VECTOR_PREFIX)
    DB-->>VectorCore: Keys only (no vector data)
    VectorCore-->>Handler: Vec<u128> IDs
    
    Note over Handler,HNSW: Step 2: Clear Existing Graph
    Handler->>DB: write_txn()
    Handler->>HNSW: edges_db.clear()
    Handler->>HNSW: Delete entry_point
    Handler->>DB: commit()
    
    Note over Handler,HNSW: Step 3: Reconnect in Batches
    loop For each batch of vectors
        Handler->>Handler: Create fresh arena
        Handler->>DB: write_txn()
        
        loop For each vector_id in batch
            Handler->>VectorCore: get_full_vector(id)
            VectorCore-->>Handler: HVector with existing level
            Handler->>VectorCore: reconnect_vector(vector)
            
            alt No entry point yet
                VectorCore->>HNSW: set_entry_point(vector)
            else Entry point exists
                VectorCore->>HNSW: get_entry_point()
                
                loop Navigate to insertion level
                    VectorCore->>HNSW: search_level(vector, level)
                    HNSW-->>VectorCore: nearest neighbors
                end
                
                loop Connect at each level
                    VectorCore->>HNSW: search_level(vector, level)
                    VectorCore->>HNSW: select_neighbors()
                    VectorCore->>HNSW: set_neighbours(vector, neighbors)
                    
                    loop Update each neighbor
                        VectorCore->>HNSW: get_neighbors(neighbor)
                        VectorCore->>HNSW: select_neighbors(neighbor)
                        VectorCore->>HNSW: set_neighbours(neighbor)
                    end
                end
            end
        end
        
        Handler->>DB: commit()
        Handler->>Handler: Drop arena (free memory)
    end
    
    Handler-->>Client: {status: "success", vectors_rebuilt: N, batch_size: 10}
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->