### PR TITLE
Add @helix-db/migrate tool for Supabase to HelixDB migration

### DIFF
--- a/tools/migrate/.gitignore
+++ b/tools/migrate/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/tools/migrate/BLANK_SLATE_SUPABASE_TO_LOCAL_HELIX_GUIDE.md
+++ b/tools/migrate/BLANK_SLATE_SUPABASE_TO_LOCAL_HELIX_GUIDE.md
@@ -1,0 +1,249 @@
+# Blank-Slate Guide: Supabase -> Local Helix Migration
+
+This guide takes an engineer from zero setup to a successful migration from a fresh Supabase project into a local Helix instance running via the Helix CLI.
+
+It uses:
+
+- Supabase Cloud (free tier is fine)
+- Local Helix via `helix push dev`
+- The migration tool in this repo (`tools/migrate`)
+
+---
+
+## 1) Prerequisites
+
+Install these first:
+
+- `git`
+- Node.js `>=18` and `npm`
+- Helix CLI
+
+Install Helix CLI:
+
+```bash
+curl -sSL "https://install.helix-db.com" | bash
+helix --version
+```
+
+switch to branch and install migration dependencies:
+
+```bash
+git switch claude/supabase-helix-migration-zqJvP
+cd helix-db
+npm --prefix tools/migrate ci
+npm --prefix tools/migrate run build
+```
+
+---
+
+## 2) Create a Supabase Project
+
+1. Go to https://supabase.com and create a new project.
+2. Wait for it to finish provisioning.
+3. Open **Project Settings -> Database -> Connection string -> URI**.
+4. Copy the URI and keep it handy. It should look like:
+
+```text
+postgresql://postgres:<PASSWORD>@<HOST>:5432/postgres?sslmode=require
+```
+
+Set it in your shell:
+
+```bash
+export SUPABASE_DB_URL='postgresql://postgres:<PASSWORD>@<HOST>:5432/postgres?sslmode=require'
+```
+
+---
+
+## 3) Seed Supabase with Test Data
+
+In Supabase, open **SQL Editor** and run the script below.
+
+This creates:
+
+- `profiles` (users)
+- `posts` (FK to profiles)
+- `documents` (FK to profiles + vector embeddings)
+
+```sql
+create extension if not exists pgcrypto;
+create extension if not exists vector;
+
+drop table if exists documents cascade;
+drop table if exists posts cascade;
+drop table if exists profiles cascade;
+
+create table profiles (
+  id uuid primary key,
+  email text not null unique,
+  full_name text not null,
+  age integer not null,
+  metadata jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create table posts (
+  id uuid primary key,
+  author_id uuid not null references profiles(id),
+  title text not null,
+  body text not null,
+  published boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create table documents (
+  id uuid primary key,
+  owner_id uuid not null references profiles(id),
+  content text not null,
+  embedding vector(3) not null,
+  created_at timestamptz not null default now()
+);
+
+insert into profiles (id, email, full_name, age, metadata) values
+  ('11111111-1111-1111-1111-111111111111', 'alice@example.com', 'Alice Doe', 31, '{"plan":"pro","region":"us"}'),
+  ('22222222-2222-2222-2222-222222222222', 'bob@example.com', 'Bob Doe', 27, '{"plan":"free","region":"eu"}'),
+  ('33333333-3333-3333-3333-333333333333', 'carol@example.com', 'Carol Doe', 35, '{"plan":"team","region":"us"}');
+
+insert into posts (id, author_id, title, body, published) values
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1', '11111111-1111-1111-1111-111111111111', 'Hello Helix', 'Migrating from Supabase', true),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2', '11111111-1111-1111-1111-111111111111', 'Second Post', 'Still testing', false),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3', '22222222-2222-2222-2222-222222222222', 'Bob Post', 'Hi there', true),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa4', '33333333-3333-3333-3333-333333333333', 'Carol Post', 'Ship it', true);
+
+insert into documents (id, owner_id, content, embedding) values
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1', '11111111-1111-1111-1111-111111111111', 'Alice document', '[0.10, 0.20, 0.30]'::vector),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb2', '22222222-2222-2222-2222-222222222222', 'Bob document',   '[0.30, 0.10, 0.50]'::vector),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb3', '33333333-3333-3333-3333-333333333333', 'Carol document', '[0.90, 0.40, 0.20]'::vector);
+```
+
+---
+
+## 4) Generate Helix Project from Supabase Schema
+
+From repo root:
+
+```bash
+node tools/migrate/dist/index.js supabase \
+  --connection-string "$SUPABASE_DB_URL" \
+  --output ./tmp/helix-project \
+  --export-dir ./tmp/helix-export \
+  --non-interactive \
+  --introspect-only
+```
+
+What this does:
+
+- introspects Supabase schema
+- generates `schema.hx`, `queries.hx`, `import.hx`
+- writes migration manifest at `./tmp/helix-project/.helix-migrate/manifest.json`
+- runs `helix check` on generated project (unless you pass `--skip-helix-check`)
+
+---
+
+## 5) Start Local Helix
+
+In terminal A:
+
+```bash
+cd ./tmp/helix-project
+helix push dev
+```
+
+Keep this terminal running.
+
+---
+
+## 6) Run Full Migration
+
+In terminal B (repo root):
+
+```bash
+node tools/migrate/dist/index.js supabase \
+  --connection-string "$SUPABASE_DB_URL" \
+  --output ./tmp/helix-project \
+  --export-dir ./tmp/helix-export \
+  --helix-url http://localhost:6969 \
+  --non-interactive
+```
+
+Notes:
+
+- Strict mode is on by default. The command fails if warnings/errors occur.
+- If you explicitly want partial migration behavior, add `--no-strict`.
+
+---
+
+## 7) Verify Migration
+
+Check migration summary:
+
+```bash
+jq '{nodesImported, edgesImported, vectorsImported, errorCount, warnings}' ./tmp/helix-export/migration-report.json
+```
+
+For the seed data above, expected totals are:
+
+- `nodesImported`: `10` (`3 profiles + 4 posts + 3 documents`)
+- `edgesImported`: `7` (`posts.author_id + documents.owner_id`)
+- `vectorsImported`: `3`
+
+Check original->new ID mapping:
+
+```bash
+jq 'keys' ./tmp/helix-export/id_mapping.json
+```
+
+Fetch one migrated profile through Helix API:
+
+```bash
+PROFILE_ID=$(jq -r '."public.profiles"["[\"11111111-1111-1111-1111-111111111111\"]"]' ./tmp/helix-export/id_mapping.json)
+
+curl -s http://localhost:6969/GetProfile \
+  -H 'content-type: application/json' \
+  -d "{\"id\":\"$PROFILE_ID\"}" | jq
+```
+
+---
+
+## 8) Test Import-Only Re-run
+
+You can re-import without re-introspecting:
+
+```bash
+node tools/migrate/dist/index.js supabase \
+  --import-only \
+  --output ./tmp/helix-project \
+  --export-dir ./tmp/helix-export \
+  --helix-url http://localhost:6969 \
+  --non-interactive
+```
+
+This uses only generated artifacts + exported JSON.
+
+---
+
+## 9) Useful Flags
+
+- `--bigint-mode string|i64` (default `string`)
+- `--include-tables public.profiles,public.posts`
+- `--exclude-tables public.audit_logs`
+- `--skip-helix-check` (skip compile gate)
+- `--no-strict` (allow partial migration)
+
+---
+
+## 10) Troubleshooting
+
+- **`helix check` fails**
+  - open `./tmp/helix-project/db/schema.hx` and `./tmp/helix-project/db/queries.hx`, fix schema/query mismatches, rerun migration.
+
+- **Strict mode fails with warnings/errors**
+  - inspect `./tmp/helix-export/migration-report.json`.
+  - fix root cause and rerun, or use `--no-strict` if partial migration is acceptable.
+
+- **Cannot connect to Supabase**
+  - confirm DB URL password/host/port.
+  - ensure `sslmode=require` is present.
+
+- **Helix API connection refused**
+  - ensure `helix push dev` is running and the URL matches `--helix-url`.

--- a/tools/migrate/README.md
+++ b/tools/migrate/README.md
@@ -1,0 +1,17 @@
+# @helix-db/migrate
+
+White-glove migration CLI for moving Supabase data to HelixDB.
+
+## Quick start
+
+```bash
+npx @helix-db/migrate supabase \
+  --connection-string "<SUPABASE_DB_URL>" \
+  --schemas "public" \
+  --helix-url "http://localhost:6969" \
+  --reset-instance --yes --non-interactive
+```
+
+See `BLANK_SLATE_SUPABASE_TO_LOCAL_HELIX_GUIDE.md` for full setup details.
+
+If you already have an existing Supabase database and existing Helix instance, use `EXISTING_SUPABASE_EXISTING_HELIX_GUIDE.md`.

--- a/tools/migrate/package-lock.json
+++ b/tools/migrate/package-lock.json
@@ -1,0 +1,835 @@
+{
+  "name": "@helix-db/migrate",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@helix-db/migrate",
+      "version": "0.1.0",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^12.1.0",
+        "ora": "^5.4.1",
+        "pg": "^8.13.0",
+        "prompts": "^2.4.2"
+      },
+      "bin": {
+        "helix-migrate": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/pg": "^8.11.0",
+        "@types/prompts": "^2.4.9",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
+      "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/prompts": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.9.tgz",
+      "integrity": "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "kleur": "^3.0.3"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.11.0",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
+      "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
+      "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+      "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/tools/migrate/package.json
+++ b/tools/migrate/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "test": "npm run build && node --test tests/*.test.js",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts"
   },

--- a/tools/migrate/package.json
+++ b/tools/migrate/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@helix-db/migrate",
+  "version": "0.1.0",
+  "description": "White-glove migration tool for moving from Supabase to HelixDB",
+  "main": "dist/index.js",
+  "bin": {
+    "helix-migrate": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "pg": "^8.13.0",
+    "chalk": "^4.1.2",
+    "ora": "^5.4.1",
+    "prompts": "^2.4.2",
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/pg": "^8.11.0",
+    "@types/prompts": "^2.4.9",
+    "typescript": "^5.6.0",
+    "ts-node": "^10.9.2"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "AGPL-3.0"
+}

--- a/tools/migrate/package.json
+++ b/tools/migrate/package.json
@@ -3,11 +3,18 @@
   "version": "0.1.0",
   "description": "White-glove migration tool for moving from Supabase to HelixDB",
   "main": "dist/index.js",
+  "files": [
+    "dist/**",
+    "README.md",
+    "BLANK_SLATE_SUPABASE_TO_LOCAL_HELIX_GUIDE.md",
+    "EXISTING_SUPABASE_EXISTING_HELIX_GUIDE.md"
+  ],
   "bin": {
     "helix-migrate": "dist/index.js"
   },
   "scripts": {
     "build": "tsc",
+    "prepack": "npm run build",
     "test": "npm run build && node --test tests/*.test.js",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts"
@@ -28,6 +35,9 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "license": "AGPL-3.0"
 }

--- a/tools/migrate/src/export-data.ts
+++ b/tools/migrate/src/export-data.ts
@@ -9,13 +9,14 @@ import { Client } from "pg";
 import * as fs from "fs";
 import * as path from "path";
 import { TableInfo, ColumnInfo } from "./introspect";
