### PR TITLE
feat: Add PREFILTER support for SearchV vector queries

### DIFF
--- a/helix-db/src/grammar.pest
+++ b/helix-db/src/grammar.pest
@@ -223,7 +223,7 @@ rerank_mmr = { "RerankMMR" ~ "(" ~ "lambda" ~ ":" ~ evaluates_to_number ~ ("," ~
 // ---------------------------------------------------------------------
 // Vector steps
 // ---------------------------------------------------------------------
-search_vector = { "SearchV" ~ "<" ~ identifier_upper ~ ">" ~ "(" ~ vector_data ~ "," ~ (integer | identifier) ~ ")" }// ~ ("::" ~ pre_filter)? }
+search_vector = { "SearchV" ~ "<" ~ identifier_upper ~ ">" ~ "(" ~ vector_data ~ "," ~ (integer | identifier) ~ ("," ~ pre_filter)? ~ ")" }
 bm25_search = { "SearchBM25" ~ "<" ~ identifier_upper ~ ">" ~ "(" ~ (string_literal | identifier) ~ "," ~ (integer | identifier) ~ ")" }
 pre_filter = { "PREFILTER" ~ "(" ~ (evaluates_to_bool | anonymous_traversal) ~ ")" }
 BatchAddV = { "BatchAddV" ~ "<" ~ identifier_upper ~ ">" ~ "(" ~ identifier ~ ")" }

--- a/helix-db/src/helix_engine/vector_core/utils.rs
+++ b/helix-db/src/helix_engine/vector_core/utils.rs
@@ -129,10 +129,13 @@ impl<'db, 'arena, 'txn, 'q> VectorFilter<'db, 'arena, 'txn, 'q>
                     continue;
                 }
 
-                if properties.label == label
+                // Expand properties into item BEFORE applying filter
+                // so that filter can access item.get_property() correctly
+                item.expand_from_vector_without_data(properties);
+
+                if item.label == label
                     && (filter.is_none() || filter.unwrap().iter().all(|f| f(&item, txn)))
                 {
-                    item.expand_from_vector_without_data(properties);
                     result.push(item);
                     break;
                 }

--- a/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
@@ -631,56 +631,56 @@ pub(crate) fn validate_traversal<'a>(
                 }
             };
 
-            // let pre_filter: Option<Vec<BoExp>> = match &sv.pre_filter {
-            //     Some(expr) => {
-            //         let (_, stmt) = infer_expr_type(
-            //             ctx,
-            //             expr,
-            //             scope,
-            //             original_query,
-            //             Some(Type::Vector(sv.vector_type.clone())),
-            //             gen_query,
-            //         );
-            //         // Where/boolean ops don't change the element type,
-            //         // so `cur_ty` stays the same.
-            //         assert!(stmt.is_some());
-            //         let stmt = stmt.unwrap();
-            //         let mut gen_traversal = GeneratedTraversal {
-            //             traversal_type: TraversalType::NestedFrom(GenRef::Std("v".to_string())),
-            //             steps: vec![],
-            //             should_collect: ShouldCollect::ToVec,
-            //             source_step: Separator::Empty(SourceStep::Anonymous),
-            //         };
-            //         match stmt {
-            //             GeneratedStatement::Traversal(tr) => {
-            //                 gen_traversal
-            //                     .steps
-            //                     .push(Separator::Period(GeneratedStep::Where(Where::Ref(
-            //                         WhereRef {
-            //                             expr: BoExp::Expr(tr),
-            //                         },
-            //                     ))));
-            //             }
-            //             GeneratedStatement::BoExp(expr) => {
-            //                 gen_traversal
-            //                     .steps
-            //                     .push(Separator::Period(GeneratedStep::Where(match expr {
-            //                         BoExp::Exists(mut traversal) => {
-            //                             traversal.should_collect = ShouldCollect::No;
-            //                             Where::Ref(WhereRef {
-            //                                 expr: BoExp::Exists(traversal),
-            //                             })
-            //                         }
-            //                         _ => Where::Ref(WhereRef { expr }),
-            //                     })));
-            //             }
-            //             _ => unreachable!(),
-            //         }
-            //         Some(vec![BoExp::Expr(gen_traversal)])
-            //     }
-            //     None => None,
-            // };
-            let pre_filter = None;
+            let pre_filter: Option<Vec<BoExp>> = match &sv.pre_filter {
+                Some(expr) => {
+                    let (_, stmt) = infer_expr_type(
+                        ctx,
+                        expr,
+                        scope,
+                        original_query,
+                        Some(Type::Vector(sv.vector_type.clone())),
+                        gen_query,
+                    );
+                    // Where/boolean ops don't change the element type,
+                    // so `cur_ty` stays the same.
+                    if stmt.is_none() {
+                        generate_error!(
+                            ctx,
+                            original_query,
+                            sv.loc.clone(),
+                            E601,
+                            "invalid pre_filter expression"
+                        );
+                        return None;
+                    }
+                    let stmt = stmt.unwrap();
+                    match stmt {
+                        GeneratedStatement::Traversal(tr) => {
+                            Some(vec![BoExp::Expr(tr)])
+                        }
+                        GeneratedStatement::BoExp(expr) => {
+                            match expr {
+                                BoExp::Exists(mut traversal) => {
+                                    traversal.should_collect = ShouldCollect::No;
+                                    Some(vec![BoExp::Exists(traversal)])
+                                }
+                                _ => Some(vec![expr]),
+                            }
+                        }
+                        _ => {
+                            generate_error!(
+                                ctx,
+                                original_query,
+                                sv.loc.clone(),
+                                E601,
+                                "pre_filter must be a boolean expression"
+                            );
+                            return None;
+                        }
+                    }
+                }
+                None => None,
+            };
 
             gen_traversal.traversal_type = TraversalType::Ref;
             gen_traversal.should_collect = ShouldCollect::ToVec;

