### PR TITLE
feat: Hybrid Search with RRF (SearchBM25 + SearchV)

### DIFF
--- a/helix-db/src/grammar.pest
+++ b/helix-db/src/grammar.pest
@@ -62,7 +62,7 @@ optional_param = { "?" }
 // Assignments and traversals
 // ---------------------------------------------------------------------
 get_stmt            = { identifier ~ "<-" ~ evaluates_to_anything }
-traversal           = { (start_node | start_edge | search_vector | start_vector) ~ step* ~ last_step? }
+traversal           = { (start_node | start_edge | search_vector | search_hybrid | start_vector) ~ step* ~ last_step? }
 id_traversal        = { identifier ~ ((step+ ~ last_step?) | last_step) }
 anonymous_traversal = { "_"  ~ ((step+ ~ last_step?) | last_step)? }
 step                = { "::" ~ (graph_step | order_by| aggregate | group_by | where_step | closure_step | object_step | exclude_field | count | ID | range_step | AddE | rerank_rrf | rerank_mmr) }
@@ -93,6 +93,7 @@ evaluates_to_anything = {
   | traversal
   | id_traversal
   | search_vector
+  | search_hybrid
   | bm25_search
   | math_function_call
   | string_literal

--- a/helix-db/src/grammar.pest
+++ b/helix-db/src/grammar.pest
@@ -225,6 +225,13 @@ rerank_mmr = { "RerankMMR" ~ "(" ~ "lambda" ~ ":" ~ evaluates_to_number ~ ("," ~
 // ---------------------------------------------------------------------
 search_vector = { "SearchV" ~ "<" ~ identifier_upper ~ ">" ~ "(" ~ vector_data ~ "," ~ (integer | identifier) ~ ")" }// ~ ("::" ~ pre_filter)? }
 bm25_search = { "SearchBM25" ~ "<" ~ identifier_upper ~ ">" ~ "(" ~ (string_literal | identifier) ~ "," ~ (integer | identifier) ~ ")" }
+search_hybrid = {
+    "SearchHybrid" ~ "<" ~ identifier_upper ~ ">" ~ "("
+    ~ vector_data ~ ","
+    ~ (string_literal | identifier) ~ ","
+    ~ (integer | identifier)
+    ~ ")"
+}
 pre_filter = { "PREFILTER" ~ "(" ~ (evaluates_to_bool | anonymous_traversal) ~ ")" }
 BatchAddV = { "BatchAddV" ~ "<" ~ identifier_upper ~ ">" ~ "(" ~ identifier ~ ")" }
 embed_method = { "Embed" ~ "(" ~ (identifier | string_literal) ~ ")" }

--- a/helix-db/src/helix_engine/traversal_core/ops/hybrid/mod.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/hybrid/mod.rs
@@ -1,0 +1,1 @@
+mod search_hybrid;

--- a/helix-db/src/helix_engine/traversal_core/ops/hybrid/mod.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/hybrid/mod.rs
@@ -1,1 +1,2 @@
 mod search_hybrid;
+pub use search_hybrid::*;

--- a/helix-db/src/helix_engine/traversal_core/ops/hybrid/search_hybrid.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/hybrid/search_hybrid.rs
@@ -172,15 +172,3 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
         })
     }
 }
-
-#[cfg(test)]
-mod tests {
-    // Integration tests would require full storage setup
-    // Unit tests for the trait signature verification
-
-    #[test]
-    fn test_search_hybrid_trait_exists() {
-        // Verify the trait compiles correctly
-        // Actual integration tests need a full HelixGraphStorage instance
-    }
-}