-import { mapPgType } from "./type-map";
+import { mapPgType, TypeMappingOptions } from "./type-map";
 
 export interface ExportOptions {
   connectionString: string;
   tables: TableInfo[];
   outputDir: string;
   batchSize: number; // rows per batch for large tables
+  typeMappingOptions: TypeMappingOptions;
 }
 
 export interface ExportResult {
@@ -31,7 +32,7 @@ export interface ExportResult {
 export async function exportData(
   options: ExportOptions
 ): Promise<ExportResult[]> {
-  const { connectionString, tables, outputDir, batchSize } = options;
+  const { connectionString, tables, outputDir, batchSize, typeMappingOptions } = options;
 
   // Ensure output directory exists
   fs.mkdirSync(outputDir, { recursive: true });
@@ -43,11 +44,20 @@ export async function exportData(
 
   try {
     for (const table of tables) {
-      const filePath = path.join(outputDir, `${table.name}.json`);
-      const rowCount = await exportTable(client, table, filePath, batchSize);
+      const filePath = path.join(
+        outputDir,
+        exportFileNameForTable(table.schema, table.name)
+      );
+      const rowCount = await exportTable(
+        client,
+        table,
+        filePath,
+        batchSize,
+        typeMappingOptions
+      );
 
       results.push({
-        table: table.name,
+        table: makeTableKey(table.schema, table.name),
         rowCount,
         filePath,
       });
@@ -67,7 +77,8 @@ async function exportTable(
   client: Client,
   table: TableInfo,
   filePath: string,
-  batchSize: number
+  batchSize: number,
+  typeMappingOptions: TypeMappingOptions
 ): Promise<number> {
   const schema = table.schema;
   const tableName = table.name;
@@ -82,7 +93,9 @@ async function exportTable(
       `SELECT ${columnNames} FROM "${schema}"."${tableName}"`
     );
 
-    const rows = result.rows.map((row) => transformRow(row, columns));
+    const rows = result.rows.map((row, idx) =>
+      transformRow(row, columns, makeTableKey(schema, tableName), idx, typeMappingOptions)
+    );
     fs.writeFileSync(filePath, JSON.stringify(rows, null, 2));
     return rows.length;
   }
@@ -108,8 +121,15 @@ async function exportTable(
 
     if (result.rows.length === 0) break;
 
-    for (const row of result.rows) {
-      const transformed = transformRow(row, columns);
+    for (let rowOffset = 0; rowOffset < result.rows.length; rowOffset += 1) {
+      const row = result.rows[rowOffset];
+      const transformed = transformRow(
+        row,
+        columns,
+        makeTableKey(schema, tableName),
+        offset + rowOffset,
+        typeMappingOptions
+      );
       if (!isFirst) {
         writeStream.write(",\n");
       }
@@ -141,7 +161,10 @@ async function exportTable(
  */
 function transformRow(
   row: Record<string, unknown>,
-  columns: ColumnInfo[]
+  columns: ColumnInfo[],
+  tableKey: string,
+  rowIndex: number,
+  typeMappingOptions: TypeMappingOptions
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
@@ -153,22 +176,21 @@ function transformRow(
       continue;
     }
 
-    const mapped = mapPgType(col.dataType, col.udtName);
+    const mapped = mapPgType(col.dataType, col.udtName, typeMappingOptions);
 
-    if (mapped.needsSerialization) {
-      // Serialize complex types to JSON string
-      result[col.name] =
-        typeof value === "string" ? value : JSON.stringify(value);
-    } else if (mapped.isVector) {
-      // Ensure vector is an array of numbers
-      if (typeof value === "string") {
-        // pgvector returns vectors as strings like "[1,2,3]"
-        result[col.name] = JSON.parse(value);
+    try {
+      if (mapped.needsSerialization) {
+        result[col.name] = serializeComplex(value);
+      } else if (mapped.isVector) {
+        result[col.name] = normalizeVector(value);
       } else {
-        result[col.name] = value;
+        result[col.name] = coerceScalar(value, mapped.helixType);
       }
-    } else {
-      result[col.name] = value;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Failed to coerce ${tableKey} row ${rowIndex} column ${col.name} (${col.dataType} -> ${mapped.helixType}): ${message}`
+      );
     }
   }
 
@@ -183,4 +205,170 @@ export function readExportedData(
 ): Record<string, unknown>[] {
   const content = fs.readFileSync(filePath, "utf-8");
   return JSON.parse(content);
+}
+
+export function makeTableKey(schema: string, table: string): string {
+  return `${schema}.${table}`;
+}
+
+export function exportFileNameForTable(schema: string, table: string): string {
+  const safeSchema = schema.replace(/[^A-Za-z0-9_-]+/g, "_");
+  const safeTable = table.replace(/[^A-Za-z0-9_-]+/g, "_");
+  return `${safeSchema}__${safeTable}.json`;
+}
+
+function serializeComplex(value: unknown): string {
+  if (Buffer.isBuffer(value)) {
+    return value.toString("base64");
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return JSON.stringify(value);
+}
+
+function normalizeVector(value: unknown): number[] {
+  if (Array.isArray(value)) {
+    return value.map((entry) => toFiniteNumber(entry));
+  }
+
+  if (typeof value === "string") {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      throw new Error("Expected vector column to be an array");
+    }
+    return parsed.map((entry) => toFiniteNumber(entry));
+  }
+
+  throw new Error("Unsupported vector value format");
+}
+
+function coerceScalar(value: unknown, helixType: string): unknown {
+  if (helixType.startsWith("[")) {
+    return normalizeArrayValue(value, helixType);
+  }
+
+  switch (helixType) {
+    case "I8":
+    case "I16":
+    case "I32":
+    case "I64":
+    case "U8":
+    case "U16":
+    case "U32":
+    case "U64":
+    case "U128":
+      return toInteger(value, helixType);
+    case "F32":
+    case "F64":
+      return toFiniteNumber(value);
+    case "Boolean":
+      return toBoolean(value);
+    case "Date":
+      if (value instanceof Date) {
+        return value.toISOString();
+      }
+      return value;
+    case "String":
+      if (value instanceof Date) {
+        return value.toISOString();
+      }
+      if (typeof value === "string") {
+        return value;
+      }
+      return String(value);
+    default:
+      return value;
+  }
+}
+
+function normalizeArrayValue(value: unknown, helixType: string): unknown {
+  const innerType = helixType.slice(1, -1).trim();
+  let arr: unknown[];
+
+  if (Array.isArray(value)) {
+    arr = value;
+  } else if (typeof value === "string") {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      throw new Error(`Expected array for ${helixType}`);
+    }
+    arr = parsed;
+  } else {
+    throw new Error(`Expected array for ${helixType}`);
+  }
+
+  return arr.map((entry) => coerceScalar(entry, innerType));
+}
+
+const JS_MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+const JS_MIN_SAFE_BIGINT = BigInt(Number.MIN_SAFE_INTEGER);
+
+function toInteger(value: unknown, helixType: string): number {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error("Expected finite number for integer field");
+    }
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(
+        `Unsafe integer for ${helixType}; use --bigint-mode string to avoid precision loss`
+      );
+    }
+    return Math.trunc(value);
+  }
+
+  if (typeof value === "string") {
+    if (!/^-?\d+$/.test(value.trim())) {
+      throw new Error(`Invalid integer literal: ${value}`);
+    }
+    const bigint = BigInt(value);
+    if (bigint > JS_MAX_SAFE_BIGINT || bigint < JS_MIN_SAFE_BIGINT) {
+      throw new Error(
+        `Integer ${value} exceeds JS safe range for ${helixType}; use --bigint-mode string`
+      );
+    }
+    return Number(bigint);
+  }
+
+  throw new Error("Expected integer-compatible value");
+}
+
+function toFiniteNumber(value: unknown): number {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error("Expected finite numeric value");
+    }
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(`Invalid numeric literal: ${value}`);
+    }
+    return parsed;
+  }
+
+  throw new Error("Expected numeric value");
+}
+
+function toBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "t", "1"].includes(normalized)) return true;
+    if (["false", "f", "0"].includes(normalized)) return false;
+  }
+
+  throw new Error("Expected boolean-compatible value");
 }

--- a/tools/migrate/src/export-data.ts
+++ b/tools/migrate/src/export-data.ts
@@ -1,0 +1,186 @@
+/**
+ * Exports data from a Supabase/PostgreSQL database as JSON.
+ *
+ * Reads all rows from each table, handles pagination for large tables,
+ * and serializes complex types (JSON, arrays) appropriately.
+ */
+
+import { Client } from "pg";
+import * as fs from "fs";
+import * as path from "path";
+import { TableInfo, ColumnInfo } from "./introspect";
+import { mapPgType } from "./type-map";
+
+export interface ExportOptions {
+  connectionString: string;
+  tables: TableInfo[];
+  outputDir: string;
+  batchSize: number; // rows per batch for large tables
+}
+
+export interface ExportResult {
+  table: string;
+  rowCount: number;
+  filePath: string;
+}
+
+/**
+ * Export all data from the specified tables to JSON files.
+ * Each table gets its own JSON file: <outputDir>/<table_name>.json
+ */
+export async function exportData(
+  options: ExportOptions
+): Promise<ExportResult[]> {
+  const { connectionString, tables, outputDir, batchSize } = options;
+
+  // Ensure output directory exists
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const client = new Client({ connectionString });
+  await client.connect();
+
+  const results: ExportResult[] = [];
+
+  try {
+    for (const table of tables) {
+      const filePath = path.join(outputDir, `${table.name}.json`);
+      const rowCount = await exportTable(client, table, filePath, batchSize);
+
+      results.push({
+        table: table.name,
+        rowCount,
+        filePath,
+      });
+    }
+  } finally {
+    await client.end();
+  }
+
+  return results;
+}
+
+/**
+ * Export a single table to a JSON file.
+ * Uses cursor-based pagination with the PK for large tables.
+ */
+async function exportTable(
+  client: Client,
+  table: TableInfo,
+  filePath: string,
+  batchSize: number
+): Promise<number> {
+  const schema = table.schema;
+  const tableName = table.name;
+
+  // Determine which columns to export (all of them, with type info for serialization)
+  const columns = table.columns;
+  const columnNames = columns.map((c) => `"${c.name}"`).join(", ");
+
+  // For small tables, just SELECT all
+  if (table.rowCount <= batchSize) {
+    const result = await client.query(
+      `SELECT ${columnNames} FROM "${schema}"."${tableName}"`
+    );
+
+    const rows = result.rows.map((row) => transformRow(row, columns));
+    fs.writeFileSync(filePath, JSON.stringify(rows, null, 2));
+    return rows.length;
+  }
+
+  // For large tables, use OFFSET pagination and stream to file
+  const writeStream = fs.createWriteStream(filePath);
+  writeStream.write("[\n");
+
+  let offset = 0;
+  let totalRows = 0;
+  let isFirst = true;
+
+  // Use a primary key or ctid for ordering
+  const orderBy = table.primaryKeys.length > 0
+    ? table.primaryKeys.map((pk) => `"${pk}"`).join(", ")
+    : "ctid";
+
+  while (true) {
+    const result = await client.query(
+      `SELECT ${columnNames} FROM "${schema}"."${tableName}" ORDER BY ${orderBy} LIMIT $1 OFFSET $2`,
+      [batchSize, offset]
+    );
+
+    if (result.rows.length === 0) break;
+
+    for (const row of result.rows) {
+      const transformed = transformRow(row, columns);
+      if (!isFirst) {
+        writeStream.write(",\n");
+      }
+      writeStream.write("  " + JSON.stringify(transformed));
+      isFirst = false;
+    }
+
+    totalRows += result.rows.length;
+    offset += batchSize;
+
+    if (result.rows.length < batchSize) break;
+  }
+
+  writeStream.write("\n]");
+  writeStream.end();
+
+  // Wait for stream to finish
+  await new Promise<void>((resolve, reject) => {
+    writeStream.on("finish", resolve);
+    writeStream.on("error", reject);
+  });
+
+  return totalRows;
+}
+
+/**
+ * Transform a row from PG format to a format suitable for HelixDB import.
+ * Handles JSON serialization, type coercion, etc.
+ */
+function transformRow(
+  row: Record<string, unknown>,
+  columns: ColumnInfo[]
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const col of columns) {
+    const value = row[col.name];
+
+    if (value === null || value === undefined) {
+      result[col.name] = null;
+      continue;
+    }
+
+    const mapped = mapPgType(col.dataType, col.udtName);
+
+    if (mapped.needsSerialization) {
+      // Serialize complex types to JSON string
+      result[col.name] =
+        typeof value === "string" ? value : JSON.stringify(value);
+    } else if (mapped.isVector) {
+      // Ensure vector is an array of numbers
+      if (typeof value === "string") {
+        // pgvector returns vectors as strings like "[1,2,3]"
+        result[col.name] = JSON.parse(value);
+      } else {
+        result[col.name] = value;
+      }
+    } else {
+      result[col.name] = value;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Read exported JSON data from a file.
+ */
+export function readExportedData(
+  filePath: string
+): Record<string, unknown>[] {
+  const content = fs.readFileSync(filePath, "utf-8");
+  return JSON.parse(content);
+}

--- a/tools/migrate/src/generate-queries.ts
+++ b/tools/migrate/src/generate-queries.ts
@@ -129,9 +129,7 @@ function generateEdgeQueries(edge: EdgeSchema): string[] {
   lines.push(
     `QUERY Add${edge.name}(from_id: ID, to_id: ID) =>`
   );
-  lines.push(`    from_node <- N<${edge.fromNode}>(from_id)`);
-  lines.push(`    to_node <- N<${edge.toNode}>(to_id)`);
-  lines.push(`    edge <- AddE<${edge.name}>::From(from_node)::To(to_node)`);
+  lines.push(`    edge <- AddE<${edge.name}>::From(from_id)::To(to_id)`);
   lines.push(`    RETURN edge`);
   lines.push("");
 
@@ -207,9 +205,7 @@ function generateEdgeImportQuery(edge: EdgeSchema): string[] {
   lines.push(
     `QUERY Import${edge.name}(from_id: ID, to_id: ID) =>`
   );
-  lines.push(`    from_node <- N<${edge.fromNode}>(from_id)`);
-  lines.push(`    to_node <- N<${edge.toNode}>(to_id)`);
-  lines.push(`    edge <- AddE<${edge.name}>::From(from_node)::To(to_node)`);
+  lines.push(`    edge <- AddE<${edge.name}>::From(from_id)::To(to_id)`);
   lines.push(`    RETURN edge`);
   lines.push("");
 

--- a/tools/migrate/src/generate-queries.ts
+++ b/tools/migrate/src/generate-queries.ts
@@ -1,0 +1,221 @@
+/**
+ * Generates HelixDB .hx query files for CRUD operations on each Node/Edge/Vector type.
+ *
+ * For each Node type, generates:
+ * - Add (insert) query
+ * - Get by ID query
+ * - Get all (with pagination) query
+ * - Update query
+ * - Delete query
+ *
+ * For each Edge type, generates:
+ * - Add edge query
+ * - Traverse outgoing query
+ *
+ * For each Vector type, generates:
+ * - Add vector query
+ * - Search query
+ *
+ * Also generates bulk import queries used by the data migration step.
+ */
+
+import { NodeSchema, EdgeSchema, VectorSchema, GeneratedSchema } from "./generate-schema";
+
+export interface GeneratedQueries {
+  queriesHx: string; // the complete queries.hx file content
+  importQueriesHx: string; // bulk import queries for data migration
+}
+
+/**
+ * Generate HelixQL query files from the generated schema.
+ */
+export function generateQueries(schema: GeneratedSchema): GeneratedQueries {
+  const queryLines: string[] = [];
+  const importLines: string[] = [];
+
+  queryLines.push("// ============================================");
+  queryLines.push("// HelixDB Queries - Auto-generated from Supabase");
+  queryLines.push("// ============================================");
+  queryLines.push("//");
+  queryLines.push("// These queries provide basic CRUD operations for your migrated data.");
+  queryLines.push("// Customize and extend these as needed for your application.");
+  queryLines.push("");
+
+  importLines.push("// ============================================");
+  importLines.push("// HelixDB Import Queries - Used during data migration");
+  importLines.push("// ============================================");
+  importLines.push("//");
+  importLines.push("// These queries are used by the migration tool to bulk-import data.");
+  importLines.push("// You can safely delete this file after migration is complete.");
+  importLines.push("");
+
+  // Generate Node queries
+  for (const node of schema.nodes) {
+    queryLines.push(...generateNodeQueries(node));
+    importLines.push(...generateNodeImportQuery(node));
+  }
+
+  // Generate Edge queries
+  for (const edge of schema.edges) {
+    queryLines.push(...generateEdgeQueries(edge));
+    importLines.push(...generateEdgeImportQuery(edge));
+  }
+
+  // Generate Vector queries
+  for (const vec of schema.vectors) {
+    queryLines.push(...generateVectorQueries(vec));
+    importLines.push(...generateVectorImportQuery(vec));
+  }
+
+  return {
+    queriesHx: queryLines.join("\n"),
+    importQueriesHx: importLines.join("\n"),
+  };
+}
+
+function generateNodeQueries(node: NodeSchema): string[] {
+  const lines: string[] = [];
+  const name = node.name;
+  const fields = node.fields;
+
+  // --- Add Node ---
+  const addParams = fields
+    .filter((f) => !f.hasDefault || !f.defaultValue)
+    .map((f) => `${f.name}: ${f.helixType}`)
+    .join(", ");
+
+  const addFields = fields
+    .filter((f) => !f.hasDefault || !f.defaultValue)
+    .map((f) => `${f.name}: ${f.name}`)
+    .join(", ");
+
+  lines.push(`// --- ${name} CRUD ---`);
+  lines.push("");
+
+  if (addParams) {
+    lines.push(`QUERY Add${name}(${addParams}) =>`);
+    lines.push(`    node <- AddN<${name}>({${addFields}})`);
+    lines.push(`    RETURN node`);
+  } else {
+    lines.push(`QUERY Add${name}() =>`);
+    lines.push(`    node <- AddN<${name}>({})`);
+    lines.push(`    RETURN node`);
+  }
+  lines.push("");
+
+  // --- Get by ID ---
+  lines.push(`QUERY Get${name}(id: ID) =>`);
+  lines.push(`    node <- N<${name}>(id)`);
+  lines.push(`    RETURN node`);
+  lines.push("");
+
+  // --- Delete ---
+  lines.push(`QUERY Delete${name}(id: ID) =>`);
+  lines.push(`    node <- N<${name}>(id)`);
+  lines.push(`    DROP node`);
+  lines.push(`    RETURN "deleted"`);
+  lines.push("");
+
+  return lines;
+}
+
+function generateEdgeQueries(edge: EdgeSchema): string[] {
+  const lines: string[] = [];
+
+  // --- Add Edge ---
+  lines.push(`// --- ${edge.name} Edge ---`);
+  lines.push("");
+  lines.push(
+    `QUERY Add${edge.name}(from_id: ID, to_id: ID) =>`
+  );
+  lines.push(`    from_node <- N<${edge.fromNode}>(from_id)`);
+  lines.push(`    to_node <- N<${edge.toNode}>(to_id)`);
+  lines.push(`    edge <- AddE<${edge.name}>::From(from_node)::To(to_node)`);
+  lines.push(`    RETURN edge`);
+  lines.push("");
+
+  // --- Traverse outgoing ---
+  lines.push(
+    `QUERY Get${edge.fromNode}${edge.toNode}Via${edge.name}(id: ID) =>`
+  );
+  lines.push(`    source <- N<${edge.fromNode}>(id)`);
+  lines.push(`    targets <- source::Out<${edge.name}>`);
+  lines.push(`    RETURN targets`);
+  lines.push("");
+
+  return lines;
+}
+
+function generateVectorQueries(vec: VectorSchema): string[] {
+  const lines: string[] = [];
+
+  // --- Search vectors ---
+  lines.push(`// --- ${vec.name} Vector Search ---`);
+  lines.push("");
+  lines.push(`QUERY Search${vec.name}(query: String, limit: I32) =>`);
+  lines.push(`    results <- SearchV<${vec.name}>(Embed(query), limit)`);
+  lines.push(`    RETURN results`);
+  lines.push("");
+
+  return lines;
+}
+
+function generateNodeImportQuery(node: NodeSchema): string[] {
+  const lines: string[] = [];
+  const fields = node.fields;
+
+  // Build parameter list for single-row import
+  const params = fields.map((f) => `${f.name}: ${f.helixType}`).join(", ");
+  const fieldAssign = fields.map((f) => `${f.name}: ${f.name}`).join(", ");
+
+  lines.push(`// Import query for ${node.originalTable}`);
+
+  if (params) {
+    lines.push(`QUERY Import${node.name}(${params}) =>`);
+    lines.push(`    node <- AddN<${node.name}>({${fieldAssign}})`);
+    lines.push(`    RETURN node`);
+  } else {
+    lines.push(`QUERY Import${node.name}() =>`);
+    lines.push(`    node <- AddN<${node.name}>({})`);
+    lines.push(`    RETURN node`);
+  }
+  lines.push("");
+
+  return lines;
+}
+
+function generateEdgeImportQuery(edge: EdgeSchema): string[] {
+  const lines: string[] = [];
+
+  lines.push(`// Import query for ${edge.originalConstraint}`);
+  lines.push(
+    `QUERY Import${edge.name}(from_id: ID, to_id: ID) =>`
+  );
+  lines.push(`    from_node <- N<${edge.fromNode}>(from_id)`);
+  lines.push(`    to_node <- N<${edge.toNode}>(to_id)`);
+  lines.push(`    edge <- AddE<${edge.name}>::From(from_node)::To(to_node)`);
+  lines.push(`    RETURN edge`);
+  lines.push("");
+
+  return lines;
+}
+
+function generateVectorImportQuery(vec: VectorSchema): string[] {
+  const lines: string[] = [];
+
+  const metaParams = vec.metadataFields.map((f) => `${f.name}: ${f.helixType}`).join(", ");
+  const metaFields = vec.metadataFields.map((f) => `${f.name}: ${f.name}`).join(", ");
+
+  lines.push(`// Import query for ${vec.originalTable} vectors`);
+  if (metaParams) {
+    lines.push(`QUERY Import${vec.name}(vector: [F64], ${metaParams}) =>`);
+    lines.push(`    v <- AddV<${vec.name}>(vector, {${metaFields}})`);
+  } else {
+    lines.push(`QUERY Import${vec.name}(vector: [F64]) =>`);
+    lines.push(`    v <- AddV<${vec.name}>(vector, {})`);
+  }
+  lines.push(`    RETURN v`);
+  lines.push("");
+
+  return lines;
+}

--- a/tools/migrate/src/generate-schema.ts
+++ b/tools/migrate/src/generate-schema.ts
@@ -3,18 +3,24 @@
  *
  * Mapping strategy:
  * - Each PG table -> N::NodeType (Node)
- * - Each PG foreign key -> E::EdgeType (Edge)
- * - Tables with pgvector columns -> V::VectorType (Vector) + N::NodeType for metadata
+ * - Each resolvable PG foreign key -> E::EdgeType (Edge)
+ * - Tables with pgvector columns -> V::VectorType (Vector)
  * - PG indexes -> INDEX / UNIQUE INDEX field modifiers
- * - PG default values -> DEFAULT modifiers where applicable
  */
 
-import { TableInfo, SchemaIntrospection } from "./introspect";
-import { mapPgType, toPascalCase, toFieldName } from "./type-map";
+import { TableInfo, SchemaIntrospection, IndexInfo } from "./introspect";
+import {
+  mapPgType,
+  toPascalCase,
+  toFieldName,
+  TypeMappingOptions,
+} from "./type-map";
 
 export interface NodeSchema {
-  name: string; // PascalCase node type name
-  originalTable: string; // original PG table name
+  name: string;
+  originalSchema: string;
+  originalTable: string;
+  tableKey: string;
   fields: FieldSchema[];
   hasVectorColumn: boolean;
 }
@@ -22,6 +28,7 @@ export interface NodeSchema {
 export interface FieldSchema {
   name: string;
   helixType: string;
+  isNullable: boolean;
   isIndexed: boolean;
   isUnique: boolean;
   hasDefault: boolean;
@@ -29,21 +36,26 @@ export interface FieldSchema {
   needsSerialization: boolean;
   originalColumn: string;
   isPrimaryKey: boolean;
-  isForeignKey: boolean; // excluded from Node fields, becomes an Edge
+  isForeignKey: boolean;
 }
 
 export interface EdgeSchema {
-  name: string; // PascalCase edge type name
+  name: string;
   fromNode: string;
   toNode: string;
+  fromTableKey: string;
+  toTableKey: string;
   originalConstraint: string;
-  originalColumn: string;
-  isUnique: boolean; // if the FK column has a unique constraint
+  originalColumns: string[];
+  referencedColumns: string[];
+  isUnique: boolean;
 }
 
 export interface VectorSchema {
-  name: string; // PascalCase vector type name
+  name: string;
+  originalSchema: string;
   originalTable: string;
+  tableKey: string;
   vectorColumn: string;
   metadataFields: FieldSchema[];
 }
@@ -52,200 +64,272 @@ export interface GeneratedSchema {
   nodes: NodeSchema[];
   edges: EdgeSchema[];
   vectors: VectorSchema[];
-  schemaHx: string; // the complete .hx schema file content
+  schemaHx: string;
 }
 
-/**
- * Generate a complete HelixDB schema from introspected PostgreSQL tables.
- */
 export function generateSchema(
-  introspection: SchemaIntrospection
+  introspection: SchemaIntrospection,
+  typeOptions: TypeMappingOptions
 ): GeneratedSchema {
   const nodes: NodeSchema[] = [];
   const edges: EdgeSchema[] = [];
   const vectors: VectorSchema[] = [];
 
-  // Track which tables are in scope for FK resolution
-  const tableMap = new Map<string, TableInfo>();
-  for (const table of introspection.tables) {
-    tableMap.set(table.name, table);
-  }
+  const userTables = introspection.tables.filter(
+    (table) => !isSupabaseInternal(table.name)
+  );
 
-  // Build a set of FK column names per table for exclusion from Node fields
-  const fkColumns = new Map<string, Set<string>>();
-  for (const table of introspection.tables) {
-    const fkCols = new Set<string>();
+  const nodeNameByTableKey = buildNodeNameMap(userTables);
+  const usedEdgeNames = new Set<string>();
+  const usedVectorNames = new Set<string>();
+
+  for (const table of userTables) {
+    const tableKey = makeTableKey(table.schema, table.name);
+    const nodeName = nodeNameByTableKey.get(tableKey);
+    if (!nodeName) {
+      continue;
+    }
+
+    const indexMetadata = buildIndexMetadata(table.indexes);
+    const fkColumnsMappedToEdges = new Set<string>();
+
     for (const fk of table.foreignKeys) {
-      fkCols.add(fk.columnName);
+      const targetKey = makeTableKey(fk.foreignTableSchema, fk.foreignTableName);
+      const toNode = nodeNameByTableKey.get(targetKey);
+      if (!toNode) {
+        continue;
+      }
+
+      const baseEdgeName = generateEdgeName(nodeName, toNode, fk.columnNames);
+      const edgeName = uniquifyName(baseEdgeName, usedEdgeNames);
+
+      edges.push({
+        name: edgeName,
+        fromNode: nodeName,
+        toNode,
+        fromTableKey: tableKey,
+        toTableKey: targetKey,
+        originalConstraint: fk.constraintName,
+        originalColumns: [...fk.columnNames],
+        referencedColumns: [...fk.foreignColumnNames],
+        isUnique: isForeignKeyUnique(table, indexMetadata.uniqueIndexGroups, fk.columnNames),
+      });
+
+      for (const fkColumn of fk.columnNames) {
+        fkColumnsMappedToEdges.add(fkColumn);
+      }
     }
-    fkColumns.set(table.name, fkCols);
-  }
 
-  // Track indexed columns per table
-  const indexedColumns = new Map<string, Map<string, { isUnique: boolean }>>();
-  for (const table of introspection.tables) {
-    const idxMap = new Map<string, { isUnique: boolean }>();
-    for (const idx of table.indexes) {
-      idxMap.set(idx.columnName, { isUnique: idx.isUnique });
-    }
-    indexedColumns.set(table.name, idxMap);
-  }
-
-  for (const table of introspection.tables) {
-    // Skip Supabase internal tables
-    if (isSupabaseInternal(table.name)) continue;
-
-    const tableFkCols = fkColumns.get(table.name) ?? new Set();
-    const tableIndexes = indexedColumns.get(table.name) ?? new Map();
-
-    // Check if this table has vector columns
+    const fields: FieldSchema[] = [];
     const vectorColumns = table.columns.filter((col) => {
-      const mapped = mapPgType(col.dataType, col.udtName);
+      const mapped = mapPgType(col.dataType, col.udtName, typeOptions);
       return mapped.isVector;
     });
 
-    // Build field list (excluding PK and FK columns)
-    const fields: FieldSchema[] = [];
     for (const col of table.columns) {
-      // Skip primary key columns (HelixDB auto-generates IDs)
-      if (col.isPrimaryKey) continue;
+      if (col.isPrimaryKey) {
+        continue;
+      }
 
-      const isFk = tableFkCols.has(col.name);
-      const mapped = mapPgType(col.dataType, col.udtName);
-      const idxInfo = tableIndexes.get(col.name);
+      const mapped = mapPgType(col.dataType, col.udtName, typeOptions);
+      if (mapped.isVector) {
+        continue;
+      }
 
-      // Skip vector columns (they'll be handled as V:: types)
-      if (mapped.isVector) continue;
+      const isMappedFk = fkColumnsMappedToEdges.has(col.name);
+      const columnIndexInfo = indexMetadata.byColumn.get(col.name);
 
       fields.push({
         name: toFieldName(col.name),
         helixType: mapped.helixType,
-        isIndexed: idxInfo !== undefined,
-        isUnique: idxInfo?.isUnique ?? false,
-        hasDefault: col.columnDefault !== null && !col.columnDefault.startsWith("nextval"),
-        defaultValue: mapDefault(col.columnDefault, mapped.helixType),
+        isNullable: col.isNullable,
+        isIndexed: columnIndexInfo?.isIndexed ?? false,
+        isUnique: columnIndexInfo?.isSingleColumnUnique ?? false,
+        hasDefault:
+          col.columnDefault !== null && !col.columnDefault.startsWith("nextval"),
+        defaultValue: mapDefault(col.columnDefault),
         needsSerialization: mapped.needsSerialization,
         originalColumn: col.name,
         isPrimaryKey: false,
-        isForeignKey: isFk,
+        isForeignKey: isMappedFk,
       });
     }
-
-    const nodeName = toPascalCase(table.name);
-
-    // Non-FK fields go into the Node definition
-    const nodeFields = fields.filter((f) => !f.isForeignKey);
 
     nodes.push({
       name: nodeName,
+      originalSchema: table.schema,
       originalTable: table.name,
-      fields: nodeFields,
+      tableKey,
+      fields,
       hasVectorColumn: vectorColumns.length > 0,
     });
 
-    // Vector columns become separate V:: types
-    for (const vecCol of vectorColumns) {
-      const metaFields = fields.filter(
-        (f) => !f.isForeignKey && f.originalColumn !== vecCol.name
-      );
+    for (const vecColumn of vectorColumns) {
+      const vectorNameBase = `${nodeName}${toPascalCase(vecColumn.name)}Embedding`;
+      const vectorName = uniquifyName(vectorNameBase, usedVectorNames);
+
       vectors.push({
-        name: `${nodeName}Embedding`,
+        name: vectorName,
+        originalSchema: table.schema,
         originalTable: table.name,
-        vectorColumn: vecCol.name,
-        metadataFields: metaFields,
-      });
-    }
-
-    // Foreign keys become edges
-    for (const fk of table.foreignKeys) {
-      const targetTable = tableMap.get(fk.foreignTableName);
-      if (!targetTable) continue;
-
-      const fromNode = nodeName;
-      const toNode = toPascalCase(fk.foreignTableName);
-
-      // Generate edge name from relationship
-      const edgeName = generateEdgeName(fromNode, toNode, fk.columnName);
-
-      // Check if the FK column has a unique constraint
-      const fkIdx = tableIndexes.get(fk.columnName);
-      const isUniqueEdge = fkIdx?.isUnique ?? false;
-
-      edges.push({
-        name: edgeName,
-        fromNode,
-        toNode,
-        originalConstraint: fk.constraintName,
-        originalColumn: fk.columnName,
-        isUnique: isUniqueEdge,
+        tableKey,
+        vectorColumn: vecColumn.name,
+        metadataFields: fields,
       });
     }
   }
 
-  // Deduplicate edge names
-  deduplicateEdges(edges);
-
   const schemaHx = renderSchemaHx(nodes, edges, vectors, introspection.enums);
-
   return { nodes, edges, vectors, schemaHx };
 }
 
-/**
- * Generate an edge type name from the relationship.
- * e.g., FK column "author_id" on Post -> User becomes "HasAuthor"
- */
-function generateEdgeName(
-  _fromNode: string,
-  toNode: string,
-  fkColumn: string
-): string {
-  // Strip common suffixes from FK column name
-  let relationship = fkColumn
-    .replace(/_id$/, "")
-    .replace(/_uuid$/, "")
-    .replace(/_fk$/, "");
-
-  // If the column name matches the target table, use "Has" prefix
-  const relPascal = toPascalCase(relationship);
-  if (relPascal === toNode) {
-    return `Has${toNode}`;
-  }
-
-  // Otherwise use the column-derived name
-  return `Has${relPascal}`;
+function makeTableKey(schema: string, table: string): string {
+  return `${schema}.${table}`;
 }
 
-/**
- * Deduplicate edge names by appending a suffix when there are conflicts.
- */
-function deduplicateEdges(edges: EdgeSchema[]): void {
-  const nameCount = new Map<string, number>();
-  for (const edge of edges) {
-    nameCount.set(edge.name, (nameCount.get(edge.name) ?? 0) + 1);
+function buildNodeNameMap(tables: TableInfo[]): Map<string, string> {
+  const tableKeyToName = new Map<string, string>();
+  const usedNames = new Set<string>();
+
+  for (const table of tables) {
+    const key = makeTableKey(table.schema, table.name);
+    const baseName = toPascalCase(table.name);
+
+    let candidate = baseName;
+    if (usedNames.has(candidate)) {
+      candidate = `${toPascalCase(table.schema)}${baseName}`;
+    }
+    candidate = uniquifyName(candidate, usedNames);
+
+    tableKeyToName.set(key, candidate);
   }
 
-  const nameIndex = new Map<string, number>();
-  for (const edge of edges) {
-    if ((nameCount.get(edge.name) ?? 0) > 1) {
-      const idx = (nameIndex.get(edge.name) ?? 0) + 1;
-      nameIndex.set(edge.name, idx);
-      if (idx > 1) {
-        edge.name = `${edge.name}${idx}`;
+  return tableKeyToName;
+}
+
+function buildIndexMetadata(indexes: IndexInfo[]): {
+  byColumn: Map<string, { isIndexed: boolean; isSingleColumnUnique: boolean }>;
+  uniqueIndexGroups: string[][];
+} {
+  const byColumn = new Map<
+    string,
+    { isIndexed: boolean; isSingleColumnUnique: boolean }
+  >();
+
+  const grouped = new Map<string, IndexInfo[]>();
+  for (const index of indexes) {
+    const entries = grouped.get(index.indexName) ?? [];
+    entries.push(index);
+    grouped.set(index.indexName, entries);
+
+    const existing = byColumn.get(index.columnName);
+    if (existing) {
+      existing.isIndexed = true;
+    } else {
+      byColumn.set(index.columnName, {
+        isIndexed: true,
+        isSingleColumnUnique: false,
+      });
+    }
+  }
+
+  const uniqueIndexGroups: string[][] = [];
+
+  for (const group of grouped.values()) {
+    const ordered = [...group].sort((a, b) => a.columnPosition - b.columnPosition);
+    if (!ordered[0]?.isUnique) {
+      continue;
+    }
+
+    const columns = ordered.map((entry) => entry.columnName);
+    uniqueIndexGroups.push(columns);
+
+    if (columns.length === 1) {
+      const col = columns[0];
+      const existing = byColumn.get(col);
+      if (existing) {
+        existing.isSingleColumnUnique = true;
       }
     }
   }
+
+  return { byColumn, uniqueIndexGroups };
 }
 
-/**
- * Map a PostgreSQL default value to a HelixDB DEFAULT expression.
- */
-function mapDefault(
-  pgDefault: string | null,
-  _helixType: string
-): string | null {
-  if (!pgDefault) return null;
+function isForeignKeyUnique(
+  table: TableInfo,
+  uniqueIndexGroups: string[][],
+  fkColumns: string[]
+): boolean {
+  if (sameColumns(table.primaryKeys, fkColumns)) {
+    return true;
+  }
 
-  // NOW() / CURRENT_TIMESTAMP -> NOW
+  for (const uniqueColumns of uniqueIndexGroups) {
+    if (sameColumns(uniqueColumns, fkColumns)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function sameColumns(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((column, index) => column === b[index]);
+}
+
+function generateEdgeName(
+  _fromNode: string,
+  toNode: string,
+  fkColumns: string[]
+): string {
+  if (fkColumns.length === 1) {
+    const relationship = fkColumns[0]
+      .replace(/_id$/, "")
+      .replace(/_uuid$/, "")
+      .replace(/_fk$/, "");
+
+    const relPascal = toPascalCase(relationship);
+    if (relPascal === toNode) {
+      return `Has${toNode}`;
+    }
+
+    return `Has${relPascal}`;
+  }
+
+  const suffix = fkColumns
+    .map((column) =>
+      toPascalCase(column.replace(/_id$/, "").replace(/_uuid$/, "").replace(/_fk$/, ""))
+    )
+    .join("");
+
+  return `Has${toNode}By${suffix}`;
+}
+
+function uniquifyName(baseName: string, usedNames: Set<string>): string {
+  if (!usedNames.has(baseName)) {
+    usedNames.add(baseName);
+    return baseName;
+  }
+
+  let suffix = 2;
+  while (usedNames.has(`${baseName}${suffix}`)) {
+    suffix += 1;
+  }
+
+  const finalName = `${baseName}${suffix}`;
+  usedNames.add(finalName);
+  return finalName;
+}
+
+function mapDefault(pgDefault: string | null): string | null {
+  if (!pgDefault) {
+    return null;
+  }
+
   if (
     pgDefault.includes("now()") ||
     pgDefault.includes("CURRENT_TIMESTAMP") ||
@@ -254,20 +338,17 @@ function mapDefault(
     return "NOW";
   }
 
-  // Skip nextval (serial/auto-increment)
-  if (pgDefault.startsWith("nextval")) return null;
+  if (pgDefault.startsWith("nextval")) {
+    return null;
+  }
 
-  // Skip gen_random_uuid (HelixDB generates IDs automatically)
   if (pgDefault.includes("gen_random_uuid") || pgDefault.includes("uuid_generate")) {
     return null;
   }
 
-  return null; // HelixDB has limited DEFAULT support; skip complex defaults
+  return null;
 }
 
-/**
- * Render the complete .hx schema file.
- */
 function renderSchemaHx(
   nodes: NodeSchema[],
   edges: EdgeSchema[],
@@ -284,29 +365,26 @@ function renderSchemaHx(
   lines.push("// See: https://docs.helix-db.com for HelixQL documentation.");
   lines.push("");
 
-  // Emit enum comments (HelixDB doesn't have native enums, so we document them)
   if (Object.keys(enums).length > 0) {
     lines.push("// --- PostgreSQL Enums (mapped to String fields) ---");
     for (const [enumName, values] of Object.entries(enums)) {
-      lines.push(`// Enum ${enumName}: ${values.map((v) => `"${v}"`).join(" | ")}`);
+      lines.push(`// Enum ${enumName}: ${values.map((value) => `\"${value}\"`).join(" | ")}`);
     }
     lines.push("");
   }
 
-  // Emit Node types
   if (nodes.length > 0) {
     lines.push("// --- Nodes ---");
     lines.push("");
   }
 
   for (const node of nodes) {
-    lines.push(`// Source table: ${node.originalTable}`);
+    lines.push(`// Source table: ${node.originalSchema}.${node.originalTable}`);
     lines.push(`N::${node.name} {`);
 
     for (const field of node.fields) {
       let line = "    ";
 
-      // Add INDEX / UNIQUE INDEX prefix
       if (field.isUnique) {
         line += "UNIQUE INDEX ";
       } else if (field.isIndexed) {
@@ -315,14 +393,12 @@ function renderSchemaHx(
 
       line += `${field.name}: ${field.helixType}`;
 
-      // Add DEFAULT if applicable
       if (field.hasDefault && field.defaultValue) {
         line += ` DEFAULT ${field.defaultValue}`;
       }
 
       line += ",";
 
-      // Add comment for serialized fields
       if (field.needsSerialization) {
         line += " // JSON-serialized from PostgreSQL";
       }
@@ -334,36 +410,34 @@ function renderSchemaHx(
     lines.push("");
   }
 
-  // Emit Edge types
   if (edges.length > 0) {
     lines.push("// --- Edges (from foreign key relationships) ---");
     lines.push("");
   }
 
   for (const edge of edges) {
-    lines.push(`// Source: ${edge.originalConstraint} (${edge.originalColumn})`);
-    if (edge.isUnique) {
-      lines.push(`UNIQUE E::${edge.name} {`);
-    } else {
-      lines.push(`E::${edge.name} {`);
-    }
+    lines.push(
+      `// Source: ${edge.originalConstraint} (${edge.originalColumns.join(", ")} -> ${edge.referencedColumns.join(", ")})`
+    );
+    lines.push(edge.isUnique ? `E::${edge.name} UNIQUE {` : `E::${edge.name} {`);
     lines.push(`    From: ${edge.fromNode},`);
     lines.push(`    To: ${edge.toNode},`);
     lines.push("}");
     lines.push("");
   }
 
-  // Emit Vector types
   if (vectors.length > 0) {
     lines.push("// --- Vectors (from pgvector columns) ---");
     lines.push("");
   }
 
-  for (const vec of vectors) {
-    lines.push(`// Source table: ${vec.originalTable}, column: ${vec.vectorColumn}`);
-    lines.push(`V::${vec.name} {`);
+  for (const vector of vectors) {
+    lines.push(
+      `// Source table: ${vector.originalSchema}.${vector.originalTable}, column: ${vector.vectorColumn}`
+    );
+    lines.push(`V::${vector.name} {`);
 
-    for (const field of vec.metadataFields) {
+    for (const field of vector.metadataFields) {
       let line = `    ${field.name}: ${field.helixType},`;
       if (field.needsSerialization) {
         line += " // JSON-serialized";
@@ -378,9 +452,6 @@ function renderSchemaHx(
   return lines.join("\n");
 }
 
-/**
- * Check if a table is a Supabase internal table that should be skipped.
- */
 function isSupabaseInternal(tableName: string): boolean {
   const internalTables = new Set([
     "schema_migrations",
@@ -408,5 +479,6 @@ function isSupabaseInternal(tableName: string): boolean {
     "sessions",
     "identities",
   ]);
+
   return internalTables.has(tableName);
 }

--- a/tools/migrate/src/generate-schema.ts
+++ b/tools/migrate/src/generate-schema.ts
@@ -1,0 +1,412 @@
+/**
+ * Generates HelixDB .hx schema files from introspected PostgreSQL schema.
+ *
+ * Mapping strategy:
+ * - Each PG table -> N::NodeType (Node)
+ * - Each PG foreign key -> E::EdgeType (Edge)
+ * - Tables with pgvector columns -> V::VectorType (Vector) + N::NodeType for metadata
+ * - PG indexes -> INDEX / UNIQUE INDEX field modifiers
+ * - PG default values -> DEFAULT modifiers where applicable
+ */
+
+import { TableInfo, SchemaIntrospection } from "./introspect";
+import { mapPgType, toPascalCase, toFieldName } from "./type-map";
+
+export interface NodeSchema {
+  name: string; // PascalCase node type name
+  originalTable: string; // original PG table name
+  fields: FieldSchema[];
+  hasVectorColumn: boolean;
+}
+
+export interface FieldSchema {
+  name: string;
+  helixType: string;
+  isIndexed: boolean;
+  isUnique: boolean;
+  hasDefault: boolean;
+  defaultValue: string | null;
+  needsSerialization: boolean;
+  originalColumn: string;
+  isPrimaryKey: boolean;
+  isForeignKey: boolean; // excluded from Node fields, becomes an Edge
+}
+
+export interface EdgeSchema {
+  name: string; // PascalCase edge type name
+  fromNode: string;
+  toNode: string;
+  originalConstraint: string;
+  originalColumn: string;
+  isUnique: boolean; // if the FK column has a unique constraint
+}
+
+export interface VectorSchema {
+  name: string; // PascalCase vector type name
+  originalTable: string;
+  vectorColumn: string;
+  metadataFields: FieldSchema[];
+}
+
+export interface GeneratedSchema {
+  nodes: NodeSchema[];
+  edges: EdgeSchema[];
+  vectors: VectorSchema[];
+  schemaHx: string; // the complete .hx schema file content
+}
+
+/**
+ * Generate a complete HelixDB schema from introspected PostgreSQL tables.
+ */
+export function generateSchema(
+  introspection: SchemaIntrospection
+): GeneratedSchema {
+  const nodes: NodeSchema[] = [];
+  const edges: EdgeSchema[] = [];
+  const vectors: VectorSchema[] = [];
+
+  // Track which tables are in scope for FK resolution
+  const tableMap = new Map<string, TableInfo>();
+  for (const table of introspection.tables) {
+    tableMap.set(table.name, table);
+  }
+
+  // Build a set of FK column names per table for exclusion from Node fields
+  const fkColumns = new Map<string, Set<string>>();
+  for (const table of introspection.tables) {
+    const fkCols = new Set<string>();
+    for (const fk of table.foreignKeys) {
+      fkCols.add(fk.columnName);
+    }
+    fkColumns.set(table.name, fkCols);
+  }
+
+  // Track indexed columns per table
+  const indexedColumns = new Map<string, Map<string, { isUnique: boolean }>>();
+  for (const table of introspection.tables) {
+    const idxMap = new Map<string, { isUnique: boolean }>();
+    for (const idx of table.indexes) {
+      idxMap.set(idx.columnName, { isUnique: idx.isUnique });
+    }
+    indexedColumns.set(table.name, idxMap);
+  }
+
+  for (const table of introspection.tables) {
+    // Skip Supabase internal tables
+    if (isSupabaseInternal(table.name)) continue;
+
+    const tableFkCols = fkColumns.get(table.name) ?? new Set();
+    const tableIndexes = indexedColumns.get(table.name) ?? new Map();
+
+    // Check if this table has vector columns
+    const vectorColumns = table.columns.filter((col) => {
+      const mapped = mapPgType(col.dataType, col.udtName);
+      return mapped.isVector;
+    });
+
+    // Build field list (excluding PK and FK columns)
+    const fields: FieldSchema[] = [];
+    for (const col of table.columns) {
+      // Skip primary key columns (HelixDB auto-generates IDs)
+      if (col.isPrimaryKey) continue;
+
+      const isFk = tableFkCols.has(col.name);
+      const mapped = mapPgType(col.dataType, col.udtName);
+      const idxInfo = tableIndexes.get(col.name);
+
+      // Skip vector columns (they'll be handled as V:: types)
+      if (mapped.isVector) continue;
+
+      fields.push({
+        name: toFieldName(col.name),
+        helixType: mapped.helixType,
+        isIndexed: idxInfo !== undefined,
+        isUnique: idxInfo?.isUnique ?? false,
+        hasDefault: col.columnDefault !== null && !col.columnDefault.startsWith("nextval"),
+        defaultValue: mapDefault(col.columnDefault, mapped.helixType),
+        needsSerialization: mapped.needsSerialization,
+        originalColumn: col.name,
+        isPrimaryKey: false,
+        isForeignKey: isFk,
+      });
+    }
+
+    const nodeName = toPascalCase(table.name);
+
+    // Non-FK fields go into the Node definition
+    const nodeFields = fields.filter((f) => !f.isForeignKey);
+
+    nodes.push({
+      name: nodeName,
+      originalTable: table.name,
+      fields: nodeFields,
+      hasVectorColumn: vectorColumns.length > 0,
+    });
+
+    // Vector columns become separate V:: types
+    for (const vecCol of vectorColumns) {
+      const metaFields = fields.filter(
+        (f) => !f.isForeignKey && f.originalColumn !== vecCol.name
+      );
+      vectors.push({
+        name: `${nodeName}Embedding`,
+        originalTable: table.name,
+        vectorColumn: vecCol.name,
+        metadataFields: metaFields,
+      });
+    }
+
+    // Foreign keys become edges
+    for (const fk of table.foreignKeys) {
+      const targetTable = tableMap.get(fk.foreignTableName);
+      if (!targetTable) continue;
+
+      const fromNode = nodeName;
+      const toNode = toPascalCase(fk.foreignTableName);
+
+      // Generate edge name from relationship
+      const edgeName = generateEdgeName(fromNode, toNode, fk.columnName);
+
+      // Check if the FK column has a unique constraint
+      const fkIdx = tableIndexes.get(fk.columnName);
+      const isUniqueEdge = fkIdx?.isUnique ?? false;
+
+      edges.push({
+        name: edgeName,
+        fromNode,
+        toNode,
+        originalConstraint: fk.constraintName,
+        originalColumn: fk.columnName,
+        isUnique: isUniqueEdge,
+      });
+    }
+  }
+
+  // Deduplicate edge names
+  deduplicateEdges(edges);
+
+  const schemaHx = renderSchemaHx(nodes, edges, vectors, introspection.enums);
+
+  return { nodes, edges, vectors, schemaHx };
+}
+
+/**
+ * Generate an edge type name from the relationship.
+ * e.g., FK column "author_id" on Post -> User becomes "HasAuthor"
+ */
+function generateEdgeName(
+  _fromNode: string,
+  toNode: string,
+  fkColumn: string
+): string {
+  // Strip common suffixes from FK column name
+  let relationship = fkColumn
+    .replace(/_id$/, "")
+    .replace(/_uuid$/, "")
+    .replace(/_fk$/, "");
+
+  // If the column name matches the target table, use "Has" prefix
+  const relPascal = toPascalCase(relationship);
+  if (relPascal === toNode) {
+    return `Has${toNode}`;
+  }
+
+  // Otherwise use the column-derived name
+  return `Has${relPascal}`;
+}
+
+/**
+ * Deduplicate edge names by appending a suffix when there are conflicts.
+ */
+function deduplicateEdges(edges: EdgeSchema[]): void {
+  const nameCount = new Map<string, number>();
+  for (const edge of edges) {
+    nameCount.set(edge.name, (nameCount.get(edge.name) ?? 0) + 1);
+  }
+
+  const nameIndex = new Map<string, number>();
+  for (const edge of edges) {
+    if ((nameCount.get(edge.name) ?? 0) > 1) {
+      const idx = (nameIndex.get(edge.name) ?? 0) + 1;
+      nameIndex.set(edge.name, idx);
+      if (idx > 1) {
+        edge.name = `${edge.name}${idx}`;
+      }
+    }
+  }
+}
+
+/**
+ * Map a PostgreSQL default value to a HelixDB DEFAULT expression.
+ */
+function mapDefault(
+  pgDefault: string | null,
+  _helixType: string
+): string | null {
+  if (!pgDefault) return null;
+
+  // NOW() / CURRENT_TIMESTAMP -> NOW
+  if (
+    pgDefault.includes("now()") ||
+    pgDefault.includes("CURRENT_TIMESTAMP") ||
+    pgDefault.includes("current_timestamp")
+  ) {
+    return "NOW";
+  }
+
+  // Skip nextval (serial/auto-increment)
+  if (pgDefault.startsWith("nextval")) return null;
+
+  // Skip gen_random_uuid (HelixDB generates IDs automatically)
+  if (pgDefault.includes("gen_random_uuid") || pgDefault.includes("uuid_generate")) {
+    return null;
+  }
+
+  return null; // HelixDB has limited DEFAULT support; skip complex defaults
+}
+
+/**
+ * Render the complete .hx schema file.
+ */
+function renderSchemaHx(
+  nodes: NodeSchema[],
+  edges: EdgeSchema[],
+  vectors: VectorSchema[],
+  enums: Record<string, string[]>
+): string {
+  const lines: string[] = [];
+
+  lines.push("// ============================================");
+  lines.push("// HelixDB Schema - Auto-generated from Supabase");
+  lines.push("// ============================================");
+  lines.push("//");
+  lines.push("// Review this schema and adjust as needed before running `helix push`.");
+  lines.push("// See: https://docs.helix-db.com for HelixQL documentation.");
+  lines.push("");
+
+  // Emit enum comments (HelixDB doesn't have native enums, so we document them)
+  if (Object.keys(enums).length > 0) {
+    lines.push("// --- PostgreSQL Enums (mapped to String fields) ---");
+    for (const [enumName, values] of Object.entries(enums)) {
+      lines.push(`// Enum ${enumName}: ${values.map((v) => `"${v}"`).join(" | ")}`);
+    }
+    lines.push("");
+  }
+
+  // Emit Node types
+  if (nodes.length > 0) {
+    lines.push("// --- Nodes ---");
+    lines.push("");
+  }
+
+  for (const node of nodes) {
+    lines.push(`// Source table: ${node.originalTable}`);
+    lines.push(`N::${node.name} {`);
+
+    for (const field of node.fields) {
+      let line = "    ";
+
+      // Add INDEX / UNIQUE INDEX prefix
+      if (field.isUnique) {
+        line += "UNIQUE INDEX ";
+      } else if (field.isIndexed) {
+        line += "INDEX ";
+      }
+
+      line += `${field.name}: ${field.helixType}`;
+
+      // Add DEFAULT if applicable
+      if (field.hasDefault && field.defaultValue) {
+        line += ` DEFAULT ${field.defaultValue}`;
+      }
+
+      line += ",";
+
+      // Add comment for serialized fields
+      if (field.needsSerialization) {
+        line += " // JSON-serialized from PostgreSQL";
+      }
+
+      lines.push(line);
+    }
+
+    lines.push("}");
+    lines.push("");
+  }
+
+  // Emit Edge types
+  if (edges.length > 0) {
+    lines.push("// --- Edges (from foreign key relationships) ---");
+    lines.push("");
+  }
+
+  for (const edge of edges) {
+    lines.push(`// Source: ${edge.originalConstraint} (${edge.originalColumn})`);
+    if (edge.isUnique) {
+      lines.push(`UNIQUE E::${edge.name} {`);
+    } else {
+      lines.push(`E::${edge.name} {`);
+    }
+    lines.push(`    From: ${edge.fromNode},`);
+    lines.push(`    To: ${edge.toNode},`);
+    lines.push("}");
+    lines.push("");
+  }
+
+  // Emit Vector types
+  if (vectors.length > 0) {
+    lines.push("// --- Vectors (from pgvector columns) ---");
+    lines.push("");
+  }
+
+  for (const vec of vectors) {
+    lines.push(`// Source table: ${vec.originalTable}, column: ${vec.vectorColumn}`);
+    lines.push(`V::${vec.name} {`);
+
+    for (const field of vec.metadataFields) {
+      let line = `    ${field.name}: ${field.helixType},`;
+      if (field.needsSerialization) {
+        line += " // JSON-serialized";
+      }
+      lines.push(line);
+    }
+
+    lines.push("}");
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Check if a table is a Supabase internal table that should be skipped.
+ */
+function isSupabaseInternal(tableName: string): boolean {
+  const internalTables = new Set([
+    "schema_migrations",
+    "supabase_migrations",
+    "supabase_functions",
+    "_realtime_subscription",
+    "buckets",
+    "objects",
+    "s3_multipart_uploads",
+    "s3_multipart_uploads_parts",
+    "migrations",
+    "hooks",
+    "mfa_factors",
+    "mfa_challenges",
+    "mfa_amr_claims",
+    "sso_providers",
+    "sso_domains",
+    "saml_providers",
+    "saml_relay_states",
+    "flow_state",
+    "one_time_tokens",
+    "audit_log_entries",
+    "refresh_tokens",
+    "instances",
+    "sessions",
+    "identities",
+  ]);
+  return internalTables.has(tableName);
+}

--- a/tools/migrate/src/import-data.ts
+++ b/tools/migrate/src/import-data.ts
@@ -1,0 +1,367 @@
+/**
+ * Imports exported Supabase data into a running HelixDB instance.
+ *
+ * Reads JSON export files and calls the generated Import* queries
+ * via the HelixDB HTTP API to load data into the graph.
+ *
+ * Also maintains a mapping from old PG primary keys to new HelixDB IDs
+ * so that edges (foreign key relationships) can be correctly linked.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { GeneratedSchema, NodeSchema, EdgeSchema } from "./generate-schema";
+import { TableInfo } from "./introspect";
+
+export interface ImportOptions {
+  helixUrl: string; // e.g., http://localhost:6969
+  exportDir: string; // directory with exported JSON files
+  schema: GeneratedSchema;
+  tables: TableInfo[]; // original PG tables for FK resolution
+  concurrency: number; // parallel requests
+  onProgress?: (table: string, imported: number, total: number) => void;
+}
+
+export interface ImportResult {
+  nodesImported: number;
+  edgesImported: number;
+  vectorsImported: number;
+  errors: ImportError[];
+  idMap: Map<string, Map<string, string>>; // table -> oldPK -> newHelixID
+}
+
+export interface ImportError {
+  table: string;
+  row: number;
+  error: string;
+}
+
+/**
+ * Import all exported data into HelixDB.
+ *
+ * Order of operations:
+ * 1. Import all Nodes (tables without FK dependencies first, then dependent tables)
+ * 2. Import all Edges (using the ID mapping from step 1)
+ * 3. Import all Vectors
+ */
+export async function importData(
+  options: ImportOptions
+): Promise<ImportResult> {
+  const { helixUrl, exportDir, schema, tables, concurrency, onProgress } = options;
+
+  const result: ImportResult = {
+    nodesImported: 0,
+    edgesImported: 0,
+    vectorsImported: 0,
+    errors: [],
+    idMap: new Map(),
+  };
+
+  // Build table info map
+  const tableInfoMap = new Map<string, TableInfo>();
+  for (const t of tables) {
+    tableInfoMap.set(t.name, t);
+  }
+
+  // Step 1: Import nodes (topologically sorted by FK dependencies)
+  const sortedNodes = topologicalSort(schema.nodes, schema.edges);
+
+  for (const node of sortedNodes) {
+    const exportFile = path.join(exportDir, `${node.originalTable}.json`);
+    if (!fs.existsSync(exportFile)) continue;
+
+    const rows: Record<string, unknown>[] = JSON.parse(
+      fs.readFileSync(exportFile, "utf-8")
+    );
+
+    const tableInfo = tableInfoMap.get(node.originalTable);
+    const pkColumns = tableInfo?.primaryKeys ?? [];
+
+    // Initialize ID map for this table
+    const tableIdMap = new Map<string, string>();
+    result.idMap.set(node.originalTable, tableIdMap);
+
+    // Import rows in batches
+    const batches = chunk(rows, concurrency);
+    let imported = 0;
+
+    for (const batch of batches) {
+      const promises = batch.map(async (row, batchIdx) => {
+        const rowIdx = imported + batchIdx;
+        try {
+          // Build the request body from node fields
+          const body: Record<string, unknown> = {};
+          for (const field of node.fields) {
+            const value = row[field.originalColumn];
+            if (value !== null && value !== undefined) {
+              body[field.name] = value;
+            }
+          }
+
+          // Call the Import query
+          const response = await callHelix(
+            helixUrl,
+            `Import${node.name}`,
+            body
+          );
+
+          // Store the ID mapping (old PK -> new Helix ID)
+          if (response && pkColumns.length > 0) {
+            const oldPk = pkColumns.map((pk) => String(row[pk])).join(":");
+            const newId = extractId(response);
+            if (newId) {
+              tableIdMap.set(oldPk, newId);
+            }
+          }
+
+          result.nodesImported++;
+        } catch (err) {
+          result.errors.push({
+            table: node.originalTable,
+            row: rowIdx,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
+
+      await Promise.all(promises);
+      imported += batch.length;
+      onProgress?.(node.originalTable, imported, rows.length);
+    }
+  }
+
+  // Step 2: Import edges using the ID mapping
+  for (const edge of schema.edges) {
+    // Find the source table for this edge
+    const sourceNode = schema.nodes.find((n) => n.name === edge.fromNode);
+    if (!sourceNode) continue;
+
+    const exportFile = path.join(exportDir, `${sourceNode.originalTable}.json`);
+    if (!fs.existsSync(exportFile)) continue;
+
+    const rows: Record<string, unknown>[] = JSON.parse(
+      fs.readFileSync(exportFile, "utf-8")
+    );
+
+    const tableInfo = tableInfoMap.get(sourceNode.originalTable);
+    const pkColumns = tableInfo?.primaryKeys ?? [];
+
+    // Find the FK column and target table
+    const fk = tableInfo?.foreignKeys.find(
+      (fk) => fk.constraintName === edge.originalConstraint
+    );
+    if (!fk) continue;
+
+    const sourceIdMap = result.idMap.get(sourceNode.originalTable);
+    const targetIdMap = result.idMap.get(fk.foreignTableName);
+    if (!sourceIdMap || !targetIdMap) continue;
+
+    let imported = 0;
+    const batches = chunk(rows, concurrency);
+
+    for (const batch of batches) {
+      const promises = batch.map(async (row, batchIdx) => {
+        const rowIdx = imported + batchIdx;
+        try {
+          // Get the old FK value
+          const oldFkValue = String(row[fk.columnName]);
+          if (!oldFkValue || oldFkValue === "null" || oldFkValue === "undefined") return;
+
+          // Look up the new Helix IDs
+          const oldSourcePk = pkColumns.map((pk) => String(row[pk])).join(":");
+          const fromId = sourceIdMap.get(oldSourcePk);
+          const toId = targetIdMap.get(oldFkValue);
+
+          if (!fromId || !toId) return;
+
+          await callHelix(helixUrl, `Import${edge.name}`, {
+            from_id: fromId,
+            to_id: toId,
+          });
+
+          result.edgesImported++;
+        } catch (err) {
+          result.errors.push({
+            table: `${edge.fromNode}->${edge.toNode}`,
+            row: rowIdx,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
+
+      await Promise.all(promises);
+      imported += batch.length;
+      onProgress?.(`Edge: ${edge.name}`, imported, rows.length);
+    }
+  }
+
+  // Step 3: Import vectors
+  for (const vec of schema.vectors) {
+    const exportFile = path.join(exportDir, `${vec.originalTable}.json`);
+    if (!fs.existsSync(exportFile)) continue;
+
+    const rows: Record<string, unknown>[] = JSON.parse(
+      fs.readFileSync(exportFile, "utf-8")
+    );
+
+    let imported = 0;
+    const batches = chunk(rows, concurrency);
+
+    for (const batch of batches) {
+      const promises = batch.map(async (row, batchIdx) => {
+        const rowIdx = imported + batchIdx;
+        try {
+          const body: Record<string, unknown> = {};
+
+          // Extract vector data
+          const vectorData = row[vec.vectorColumn];
+          if (!vectorData) return;
+          body.vector = Array.isArray(vectorData)
+            ? vectorData
+            : JSON.parse(String(vectorData));
+
+          // Extract metadata
+          for (const field of vec.metadataFields) {
+            const value = row[field.originalColumn];
+            if (value !== null && value !== undefined) {
+              body[field.name] = value;
+            }
+          }
+
+          await callHelix(helixUrl, `Import${vec.name}`, body);
+          result.vectorsImported++;
+        } catch (err) {
+          result.errors.push({
+            table: vec.originalTable,
+            row: rowIdx,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
+
+      await Promise.all(promises);
+      imported += batch.length;
+      onProgress?.(`Vector: ${vec.name}`, imported, rows.length);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Call a HelixDB query via its HTTP API.
+ */
+async function callHelix(
+  baseUrl: string,
+  queryName: string,
+  body: Record<string, unknown>
+): Promise<unknown> {
+  const url = `${baseUrl}/${queryName}`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`HelixDB API error (${response.status}): ${errorText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Extract the HelixDB ID from a query response.
+ */
+function extractId(response: unknown): string | null {
+  if (!response || typeof response !== "object") return null;
+
+  const obj = response as Record<string, unknown>;
+
+  // HelixDB returns node data with an "id" field
+  if (typeof obj.id === "string") return obj.id;
+
+  // Check nested response formats
+  if (Array.isArray(response) && response.length > 0) {
+    const first = response[0] as Record<string, unknown>;
+    if (typeof first?.id === "string") return first.id;
+  }
+
+  return null;
+}
+
+/**
+ * Topologically sort nodes so that tables with no FK dependencies come first.
+ */
+function topologicalSort(
+  nodes: NodeSchema[],
+  edges: EdgeSchema[]
+): NodeSchema[] {
+  // Build adjacency: fromNode depends on toNode (toNode must be imported first)
+  const deps = new Map<string, Set<string>>();
+  for (const node of nodes) {
+    deps.set(node.name, new Set());
+  }
+  for (const edge of edges) {
+    if (edge.fromNode !== edge.toNode) {
+      // fromNode depends on toNode
+      deps.get(edge.fromNode)?.add(edge.toNode);
+    }
+  }
+
+  const sorted: NodeSchema[] = [];
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+
+  function visit(name: string): void {
+    if (visited.has(name)) return;
+    if (visiting.has(name)) return; // cycle, skip
+
+    visiting.add(name);
+    const nodeDeps = deps.get(name);
+    if (nodeDeps) {
+      for (const dep of nodeDeps) {
+        visit(dep);
+      }
+    }
+    visiting.delete(name);
+    visited.add(name);
+
+    const node = nodes.find((n) => n.name === name);
+    if (node) sorted.push(node);
+  }
+
+  for (const node of nodes) {
+    visit(node.name);
+  }
+
+  return sorted;
+}
+
+/**
+ * Split an array into chunks of a given size.
+ */
+function chunk<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Generate an ID mapping file for reference.
+ * Maps old Supabase PKs to new HelixDB IDs.
+ */
+export function saveIdMapping(
+  idMap: Map<string, Map<string, string>>,
+  outputPath: string
+): void {
+  const serializable: Record<string, Record<string, string>> = {};
+  for (const [table, mapping] of idMap) {
+    serializable[table] = Object.fromEntries(mapping);
+  }
+  fs.writeFileSync(outputPath, JSON.stringify(serializable, null, 2));
+}

--- a/tools/migrate/src/import-data.ts
+++ b/tools/migrate/src/import-data.ts
@@ -1,33 +1,27 @@
 /**
  * Imports exported Supabase data into a running HelixDB instance.
- *
- * Reads JSON export files and calls the generated Import* queries
- * via the HelixDB HTTP API to load data into the graph.
- *
- * Also maintains a mapping from old PG primary keys to new HelixDB IDs
- * so that edges (foreign key relationships) can be correctly linked.
  */
 
 import * as fs from "fs";
 import * as path from "path";
-import { GeneratedSchema, NodeSchema, EdgeSchema } from "./generate-schema";
+import {
+  GeneratedSchema,
+  NodeSchema,
+  EdgeSchema,
+  FieldSchema,
+  VectorSchema,
+} from "./generate-schema";
+import { nodeNullableSetterQueryName } from "./generate-queries";
 import { TableInfo } from "./introspect";
+import { exportFileNameForTable, makeTableKey } from "./export-data";
 
 export interface ImportOptions {
-  helixUrl: string; // e.g., http://localhost:6969
-  exportDir: string; // directory with exported JSON files
+  helixUrl: string;
+  exportDir: string;
   schema: GeneratedSchema;
-  tables: TableInfo[]; // original PG tables for FK resolution
-  concurrency: number; // parallel requests
+  tables: TableInfo[];
+  concurrency: number;
   onProgress?: (table: string, imported: number, total: number) => void;
-}
-
-export interface ImportResult {
-  nodesImported: number;
-  edgesImported: number;
-  vectorsImported: number;
-  errors: ImportError[];
-  idMap: Map<string, Map<string, string>>; // table -> oldPK -> newHelixID
 }
 
 export interface ImportError {
@@ -36,88 +30,163 @@ export interface ImportError {
   error: string;
 }
 
-/**
- * Import all exported data into HelixDB.
- *
- * Order of operations:
- * 1. Import all Nodes (tables without FK dependencies first, then dependent tables)
- * 2. Import all Edges (using the ID mapping from step 1)
- * 3. Import all Vectors
- */
-export async function importData(
-  options: ImportOptions
-): Promise<ImportResult> {
+export interface ImportEntityStats {
+  attempted: number;
+  imported: number;
+  failed: number;
+  skipped: number;
+  unresolved: number;
+}
+
+export interface ImportResult {
+  nodesImported: number;
+  edgesImported: number;
+  vectorsImported: number;
+  errors: ImportError[];
+  warnings: string[];
+  idMap: Map<string, Map<string, string>>;
+  nodeStats: Record<string, ImportEntityStats>;
+  edgeStats: Record<string, ImportEntityStats>;
+  vectorStats: Record<string, ImportEntityStats>;
+}
+
+const HELIX_TIMEOUT_MS = 30_000;
+const HELIX_MAX_ATTEMPTS = 4;
+
+export async function importData(options: ImportOptions): Promise<ImportResult> {
   const { helixUrl, exportDir, schema, tables, concurrency, onProgress } = options;
+
+  const safeConcurrency = Math.max(1, Math.floor(concurrency));
 
   const result: ImportResult = {
     nodesImported: 0,
     edgesImported: 0,
     vectorsImported: 0,
     errors: [],
+    warnings: [],
     idMap: new Map(),
+    nodeStats: {},
+    edgeStats: {},
+    vectorStats: {},
   };
 
-  // Build table info map
-  const tableInfoMap = new Map<string, TableInfo>();
-  for (const t of tables) {
-    tableInfoMap.set(t.name, t);
+  const tableInfoByKey = new Map<string, TableInfo>();
+  for (const table of tables) {
+    tableInfoByKey.set(makeTableKey(table.schema, table.name), table);
   }
 
-  // Step 1: Import nodes (topologically sorted by FK dependencies)
+  const tableLookupMaps = new Map<string, Map<string, Map<string, string>>>();
   const sortedNodes = topologicalSort(schema.nodes, schema.edges);
 
   for (const node of sortedNodes) {
-    const exportFile = path.join(exportDir, `${node.originalTable}.json`);
-    if (!fs.existsSync(exportFile)) continue;
+    const tableKey = node.tableKey;
+    const stats = getStats(result.nodeStats, tableKey);
 
-    const rows: Record<string, unknown>[] = JSON.parse(
-      fs.readFileSync(exportFile, "utf-8")
+    const exportFile = path.join(
+      exportDir,
+      exportFileNameForTable(node.originalSchema, node.originalTable)
     );
+    if (!fs.existsSync(exportFile)) {
+      result.warnings.push(`Missing export file for ${tableKey}: ${exportFile}`);
+      continue;
+    }
 
-    const tableInfo = tableInfoMap.get(node.originalTable);
-    const pkColumns = tableInfo?.primaryKeys ?? [];
+    const rows = readRows(exportFile);
+    const tableInfo = tableInfoByKey.get(tableKey);
+    if (!tableInfo) {
+      result.warnings.push(`Missing table metadata for ${tableKey}; skipping node import`);
+      continue;
+    }
 
-    // Initialize ID map for this table
+    const pkColumns = tableInfo.primaryKeys;
+    const uniqueKeySets = getUniqueColumnSets(tableInfo);
+
+    const lookupByKeySet = initializeLookupMaps(tableLookupMaps, tableKey, uniqueKeySets);
+
+    const requiredFields = node.fields.filter((field) => !field.isNullable);
+    const nullableFields = node.fields.filter((field) => field.isNullable);
+
     const tableIdMap = new Map<string, string>();
-    result.idMap.set(node.originalTable, tableIdMap);
+    result.idMap.set(tableKey, tableIdMap);
 
-    // Import rows in batches
-    const batches = chunk(rows, concurrency);
-    let imported = 0;
+    let importedInTable = 0;
+    const batches = chunk(rows, safeConcurrency);
 
     for (const batch of batches) {
       const promises = batch.map(async (row, batchIdx) => {
-        const rowIdx = imported + batchIdx;
+        const rowIdx = importedInTable + batchIdx;
+        stats.attempted += 1;
+
         try {
-          // Build the request body from node fields
           const body: Record<string, unknown> = {};
-          for (const field of node.fields) {
-            const value = row[field.originalColumn];
-            if (value !== null && value !== undefined) {
-              body[field.name] = value;
+          for (const field of requiredFields) {
+            const raw = row[field.originalColumn];
+            if (raw === null || raw === undefined) {
+              throw new Error(
+                `Missing required column ${field.originalColumn} for non-nullable field ${field.name}`
+              );
             }
+
+            body[field.name] = coerceFieldValue(
+              raw,
+              field,
+              `${tableKey} row ${rowIdx} column ${field.originalColumn}`
+            );
           }
 
-          // Call the Import query
-          const response = await callHelix(
-            helixUrl,
-            `Import${node.name}`,
-            body
-          );
-
-          // Store the ID mapping (old PK -> new Helix ID)
-          if (response && pkColumns.length > 0) {
-            const oldPk = pkColumns.map((pk) => String(row[pk])).join(":");
-            const newId = extractId(response);
-            if (newId) {
-              tableIdMap.set(oldPk, newId);
-            }
+          const response = await callHelix(helixUrl, `Import${node.name}`, body);
+          const newId = extractId(response);
+          if (!newId) {
+            throw new Error(
+              `Import${node.name} did not return an id; cannot complete import for this row`
+            );
           }
 
-          result.nodesImported++;
+          if (pkColumns.length > 0) {
+            const oldPkKey = buildCompositeKeyFromColumns(row, pkColumns);
+            if (oldPkKey === null) {
+              throw new Error(
+                `Primary key columns missing for ${tableKey} (${pkColumns.join(", ")})`
+              );
+            }
+            tableIdMap.set(oldPkKey, newId);
+          }
+
+          for (const keySet of uniqueKeySets) {
+            const lookupKey = buildCompositeKeyFromColumns(row, keySet);
+            if (lookupKey === null) {
+              continue;
+            }
+
+            const keySetMap = lookupByKeySet.get(columnSignature(keySet));
+            keySetMap?.set(lookupKey, newId);
+          }
+
+          for (const field of nullableFields) {
+            const raw = row[field.originalColumn];
+            if (raw === null || raw === undefined) {
+              continue;
+            }
+
+            const setterName = nodeNullableSetterQueryName(node.name, field.name);
+            const value = coerceFieldValue(
+              raw,
+              field,
+              `${tableKey} row ${rowIdx} nullable column ${field.originalColumn}`
+            );
+
+            await callHelix(helixUrl, setterName, {
+              id: newId,
+              value,
+            });
+          }
+
+          stats.imported += 1;
+          result.nodesImported += 1;
         } catch (err) {
+          stats.failed += 1;
           result.errors.push({
-            table: node.originalTable,
+            table: tableKey,
             row: rowIdx,
             error: err instanceof Error ? err.message : String(err),
           });
@@ -125,64 +194,117 @@ export async function importData(
       });
 
       await Promise.all(promises);
-      imported += batch.length;
-      onProgress?.(node.originalTable, imported, rows.length);
+      importedInTable += batch.length;
+      onProgress?.(tableKey, importedInTable, rows.length);
+    }
+
+    if (pkColumns.length > 0 && stats.imported > 0 && tableIdMap.size !== stats.imported) {
+      throw new Error(
+        `ID mapping mismatch for ${tableKey}: imported ${stats.imported} rows but mapped ${tableIdMap.size} IDs`
+      );
     }
   }
 
-  // Step 2: Import edges using the ID mapping
   for (const edge of schema.edges) {
-    // Find the source table for this edge
-    const sourceNode = schema.nodes.find((n) => n.name === edge.fromNode);
-    if (!sourceNode) continue;
+    const edgeStatKey = `${edge.fromTableKey}::${edge.name}`;
+    const stats = getStats(result.edgeStats, edgeStatKey);
 
-    const exportFile = path.join(exportDir, `${sourceNode.originalTable}.json`);
-    if (!fs.existsSync(exportFile)) continue;
+    const sourceNode = schema.nodes.find((node) => node.tableKey === edge.fromTableKey);
+    if (!sourceNode) {
+      result.warnings.push(`Skipping edge ${edge.name}: missing source node ${edge.fromTableKey}`);
+      continue;
+    }
 
-    const rows: Record<string, unknown>[] = JSON.parse(
-      fs.readFileSync(exportFile, "utf-8")
+    const sourceInfo = tableInfoByKey.get(edge.fromTableKey);
+    const targetInfo = tableInfoByKey.get(edge.toTableKey);
+    if (!sourceInfo || !targetInfo) {
+      result.warnings.push(
+        `Skipping edge ${edge.name}: missing table metadata for ${edge.fromTableKey} or ${edge.toTableKey}`
+      );
+      continue;
+    }
+
+    if (sourceInfo.primaryKeys.length === 0) {
+      result.warnings.push(
+        `Skipping edge ${edge.name}: source table ${edge.fromTableKey} has no primary key`
+      );
+      continue;
+    }
+
+    const sourceIdMap = result.idMap.get(edge.fromTableKey);
+    if (!sourceIdMap) {
+      result.warnings.push(
+        `Skipping edge ${edge.name}: no source ID map found for ${edge.fromTableKey}`
+      );
+      continue;
+    }
+
+    const targetLookup = tableLookupMaps
+      .get(edge.toTableKey)
+      ?.get(columnSignature(edge.referencedColumns));
+    if (!targetLookup) {
+      result.warnings.push(
+        `Skipping edge ${edge.name}: target columns (${edge.referencedColumns.join(", ")}) are not a known unique key on ${edge.toTableKey}`
+      );
+      continue;
+    }
+
+    const exportFile = path.join(
+      exportDir,
+      exportFileNameForTable(sourceNode.originalSchema, sourceNode.originalTable)
     );
+    if (!fs.existsSync(exportFile)) {
+      result.warnings.push(`Missing export file for edge ${edge.name}: ${exportFile}`);
+      continue;
+    }
 
-    const tableInfo = tableInfoMap.get(sourceNode.originalTable);
-    const pkColumns = tableInfo?.primaryKeys ?? [];
+    const rows = readRows(exportFile);
+    const deferred: Array<{ row: Record<string, unknown>; rowIdx: number }> = [];
 
-    // Find the FK column and target table
-    const fk = tableInfo?.foreignKeys.find(
-      (fk) => fk.constraintName === edge.originalConstraint
-    );
-    if (!fk) continue;
-
-    const sourceIdMap = result.idMap.get(sourceNode.originalTable);
-    const targetIdMap = result.idMap.get(fk.foreignTableName);
-    if (!sourceIdMap || !targetIdMap) continue;
-
-    let imported = 0;
-    const batches = chunk(rows, concurrency);
+    let importedInEdge = 0;
+    const batches = chunk(rows, safeConcurrency);
 
     for (const batch of batches) {
       const promises = batch.map(async (row, batchIdx) => {
-        const rowIdx = imported + batchIdx;
+        const rowIdx = importedInEdge + batchIdx;
+        stats.attempted += 1;
+
         try {
-          // Get the old FK value
-          const oldFkValue = String(row[fk.columnName]);
-          if (!oldFkValue || oldFkValue === "null" || oldFkValue === "undefined") return;
+          const sourcePkKey = buildCompositeKeyFromColumns(row, sourceInfo.primaryKeys);
+          if (sourcePkKey === null) {
+            stats.failed += 1;
+            result.errors.push({
+              table: edgeStatKey,
+              row: rowIdx,
+              error: `Missing source primary key values (${sourceInfo.primaryKeys.join(", ")})`,
+            });
+            return;
+          }
 
-          // Look up the new Helix IDs
-          const oldSourcePk = pkColumns.map((pk) => String(row[pk])).join(":");
-          const fromId = sourceIdMap.get(oldSourcePk);
-          const toId = targetIdMap.get(oldFkValue);
+          const fkKey = buildCompositeKeyFromColumns(row, edge.originalColumns);
+          if (fkKey === null) {
+            stats.skipped += 1;
+            return;
+          }
 
-          if (!fromId || !toId) return;
+          const fromId = sourceIdMap.get(sourcePkKey);
+          const toId = targetLookup.get(fkKey);
+          if (!fromId || !toId) {
+            deferred.push({ row, rowIdx });
+            return;
+          }
 
           await callHelix(helixUrl, `Import${edge.name}`, {
             from_id: fromId,
             to_id: toId,
           });
 
-          result.edgesImported++;
+          stats.imported += 1;
+          result.edgesImported += 1;
         } catch (err) {
+          stats.failed += 1;
           result.errors.push({
-            table: `${edge.fromNode}->${edge.toNode}`,
+            table: edgeStatKey,
             row: rowIdx,
             error: err instanceof Error ? err.message : String(err),
           });
@@ -190,49 +312,127 @@ export async function importData(
       });
 
       await Promise.all(promises);
-      imported += batch.length;
-      onProgress?.(`Edge: ${edge.name}`, imported, rows.length);
+      importedInEdge += batch.length;
+      onProgress?.(`Edge: ${edge.name}`, importedInEdge, rows.length);
+    }
+
+    for (const { row, rowIdx } of deferred) {
+      try {
+        const sourcePkKey = buildCompositeKeyFromColumns(row, sourceInfo.primaryKeys);
+        const fkKey = buildCompositeKeyFromColumns(row, edge.originalColumns);
+
+        if (!sourcePkKey || !fkKey) {
+          stats.unresolved += 1;
+          continue;
+        }
+
+        const fromId = sourceIdMap.get(sourcePkKey);
+        const toId = targetLookup.get(fkKey);
+        if (!fromId || !toId) {
+          stats.unresolved += 1;
+          result.errors.push({
+            table: edgeStatKey,
+            row: rowIdx,
+            error: `Unresolved FK mapping for edge ${edge.name}`,
+          });
+          continue;
+        }
+
+        await callHelix(helixUrl, `Import${edge.name}`, {
+          from_id: fromId,
+          to_id: toId,
+        });
+
+        stats.imported += 1;
+        result.edgesImported += 1;
+      } catch (err) {
+        stats.failed += 1;
+        result.errors.push({
+          table: edgeStatKey,
+          row: rowIdx,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
   }
 
-  // Step 3: Import vectors
-  for (const vec of schema.vectors) {
-    const exportFile = path.join(exportDir, `${vec.originalTable}.json`);
-    if (!fs.existsSync(exportFile)) continue;
+  for (const vector of schema.vectors) {
+    const vectorStatKey = `${vector.tableKey}::${vector.name}`;
+    const stats = getStats(result.vectorStats, vectorStatKey);
 
-    const rows: Record<string, unknown>[] = JSON.parse(
-      fs.readFileSync(exportFile, "utf-8")
+    const exportFile = path.join(
+      exportDir,
+      exportFileNameForTable(vector.originalSchema, vector.originalTable)
     );
+    if (!fs.existsSync(exportFile)) {
+      result.warnings.push(
+        `Missing export file for vector ${vector.name}: ${exportFile}`
+      );
+      continue;
+    }
 
-    let imported = 0;
-    const batches = chunk(rows, concurrency);
+    const rows = readRows(exportFile);
+    const requiredMetadata = vector.metadataFields.filter((field) => !field.isNullable);
+    const nullableMetadata = vector.metadataFields.filter((field) => field.isNullable);
+
+    if (nullableMetadata.length > 0) {
+      result.warnings.push(
+        `Vector ${vector.name} has nullable metadata fields that are not imported (${nullableMetadata
+          .map((field) => field.name)
+          .join(", ")})`
+      );
+    }
+
+    let importedInVector = 0;
+    const batches = chunk(rows, safeConcurrency);
 
     for (const batch of batches) {
       const promises = batch.map(async (row, batchIdx) => {
-        const rowIdx = imported + batchIdx;
+        const rowIdx = importedInVector + batchIdx;
+        stats.attempted += 1;
+
         try {
-          const body: Record<string, unknown> = {};
+          const vectorValue = row[vector.vectorColumn];
+          if (vectorValue === null || vectorValue === undefined) {
+            stats.skipped += 1;
+            return;
+          }
 
-          // Extract vector data
-          const vectorData = row[vec.vectorColumn];
-          if (!vectorData) return;
-          body.vector = Array.isArray(vectorData)
-            ? vectorData
-            : JSON.parse(String(vectorData));
+          const body: Record<string, unknown> = {
+            vector: parseVectorValue(vectorValue),
+          };
 
-          // Extract metadata
-          for (const field of vec.metadataFields) {
-            const value = row[field.originalColumn];
-            if (value !== null && value !== undefined) {
-              body[field.name] = value;
+          for (const field of requiredMetadata) {
+            const raw = row[field.originalColumn];
+            if (raw === null || raw === undefined) {
+              throw new Error(
+                `Missing required metadata column ${field.originalColumn} for vector ${vector.name}`
+              );
+            }
+
+            body[field.name] = coerceFieldValue(
+              raw,
+              field,
+              `${vector.tableKey} row ${rowIdx} vector metadata ${field.originalColumn}`
+            );
+          }
+
+          for (const field of nullableMetadata) {
+            const raw = row[field.originalColumn];
+            if (raw !== null && raw !== undefined) {
+              stats.skipped += 1;
+              break;
             }
           }
 
-          await callHelix(helixUrl, `Import${vec.name}`, body);
-          result.vectorsImported++;
+          await callHelix(helixUrl, `Import${vector.name}`, body);
+
+          stats.imported += 1;
+          result.vectorsImported += 1;
         } catch (err) {
+          stats.failed += 1;
           result.errors.push({
-            table: vec.originalTable,
+            table: vectorStatKey,
             row: rowIdx,
             error: err instanceof Error ? err.message : String(err),
           });
@@ -240,74 +440,146 @@ export async function importData(
       });
 
       await Promise.all(promises);
-      imported += batch.length;
-      onProgress?.(`Vector: ${vec.name}`, imported, rows.length);
+      importedInVector += batch.length;
+      onProgress?.(`Vector: ${vector.name}`, importedInVector, rows.length);
     }
   }
 
   return result;
 }
 
-/**
- * Call a HelixDB query via its HTTP API.
- */
 async function callHelix(
   baseUrl: string,
   queryName: string,
   body: Record<string, unknown>
 ): Promise<unknown> {
-  const url = `${baseUrl}/${queryName}`;
+  const url = `${baseUrl.replace(/\/+$/, "")}/${queryName}`;
+  let lastError: unknown;
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  for (let attempt = 1; attempt <= HELIX_MAX_ATTEMPTS; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), HELIX_TIMEOUT_MS);
 
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`HelixDB API error (${response.status}): ${errorText}`);
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeout);
+
+      if (!response.ok) {
+        const text = await response.text();
+        const retryable = response.status >= 500 || response.status === 429;
+
+        if (retryable && attempt < HELIX_MAX_ATTEMPTS) {
+          await wait(backoffMs(attempt));
+          continue;
+        }
+
+        throw new Error(`HelixDB API error (${response.status}): ${text}`);
+      }
+
+      const raw = await response.text();
+      if (!raw.trim()) {
+        return {};
+      }
+
+      try {
+        return JSON.parse(raw);
+      } catch {
+        return raw;
+      }
+    } catch (err) {
+      clearTimeout(timeout);
+      lastError = err;
+
+      const isAbort = err instanceof Error && err.name === "AbortError";
+      const isNetwork = err instanceof TypeError;
+      if ((isAbort || isNetwork) && attempt < HELIX_MAX_ATTEMPTS) {
+        await wait(backoffMs(attempt));
+        continue;
+      }
+
+      if (attempt >= HELIX_MAX_ATTEMPTS) {
+        break;
+      }
+    }
   }
 
-  return response.json();
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Failed to call HelixDB API");
 }
 
-/**
- * Extract the HelixDB ID from a query response.
- */
-function extractId(response: unknown): string | null {
-  if (!response || typeof response !== "object") return null;
-
-  const obj = response as Record<string, unknown>;
-
-  // HelixDB returns node data with an "id" field
-  if (typeof obj.id === "string") return obj.id;
-
-  // Check nested response formats
-  if (Array.isArray(response) && response.length > 0) {
-    const first = response[0] as Record<string, unknown>;
-    if (typeof first?.id === "string") return first.id;
+export function extractId(response: unknown): string | null {
+  if (typeof response === "string") {
+    return response;
   }
 
-  return null;
+  const seen = new Set<unknown>();
+
+  function visit(value: unknown, depth: number): string | null {
+    if (depth > 10 || value === null || value === undefined) {
+      return null;
+    }
+
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      return null;
+    }
+
+    if (typeof value !== "object") {
+      return null;
+    }
+
+    if (seen.has(value)) {
+      return null;
+    }
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const found = visit(item, depth + 1);
+        if (found) {
+          return found;
+        }
+      }
+      return null;
+    }
+
+    const objectValue = value as Record<string, unknown>;
+
+    if (typeof objectValue.id === "string") {
+      return objectValue.id;
+    }
+    if (typeof objectValue.id === "number") {
+      return String(objectValue.id);
+    }
+
+    for (const nested of Object.values(objectValue)) {
+      const found = visit(nested, depth + 1);
+      if (found) {
+        return found;
+      }
+    }
+
+    return null;
+  }
+
+  return visit(response, 0);
 }
 
-/**
- * Topologically sort nodes so that tables with no FK dependencies come first.
- */
-function topologicalSort(
-  nodes: NodeSchema[],
-  edges: EdgeSchema[]
-): NodeSchema[] {
-  // Build adjacency: fromNode depends on toNode (toNode must be imported first)
+function topologicalSort(nodes: NodeSchema[], edges: EdgeSchema[]): NodeSchema[] {
   const deps = new Map<string, Set<string>>();
   for (const node of nodes) {
-    deps.set(node.name, new Set());
+    deps.set(node.tableKey, new Set());
   }
+
   for (const edge of edges) {
-    if (edge.fromNode !== edge.toNode) {
-      // fromNode depends on toNode
-      deps.get(edge.fromNode)?.add(edge.toNode);
+    if (edge.fromTableKey !== edge.toTableKey) {
+      deps.get(edge.fromTableKey)?.add(edge.toTableKey);
     }
   }
 
@@ -315,53 +587,359 @@ function topologicalSort(
   const visited = new Set<string>();
   const visiting = new Set<string>();
 
-  function visit(name: string): void {
-    if (visited.has(name)) return;
-    if (visiting.has(name)) return; // cycle, skip
+  function visit(tableKey: string): void {
+    if (visited.has(tableKey)) {
+      return;
+    }
+    if (visiting.has(tableKey)) {
+      return;
+    }
 
-    visiting.add(name);
-    const nodeDeps = deps.get(name);
-    if (nodeDeps) {
-      for (const dep of nodeDeps) {
+    visiting.add(tableKey);
+    const dependencies = deps.get(tableKey);
+    if (dependencies) {
+      for (const dep of dependencies) {
         visit(dep);
       }
     }
-    visiting.delete(name);
-    visited.add(name);
+    visiting.delete(tableKey);
+    visited.add(tableKey);
 
-    const node = nodes.find((n) => n.name === name);
-    if (node) sorted.push(node);
+    const node = nodes.find((candidate) => candidate.tableKey === tableKey);
+    if (node) {
+      sorted.push(node);
+    }
   }
 
   for (const node of nodes) {
-    visit(node.name);
+    visit(node.tableKey);
   }
 
   return sorted;
 }
 
-/**
- * Split an array into chunks of a given size.
- */
 function chunk<T>(arr: T[], size: number): T[][] {
+  const safeSize = Math.max(1, size);
   const chunks: T[][] = [];
-  for (let i = 0; i < arr.length; i += size) {
-    chunks.push(arr.slice(i, i + size));
+
+  for (let i = 0; i < arr.length; i += safeSize) {
+    chunks.push(arr.slice(i, i + safeSize));
   }
+
   return chunks;
 }
 
-/**
- * Generate an ID mapping file for reference.
- * Maps old Supabase PKs to new HelixDB IDs.
- */
+function readRows(filePath: string): Record<string, unknown>[] {
+  return JSON.parse(fs.readFileSync(filePath, "utf-8")) as Record<string, unknown>[];
+}
+
+export function buildCompositeKeyFromColumns(
+  row: Record<string, unknown>,
+  columns: string[]
+): string | null {
+  if (columns.length === 0) {
+    return null;
+  }
+
+  const values: unknown[] = [];
+
+  for (const column of columns) {
+    const value = row[column];
+    if (value === null || value === undefined) {
+      return null;
+    }
+    values.push(normalizeKeyValue(value));
+  }
+
+  return JSON.stringify(values);
+}
+
+function normalizeKeyValue(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return value.toString("base64");
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeKeyValue(entry));
+  }
+
+  if (value && typeof value === "object") {
+    return JSON.stringify(value);
+  }
+
+  return value;
+}
+
+function parseVectorValue(value: unknown): number[] {
+  let parsed: unknown = value;
+
+  if (typeof value === "string") {
+    parsed = JSON.parse(value);
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("Vector value must be an array");
+  }
+
+  return parsed.map((entry) => toFiniteNumber(entry));
+}
+
+function coerceFieldValue(
+  value: unknown,
+  field: FieldSchema,
+  context: string
+): unknown {
+  try {
+    return coerceForHelix(value, field);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to coerce ${context}: ${message}`);
+  }
+}
+
+function coerceForHelix(value: unknown, field: FieldSchema): unknown {
+  if (field.helixType.startsWith("[")) {
+    return coerceArray(value, field.helixType);
+  }
+
+  switch (field.helixType) {
+    case "I8":
+    case "I16":
+    case "I32":
+    case "I64":
+    case "U8":
+    case "U16":
+    case "U32":
+    case "U64":
+    case "U128":
+      return toInteger(value);
+    case "F32":
+    case "F64":
+      return toFiniteNumber(value);
+    case "Boolean":
+      return toBoolean(value);
+    case "Date":
+      if (value instanceof Date) {
+        return value.toISOString();
+      }
+      return value;
+    case "String":
+      if (typeof value === "string") {
+        return value;
+      }
+      if (value instanceof Date) {
+        return value.toISOString();
+      }
+      if (field.needsSerialization && typeof value === "object") {
+        return JSON.stringify(value);
+      }
+      return String(value);
+    default:
+      return value;
+  }
+}
+
+function coerceArray(value: unknown, helixType: string): unknown[] {
+  const innerType = helixType.slice(1, -1).trim();
+  let arr: unknown[];
+
+  if (Array.isArray(value)) {
+    arr = value;
+  } else if (typeof value === "string") {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      throw new Error(`Expected array for ${helixType}`);
+    }
+    arr = parsed;
+  } else {
+    throw new Error(`Expected array for ${helixType}`);
+  }
+
+  return arr.map((entry) => coerceSimpleValue(entry, innerType));
+}
+
+function coerceSimpleValue(value: unknown, helixType: string): unknown {
+  switch (helixType) {
+    case "I8":
+    case "I16":
+    case "I32":
+    case "I64":
+    case "U8":
+    case "U16":
+    case "U32":
+    case "U64":
+    case "U128":
+      return toInteger(value);
+    case "F32":
+    case "F64":
+      return toFiniteNumber(value);
+    case "Boolean":
+      return toBoolean(value);
+    default:
+      return value;
+  }
+}
+
+function toInteger(value: unknown): number {
+  const maxSafe = BigInt(Number.MAX_SAFE_INTEGER);
+  const minSafe = BigInt(Number.MIN_SAFE_INTEGER);
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error("Expected finite integer value");
+    }
+    if (!Number.isSafeInteger(value)) {
+      throw new Error("Unsafe integer; use --bigint-mode string to avoid precision loss");
+    }
+    return Math.trunc(value);
+  }
+
+  if (typeof value === "string") {
+    if (!/^-?\d+$/.test(value.trim())) {
+      throw new Error(`Invalid integer literal: ${value}`);
+    }
+    const asBigInt = BigInt(value);
+    if (asBigInt > maxSafe || asBigInt < minSafe) {
+      throw new Error(
+        `Integer ${value} exceeds JS safe range; use --bigint-mode string`
+      );
+    }
+    return Number(asBigInt);
+  }
+
+  throw new Error("Expected integer-compatible value");
+}
+
+function toFiniteNumber(value: unknown): number {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error("Expected finite number");
+    }
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(`Invalid numeric literal: ${value}`);
+    }
+    return parsed;
+  }
+
+  throw new Error("Expected numeric-compatible value");
+}
+
+function toBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "t", "1"].includes(normalized)) return true;
+    if (["false", "f", "0"].includes(normalized)) return false;
+  }
+
+  throw new Error("Expected boolean-compatible value");
+}
+
+function getUniqueColumnSets(table: TableInfo): string[][] {
+  const keySets: string[][] = [];
+
+  if (table.primaryKeys.length > 0) {
+    keySets.push([...table.primaryKeys]);
+  }
+
+  const grouped = new Map<string, typeof table.indexes>();
+  for (const index of table.indexes) {
+    const list = grouped.get(index.indexName) ?? [];
+    list.push(index);
+    grouped.set(index.indexName, list);
+  }
+
+  for (const group of grouped.values()) {
+    if (!group[0]?.isUnique) {
+      continue;
+    }
+
+    const ordered = [...group].sort((a, b) => a.columnPosition - b.columnPosition);
+    const columns = ordered.map((index) => index.columnName);
+    const signature = columnSignature(columns);
+    if (!keySets.some((existing) => columnSignature(existing) === signature)) {
+      keySets.push(columns);
+    }
+  }
+
+  return keySets;
+}
+
+function initializeLookupMaps(
+  tableLookupMaps: Map<string, Map<string, Map<string, string>>>,
+  tableKey: string,
+  keySets: string[][]
+): Map<string, Map<string, string>> {
+  const lookupByKeySet = new Map<string, Map<string, string>>();
+
+  for (const keySet of keySets) {
+    lookupByKeySet.set(columnSignature(keySet), new Map());
+  }
+
+  tableLookupMaps.set(tableKey, lookupByKeySet);
+  return lookupByKeySet;
+}
+
+function columnSignature(columns: string[]): string {
+  return JSON.stringify(columns);
+}
+
+function getStats(
+  bucket: Record<string, ImportEntityStats>,
+  key: string
+): ImportEntityStats {
+  if (!bucket[key]) {
+    bucket[key] = {
+      attempted: 0,
+      imported: 0,
+      failed: 0,
+      skipped: 0,
+      unresolved: 0,
+    };
+  }
+
+  return bucket[key];
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function backoffMs(attempt: number): number {
+  const base = 250;
+  return Math.min(4_000, base * 2 ** Math.max(0, attempt - 1));
+}
+
 export function saveIdMapping(
   idMap: Map<string, Map<string, string>>,
   outputPath: string
 ): void {
   const serializable: Record<string, Record<string, string>> = {};
-  for (const [table, mapping] of idMap) {
-    serializable[table] = Object.fromEntries(mapping);
+
+  for (const [tableKey, mapping] of idMap) {
+    serializable[tableKey] = Object.fromEntries(mapping);
   }
+
   fs.writeFileSync(outputPath, JSON.stringify(serializable, null, 2));
 }

--- a/tools/migrate/src/index.ts
+++ b/tools/migrate/src/index.ts
@@ -1,0 +1,530 @@
+#!/usr/bin/env node
+
+/**
+ * @helix-db/migrate - White-glove migration tool for Supabase -> HelixDB
+ *
+ * Usage:
+ *   npx @helix-db/migrate supabase
+ *   npx @helix-db/migrate supabase --connection-string "postgresql://..."
+ *   npx @helix-db/migrate supabase --introspect-only
+ *   npx @helix-db/migrate supabase --import-only --helix-url http://localhost:6969
+ */
+
+import { Command } from "commander";
+import prompts from "prompts";
+import chalk from "chalk";
+import ora from "ora";
+import * as fs from "fs";
+import * as path from "path";
+import { introspectDatabase, SchemaIntrospection, TableInfo } from "./introspect";
+import { generateSchema, GeneratedSchema } from "./generate-schema";
+import { generateQueries, GeneratedQueries } from "./generate-queries";
+import { exportData } from "./export-data";
+import { importData, saveIdMapping } from "./import-data";
+
+const program = new Command();
+
+program
+  .name("helix-migrate")
+  .description("White-glove migration tool for moving from Supabase to HelixDB")
+  .version("0.1.0");
+
+program
+  .command("supabase")
+  .description("Migrate a Supabase project to HelixDB")
+  .option("-c, --connection-string <string>", "Supabase PostgreSQL connection string")
+  .option("-o, --output <dir>", "Output directory for the generated HelixDB project", "./helix-project")
+  .option("--schemas <schemas>", "Comma-separated list of PostgreSQL schemas to migrate", "public")
+  .option("--introspect-only", "Only introspect and generate schema (no data migration)")
+  .option("--import-only", "Only import data (assumes schema is already deployed)")
+  .option("--helix-url <url>", "HelixDB instance URL for data import", "http://localhost:6969")
+  .option("--batch-size <n>", "Rows per export batch", "5000")
+  .option("--concurrency <n>", "Parallel import requests", "10")
+  .option("--export-dir <dir>", "Directory for exported JSON data", "./helix-export")
+  .action(migrateSupabase);
+
+program.parse();
+
+async function migrateSupabase(options: {
+  connectionString?: string;
+  output: string;
+  schemas: string;
+  introspectOnly?: boolean;
+  importOnly?: boolean;
+  helixUrl: string;
+  batchSize: string;
+  concurrency: string;
+  exportDir: string;
+}) {
+  console.log("");
+  console.log(chalk.bold("  Supabase → HelixDB Migration Tool"));
+  console.log(chalk.gray("  ─────────────────────────────────"));
+  console.log("");
+
+  // Step 1: Get connection string
+  let connectionString = options.connectionString;
+
+  if (!connectionString && !options.importOnly) {
+    const response = await prompts({
+      type: "text",
+      name: "connectionString",
+      message: "Supabase PostgreSQL connection string:",
+      hint: "Found in Supabase Dashboard → Settings → Database → Connection string (URI)",
+      validate: (value: string) =>
+        value.startsWith("postgresql://") || value.startsWith("postgres://")
+          ? true
+          : "Must be a PostgreSQL connection string (starts with postgresql:// or postgres://)",
+    });
+
+    if (!response.connectionString) {
+      console.log(chalk.red("\nAborted."));
+      process.exit(1);
+    }
+
+    connectionString = response.connectionString;
+  }
+
+  const schemas = options.schemas.split(",").map((s) => s.trim());
+
+  // ─── Phase 1: Introspect ───────────────────────────────────────
+
+  if (options.importOnly) {
+    // Skip directly to import
+    await runImport(options);
+    return;
+  }
+
+  const spinner = ora("Connecting to Supabase database...").start();
+
+  let introspection: SchemaIntrospection;
+  try {
+    introspection = await introspectDatabase(connectionString!, schemas);
+    spinner.succeed(
+      `Connected. Found ${introspection.tables.length} tables across schemas: ${schemas.join(", ")}`
+    );
+  } catch (err) {
+    spinner.fail("Failed to connect to Supabase database");
+    console.error(chalk.red(`\n  ${err instanceof Error ? err.message : err}`));
+    console.log(chalk.gray("\n  Tip: Make sure your connection string is correct and the database is accessible."));
+    console.log(chalk.gray("  Find it in: Supabase Dashboard → Settings → Database → Connection string (URI)"));
+    process.exit(1);
+  }
+
+  // Show discovered schema summary
+  console.log("");
+  console.log(chalk.bold("  Discovered Schema:"));
+  console.log("");
+
+  const userTables = introspection.tables.filter(
+    (t) => !isSupabaseInternal(t.name)
+  );
+
+  for (const table of userTables) {
+    const fkCount = table.foreignKeys.length;
+    const idxCount = table.indexes.length;
+    const hasVector = table.columns.some((c) => c.udtName === "vector");
+
+    console.log(
+      `  ${chalk.cyan("┃")} ${chalk.bold(table.name)} ${chalk.gray(`(${table.rowCount} rows, ${table.columns.length} cols` +
+        (fkCount > 0 ? `, ${fkCount} FK` : "") +
+        (idxCount > 0 ? `, ${idxCount} idx` : "") +
+        (hasVector ? ", vectors" : "") +
+        ")")}`
+    );
+  }
+  console.log("");
+
+  if (Object.keys(introspection.enums).length > 0) {
+    console.log(chalk.bold("  Enums:"));
+    for (const [name, values] of Object.entries(introspection.enums)) {
+      console.log(`  ${chalk.cyan("┃")} ${name}: ${values.join(", ")}`);
+    }
+    console.log("");
+  }
+
+  // ─── Phase 2: Generate Schema ──────────────────────────────────
+
+  const schemaSpinner = ora("Generating HelixDB schema...").start();
+
+  const generatedSchema = generateSchema(introspection);
+  const generatedQueries = generateQueries(generatedSchema);
+
+  schemaSpinner.succeed(
+    `Generated ${generatedSchema.nodes.length} Nodes, ${generatedSchema.edges.length} Edges, ${generatedSchema.vectors.length} Vectors`
+  );
+
+  // ─── Phase 3: Write Project Files ──────────────────────────────
+
+  const outputDir = path.resolve(options.output);
+  const writeSpinner = ora(`Writing HelixDB project to ${outputDir}...`).start();
+
+  try {
+    writeHelixProject(
+      outputDir,
+      generatedSchema,
+      generatedQueries,
+      introspection
+    );
+    writeSpinner.succeed(`HelixDB project written to ${outputDir}`);
+  } catch (err) {
+    writeSpinner.fail("Failed to write project files");
+    console.error(chalk.red(`\n  ${err instanceof Error ? err.message : err}`));
+    process.exit(1);
+  }
+
+  // Show generated files
+  console.log("");
+  console.log(chalk.bold("  Generated Files:"));
+  console.log(`  ${chalk.cyan("┃")} ${path.join(outputDir, "helix.toml")} ${chalk.gray("(project config)")}`);
+  console.log(`  ${chalk.cyan("┃")} ${path.join(outputDir, "db", "schema.hx")} ${chalk.gray("(schema definitions)")}`);
+  console.log(`  ${chalk.cyan("┃")} ${path.join(outputDir, "db", "queries.hx")} ${chalk.gray("(CRUD queries)")}`);
+  console.log(`  ${chalk.cyan("┃")} ${path.join(outputDir, "db", "import.hx")} ${chalk.gray("(import queries)")}`);
+  console.log(`  ${chalk.cyan("┃")} ${path.join(outputDir, "MIGRATION_GUIDE.md")} ${chalk.gray("(API mapping guide)")}`);
+  console.log("");
+
+  if (options.introspectOnly) {
+    console.log(chalk.green("  Schema generation complete (--introspect-only mode)."));
+    console.log("");
+    console.log(chalk.bold("  Next steps:"));
+    console.log(`  1. Review the generated schema in ${chalk.cyan(path.join(outputDir, "db", "schema.hx"))}`);
+    console.log(`  2. Start HelixDB: ${chalk.cyan("cd " + outputDir + " && helix push dev")}`);
+    console.log(`  3. Run the data import: ${chalk.cyan("helix-migrate supabase --import-only")}`);
+    console.log("");
+    return;
+  }
+
+  // ─── Phase 4: Export Data ──────────────────────────────────────
+
+  const { proceed } = await prompts({
+    type: "confirm",
+    name: "proceed",
+    message: "Export data from Supabase?",
+    initial: true,
+  });
+
+  if (!proceed) {
+    console.log(chalk.yellow("\n  Data export skipped. You can run it later with --import-only."));
+    printNextSteps(outputDir);
+    return;
+  }
+
+  const exportDir = path.resolve(options.exportDir);
+  const exportSpinner = ora("Exporting data from Supabase...").start();
+
+  try {
+    const exportResults = await exportData({
+      connectionString: connectionString!,
+      tables: userTables,
+      outputDir: exportDir,
+      batchSize: parseInt(options.batchSize, 10),
+    });
+
+    const totalRows = exportResults.reduce((sum, r) => sum + r.rowCount, 0);
+    exportSpinner.succeed(`Exported ${totalRows} rows from ${exportResults.length} tables to ${exportDir}`);
+
+    for (const result of exportResults) {
+      console.log(
+        `  ${chalk.cyan("┃")} ${result.table}: ${result.rowCount} rows → ${result.filePath}`
+      );
+    }
+    console.log("");
+  } catch (err) {
+    exportSpinner.fail("Failed to export data");
+    console.error(chalk.red(`\n  ${err instanceof Error ? err.message : err}`));
+    process.exit(1);
+  }
+
+  // ─── Phase 5: Import Data ─────────────────────────────────────
+
+  const { doImport } = await prompts({
+    type: "confirm",
+    name: "doImport",
+    message: `Import data into HelixDB at ${options.helixUrl}?`,
+    initial: false,
+  });
+
+  if (!doImport) {
+    console.log(chalk.yellow("\n  Data import skipped."));
+    printNextSteps(outputDir);
+    return;
+  }
+
+  await runImportWithProgress(
+    options.helixUrl,
+    exportDir,
+    generatedSchema,
+    userTables,
+    parseInt(options.concurrency, 10)
+  );
+
+  // ─── Done ─────────────────────────────────────────────────────
+
+  console.log("");
+  console.log(chalk.green.bold("  Migration complete!"));
+  printNextSteps(outputDir);
+}
+
+async function runImport(options: {
+  helixUrl: string;
+  exportDir: string;
+  concurrency: string;
+  output: string;
+  schemas: string;
+}) {
+  // Read the generated schema from the project directory
+  const schemaPath = path.join(options.output, "db", "schema.hx");
+  if (!fs.existsSync(schemaPath)) {
+    console.error(chalk.red(`\n  Schema file not found: ${schemaPath}`));
+    console.error(chalk.gray("  Run without --import-only first to generate the schema."));
+    process.exit(1);
+  }
+
+  console.log(chalk.yellow("  --import-only mode: skipping introspection and schema generation."));
+  console.log(chalk.yellow("  Make sure HelixDB is running with the generated schema deployed."));
+  console.log("");
+}
+
+async function runImportWithProgress(
+  helixUrl: string,
+  exportDir: string,
+  schema: GeneratedSchema,
+  tables: TableInfo[],
+  concurrency: number
+) {
+  const importSpinner = ora("Importing data into HelixDB...").start();
+
+  try {
+    const importResult = await importData({
+      helixUrl,
+      exportDir,
+      schema,
+      tables,
+      concurrency,
+      onProgress: (table, imported, total) => {
+        importSpinner.text = `Importing ${table}: ${imported}/${total}`;
+      },
+    });
+
+    importSpinner.succeed(
+      `Imported ${importResult.nodesImported} nodes, ${importResult.edgesImported} edges, ${importResult.vectorsImported} vectors`
+    );
+
+    if (importResult.errors.length > 0) {
+      console.log(chalk.yellow(`\n  ${importResult.errors.length} errors during import:`));
+      for (const err of importResult.errors.slice(0, 10)) {
+        console.log(`  ${chalk.red("✗")} ${err.table} row ${err.row}: ${err.error}`);
+      }
+      if (importResult.errors.length > 10) {
+        console.log(chalk.gray(`  ... and ${importResult.errors.length - 10} more`));
+      }
+    }
+
+    // Save ID mapping for reference
+    const mappingPath = path.join(exportDir, "id_mapping.json");
+    saveIdMapping(importResult.idMap, mappingPath);
+    console.log(chalk.gray(`\n  ID mapping saved to ${mappingPath}`));
+  } catch (err) {
+    importSpinner.fail("Failed to import data");
+    console.error(chalk.red(`\n  ${err instanceof Error ? err.message : err}`));
+    process.exit(1);
+  }
+}
+
+function writeHelixProject(
+  outputDir: string,
+  schema: GeneratedSchema,
+  queries: GeneratedQueries,
+  introspection: SchemaIntrospection
+) {
+  const dbDir = path.join(outputDir, "db");
+  fs.mkdirSync(dbDir, { recursive: true });
+
+  // helix.toml
+  const projectName = path.basename(outputDir);
+  const helixToml = `[project]
+name = "${projectName}"
+queries = "db/"
+
+[local.dev]
+port = 6969
+build_mode = "debug"
+`;
+  fs.writeFileSync(path.join(outputDir, "helix.toml"), helixToml);
+
+  // db/schema.hx
+  fs.writeFileSync(path.join(dbDir, "schema.hx"), schema.schemaHx);
+
+  // db/queries.hx
+  fs.writeFileSync(path.join(dbDir, "queries.hx"), queries.queriesHx);
+
+  // db/import.hx
+  fs.writeFileSync(path.join(dbDir, "import.hx"), queries.importQueriesHx);
+
+  // MIGRATION_GUIDE.md
+  const guide = generateMigrationGuide(schema, introspection);
+  fs.writeFileSync(path.join(outputDir, "MIGRATION_GUIDE.md"), guide);
+}
+
+function generateMigrationGuide(
+  schema: GeneratedSchema,
+  introspection: SchemaIntrospection
+): string {
+  const lines: string[] = [];
+
+  lines.push("# Supabase to HelixDB Migration Guide");
+  lines.push("");
+  lines.push("This guide maps your Supabase tables and operations to their HelixDB equivalents.");
+  lines.push("");
+  lines.push("## Schema Mapping");
+  lines.push("");
+  lines.push("| Supabase Table | HelixDB Type | Notes |");
+  lines.push("|---|---|---|");
+
+  for (const node of schema.nodes) {
+    const table = introspection.tables.find((t) => t.name === node.originalTable);
+    const notes = node.hasVectorColumn ? "Has vector embeddings" : "";
+    lines.push(
+      `| \`${node.originalTable}\` | \`N::${node.name}\` | ${notes} |`
+    );
+  }
+  lines.push("");
+
+  if (schema.edges.length > 0) {
+    lines.push("## Relationship Mapping");
+    lines.push("");
+    lines.push("| Supabase FK | HelixDB Edge | From | To |");
+    lines.push("|---|---|---|---|");
+    for (const edge of schema.edges) {
+      lines.push(
+        `| \`${edge.originalColumn}\` | \`E::${edge.name}\` | \`${edge.fromNode}\` | \`${edge.toNode}\` |`
+      );
+    }
+    lines.push("");
+  }
+
+  lines.push("## API Mapping");
+  lines.push("");
+  lines.push("### Supabase JS SDK → HelixDB TypeScript SDK");
+  lines.push("");
+  lines.push("```typescript");
+  lines.push('import HelixDB from "helix-ts";');
+  lines.push("const helix = new HelixDB();");
+  lines.push("```");
+  lines.push("");
+
+  for (const node of schema.nodes) {
+    const table = introspection.tables.find((t) => t.name === node.originalTable);
+    if (!table) continue;
+
+    lines.push(`### ${table.name}`);
+    lines.push("");
+
+    // INSERT
+    lines.push("**Insert:**");
+    lines.push("```typescript");
+    lines.push("// Before (Supabase)");
+    lines.push(`// const { data } = await supabase.from('${table.name}').insert({ ... });`);
+    lines.push("");
+    lines.push("// After (HelixDB)");
+    lines.push(`const data = await helix.query("Add${node.name}", { ... });`);
+    lines.push("```");
+    lines.push("");
+
+    // SELECT by ID
+    lines.push("**Get by ID:**");
+    lines.push("```typescript");
+    lines.push("// Before (Supabase)");
+    lines.push(`// const { data } = await supabase.from('${table.name}').select().eq('id', id);`);
+    lines.push("");
+    lines.push("// After (HelixDB)");
+    lines.push(`const data = await helix.query("Get${node.name}", { id });`);
+    lines.push("```");
+    lines.push("");
+
+    // DELETE
+    lines.push("**Delete:**");
+    lines.push("```typescript");
+    lines.push("// Before (Supabase)");
+    lines.push(`// const { data } = await supabase.from('${table.name}').delete().eq('id', id);`);
+    lines.push("");
+    lines.push("// After (HelixDB)");
+    lines.push(`const data = await helix.query("Delete${node.name}", { id });`);
+    lines.push("```");
+    lines.push("");
+  }
+
+  if (schema.vectors.length > 0) {
+    lines.push("## Vector Search");
+    lines.push("");
+    for (const vec of schema.vectors) {
+      lines.push(`### ${vec.name}`);
+      lines.push("```typescript");
+      lines.push("// Before (Supabase with pgvector)");
+      lines.push(`// const { data } = await supabase.rpc('match_${vec.originalTable}', { query_embedding: [...], match_count: 10 });`);
+      lines.push("");
+      lines.push("// After (HelixDB - built-in vector search with auto-embedding)");
+      lines.push(`const results = await helix.query("Search${vec.name}", { query: "search text", limit: 10 });`);
+      lines.push("```");
+      lines.push("");
+    }
+  }
+
+  lines.push("## Next Steps");
+  lines.push("");
+  lines.push("1. Review and customize the generated schema in `db/schema.hx`");
+  lines.push("2. Review and extend the generated queries in `db/queries.hx`");
+  lines.push("3. Start HelixDB locally: `helix push dev`");
+  lines.push("4. Update your application code using the mappings above");
+  lines.push("5. Delete `db/import.hx` after migration is complete");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function printNextSteps(outputDir: string) {
+  console.log("");
+  console.log(chalk.bold("  Next steps:"));
+  console.log("");
+  console.log(`  1. Review the generated schema:`);
+  console.log(chalk.cyan(`     ${path.join(outputDir, "db", "schema.hx")}`));
+  console.log("");
+  console.log(`  2. Start HelixDB:`);
+  console.log(chalk.cyan(`     cd ${outputDir} && helix push dev`));
+  console.log("");
+  console.log(`  3. Update your app code using the migration guide:`);
+  console.log(chalk.cyan(`     ${path.join(outputDir, "MIGRATION_GUIDE.md")}`));
+  console.log("");
+  console.log(`  4. Clean up import queries after migration:`);
+  console.log(chalk.cyan(`     rm ${path.join(outputDir, "db", "import.hx")}`));
+  console.log("");
+}
+
+function isSupabaseInternal(tableName: string): boolean {
+  const internalTables = new Set([
+    "schema_migrations",
+    "supabase_migrations",
+    "supabase_functions",
+    "_realtime_subscription",
+    "buckets",
+    "objects",
+    "s3_multipart_uploads",
+    "s3_multipart_uploads_parts",
+    "migrations",
+    "hooks",
+    "mfa_factors",
+    "mfa_challenges",
+    "mfa_amr_claims",
+    "sso_providers",
+    "sso_domains",
+    "saml_providers",
+    "saml_relay_states",
+    "flow_state",
+    "one_time_tokens",
+    "audit_log_entries",
+    "refresh_tokens",
+    "instances",
+    "sessions",
+    "identities",
+  ]);
+  return internalTables.has(tableName);
+}

--- a/tools/migrate/src/introspect.ts
+++ b/tools/migrate/src/introspect.ts
@@ -1,0 +1,301 @@
+/**
+ * Introspects a PostgreSQL (Supabase) database schema.
+ *
+ * Reads table definitions, columns, types, foreign keys, indexes,
+ * and primary keys from the information_schema and pg_catalog.
+ */
+
+import { Client } from "pg";
+
+export interface ColumnInfo {
+  name: string;
+  dataType: string;
+  udtName: string;
+  isNullable: boolean;
+  columnDefault: string | null;
+  characterMaxLength: number | null;
+  ordinalPosition: number;
+  isPrimaryKey: boolean;
+}
+
+export interface ForeignKey {
+  constraintName: string;
+  columnName: string;
+  foreignTableSchema: string;
+  foreignTableName: string;
+  foreignColumnName: string;
+}
+
+export interface IndexInfo {
+  indexName: string;
+  columnName: string;
+  isUnique: boolean;
+}
+
+export interface TableInfo {
+  schema: string;
+  name: string;
+  columns: ColumnInfo[];
+  primaryKeys: string[];
+  foreignKeys: ForeignKey[];
+  indexes: IndexInfo[];
+  rowCount: number;
+}
+
+export interface SchemaIntrospection {
+  tables: TableInfo[];
+  enums: Record<string, string[]>; // enum_name -> values
+}
+
+/**
+ * Introspect a Supabase/PostgreSQL database and return full schema info.
+ */
+export async function introspectDatabase(
+  connectionString: string,
+  schemas: string[] = ["public"]
+): Promise<SchemaIntrospection> {
+  const client = new Client({ connectionString });
+  await client.connect();
+
+  try {
+    const [tables, enums] = await Promise.all([
+      getTables(client, schemas),
+      getEnums(client, schemas),
+    ]);
+
+    return { tables, enums };
+  } finally {
+    await client.end();
+  }
+}
+
+async function getTables(
+  client: Client,
+  schemas: string[]
+): Promise<TableInfo[]> {
+  // Get all tables in the specified schemas
+  const schemaList = schemas.map((s) => `'${s}'`).join(",");
+
+  const tablesResult = await client.query(`
+    SELECT table_schema, table_name
+    FROM information_schema.tables
+    WHERE table_schema IN (${schemaList})
+      AND table_type = 'BASE TABLE'
+    ORDER BY table_schema, table_name
+  `);
+
+  const tables: TableInfo[] = [];
+
+  for (const row of tablesResult.rows) {
+    const schema = row.table_schema;
+    const tableName = row.table_name;
+
+    // Fetch columns, primary keys, foreign keys, indexes, and row count in parallel
+    const [columns, primaryKeys, foreignKeys, indexes, rowCount] =
+      await Promise.all([
+        getColumns(client, schema, tableName),
+        getPrimaryKeys(client, schema, tableName),
+        getForeignKeys(client, schema, tableName),
+        getIndexes(client, schema, tableName),
+        getRowCount(client, schema, tableName),
+      ]);
+
+    // Mark primary key columns
+    for (const col of columns) {
+      col.isPrimaryKey = primaryKeys.includes(col.name);
+    }
+
+    tables.push({
+      schema,
+      name: tableName,
+      columns,
+      primaryKeys,
+      foreignKeys,
+      indexes,
+      rowCount,
+    });
+  }
+
+  return tables;
+}
+
+async function getColumns(
+  client: Client,
+  schema: string,
+  tableName: string
+): Promise<ColumnInfo[]> {
+  const result = await client.query(
+    `
+    SELECT
+      column_name,
+      data_type,
+      udt_name,
+      is_nullable,
+      column_default,
+      character_maximum_length,
+      ordinal_position
+    FROM information_schema.columns
+    WHERE table_schema = $1 AND table_name = $2
+    ORDER BY ordinal_position
+  `,
+    [schema, tableName]
+  );
+
+  return result.rows.map((row) => ({
+    name: row.column_name,
+    dataType: row.data_type,
+    udtName: row.udt_name,
+    isNullable: row.is_nullable === "YES",
+    columnDefault: row.column_default,
+    characterMaxLength: row.character_maximum_length,
+    ordinalPosition: row.ordinal_position,
+    isPrimaryKey: false, // set later
+  }));
+}
+
+async function getPrimaryKeys(
+  client: Client,
+  schema: string,
+  tableName: string
+): Promise<string[]> {
+  const result = await client.query(
+    `
+    SELECT kcu.column_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+      AND tc.table_schema = kcu.table_schema
+    WHERE tc.table_schema = $1
+      AND tc.table_name = $2
+      AND tc.constraint_type = 'PRIMARY KEY'
+    ORDER BY kcu.ordinal_position
+  `,
+    [schema, tableName]
+  );
+
+  return result.rows.map((row) => row.column_name);
+}
+
+async function getForeignKeys(
+  client: Client,
+  schema: string,
+  tableName: string
+): Promise<ForeignKey[]> {
+  const result = await client.query(
+    `
+    SELECT
+      tc.constraint_name,
+      kcu.column_name,
+      ccu.table_schema AS foreign_table_schema,
+      ccu.table_name AS foreign_table_name,
+      ccu.column_name AS foreign_column_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+      AND tc.table_schema = kcu.table_schema
+    JOIN information_schema.constraint_column_usage ccu
+      ON tc.constraint_name = ccu.constraint_name
+      AND tc.table_schema = ccu.table_schema
+    WHERE tc.table_schema = $1
+      AND tc.table_name = $2
+      AND tc.constraint_type = 'FOREIGN KEY'
+  `,
+    [schema, tableName]
+  );
+
+  return result.rows.map((row) => ({
+    constraintName: row.constraint_name,
+    columnName: row.column_name,
+    foreignTableSchema: row.foreign_table_schema,
+    foreignTableName: row.foreign_table_name,
+    foreignColumnName: row.foreign_column_name,
+  }));
+}
+
+async function getIndexes(
+  client: Client,
+  schema: string,
+  tableName: string
+): Promise<IndexInfo[]> {
+  const result = await client.query(
+    `
+    SELECT
+      i.relname AS index_name,
+      a.attname AS column_name,
+      ix.indisunique AS is_unique
+    FROM pg_catalog.pg_class t
+    JOIN pg_catalog.pg_index ix ON t.oid = ix.indrelid
+    JOIN pg_catalog.pg_class i ON i.oid = ix.indexrelid
+    JOIN pg_catalog.pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+    JOIN pg_catalog.pg_namespace n ON n.oid = t.relnamespace
+    WHERE n.nspname = $1
+      AND t.relname = $2
+      AND NOT ix.indisprimary
+    ORDER BY i.relname
+  `,
+    [schema, tableName]
+  );
+
+  return result.rows.map((row) => ({
+    indexName: row.index_name,
+    columnName: row.column_name,
+    isUnique: row.is_unique,
+  }));
+}
+
+async function getRowCount(
+  client: Client,
+  schema: string,
+  tableName: string
+): Promise<number> {
+  // Use estimate for large tables, exact for small ones
+  const result = await client.query(
+    `
+    SELECT reltuples::bigint AS estimate
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = $1 AND c.relname = $2
+  `,
+    [schema, tableName]
+  );
+
+  const estimate = parseInt(result.rows[0]?.estimate ?? "0", 10);
+
+  // If estimate is small or negative (never analyzed), do exact count
+  if (estimate < 10000) {
+    const countResult = await client.query(
+      `SELECT COUNT(*) AS count FROM "${schema}"."${tableName}"`
+    );
+    return parseInt(countResult.rows[0].count, 10);
+  }
+
+  return estimate;
+}
+
+async function getEnums(
+  client: Client,
+  schemas: string[]
+): Promise<Record<string, string[]>> {
+  const schemaList = schemas.map((s) => `'${s}'`).join(",");
+
+  const result = await client.query(`
+    SELECT
+      t.typname AS enum_name,
+      e.enumlabel AS enum_value
+    FROM pg_catalog.pg_type t
+    JOIN pg_catalog.pg_enum e ON t.oid = e.enumtypid
+    JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname IN (${schemaList})
+    ORDER BY t.typname, e.enumsortorder
+  `);
+
+  const enums: Record<string, string[]> = {};
+  for (const row of result.rows) {
+    if (!enums[row.enum_name]) {
+      enums[row.enum_name] = [];
+    }
+    enums[row.enum_name].push(row.enum_value);
+  }
+
+  return enums;
+}

--- a/tools/migrate/src/type-map.ts
+++ b/tools/migrate/src/type-map.ts
@@ -1,0 +1,158 @@
+/**
+ * Maps PostgreSQL data types to HelixDB (HelixQL) data types.
+ *
+ * Supabase uses standard PostgreSQL, so we map all common PG types
+ * to their closest HelixDB equivalents.
+ */
+
+export interface TypeMapping {
+  helixType: string;
+  isVector: boolean;
+  needsSerialization: boolean; // for JSON/JSONB -> String
+}
+
+const PG_TO_HELIX: Record<string, TypeMapping> = {
+  // Text types
+  text: { helixType: "String", isVector: false, needsSerialization: false },
+  varchar: { helixType: "String", isVector: false, needsSerialization: false },
+  "character varying": { helixType: "String", isVector: false, needsSerialization: false },
+  char: { helixType: "String", isVector: false, needsSerialization: false },
+  character: { helixType: "String", isVector: false, needsSerialization: false },
+  name: { helixType: "String", isVector: false, needsSerialization: false },
+  citext: { helixType: "String", isVector: false, needsSerialization: false },
+
+  // Integer types
+  smallint: { helixType: "I16", isVector: false, needsSerialization: false },
+  int2: { helixType: "I16", isVector: false, needsSerialization: false },
+  integer: { helixType: "I32", isVector: false, needsSerialization: false },
+  int4: { helixType: "I32", isVector: false, needsSerialization: false },
+  int: { helixType: "I32", isVector: false, needsSerialization: false },
+  bigint: { helixType: "I64", isVector: false, needsSerialization: false },
+  int8: { helixType: "I64", isVector: false, needsSerialization: false },
+  serial: { helixType: "I32", isVector: false, needsSerialization: false },
+  bigserial: { helixType: "I64", isVector: false, needsSerialization: false },
+  smallserial: { helixType: "I16", isVector: false, needsSerialization: false },
+
+  // Float types
+  real: { helixType: "F32", isVector: false, needsSerialization: false },
+  float4: { helixType: "F32", isVector: false, needsSerialization: false },
+  "double precision": { helixType: "F64", isVector: false, needsSerialization: false },
+  float8: { helixType: "F64", isVector: false, needsSerialization: false },
+  numeric: { helixType: "F64", isVector: false, needsSerialization: false },
+  decimal: { helixType: "F64", isVector: false, needsSerialization: false },
+  money: { helixType: "F64", isVector: false, needsSerialization: false },
+
+  // Boolean
+  boolean: { helixType: "Boolean", isVector: false, needsSerialization: false },
+  bool: { helixType: "Boolean", isVector: false, needsSerialization: false },
+
+  // Date/Time types
+  timestamp: { helixType: "Date", isVector: false, needsSerialization: false },
+  "timestamp without time zone": { helixType: "Date", isVector: false, needsSerialization: false },
+  "timestamp with time zone": { helixType: "Date", isVector: false, needsSerialization: false },
+  timestamptz: { helixType: "Date", isVector: false, needsSerialization: false },
+  date: { helixType: "Date", isVector: false, needsSerialization: false },
+  time: { helixType: "String", isVector: false, needsSerialization: false },
+  "time without time zone": { helixType: "String", isVector: false, needsSerialization: false },
+  "time with time zone": { helixType: "String", isVector: false, needsSerialization: false },
+  interval: { helixType: "String", isVector: false, needsSerialization: false },
+
+  // UUID
+  uuid: { helixType: "String", isVector: false, needsSerialization: false },
+
+  // JSON types -> serialized as String
+  json: { helixType: "String", isVector: false, needsSerialization: true },
+  jsonb: { helixType: "String", isVector: false, needsSerialization: true },
+
+  // Binary
+  bytea: { helixType: "String", isVector: false, needsSerialization: true },
+
+  // Network types
+  inet: { helixType: "String", isVector: false, needsSerialization: false },
+  cidr: { helixType: "String", isVector: false, needsSerialization: false },
+  macaddr: { helixType: "String", isVector: false, needsSerialization: false },
+
+  // pgvector type -> HelixDB Vector
+  vector: { helixType: "[F64]", isVector: true, needsSerialization: false },
+
+  // Enum types get mapped to String
+  "USER-DEFINED": { helixType: "String", isVector: false, needsSerialization: false },
+
+  // Array types (we'll handle these specially in mapPgType)
+  ARRAY: { helixType: "String", isVector: false, needsSerialization: true },
+};
+
+/**
+ * Map a PostgreSQL column type to the corresponding HelixDB type.
+ */
+export function mapPgType(
+  pgType: string,
+  udtName?: string
+): TypeMapping {
+  // Normalize
+  const normalized = pgType.toLowerCase().trim();
+
+  // Handle array types (e.g., _text, _int4, text[], integer[])
+  if (normalized === "array" || normalized.endsWith("[]") || (udtName && udtName.startsWith("_"))) {
+    // Check if it's a vector-like array of floats
+    const baseType = udtName ? udtName.replace(/^_/, "") : normalized.replace(/\[\]$/, "");
+    if (["float4", "float8", "real", "double precision", "numeric"].includes(baseType)) {
+      return { helixType: "[F64]", isVector: false, needsSerialization: false };
+    }
+    if (["int4", "int8", "integer", "bigint"].includes(baseType)) {
+      return { helixType: "[I64]", isVector: false, needsSerialization: false };
+    }
+    if (["text", "varchar", "character varying"].includes(baseType)) {
+      return { helixType: "[String]", isVector: false, needsSerialization: false };
+    }
+    // Default: serialize as JSON string
+    return { helixType: "String", isVector: false, needsSerialization: true };
+  }
+
+  // Handle vector type from pgvector (udt_name = 'vector')
+  if (udtName === "vector") {
+    return { helixType: "[F64]", isVector: true, needsSerialization: false };
+  }
+
+  // Direct lookup
+  if (PG_TO_HELIX[normalized]) {
+    return PG_TO_HELIX[normalized];
+  }
+
+  // Check if it's a user-defined enum
+  if (normalized === "user-defined") {
+    return { helixType: "String", isVector: false, needsSerialization: false };
+  }
+
+  // Fallback: treat unknown types as String with serialization
+  return { helixType: "String", isVector: false, needsSerialization: true };
+}
+
+/**
+ * Convert a PostgreSQL table name to a HelixDB Node type name.
+ * e.g., "user_profiles" -> "UserProfile"
+ */
+export function toPascalCase(snakeCase: string): string {
+  // Remove trailing 's' for simple plurals (users -> User, posts -> Post)
+  let name = snakeCase;
+  if (name.endsWith("ies")) {
+    name = name.slice(0, -3) + "y";
+  } else if (name.endsWith("ses") || name.endsWith("xes") || name.endsWith("zes")) {
+    name = name.slice(0, -2);
+  } else if (name.endsWith("s") && !name.endsWith("ss") && !name.endsWith("us")) {
+    name = name.slice(0, -1);
+  }
+
+  return name
+    .split(/[_\-\s]+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join("");
+}
+
+/**
+ * Convert a PostgreSQL column name to a HelixDB field name.
+ * Keeps snake_case as-is (HelixDB supports it).
+ */
+export function toFieldName(pgColumn: string): string {
+  return pgColumn;
+}

--- a/tools/migrate/tests/helix-compile.test.js
+++ b/tools/migrate/tests/helix-compile.test.js
@@ -1,0 +1,97 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const { generateSchema } = require("../dist/generate-schema.js");
+const { generateQueries } = require("../dist/generate-queries.js");
+const { resolveTypeMappingOptions } = require("../dist/type-map.js");
+
+function makeColumn({
+  name,
+  dataType = "text",
+  udtName = "text",
+  isNullable = false,
+  isPrimaryKey = false,
+}) {
+  return {
+    name,
+    dataType,
+    udtName,
+    isNullable,
+    columnDefault: null,
+    characterMaxLength: null,
+    ordinalPosition: 1,
+    isPrimaryKey,
+  };
+}
+
+test("generated fixture project passes helix check", (t) => {
+  const helix = spawnSync("helix", ["--version"], { encoding: "utf-8" });
+  if (helix.status !== 0) {
+    t.skip("helix CLI not available");
+    return;
+  }
+
+  const introspection = {
+    tables: [
+      {
+        schema: "public",
+        name: "docs",
+        columns: [
+          makeColumn({ name: "id", dataType: "uuid", udtName: "uuid", isPrimaryKey: true }),
+          makeColumn({ name: "content", dataType: "text", udtName: "text" }),
+          makeColumn({ name: "note", dataType: "text", udtName: "text", isNullable: true }),
+          makeColumn({
+            name: "embedding",
+            dataType: "USER-DEFINED",
+            udtName: "vector",
+            isNullable: true,
+          }),
+        ],
+        primaryKeys: ["id"],
+        foreignKeys: [],
+        indexes: [],
+        rowCount: 0,
+      },
+    ],
+    enums: {},
+    unsupportedFeatures: [],
+  };
+
+  const generatedSchema = generateSchema(
+    introspection,
+    resolveTypeMappingOptions({ bigintMode: "string" })
+  );
+  const generatedQueries = generateQueries(generatedSchema);
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "helix-migrate-compile-"));
+  fs.mkdirSync(path.join(tempDir, "db"), { recursive: true });
+
+  const helixToml = `[project]
+name = "helix-migrate-compile"
+queries = "db/"
+
+[local.dev]
+port = 6969
+build_mode = "dev"
+`;
+
+  fs.writeFileSync(path.join(tempDir, "helix.toml"), helixToml);
+  fs.writeFileSync(path.join(tempDir, "db", "schema.hx"), generatedSchema.schemaHx);
+  fs.writeFileSync(path.join(tempDir, "db", "queries.hx"), generatedQueries.queriesHx);
+  fs.writeFileSync(path.join(tempDir, "db", "import.hx"), generatedQueries.importQueriesHx);
+
+  const check = spawnSync("helix", ["check"], {
+    cwd: tempDir,
+    encoding: "utf-8",
+  });
+
+  assert.equal(
+    check.status,
+    0,
+    `helix check failed:\n${check.stdout || ""}\n${check.stderr || ""}`
+  );
+});

--- a/tools/migrate/tests/import-utils.test.js
+++ b/tools/migrate/tests/import-utils.test.js
@@ -1,0 +1,36 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  extractId,
+  buildCompositeKeyFromColumns,
+} = require("../dist/import-data.js");
+
+test("extractId finds nested id values", () => {
+  const response = {
+    node: {
+      created: {
+        id: "node-123",
+      },
+    },
+  };
+
+  assert.equal(extractId(response), "node-123");
+});
+
+test("extractId can read ids from arrays", () => {
+  const response = [{ edge: { id: "edge-1" } }];
+  assert.equal(extractId(response), "edge-1");
+});
+
+test("buildCompositeKeyFromColumns is deterministic", () => {
+  const row = { a: 1, b: "x" };
+  const key = buildCompositeKeyFromColumns(row, ["a", "b"]);
+  assert.equal(key, JSON.stringify([1, "x"]));
+});
+
+test("buildCompositeKeyFromColumns returns null for missing values", () => {
+  const row = { a: 1, b: null };
+  const key = buildCompositeKeyFromColumns(row, ["a", "b"]);
+  assert.equal(key, null);
+});

--- a/tools/migrate/tests/query-generation.test.js
+++ b/tools/migrate/tests/query-generation.test.js
@@ -1,0 +1,55 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { generateQueries } = require("../dist/generate-queries.js");
+
+test("import query uses required params and emits nullable setters", () => {
+  const schema = {
+    nodes: [
+      {
+        name: "User",
+        originalSchema: "public",
+        originalTable: "users",
+        tableKey: "public.users",
+        hasVectorColumn: false,
+        fields: [
+          {
+            name: "email",
+            helixType: "String",
+            isNullable: false,
+            isIndexed: false,
+            isUnique: false,
+            hasDefault: false,
+            defaultValue: null,
+            needsSerialization: false,
+            originalColumn: "email",
+            isPrimaryKey: false,
+            isForeignKey: false,
+          },
+          {
+            name: "bio",
+            helixType: "String",
+            isNullable: true,
+            isIndexed: false,
+            isUnique: false,
+            hasDefault: false,
+            defaultValue: null,
+            needsSerialization: false,
+            originalColumn: "bio",
+            isPrimaryKey: false,
+            isForeignKey: false,
+          },
+        ],
+      },
+    ],
+    edges: [],
+    vectors: [],
+    schemaHx: "",
+  };
+
+  const generated = generateQueries(schema);
+
+  assert.match(generated.importQueriesHx, /QUERY ImportUser\(email: String\)/);
+  assert.doesNotMatch(generated.importQueriesHx, /QUERY ImportUser\([^)]*bio: String/);
+  assert.match(generated.importQueriesHx, /QUERY ImportSetUserBio\(id: ID, value: String\)/);
+});

--- a/tools/migrate/tests/schema-generation.test.js
+++ b/tools/migrate/tests/schema-generation.test.js
@@ -1,0 +1,87 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { generateSchema } = require("../dist/generate-schema.js");
+const { resolveTypeMappingOptions } = require("../dist/type-map.js");
+
+function makeColumn({
+  name,
+  dataType = "text",
+  udtName = "text",
+  isNullable = false,
+  isPrimaryKey = false,
+}) {
+  return {
+    name,
+    dataType,
+    udtName,
+    isNullable,
+    columnDefault: null,
+    characterMaxLength: null,
+    ordinalPosition: 1,
+    isPrimaryKey,
+  };
+}
+
+test("schema generation keeps FK columns and emits UNIQUE edges", () => {
+  const introspection = {
+    tables: [
+      {
+        schema: "public",
+        name: "authors",
+        columns: [
+          makeColumn({ name: "id", dataType: "uuid", udtName: "uuid", isPrimaryKey: true }),
+          makeColumn({ name: "name" }),
+        ],
+        primaryKeys: ["id"],
+        foreignKeys: [],
+        indexes: [],
+        rowCount: 1,
+      },
+      {
+        schema: "public",
+        name: "posts",
+        columns: [
+          makeColumn({ name: "id", dataType: "uuid", udtName: "uuid", isPrimaryKey: true }),
+          makeColumn({ name: "author_id", dataType: "uuid", udtName: "uuid" }),
+          makeColumn({ name: "title" }),
+        ],
+        primaryKeys: ["id"],
+        foreignKeys: [
+          {
+            constraintName: "posts_author_fkey",
+            columnNames: ["author_id"],
+            foreignTableSchema: "public",
+            foreignTableName: "authors",
+            foreignColumnNames: ["id"],
+          },
+        ],
+        indexes: [
+          {
+            indexName: "posts_author_id_unique",
+            columnName: "author_id",
+            isUnique: true,
+            columnPosition: 1,
+          },
+        ],
+        rowCount: 1,
+      },
+    ],
+    enums: {},
+    unsupportedFeatures: [],
+  };
+
+  const schema = generateSchema(
+    introspection,
+    resolveTypeMappingOptions({ bigintMode: "string" })
+  );
+
+  const postNode = schema.nodes.find((node) => node.name === "Post");
+  assert.ok(postNode, "Post node should exist");
+  assert.ok(
+    postNode.fields.some((field) => field.name === "author_id"),
+    "FK column should remain on node fields"
+  );
+
+  assert.match(schema.schemaHx, /E::HasAuthor UNIQUE \{/);
+});

--- a/tools/migrate/tests/type-map.test.js
+++ b/tools/migrate/tests/type-map.test.js
@@ -1,0 +1,26 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  mapPgType,
+  resolveTypeMappingOptions,
+  toFieldName,
+  toPascalCase,
+} = require("../dist/type-map.js");
+
+test("bigint maps to String in safe mode", () => {
+  const options = resolveTypeMappingOptions({ bigintMode: "string" });
+  const mapping = mapPgType("bigint", "int8", options);
+  assert.equal(mapping.helixType, "String");
+});
+
+test("bigint maps to I64 in i64 mode", () => {
+  const options = resolveTypeMappingOptions({ bigintMode: "i64" });
+  const mapping = mapPgType("bigint", "int8", options);
+  assert.equal(mapping.helixType, "I64");
+});
+
+test("identifier sanitization avoids reserved words", () => {
+  assert.equal(toFieldName("RETURN"), "RETURN_value");
+  assert.equal(toPascalCase("query"), "QueryType");
+});

--- a/tools/migrate/tsconfig.json
+++ b/tools/migrate/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Description

This PR introduces `@helix-db/migrate`, a comprehensive white-glove migration tool for moving projects from Supabase (PostgreSQL) to HelixDB. The tool automates the entire migration pipeline in five phases:

1. **Introspection**: Connects to a Supabase database and analyzes the schema (tables, columns, types, foreign keys, indexes, enums)
2. **Schema Generation**: Converts PostgreSQL schema to HelixDB schema format (.hx files):
   - Tables → Node types
   - Foreign keys → Edge types
   - pgvector columns → Vector types with metadata
3. **Project Generation**: Creates a complete HelixDB project structure with configuration and CRUD queries
4. **Data Export**: Exports all data from Supabase tables as JSON files with proper type serialization
5. **Data Import**: Imports exported data into a running HelixDB instance, maintaining referential integrity through ID mapping

### Key Features

- **Interactive CLI** with prompts for connection strings and migration options
- **Type Mapping**: Comprehensive PostgreSQL to HelixDB type conversion (integers, floats, strings, dates, JSON, arrays, vectors)
- **Relationship Handling**: Automatically converts foreign keys to edges with proper cardinality detection
- **Vector Support**: Detects pgvector columns and generates appropriate Vector types
- **Batch Processing**: Configurable batch sizes and concurrency for efficient data export/import
- **Error Handling**: Detailed error reporting with row-level diagnostics
- **ID Mapping**: Maintains mapping between old PostgreSQL PKs and new HelixDB IDs for edge creation
- **Flexible Modes**: Supports `--introspect-only`, `--import-only`, and full migration workflows

### Implementation Details

- **introspect.ts**: PostgreSQL schema introspection using pg client and information_schema queries
- **generate-schema.ts**: Converts introspected schema to HelixDB Node/Edge/Vector definitions with proper field mapping
- **generate-queries.ts**: Generates CRUD and import queries for all generated types
- **export-data.ts**: Exports table data with cursor-based pagination for large tables
- **import-data.ts**: Imports data via HelixDB HTTP API with topological sorting for FK dependencies
- **type-map.ts**: Comprehensive PostgreSQL to HelixDB type mapping with serialization rules
- **index.ts**: Main CLI orchestration with progress tracking and user guidance

## Related Issues

Closes #

## Checklist when merging to main

- [x] No compiler warnings
- [x] Code is formatted
- [x] Code is easy to understand
- [x] Doc comments provided for all modules and key functions
- [x] TypeScript strict mode enabled

## Additional Notes

The migration tool is designed to be user-friendly with:
- Clear progress indicators using ora spinners
- Helpful error messages with troubleshooting tips
- Colored output for better readability
- Detailed migration guide generation
- Support for partial migrations (schema-only or data-only modes)

The tool handles edge cases like:
- Supabase internal tables (automatically filtered)
- Composite primary keys
- Circular foreign key dependencies (topological sorting)
- Large tables (cursor-based pagination)
- Complex PostgreSQL types (JSON, arrays, custom types)

https://claude.ai/code/session_019kCQvvethhN4B7APgabxFy

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces `@helix-db/migrate`, a comprehensive CLI tool for migrating Supabase (PostgreSQL) projects to HelixDB. The tool automates schema introspection, conversion, data export, and import in five phases.

**Key changes:**
- Introspects PostgreSQL schema (tables, columns, types, FKs, indexes, enums) and converts to HelixDB format
- Generates Node types from tables, Edge types from foreign keys, and Vector types from pgvector columns
- Exports data with cursor-based pagination and imports with topological sorting for FK dependencies
- Creates complete HelixDB project structure with CRUD queries and migration guide

**Critical security issues found:**
- SQL injection vulnerabilities in `introspect.ts` (lines 77, 279) where schema names are concatenated directly into queries without parameterization
- SQL injection vulnerabilities in `export-data.ts` (lines 82, 105, 267) where schema/table names are interpolated without proper escaping
- While these values come from database introspection, they should still use parameterized queries or proper identifier escaping to prevent potential attacks

**Other observations:**
- TypeScript strict mode is enabled as required
- Code is well-documented with clear comments
- Error handling is comprehensive with helpful user messages
- The tool properly handles edge cases like composite PKs, circular dependencies, and large tables

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tools/migrate/src/index.ts | Main CLI orchestration with interactive prompts, handles all five migration phases with proper error handling |
| tools/migrate/src/introspect.ts | PostgreSQL schema introspection with potential SQL injection in schema list construction |
| tools/migrate/src/generate-schema.ts | Schema generation converts PG tables to HelixDB nodes/edges/vectors with proper field mapping |
| tools/migrate/src/export-data.ts | Data export with cursor-based pagination, has SQL injection vulnerability in table/schema identifiers |
| tools/migrate/src/import-data.ts | Data import with topological sorting for FK dependencies, proper ID mapping for edge creation |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as CLI (index.ts)
    participant Intro as Introspect (introspect.ts)
    participant GenSchema as Generate Schema (generate-schema.ts)
    participant GenQueries as Generate Queries (generate-queries.ts)
    participant Export as Export Data (export-data.ts)
    participant Import as Import Data (import-data.ts)
    participant PG as PostgreSQL/Supabase
    participant Helix as HelixDB Instance

    User->>CLI: Run helix-migrate supabase
    CLI->>User: Prompt for connection string
    User->>CLI: Provide connection string

    Note over CLI,Intro: Phase 1: Introspection
    CLI->>Intro: introspectDatabase(connectionString, schemas)
    Intro->>PG: Query information_schema (tables, columns, PKs, FKs, indexes)
    PG-->>Intro: Schema metadata
    Intro->>PG: Query pg_catalog (enums, row counts)
    PG-->>Intro: Additional metadata
    Intro-->>CLI: SchemaIntrospection

    Note over CLI,GenQueries: Phase 2: Schema Generation
    CLI->>GenSchema: generateSchema(introspection)
    GenSchema->>GenSchema: Convert tables to Nodes
    GenSchema->>GenSchema: Convert FKs to Edges
    GenSchema->>GenSchema: Extract vector columns to Vectors
    GenSchema-->>CLI: GeneratedSchema (.hx files)
    CLI->>GenQueries: generateQueries(schema)
    GenQueries-->>CLI: CRUD and Import queries

    Note over CLI: Phase 3: Write Project Files
    CLI->>CLI: Write helix.toml, schema.hx, queries.hx, import.hx, MIGRATION_GUIDE.md

    CLI->>User: Prompt to export data
    User->>CLI: Confirm export

    Note over CLI,Export: Phase 4: Data Export
    CLI->>Export: exportData(connectionString, tables, outputDir)
    loop For each table
        Export->>PG: SELECT with pagination (OFFSET/LIMIT)
        PG-->>Export: Batch of rows
        Export->>Export: Transform and serialize (JSON, arrays, vectors)
        Export->>Export: Write to JSON file
    end
    Export-->>CLI: Export results

    CLI->>User: Prompt to import data into HelixDB
    User->>CLI: Confirm import

    Note over CLI,Import: Phase 5: Data Import
    CLI->>Import: importData(helixUrl, exportDir, schema, tables)
    Import->>Import: Topological sort nodes by FK dependencies
    loop For each node (sorted)
        Import->>Import: Read exported JSON file
        loop For each row (batched)
            Import->>Helix: POST /{ImportNodeQuery} with data
            Helix-->>Import: New HelixDB ID
            Import->>Import: Map old PK to new ID
        end
    end
    loop For each edge
        Import->>Import: Read source table JSON
        loop For each row with FK
            Import->>Import: Lookup from_id and to_id via ID mapping
            Import->>Helix: POST /{ImportEdgeQuery} with from_id, to_id
            Helix-->>Import: Edge created
        end
    end
    loop For each vector
        Import->>Import: Read exported JSON file
        loop For each row with vector
            Import->>Helix: POST /{ImportVectorQuery} with vector data
            Helix-->>Import: Vector created
        end
    end
    Import-->>CLI: Import results (counts, errors, ID mapping)

    CLI->>User: Migration complete! Display next steps
```
</details>


<sub>Last reviewed commit: e00872f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->