--- a/helix-db/src/helixc/generator/source_steps.rs
+++ b/helix-db/src/helixc/generator/source_steps.rs
@@ -443,7 +443,7 @@ impl Display for SearchVector {
                 self.label,
                 pre_filter
                     .iter()
-                    .map(|f| format!("|v: &HVector, txn: &RoTxn| {f}"))
+                    .map(|f| format!("|val: &HVector, txn: &RoTxn| {f}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             ),


### PR DESCRIPTION
## Summary

Enables pre-filtering during HNSW traversal for more efficient filtered vector searches.

### Problem

Currently, filtering in SearchV is done post-retrieval:

```helix
results <- SearchV<Node>(Embed(query), 10)
results <- results::WHERE(_::{isLeaf}::EQ("true"))
```

This returns fewer than 10 results if many are filtered out, which is problematic when you need exactly N matching results.

### Solution

Add PREFILTER syntax that filters during HNSW traversal:

```helix
results <- SearchV<Node>(Embed(query), 10, PREFILTER(_::{isLeaf}::EQ("true")))
```

This returns exactly 10 matching results by applying the filter during the search, not after.

## Changes

| File | Change |
|------|--------|
| `grammar.pest` | Enable PREFILTER in search_vector rule (was commented out) |
| `expression_parse_methods.rs` | Parse PREFILTER with proper anonymous_traversal support |
| `traversal_validation.rs` | Analyze pre_filter expression and generate BoExp |
| `source_steps.rs` | Generate closure with correct parameter name (`val`) |

## Test Plan

- [x] `cargo check -p helix-db` passes
- [x] Add integration test for PREFILTER queries
- [x] Test with real vector data

## Example Usage

```helix
// Search for 10 billable codes matching "diabetes"
QUERY SearchBillableCodesPrefilter(query: String, limit: I64) =>
    results <- SearchV<ICDCode>(Embed(query), limit, PREFILTER(_::{isLeaf}::EQ("true")))
    RETURN results
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR enables PREFILTER support for SearchV vector queries, allowing filters to be applied during HNSW traversal rather than post-retrieval. This ensures that exactly k matching results are returned even when many candidates are filtered out.

**Key Changes:**
- Enabled PREFILTER syntax in the grammar by uncommenting the optional pre_filter parameter in `search_vector` rule
- Implemented proper parsing for PREFILTER expressions supporting both `anonymous_traversal` and `evaluates_to_bool` patterns
- Uncommented and simplified the pre_filter validation logic in the analyzer to generate correct BoExp
- **Critical fix**: Modified `vector_core/utils.rs` to expand vector properties BEFORE applying the filter, ensuring property access works correctly in filter expressions
- Corrected closure parameter name from `v` to `val` to match the `DEFAULT_VAR_NAME` constant used throughout the codebase

**Implementation Quality:**
The changes are well-structured and follow the existing codebase patterns. The fix to expand properties before filtering (in `utils.rs`) is particularly important as it resolves a critical bug where filters couldn't access properties via `get_property()` because the item wasn't fully expanded yet.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/src/helix_engine/vector_core/utils.rs | Moved item expansion before filter evaluation to ensure property access works correctly in PREFILTER |
| helix-db/src/helixc/analyzer/methods/traversal_validation.rs | Uncommented and simplified pre_filter validation logic, properly handles BoExp generation |
| helix-db/src/helixc/parser/expression_parse_methods.rs | Added proper parsing for PREFILTER with support for both anonymous_traversal and evaluates_to_bool |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as HelixQL Query
    participant Parser as Parser
    participant Analyzer as Analyzer
    participant Generator as Generator
    participant Runtime as Vector Search Runtime

    User->>Parser: SearchV<Node>(vec, 10, PREFILTER(...))
    Parser->>Parser: Parse PREFILTER expression
    Note over Parser: Handles anonymous_traversal<br/>or evaluates_to_bool
    Parser->>Analyzer: Expression AST with pre_filter
    Analyzer->>Analyzer: Validate pre_filter expression
    Note over Analyzer: infer_expr_type with<br/>Type::Vector context
    Analyzer->>Analyzer: Generate BoExp from expression
    Analyzer->>Generator: GeneratedTraversal with pre_filter
    Generator->>Generator: Generate closure with |val: &HVector, txn|
    Note over Generator: Changed parameter name<br/>from 'v' to 'val'
    Generator->>Runtime: search_v with filter closures
    Runtime->>Runtime: HNSW traversal
    loop For each candidate
        Runtime->>Runtime: Expand properties BEFORE filter
        Note over Runtime: Critical fix: expand_from_vector_without_data<br/>called before applying filter
        Runtime->>Runtime: Apply filter(s) to expanded item
        alt Filter passes
            Runtime->>Runtime: Add to results
        else Filter fails
            Runtime->>Runtime: Continue search
        end
    end
    Runtime->>User: Return exactly k matching results
```
</details>


<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->