--- a/helix-db/src/helix_engine/traversal_core/ops/hybrid/search_hybrid.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/hybrid/search_hybrid.rs
@@ -1,0 +1,186 @@
+use crate::helix_engine::{
+    bm25::bm25::BM25,
+    traversal_core::{
+        LMDB_STRING_HEADER_LENGTH, traversal_iter::RoTraversalIterator,
+        traversal_value::TraversalValue,
+    },
+    types::GraphError,
+    vector_core::hnsw::HNSW,
+};
+
+/// Trait that adds hybrid search capability (vector + BM25) to traversal iterators.
+///
+/// This trait enables combining semantic vector search with keyword-based BM25 search,
+/// returning combined results that can be fused using `RerankRRF` or `RerankMMR`.
+pub trait SearchHybridAdapter<'db, 'arena, 'txn>:
+    Iterator<Item = Result<TraversalValue<'arena>, GraphError>>
+{
+    /// Perform a hybrid search combining vector similarity and BM25 keyword search.
+    ///
+    /// # Arguments
+    /// * `label` - The type label for the vectors/documents to search
+    /// * `query_vec` - The query vector for similarity search
+    /// * `query_text` - The query text for BM25 keyword search
+    /// * `k` - Number of results to return from each search
+    ///
+    /// # Returns
+    /// A traversal iterator containing combined results from both searches.
+    /// Results can be piped to `::RerankRRF` or `::RerankMMR` for fusion.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let results = storage
+    ///     .search_hybrid("Document", query_vec, "search query", 10)?
+    ///     .rerank(RRFReranker::new(), None)
+    ///     .collect_to::<Vec<_>>();
+    /// ```
+    fn search_hybrid<K>(
+        self,
+        label: &'arena str,
+        query_vec: &'arena [f64],
+        query_text: &str,
+        k: K,
+    ) -> Result<
+        RoTraversalIterator<
+            'db,
+            'arena,
+            'txn,
+            impl Iterator<Item = Result<TraversalValue<'arena>, GraphError>>,
+        >,
+        GraphError,
+    >
+    where
+        K: TryInto<usize> + Copy,
+        K::Error: std::fmt::Debug;
+}
+
+impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphError>>>
+    SearchHybridAdapter<'db, 'arena, 'txn> for RoTraversalIterator<'db, 'arena, 'txn, I>
+{
+    fn search_hybrid<K>(
+        self,
+        label: &'arena str,
+        query_vec: &'arena [f64],
+        query_text: &str,
+        k: K,
+    ) -> Result<
+        RoTraversalIterator<
+            'db,
+            'arena,
+            'txn,
+            impl Iterator<Item = Result<TraversalValue<'arena>, GraphError>>,
+        >,
+        GraphError,
+    >
+    where
+        K: TryInto<usize> + Copy,
+        K::Error: std::fmt::Debug,
+    {
+        let k_usize = k.try_into().unwrap();
+
+        // 1. Execute vector search
+        let vector_results =
+            self.storage.vectors.search(
+                self.txn,
+                query_vec,
+                k_usize,
+                label,
+                None::<
+                    &[fn(
+                        &crate::helix_engine::vector_core::vector::HVector,
+                        &heed3::RoTxn,
+                    ) -> bool],
+                >,
+                false,
+                self.arena,
+            );
+
+        // 2. Execute BM25 search
+        let bm25_results = match self.storage.bm25.as_ref() {
+            Some(bm25) => bm25.search(self.txn, query_text, k_usize, self.arena)?,
+            None => return Err(GraphError::from("BM25 not enabled for hybrid search")),
+        };
+
+        // 3. Collect vector results as TraversalValues
+        let vector_iter: Vec<Result<TraversalValue<'arena>, GraphError>> = match vector_results {
+            Ok(vectors) => vectors
+                .into_iter()
+                .map(|vector| Ok(TraversalValue::Vector(vector)))
+                .collect(),
+            Err(e) => {
+                vec![Err(GraphError::VectorError(format!(
+                    "Vector search error: {:?}",
+                    e
+                )))]
+            }
+        };
+
+        // 4. Collect BM25 results as TraversalValues
+        // BM25 returns (doc_id, score), we need to look up the actual nodes
+        let label_as_bytes = label.as_bytes();
+        let bm25_iter: Vec<Result<TraversalValue<'arena>, GraphError>> = bm25_results
+            .into_iter()
+            .filter_map(|(id, score)| {
+                if let Ok(Some(value)) = self.storage.nodes_db.get(self.txn, &id) {
+                    if value.len() < LMDB_STRING_HEADER_LENGTH {
+                        return None;
+                    }
+
+                    let length_of_label_in_lmdb =
+                        u64::from_le_bytes(value[..LMDB_STRING_HEADER_LENGTH].try_into().unwrap())
+                            as usize;
+
+                    if length_of_label_in_lmdb != label.len() {
+                        return None;
+                    }
+
+                    if value.len() < length_of_label_in_lmdb + LMDB_STRING_HEADER_LENGTH {
+                        return None;
+                    }
+
+                    let label_in_lmdb = &value[LMDB_STRING_HEADER_LENGTH
+                        ..LMDB_STRING_HEADER_LENGTH + length_of_label_in_lmdb];
+
+                    if label_in_lmdb == label_as_bytes {
+                        match crate::utils::items::Node::from_bincode_bytes(id, value, self.arena) {
+                            Ok(node) => {
+                                return Some(Ok(TraversalValue::NodeWithScore {
+                                    node,
+                                    score: score as f64,
+                                }));
+                            }
+                            Err(e) => {
+                                return Some(Err(GraphError::ConversionError(e.to_string())));
+                            }
+                        }
+                    }
+                }
+                None
+            })
+            .collect();
+
+        // 5. Combine both result sets
+        // Vector results come first, then BM25 results
+        // The RerankRRF/RerankMMR will handle fusion based on their positions
+        let combined_iter = vector_iter.into_iter().chain(bm25_iter.into_iter());
+
+        Ok(RoTraversalIterator {
+            storage: self.storage,
+            arena: self.arena,
+            txn: self.txn,
+            inner: combined_iter,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Integration tests would require full storage setup
+    // Unit tests for the trait signature verification
+
+    #[test]
+    fn test_search_hybrid_trait_exists() {
+        // Verify the trait compiles correctly
+        // Actual integration tests need a full HelixGraphStorage instance
+    }
+}

--- a/helix-db/src/helix_engine/traversal_core/ops/mod.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/mod.rs
@@ -1,5 +1,6 @@
 pub mod bm25;
 pub mod g;
+pub mod hybrid;
 pub mod in_;
 pub mod out;
 pub mod source;

--- a/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
+++ b/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
@@ -20,7 +20,8 @@ use crate::{
             bool_ops::BoExp,
             queries::Query as GeneratedQuery,
             source_steps::{
-                AddE, AddN, AddV, SearchBM25, SearchVector as GeneratedSearchVector, SourceStep,
+                AddE, AddN, AddV, SearchBM25, SearchHybrid as GeneratedSearchHybrid,
+                SearchVector as GeneratedSearchVector, SourceStep,
             },
             statements::Statement as GeneratedStatement,
             traversal_steps::{
@@ -1127,6 +1128,8 @@ pub(crate) fn infer_expr_type<'a>(
         //     }
         //     Type::Vector(add.vector_type.as_deref())
         // }
+        // search hybrid goes here
+        // SearchHybrid(sh) => {}
         SearchVector(sv) => {
             if let Some(ref ty) = sv.vector_type
                 && !ctx.vector_set.contains(ty.as_str())
@@ -1635,6 +1638,190 @@ pub(crate) fn infer_expr_type<'a>(
                     steps: vec![],
                     should_collect: ShouldCollect::ToVec,
                     source_step: Separator::Period(SourceStep::SearchBM25(search_bm25)),
+                    ..Default::default()
+                })),
+            )
+        }
+        SearchHybrid(sh) => {
+            if let Some(ref ty) = sh.label
+                && !ctx.vector_set.contains(ty.as_str())
+            {
+                generate_error!(ctx, original_query, sh.loc.clone(), E103, ty.as_str());
+            }
+
+            // Process vector_data (like SearchVector)
+            let vec: VecData = match &sh.vector_data {
+                Some(VectorData::Vector(v)) => {
+                    VecData::Standard(GeneratedValue::Literal(GenRef::Ref(format!(
+                        "[{}]",
+                        v.iter()
+                            .map(|f| f.to_string())
+                            .collect::<Vec<String>>()
+                            .join(",")
+                    ))))
+                }
+                Some(VectorData::Identifier(i)) => {
+                    is_valid_identifier(ctx, original_query, sh.loc.clone(), i.as_str());
+                    if let Some(var_type) =
+                        type_in_scope(ctx, original_query, sh.loc.clone(), scope, i.as_str())
+                    {
+                        let expected_type = Type::Array(Box::new(Type::Scalar(FieldType::F64)));
+                        if var_type != expected_type {
+                            generate_error!(
+                                ctx,
+                                original_query,
+                                sh.loc.clone(),
+                                E205,
+                                i.as_str(),
+                                &var_type.to_string(),
+                                "[F64]",
+                                "SearchHybrid",
+                                sh.label.as_deref().unwrap_or("unknown")
+                            );
+                        }
+                    }
+                    VecData::Standard(gen_identifier_or_param(
+                        original_query,
+                        i.as_str(),
+                        true,
+                        false,
+                    ))
+                }
+                Some(VectorData::Embed(e)) => {
+                    let embed_data = match &e.value {
+                        EvaluatesToString::Identifier(i) => {
+                            type_in_scope(ctx, original_query, sh.loc.clone(), scope, i.as_str());
+                            EmbedData {
+                                data: gen_identifier_or_param(
+                                    original_query,
+                                    i.as_str(),
+                                    true,
+                                    false,
+                                ),
+                                model_name: gen_query.embedding_model_to_use.clone(),
+                            }
+                        }
+                        EvaluatesToString::StringLiteral(s) => EmbedData {
+                            data: GeneratedValue::Literal(GenRef::Ref(s.clone())),
+                            model_name: gen_query.embedding_model_to_use.clone(),
+                        },
+                        EvaluatesToString::Arguments(args) => {
+                            let concatenated = args.join(" ");
+                            EmbedData {
+                                data: GeneratedValue::Literal(GenRef::Ref(concatenated)),
+                                model_name: gen_query.embedding_model_to_use.clone(),
+                            }
+                        }
+                    };
+                    VecData::Hoisted(gen_query.add_hoisted_embed(embed_data))
+                }
+                _ => {
+                    generate_error!(
+                        ctx,
+                        original_query,
+                        sh.loc.clone(),
+                        E305,
+                        ["vector_data", "SearchHybrid"],
+                        ["vector_data"]
+                    );
+                    VecData::Unknown
+                }
+            };
+
+            // Process query (like BM25Search)
+            let query = match &sh.query {
+                Some(ValueType::Literal { value, loc: _ }) => {
+                    GeneratedValue::Literal(GenRef::Std(value.inner_stringify()))
+                }
+                Some(ValueType::Identifier { value: i, loc: _ }) => {
+                    is_valid_identifier(ctx, original_query, sh.loc.clone(), i.as_str());
+                    if is_in_scope(scope, i.as_str()) {
+                        gen_identifier_or_param(original_query, i, true, false)
+                    } else {
+                        generate_error!(ctx, original_query, sh.loc.clone(), E301, i.as_str());
+                        GeneratedValue::Unknown
+                    }
+                }
+                _ => {
+                    generate_error!(
+                        ctx,
+                        original_query,
+                        sh.loc.clone(),
+                        E305,
+                        ["query", "SearchHybrid"],
+                        ["query"]
+                    );
+                    GeneratedValue::Unknown
+                }
+            };
+
+            // Process k
+            let k = match &sh.k {
+                Some(k) => match &k.value {
+                    EvaluatesToNumberType::I8(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::I16(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::I32(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::I64(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::U8(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::U16(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::U32(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::U64(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::U128(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::Identifier(i) => {
+                        is_valid_identifier(ctx, original_query, sh.loc.clone(), i.as_str());
+                        type_in_scope(ctx, original_query, sh.loc.clone(), scope, i.as_str());
+                        gen_identifier_or_param(original_query, i, false, false)
+                    }
+                    _ => {
+                        generate_error!(
+                            ctx,
+                            original_query,
+                            sh.loc.clone(),
+                            E305,
+                            ["k", "SearchHybrid"],
+                            ["k"]
+                        );
+                        GeneratedValue::Unknown
+                    }
+                },
+                None => {
+                    generate_error!(ctx, original_query, sh.loc.clone(), E601, &sh.loc.span);
+                    GeneratedValue::Unknown
+                }
+            };
+
+            let search_hybrid = GeneratedSearchHybrid {
+                label: GenRef::Literal(sh.label.clone().unwrap_or_default()),
+                vec,
+                query,
+                k,
+            };
+
+            (
+                Type::Vectors(sh.label.clone()),
+                Some(GeneratedStatement::Traversal(GeneratedTraversal {
+                    traversal_type: TraversalType::Ref,
+                    steps: vec![],
+                    should_collect: ShouldCollect::ToVec,
+                    source_step: Separator::Period(SourceStep::SearchHybrid(search_hybrid)),
                     ..Default::default()
                 })),
             )

--- a/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
+++ b/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
@@ -1128,8 +1128,6 @@ pub(crate) fn infer_expr_type<'a>(
         //     }
         //     Type::Vector(add.vector_type.as_deref())
         // }
-        // search hybrid goes here
-        // SearchHybrid(sh) => {}
         SearchVector(sv) => {
             if let Some(ref ty) = sv.vector_type
                 && !ctx.vector_set.contains(ty.as_str())

--- a/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
+++ b/helix-db/src/helixc/analyzer/methods/infer_expr_type.rs
@@ -32,7 +32,7 @@ use crate::{
         },
         parser::types::*,
     },
-    protocol::date::Date,
+    protocol::{date::Date, value::Value},
 };
 use paste::paste;
 use std::collections::HashMap;
@@ -741,7 +741,9 @@ pub(crate) fn infer_expr_type<'a>(
                             false,
                         ),
                         // Parser guarantees edge from_id is Identifier or Literal
-                        _ => unreachable!("parser guarantees edge from_id is Identifier or Literal"),
+                        _ => {
+                            unreachable!("parser guarantees edge from_id is Identifier or Literal")
+                        }
                     },
                     _ => {
                         generate_error!(ctx, original_query, add.loc.clone(), E612);
@@ -1524,7 +1526,10 @@ pub(crate) fn infer_expr_type<'a>(
             }
             let vec = match &bm25_search.data {
                 Some(ValueType::Literal { value, loc: _ }) => {
-                    GeneratedValue::Literal(GenRef::Std(value.inner_stringify()))
+                    GeneratedValue::Literal(GenRef::Std(match value {
+                        Value::String(s) => format!("\"{s}\""),
+                        other => other.inner_stringify(),
+                    }))
                 }
                 Some(ValueType::Identifier { value: i, loc: _ }) => {
                     is_valid_identifier(ctx, original_query, bm25_search.loc.clone(), i.as_str());
@@ -1703,13 +1708,6 @@ pub(crate) fn infer_expr_type<'a>(
                             data: GeneratedValue::Literal(GenRef::Ref(s.clone())),
                             model_name: gen_query.embedding_model_to_use.clone(),
                         },
-                        EvaluatesToString::Arguments(args) => {
-                            let concatenated = args.join(" ");
-                            EmbedData {
-                                data: GeneratedValue::Literal(GenRef::Ref(concatenated)),
-                                model_name: gen_query.embedding_model_to_use.clone(),
-                            }
-                        }
                     };
                     VecData::Hoisted(gen_query.add_hoisted_embed(embed_data))
                 }
@@ -1729,7 +1727,10 @@ pub(crate) fn infer_expr_type<'a>(
             // Process query (like BM25Search)
             let query = match &sh.query {
                 Some(ValueType::Literal { value, loc: _ }) => {
-                    GeneratedValue::Literal(GenRef::Std(value.inner_stringify()))
+                    GeneratedValue::Literal(GenRef::Std(match value {
+                        Value::String(s) => format!("\"{s}\""),
+                        other => other.inner_stringify(),
+                    }))
                 }
                 Some(ValueType::Identifier { value: i, loc: _ }) => {
                     is_valid_identifier(ctx, original_query, sh.loc.clone(), i.as_str());

--- a/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
@@ -3,7 +3,7 @@ use crate::helixc::analyzer::utils::{
     DEFAULT_VAR_NAME, VariableInfo, check_identifier_is_fieldtype,
 };
 use crate::helixc::generator::bool_ops::{Contains, IsIn, PropertyEq, PropertyNeq};
-use crate::helixc::generator::source_steps::{SearchVector, VFromID, VFromType};
+use crate::helixc::generator::source_steps::{SearchHybrid, SearchVector, VFromID, VFromType};
 use crate::helixc::generator::traversal_steps::{AggregateBy, GroupBy};
 use crate::helixc::generator::utils::{EmbedData, VecData};
 use crate::{
@@ -516,6 +516,169 @@ pub(crate) fn validate_traversal<'a>(
                 TraversalType::FromSingle(GenRef::Std(DEFAULT_VAR_NAME.to_string()));
             gen_traversal.source_step = Separator::Empty(SourceStep::Anonymous);
             parent
+        }
+        StartNode::SearchHybrid(sh) => {
+            // Validate label exists in vector set
+            if let Some(ref ty) = sh.label
+                && !ctx.vector_set.contains(ty.as_str())
+            {
+                generate_error!(ctx, original_query, sh.loc.clone(), E103, ty.as_str());
+            }
+
+            // Process vector_data (similar to SearchVector)
+            let vec: VecData = match &sh.vector_data {
+                Some(VectorData::Vector(v)) => {
+                    VecData::Standard(GeneratedValue::Literal(GenRef::Ref(format!(
+                        "[{}]",
+                        v.iter()
+                            .map(|f| f.to_string())
+                            .collect::<Vec<String>>()
+                            .join(",")
+                    ))))
+                }
+                Some(VectorData::Identifier(i)) => {
+                    is_valid_identifier(ctx, original_query, sh.loc.clone(), i.as_str());
+                    let _ = type_in_scope(ctx, original_query, sh.loc.clone(), scope, i.as_str());
+                    VecData::Standard(gen_identifier_or_param(
+                        original_query,
+                        i.as_str(),
+                        true,
+                        false,
+                    ))
+                }
+                Some(VectorData::Embed(e)) => {
+                    let embed_data = match &e.value {
+                        EvaluatesToString::Identifier(i) => {
+                            type_in_scope(ctx, original_query, sh.loc.clone(), scope, i.as_str());
+                            EmbedData {
+                                data: gen_identifier_or_param(
+                                    original_query,
+                                    i.as_str(),
+                                    true,
+                                    false,
+                                ),
+                                model_name: gen_query.embedding_model_to_use.clone(),
+                            }
+                        }
+                        EvaluatesToString::StringLiteral(s) => EmbedData {
+                            data: GeneratedValue::Literal(GenRef::Ref(s.clone())),
+                            model_name: gen_query.embedding_model_to_use.clone(),
+                        },
+                        EvaluatesToString::Arguments(args) => {
+                            let concatenated = args.join(" ");
+                            EmbedData {
+                                data: GeneratedValue::Literal(GenRef::Ref(concatenated)),
+                                model_name: gen_query.embedding_model_to_use.clone(),
+                            }
+                        }
+                    };
+                    VecData::Hoisted(gen_query.add_hoisted_embed(embed_data))
+                }
+                _ => {
+                    generate_error!(
+                        ctx,
+                        original_query,
+                        sh.loc.clone(),
+                        E305,
+                        ["vector_data", "SearchHybrid"],
+                        ["vector_data"]
+                    );
+                    VecData::Unknown
+                }
+            };
+
+            // Process query (similar to BM25Search)
+            let query = match &sh.query {
+                Some(ValueType::Literal { value, loc: _ }) => {
+                    GeneratedValue::Literal(GenRef::Std(value.inner_stringify()))
+                }
+                Some(ValueType::Identifier { value: i, loc: _ }) => {
+                    is_valid_identifier(ctx, original_query, sh.loc.clone(), i.as_str());
+                    if let Some(_) =
+                        type_in_scope(ctx, original_query, sh.loc.clone(), scope, i.as_str())
+                    {
+                        gen_identifier_or_param(original_query, i, true, false)
+                    } else {
+                        generate_error!(ctx, original_query, sh.loc.clone(), E301, i.as_str());
+                        GeneratedValue::Unknown
+                    }
+                }
+                _ => {
+                    generate_error!(
+                        ctx,
+                        original_query,
+                        sh.loc.clone(),
+                        E305,
+                        ["query", "SearchHybrid"],
+                        ["query"]
+                    );
+                    GeneratedValue::Unknown
+                }
+            };
+
+            // Process k
+            let k = match &sh.k {
+                Some(k) => match &k.value {
+                    EvaluatesToNumberType::I8(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::I16(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::I32(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::I64(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::U8(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::U16(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::U32(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::U64(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::U128(i) => {
+                        GeneratedValue::Primitive(GenRef::Std(i.to_string()))
+                    }
+                    EvaluatesToNumberType::Identifier(i) => {
+                        is_valid_identifier(ctx, original_query, sh.loc.clone(), i.as_str());
+                        type_in_scope(ctx, original_query, sh.loc.clone(), scope, i.as_str());
+                        gen_identifier_or_param(original_query, i, false, true)
+                    }
+                    _ => {
+                        generate_error!(
+                            ctx,
+                            original_query,
+                            sh.loc.clone(),
+                            E305,
+                            ["k", "SearchHybrid"],
+                            ["k"]
+                        );
+                        GeneratedValue::Unknown
+                    }
+                },
+                None => {
+                    generate_error!(ctx, original_query, sh.loc.clone(), E601, &sh.loc.span);
+                    GeneratedValue::Unknown
+                }
+            };
+
+            gen_traversal.traversal_type = TraversalType::Ref;
+            gen_traversal.should_collect = ShouldCollect::ToVec;
+            gen_traversal.source_step = Separator::Period(SourceStep::SearchHybrid(SearchHybrid {
+                label: GenRef::Literal(sh.label.clone().unwrap_or_default()),
+                vec,
+                query,
+                k,
+            }));
+            // SearchHybrid returns vectors (like SearchVector)
+            Type::Vectors(sh.label.clone())
         }
         StartNode::SearchVector(sv) => {
             if let Some(ref ty) = sv.vector_type

--- a/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
@@ -564,13 +564,6 @@ pub(crate) fn validate_traversal<'a>(
                             data: GeneratedValue::Literal(GenRef::Ref(s.clone())),
                             model_name: gen_query.embedding_model_to_use.clone(),
                         },
-                        EvaluatesToString::Arguments(args) => {
-                            let concatenated = args.join(" ");
-                            EmbedData {
-                                data: GeneratedValue::Literal(GenRef::Ref(concatenated)),
-                                model_name: gen_query.embedding_model_to_use.clone(),
-                            }
-                        }
                     };
                     VecData::Hoisted(gen_query.add_hoisted_embed(embed_data))
                 }
@@ -590,7 +583,10 @@ pub(crate) fn validate_traversal<'a>(
             // Process query (similar to BM25Search)
             let query = match &sh.query {
                 Some(ValueType::Literal { value, loc: _ }) => {
-                    GeneratedValue::Literal(GenRef::Std(value.inner_stringify()))
+                    GeneratedValue::Literal(GenRef::Std(match value {
+                        Value::String(s) => format!("\"{s}\""),
+                        other => other.inner_stringify(),
+                    }))
                 }
                 Some(ValueType::Identifier { value: i, loc: _ }) => {
                     is_valid_identifier(ctx, original_query, sh.loc.clone(), i.as_str());

--- a/helix-db/src/helixc/generator/source_steps.rs
+++ b/helix-db/src/helixc/generator/source_steps.rs
@@ -38,6 +38,8 @@ pub enum SourceStep {
     SearchVector(SearchVector),
     /// Search for vectors using BM25
     SearchBM25(SearchBM25),
+    /// Search with vectors and BM25
+    SearchHybrid(SearchHybrid),
     Upsert(Upsert),
     /// Traversal starts from an anonymous node
     Anonymous,
@@ -408,6 +410,7 @@ impl Display for SourceStep {
             SourceStep::EFromType(e_from_type) => write!(f, "{e_from_type}"),
             SourceStep::SearchVector(search_vector) => write!(f, "{search_vector}"),
             SourceStep::SearchBM25(search_bm25) => write!(f, "{search_bm25}"),
+            SourceStep::SearchHybrid(search_hybrid) => write!(f, "{search_hybrid}"),
             SourceStep::Upsert(upsert) => write!(f, "upsert({:?})", upsert),
             SourceStep::Anonymous => write!(f, ""),
             SourceStep::Empty => {
@@ -453,6 +456,28 @@ impl Display for SearchVector {
                 self.vec, self.k, self.label,
             ),
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SearchHybrid {
+    /// Label of vector type to search
+    pub label: GenRef<String>,
+    /// Vector data for similarity search
+    pub vec: VecData,
+    /// Query string for BM25 search
+    pub query: GeneratedValue,
+    /// Number of results to return
+    pub k: GeneratedValue,
+}
+
+impl Display for SearchHybrid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "search_hybrid({}, {}, {}, {})?",
+            self.label, self.vec, self.query, self.k
+        )
     }
 }
 

--- a/helix-db/src/helixc/generator/utils.rs
+++ b/helix-db/src/helixc/generator/utils.rs
@@ -59,14 +59,20 @@ where
             GenRef::RefLiteral(t) => t,
             GenRef::Unknown => {
                 // This should have been caught during analysis
-                debug_assert!(false, "Code generation error: Unknown reference type encountered. This indicates a bug in the analyzer.");
+                debug_assert!(
+                    false,
+                    "Code generation error: Unknown reference type encountered. This indicates a bug in the analyzer."
+                );
                 // Return a placeholder that will cause a compile error downstream
                 unreachable!("GenRef::Unknown should have been caught by analyzer")
             }
             GenRef::Std(t) => t,
             GenRef::Id(_) => {
                 // Id doesn't have an inner T, it's just a String identifier
-                debug_assert!(false, "Code generation error: Cannot get inner value of Id type. Use the identifier directly.");
+                debug_assert!(
+                    false,
+                    "Code generation error: Cannot get inner value of Id type. Use the identifier directly."
+                );
                 unreachable!("GenRef::Id does not have an inner T")
             }
         }
@@ -216,7 +222,10 @@ pub fn write_properties_slice(properties: &Option<Vec<(String, GeneratedValue)>>
             )
         }
         None => {
-            debug_assert!(false, "write_properties_slice called with None - should be caught by analyzer");
+            debug_assert!(
+                false,
+                "write_properties_slice called with None - should be caught by analyzer"
+            );
             "&[]".to_string()
         }
     }
@@ -260,12 +269,18 @@ impl GeneratedValue {
             GeneratedValue::Traversal(_) => {
                 // This should not be called for traversals
                 // The caller should handle traversals specially
-                debug_assert!(false, "Code generation error: Cannot get inner value of Traversal. Traversals should be handled specially.");
+                debug_assert!(
+                    false,
+                    "Code generation error: Cannot get inner value of Traversal. Traversals should be handled specially."
+                );
                 unreachable!("GeneratedValue::Traversal does not have an inner GenRef")
             }
             GeneratedValue::Unknown => {
                 // This indicates a bug in the analyzer
-                debug_assert!(false, "Code generation error: Unknown GeneratedValue encountered. This indicates incomplete type inference in the analyzer.");
+                debug_assert!(
+                    false,
+                    "Code generation error: Unknown GeneratedValue encountered. This indicates incomplete type inference in the analyzer."
+                );
                 unreachable!("GeneratedValue::Unknown should have been caught by analyzer")
             }
         }
@@ -442,6 +457,7 @@ use helix_db::{
             config::{Config, GraphConfig, VectorConfig},
             ops::{
                 bm25::search_bm25::SearchBM25Adapter,
+                hybrid::SearchHybridAdapter,
                 g::G,
                 in_::{in_::InAdapter, in_e::InEdgesAdapter, to_n::ToNAdapter, to_v::ToVAdapter},
                 out::{

--- a/helix-db/src/helixc/parser/traversal_parse_methods.rs
+++ b/helix-db/src/helixc/parser/traversal_parse_methods.rs
@@ -207,6 +207,7 @@ impl HelixParser {
             }
             Rule::identifier => Ok(StartNode::Identifier(pair.as_str().to_string())),
             Rule::search_vector => Ok(StartNode::SearchVector(self.parse_search_vector(pair)?)),
+            Rule::search_hybrid => Ok(StartNode::SearchHybrid(self.parse_search_hybrid(pair)?)),
             Rule::start_vector => {
                 let pairs = pair.into_inner();
                 let mut vector_type = String::new();

--- a/helix-db/src/helixc/parser/types.rs
+++ b/helix-db/src/helixc/parser/types.rs
@@ -609,6 +609,7 @@ pub enum ExpressionType {
     Or(Vec<Expression>),
     SearchVector(SearchVector),
     BM25Search(BM25Search),
+    SearchHybrid(SearchHybrid),
     MathFunctionCall(MathFunctionCall),
     Empty,
 }
@@ -640,6 +641,7 @@ impl Debug for ExpressionType {
             ExpressionType::Or(exprs) => write!(f, "Or({exprs:?})"),
             ExpressionType::SearchVector(sv) => write!(f, "SearchVector({sv:?})"),
             ExpressionType::BM25Search(bm25) => write!(f, "BM25Search({bm25:?})"),
+            ExpressionType::SearchHybrid(sh) => write!(f, "SearchHybrid({sh:?})"),
             ExpressionType::MathFunctionCall(mfc) => write!(f, "MathFunctionCall({mfc:?})"),
             ExpressionType::Empty => write!(f, "Empty"),
         }
@@ -664,6 +666,7 @@ impl Display for ExpressionType {
             ExpressionType::Or(exprs) => write!(f, "Or({exprs:?})"),
             ExpressionType::SearchVector(sv) => write!(f, "SearchVector({sv:?})"),
             ExpressionType::BM25Search(bm25) => write!(f, "BM25Search({bm25:?})"),
+            ExpressionType::SearchHybrid(sh) => write!(f, "SearchHybrid({sh:?})"),
             ExpressionType::MathFunctionCall(mfc) => {
                 write!(f, "{}({:?})", mfc.function.name(), mfc.args)
             }
@@ -702,6 +705,7 @@ pub enum StartNode {
         ids: Option<Vec<IdType>>,
     },
     SearchVector(SearchVector),
+    SearchHybrid(SearchHybrid),
     Identifier(String),
     Anonymous,
 }
@@ -859,6 +863,7 @@ pub enum GraphStepType {
     ShortestPathBFS(ShortestPathBFS),
     ShortestPathAStar(ShortestPathAStar),
     SearchVector(SearchVector),
+    SearchHybrid(SearchHybrid),
 }
 impl GraphStep {
     pub fn get_item_type(&self) -> Option<String> {
@@ -867,7 +872,8 @@ impl GraphStep {
             GraphStepType::In(s) => Some(s.clone()),
             GraphStepType::OutE(s) => Some(s.clone()),
             GraphStepType::InE(s) => Some(s.clone()),
-            GraphStepType::SearchVector(s) => s.vector_type.clone(),
+            GraphStepType::SearchVector(s) => Some(s.vector_type.clone().unwrap()),
+            GraphStepType::SearchHybrid(s) => Some(s.label.clone().unwrap()),
             _ => None,
         }
     }
@@ -977,6 +983,15 @@ pub struct BM25Search {
     pub loc: Loc,
     pub type_arg: Option<String>,
     pub data: Option<ValueType>,
+    pub k: Option<EvaluatesToNumber>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchHybrid {
+    pub loc: Loc,
+    pub label: Option<String>,
+    pub vector_data: Option<VectorData>,
+    pub query: Option<ValueType>,
     pub k: Option<EvaluatesToNumber>,
 }
 

--- a/hql-tests/tests/search_hybrid/config.hx.json
+++ b/hql-tests/tests/search_hybrid/config.hx.json
@@ -1,0 +1,14 @@
+{
+  "vector_config": {
+    "m": 16,
+    "ef_construction": 128,
+    "ef_search": 768,
+    "db_max_size": 20
+  },
+  "graph_config": {
+    "secondary_indices": []
+  },
+  "db_max_size_gb": 20,
+  "mcp": true,
+  "bm25": true
+}

--- a/hql-tests/tests/search_hybrid/helix.toml
+++ b/hql-tests/tests/search_hybrid/helix.toml
@@ -1,0 +1,9 @@
+[project]
+name = "search_hybrid"
+queries = "."
+
+[local.dev]
+port = 6969
+build_mode = "dev"
+
+[cloud]

--- a/hql-tests/tests/search_hybrid/queries.hx
+++ b/hql-tests/tests/search_hybrid/queries.hx
@@ -1,0 +1,65 @@
+// Test schema for hybrid search (vector + BM25)
+V::Document {
+    content: String,
+}
+
+N::Article {
+    title: String,
+    content: String,
+}
+
+// Test 1: Basic SearchHybrid with vector and text query
+QUERY testHybridBasic(query_vec: [F64]) =>
+    results <- SearchHybrid<Document>(query_vec, "search query", 10)
+    RETURN results
+
+// Test 2: SearchHybrid with Embed for vector
+QUERY testHybridWithEmbed(query_text: String) =>
+    results <- SearchHybrid<Document>(Embed(query_text), query_text, 10)
+    RETURN results
+
+// Test 3: SearchHybrid with variable k
+QUERY testHybridVariableK(query_vec: [F64], search_text: String, k: I32) =>
+    results <- SearchHybrid<Document>(query_vec, search_text, k)
+    RETURN results
+
+// Test 4: SearchHybrid with RerankRRF (main use case)
+QUERY testHybridWithRRF(query_vec: [F64]) =>
+    results <- SearchHybrid<Document>(query_vec, "search query", 10)
+        ::RerankRRF
+    RETURN results
+
+// Test 5: SearchHybrid with RerankRRF custom k
+QUERY testHybridWithRRFCustomK(query_vec: [F64], rrf_k: F64) =>
+    results <- SearchHybrid<Document>(query_vec, "search query", 20)
+        ::RerankRRF(k: rrf_k)
+        ::RANGE(0, 10)
+    RETURN results
+
+// Test 6: SearchHybrid with RerankMMR for diversity
+QUERY testHybridWithMMR(query_vec: [F64]) =>
+    results <- SearchHybrid<Document>(query_vec, "search query", 20)
+        ::RerankMMR(lambda: 0.7)
+        ::RANGE(0, 10)
+    RETURN results
+
+// Test 7: SearchHybrid with identifier for query text
+QUERY testHybridWithIdentifierQuery(query_vec: [F64], search_text: String) =>
+    results <- SearchHybrid<Document>(query_vec, search_text, 10)
+        ::RerankRRF
+    RETURN results
+
+// Test 8: SearchHybrid with chained rerankers
+QUERY testHybridChainedRerankers(query_vec: [F64]) =>
+    results <- SearchHybrid<Document>(query_vec, "search query", 50)
+        ::RerankRRF(k: 60)
+        ::RerankMMR(lambda: 0.5)
+        ::RANGE(0, 10)
+    RETURN results
+
+// Test 9: SearchHybrid with Embed and variable query
+QUERY testHybridEmbedVariable(query_text: String) =>
+    results <- SearchHybrid<Document>(Embed(query_text), query_text, 15)
+        ::RerankRRF
+        ::RANGE(0, 5)
+    RETURN results

--- a/hql-tests/tests/search_hybrid/schema.hx
+++ b/hql-tests/tests/search_hybrid/schema.hx
@@ -1,0 +1,21 @@
+// Schema for SearchHybrid tests
+// SearchHybrid combines vector similarity search with BM25 keyword search
+
+// Vector schema for documents with embeddings
+V::Document {
+    content: String,
+    title: String,
+}
+
+// Node schema for articles (used in some hybrid search scenarios)
+N::Article {
+    title: String,
+    content: String,
+    category: String,
+}
+
+// Edge connecting articles to their document embeddings
+E::HasEmbedding {
+    From: Article,
+    To: Document,
+}


### PR DESCRIPTION
## Description
implements a new `SearchHybrid` operator that runs both vector (HNSW) and BM25 keyword searches, returning combined results that can be fused using existing `RerankRRF` or `RerankMMR` steps.

This feature lets users combine vector search and keyword-based in a single query

## Related Issues
N/A

Closes #828 

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `SearchHybrid` operator that combines vector similarity search (HNSW) with BM25 keyword search, allowing users to leverage both semantic and keyword-based retrieval in a single query. Results are returned as a combined iterator that can be fused using existing `RerankRRF` or `RerankMMR` operators.

**Key Changes:**
- Implemented `SearchHybridAdapter` trait in runtime that executes both vector and BM25 searches, returning combined results
- Extended grammar, parser, analyzer, and code generator to support `SearchHybrid<Label>(vector_data, query_text, k)` syntax
- Added comprehensive test coverage with 9 test queries covering various usage patterns
- Fixed string literal formatting for BM25 queries (wrapping strings in quotes)

**Architecture:**
The implementation follows the existing pattern of `SearchVector` and `SearchBM25`, integrating cleanly into the compiler pipeline from parsing through code generation. Vector results are returned first, followed by BM25 results, allowing downstream rerankers to properly fuse them based on position.

**Testing:**
Tests cover basic usage, `Embed()` for vector generation, variable parameters, and chaining with `RerankRRF` and `RerankMMR` operators.

**Checklist Status:**
Two checklist items remain unchecked: doc comments and version number updates. Consider adding doc comments to key public functions and updating version numbers before merging.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/src/helix_engine/traversal_core/ops/hybrid/search_hybrid.rs | New hybrid search implementation combining vector and BM25 search. Returns combined results as chained iterators. Implementation looks solid with proper error handling. |
| helix-db/src/grammar.pest | Grammar updated to add `search_hybrid` rule with proper syntax for vector_data, query text, and k parameter. Follows existing patterns for SearchV and SearchBM25. |
| helix-db/src/helixc/analyzer/methods/infer_expr_type.rs | Added type inference for SearchHybrid expression. Validates vector data, query string, and k parameter. Includes string formatting fix for BM25 literals. |
| helix-db/src/helixc/analyzer/methods/traversal_validation.rs | Added traversal validation for SearchHybrid, validates label exists in vector set, processes vector_data, query, and k parameters similar to SearchVector and SearchBM25. |
| helix-db/src/helixc/parser/expression_parse_methods.rs | Added parse_search_hybrid method to parse SearchHybrid syntax including label, vector_data, query, and k. Properly handles identifiers, string literals, and Embed expressions. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Parser
    participant Analyzer
    participant Generator
    participant Runtime
    participant VectorSearch
    participant BM25Search

    User->>Parser: SearchHybrid<Document>(vec, "query", 10)
    Parser->>Parser: parse_search_hybrid()
    Parser->>Parser: Extract label, vector_data, query, k
    Parser-->>Analyzer: SearchHybrid AST

    Analyzer->>Analyzer: infer_expr_type()
    Analyzer->>Analyzer: Validate label exists in vector_set
    Analyzer->>Analyzer: Process vector_data (literal/identifier/Embed)
    Analyzer->>Analyzer: Process query (string/identifier)
    Analyzer->>Analyzer: Process k parameter
    Analyzer-->>Generator: GeneratedSearchHybrid

    Generator->>Generator: Generate Rust code
    Generator->>Generator: Format: search_hybrid(label, vec, query, k)?
    Generator-->>Runtime: Compiled trait method call

    Runtime->>Runtime: search_hybrid() execution
    Runtime->>VectorSearch: vectors.search(query_vec, k, label)
    VectorSearch-->>Runtime: Vec<HVector> with scores
    
    Runtime->>BM25Search: bm25.search(query_text, k)
    BM25Search-->>Runtime: Vec<(doc_id, score)>
    
    Runtime->>Runtime: Convert vectors to TraversalValue::Vector
    Runtime->>Runtime: Lookup BM25 doc_ids in nodes_db
    Runtime->>Runtime: Filter by label
    Runtime->>Runtime: Convert to TraversalValue::NodeWithScore
    Runtime->>Runtime: Chain vector_results + bm25_results
    Runtime-->>User: RoTraversalIterator with combined results
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->