### PR TITLE
chore: unify workspace dependencies with cargo-rail

### DIFF
--- a/.config/rail.toml
+++ b/.config/rail.toml
@@ -1,0 +1,53 @@
+# cargo-rail configuration for helix-db fork
+# Documentation: https://github.com/loadingalias/cargo-rail
+
+# Targets
+targets = [
+  "aarch64-apple-darwin",
+  "aarch64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+  "x86_64-unknown-linux-gnu",
+]
+
+[unify]
+include_paths = true
+include_renamed = false
+
+pin_transitives = false  # enable for hakari/workspace-hack users
+transitive_host = "root"  # only used if pin_transitives = true
+
+strict_version_compat = true
+exact_pin_handling = "warn"
+major_version_conflict = "warn"  # warn = skip, bump = force highest
+
+msrv = true
+msrv_source = "workspace"  # deps | workspace | max
+enforce_msrv_inheritance = false  # Ensure members inherit workspace rust-version
+
+detect_unused = true
+remove_unused = true  # requires detect_unused = true
+
+prune_dead_features = true
+preserve_features = []  # glob patterns to keep from pruning
+detect_undeclared_features = true
+fix_undeclared_features = true  # requires detect_undeclared_features = true
+skip_undeclared_patterns = [
+  "default",
+  "std",
+  "alloc",
+  "*_backend",
+  "*_impl",
+]
+
+exclude = []  # excluding one workspace member excludes its whole member cohort
+include = []  # workspace-member cohorts are auto-included
+max_backups = 3
+sort_dependencies = false  # false to preserve existing order
+
+
+[release]
+
+[change-detection]
+
+[run]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,32 @@ members = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+serde_json = "^1.0.143" #unified
+reqwest = { version = "^0.12.23", features = ["blocking", "json"] } #unified
+helix-metrics = { path = "metrics", version = "^0.1.1" } #unified
+clap = { version = "^4.5.53", features = ["derive"] } #unified
+helix-db = { path = "helix-db", version = "^1.2.8" } #unified
+serial_test = "^3.2.0" #unified
+sha2 = "^0.10.8" #unified
+dotenvy = "^0.15.7" #unified
+chrono = { version = "^0.4.42", features = ["serde"] } #unified
+bumpalo = { version = "^3.19.0", features = ["boxed", "collections", "serde"] } #unified
+tracing = "^0.1.41" #unified
+flume = { version = "^0.12.0", default-features = false, features = ["async", "select"] } #unified
+tokio = { version = "^1.47.1", features = ["full"] } #unified
+helix-macros = { path = "helix-macros", version = "^0.1.7" } #unified
+rand = "^0.9.1" #unified
+heed3 = "^0.22.0" #unified
+inventory = "^0.3.19" #unified
+tempfile = "^3.23.0" #unified
+num_cpus = "^1.17.0" #unified
+serde = { version = "^1.0.228", features = ["derive"] } #unified
+uuid = { version = "^1.18.1", features = ["fast-rng"] } #unified
+
+[workspace.package]
+rust-version = "1.88.0"
+
 [profile.release]
 opt-level = 2
 codegen-units = 1

--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -4,39 +4,39 @@ version = "2.2.8"
 edition = "2024"
 
 [dependencies]
-helix-metrics = { path = "../metrics" }
-helix-db = { path = "../helix-db" }
-clap = { version = "4.5.53", features = ["derive"] }
-serde = { version = "1.0.228", features = ["derive"] }
-tokio = { version = "1.47.1", features = ["full"] }
+helix-metrics = { workspace = true } #unified
+helix-db = { workspace = true } #unified
+clap = { workspace = true } #unified
+serde = { workspace = true } #unified
+tokio = { workspace = true } #unified
 eyre = "0.6.12"
 toml = "0.9.5"
 dirs = "6.0.0"
-reqwest = { version = "0.12.23", features = ["json"] }
-serde_json = "1.0.143"
+reqwest = { workspace = true, features = ["blocking"] } #unified
+serde_json = { workspace = true } #unified
 color-eyre = "0.6.5"
 cliclack = "0.3.7"
 async-trait = "0.1.89"
 iota = "0.2.3"
 self_update = "0.42.0"
-uuid = { version = "1.18.1", features = ["v4", "v6", "fast-rng"] }
-chrono = "0.4.42"
-flume = { version = "0.12.0",default-features = false,  features = ["async", "select"] }
-dotenvy = "0.15.7"
+uuid = { workspace = true, features = ["serde", "v4", "v6", "v7"] } #unified
+chrono = { workspace = true, features = ["serde"] } #unified
+flume = { workspace = true } #unified
+dotenvy = { workspace = true } #unified
 tokio-tungstenite = "0.28.0"
 futures-util = "0.3.31"
 regex = "1.11.2"
 reqwest-eventsource = "0.6"
 indicatif = "0.18.3"
 webbrowser = "1.0"
-heed3 = "0.22.0"
+heed3 = { workspace = true } #unified
 open = "5.3"
 ratatui = "0.29"
 crossterm = "0.28"
 
 [dev-dependencies]
-tempfile = "3.23.0"
-serial_test = "3.2"
+tempfile = { workspace = true } #unified
+serial_test = { workspace = true } #unified
 
 [lib]
 name = "helix_cli"

--- a/helix-container/Cargo.toml
+++ b/helix-container/Cargo.toml
@@ -4,24 +4,23 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-helix-db = { path = "../helix-db" }
-helix-macros = { path = "../helix-macros" }
-
-inventory = "0.3.16"
-rand = "0.9.1"
+helix-db = { workspace = true } #unified
+helix-macros = { workspace = true } #unified
+inventory = { workspace = true } #unified
+rand = { workspace = true } #unified
 dirs = "5.0.1"
-chrono = { version = "0.4.41", features = ["serde"] }
-serde = { version = "1.0.219", features = ["derive"] }
+chrono = { workspace = true } #unified
+serde = { workspace = true } #unified
 sonic-rs = "0.5.0"
-tokio = { version = "1.44.2", features = ["full"] }
-serde_json = "1.0.140"
-uuid = { version = "1.12.1", features = ["std", "v4", "v6", "fast-rng"] }
-heed3 = "0.22.0"
+tokio = { workspace = true } #unified
+serde_json = { workspace = true } #unified
+uuid = { workspace = true, features = ["serde", "std", "v4", "v6", "v7"] } #unified
+heed3 = { workspace = true } #unified
 async-trait = "0.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
-tracing = "0.1.41"
-dotenvy = "0.15.7"
-bumpalo = "3.19.0"
+tracing = { workspace = true } #unified
+dotenvy = { workspace = true } #unified
+bumpalo = { workspace = true, features = ["boxed", "collections", "serde"] } #unified
 
 [features]
 dev = ["helix-db/dev-instance"]

--- a/helix-db/Cargo.toml
+++ b/helix-db/Cargo.toml
@@ -8,31 +8,25 @@ authors = ["HelixDB Team"]
 repository = "https://github.com/HelixDB/helix-db"
 
 [dependencies]
-# HelixDB dependencies
-helix-macros = { path = "../helix-macros" }
-helix-metrics = { path = "../metrics" }
-
-# external dependencies
-tokio = { version = "1.44.2", features = ["full"] }
-serde = { version = "1.0.217", features = ["derive"] }
+helix-macros = { workspace = true } #unified
+helix-metrics = { workspace = true } #unified
+tokio = { workspace = true } #unified
+serde = { workspace = true } #unified
 bincode = "1.3.3" # TODO: Figure out bincode 2 impl with current serde impl
 sonic-rs = "0.5.0"
-inventory = "0.3.16"
+inventory = { workspace = true } #unified
 twox-hash = "2.1.0"
-heed3 = "0.22.0"
-uuid = { version = "1.12.1", features = ["serde", "v4", "v6", "fast-rng"] }
-rand = "0.9.0"
-chrono = "0.4.39"
-flume = { version = "0.12.0", default-features = false, features = [
-    "async",
-    "select",
-] }
+heed3 = { workspace = true } #unified
+uuid = { workspace = true, features = ["serde", "v4", "v6", "v7"] } #unified
+rand = { workspace = true } #unified
+chrono = { workspace = true, features = ["serde"] } #unified
+flume = { workspace = true } #unified
 itertools = "0.14.0"
-tempfile = "3.20.0"
+tempfile = { workspace = true } #unified
 paste = "1.0.15"
 rayon = "1.11.0"
 mimalloc = "0.1.48"
-bumpalo = { version = "3.19.0", features = ["collections", "boxed", "serde"] }
+bumpalo = { workspace = true } #unified
 bytemuck = "1.24.0"
 indexmap = { version = "2.7", features = ["serde"] }
 
@@ -40,16 +34,11 @@ indexmap = { version = "2.7", features = ["serde"] }
 pest = { version = "2.7", optional = true }
 pest_derive = { version = "2.7", optional = true }
 ariadne = { version = "0.5", optional = true }
-
-# embedding dependencies
-reqwest = { version = "0.12.15", features = [
-    "json",
-    "blocking",
-], optional = true }
+reqwest = { workspace = true, optional = true } #unified
 url = { version = "2.5", optional = true }
 tokio-util = { version = "0.7.15", features = ["compat"] }
 axum = "0.8.4"
-tracing = "0.1.41"
+tracing = { workspace = true } #unified
 core_affinity = "0.8.3"
 async-trait = "0.1.88"
 thiserror = "2.0.12"
@@ -58,18 +47,18 @@ polars = { version = "0.46.0", features = [
     "lazy",
     "json",
 ], optional = true }
-sha2 = "0.10"
+sha2 = { workspace = true } #unified
 subtle = "2.5"
 
 [dev-dependencies]
-rand = "0.9.0"
+rand = { workspace = true } #unified
 lazy_static = "1.4.0"
-num_cpus = "1.17"     # TODO: write ourselves
+num_cpus = { workspace = true } #unified
 proptest = "1.4"
 criterion = "0.5"
 loom = "0.7"          # Concurrency model checking
 tokio-test = "0.4"    # Tokio testing utilities
-serial_test = "3.2"   # Serialize LMDB stress tests to avoid interference
+serial_test = { workspace = true } #unified
 
 [features]
 debug-output = ["helix-macros/debug-output"]

--- a/hql-tests/Cargo.toml
+++ b/hql-tests/Cargo.toml
@@ -8,11 +8,11 @@ name = "test"
 path = "src/main.rs"
 
 [dependencies]
-tokio = { version = "1.0", features = ["full"] }
-clap = { version = "4.0", features = ["derive"] }
+tokio = { workspace = true } #unified
+clap = { workspace = true } #unified
 anyhow = "1.0"
 futures = "0.3" 
 octocrab = "0.44.1"
-serde = { version = "1.0", features = ["derive"] }
-sha2 = "0.10"
+serde = { workspace = true } #unified
+sha2 = { workspace = true } #unified
 base64 = "0.22" 

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -8,12 +8,12 @@ license = "AGPL-3.0"
 description = "Metrics for HelixDB"
 
 [dependencies]
-reqwest = "0.12.11"
-serde = { version = "1.0", features = ["derive"] }
+reqwest = { workspace = true, features = ["blocking", "json"] } #unified
+serde = { workspace = true } #unified
 sonic-rs = "0.5.3"
-chrono = "0.4"
-uuid = { version = "1.18.0", features = ["v7", "fast-rng"] }
-tokio = { version = "1.39", features = ["full"] }
+chrono = { workspace = true, features = ["serde"] } #unified
+uuid = { workspace = true, features = ["serde", "v4", "v6", "v7"] } #unified
+tokio = { workspace = true } #unified
 async-trait = "0.1.88"
-flume = { version = "0.12.0", default-features = false, features = ["async", "select"] }
-num_cpus = "1.17.0"
+flume = { workspace = true } #unified
+num_cpus = { workspace = true } #unified


### PR DESCRIPTION
## Summary
Workspace dependency unification generated with `cargo-rail v0.10.7`.

## What changed
- Unified **21 dependencies** into root `[workspace.dependencies]`
- Updated member manifests to consume workspace deps where applicable
- Fixed **17 undeclared features** across 4 crates
- Wrote workspace `rust-version = "1.88.0"`
- Manifest-only maintenance change (`Cargo.toml` + `.config/rail.toml`)

## Validation commands used
- `cargo rail unify --check --explain`
- `cargo rail unify`

## Notes
- No explicit `exclude` entries were used in this run.
- This change focuses on dependency graph hygiene and reproducibility.

## Unified dependencies
- tempfile
- clap
- serial_test
- bumpalo
- num_cpus
- helix-macros
- serde_json
- heed3
- tracing
- helix-metrics
- rand
- tokio
- uuid
- helix-db
- serde
- dotenvy
- chrono
- reqwest
- inventory
- sha2
- flume

## Why undeclared features matter
Cargo resolves features at the workspace level. If one crate enables a dependency feature and another crate relies on it without declaring it, builds can pass by accident and then fail in isolated builds, publish flows, or CI matrices. This PR explicitly declares borrowed features to make dependency behavior deterministic.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR unifies 21 dependencies into `[workspace.dependencies]` across 6 workspace member crates using `cargo-rail v0.10.7`. It bumps all shared dependencies to their highest version across the workspace, adds `rust-version = "1.88.0"` to `[workspace.package]`, and introduces a `.config/rail.toml` configuration file.

- **Dependency unification**: All shared deps now use `workspace = true` references, ensuring consistent versioning across `helix-db`, `helix-cli`, `helix-container`, `hql-tests`, and `metrics`
- **Version bumps**: All unified deps are bumped to the highest version previously used by any member (e.g., `tokio` 1.44.2 → 1.47.1, `inventory` 0.3.16 → 0.3.19)
- **Feature broadening**: Some crates gain features they don't directly use (e.g., `uuid` `v7` spread to all crates, `bumpalo` features added to `helix-container` where it's unused) — this is a trade-off of workspace unification and increases compile scope slightly
- **No source code changes**: This is a manifest-only change with no runtime behavior differences

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .config/rail.toml | New cargo-rail configuration file. Settings are reasonable and well-documented. No issues found. |
| Cargo.toml | Adds 21 workspace dependencies and MSRV 1.88.0. Versions are bumped to highest across all members. Feature sets are the union of all member requirements, which is correct for workspace deps. |
| helix-cli/Cargo.toml | Dependencies migrated to workspace references. Feature inheritance works correctly — json feature is preserved via workspace definition. The blocking feature addition is unnecessary but harmless. |
| helix-container/Cargo.toml | Dependencies migrated to workspace references. bumpalo features (boxed, collections, serde) are added but bumpalo is not used in this crate's source code — inherited transitively via helix-db. |
| helix-db/Cargo.toml | Core database crate migrated to workspace deps. The bumpalo features are correctly preserved (heavily used in source). uuid v7 feature added but not used in source. |
| hql-tests/Cargo.toml | Clean migration to workspace deps. No feature changes, just version unification. No issues found. |
| metrics/Cargo.toml | Dependencies migrated to workspace references. uuid gains v4/v6/serde features that aren't used in source, and reqwest gains blocking/json features. Functionally correct but adds unused features. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
flowchart TD
    WS["Cargo.toml\n[workspace.dependencies]\n21 unified deps"]
    
    WS --> CLI["helix-cli\n(workspace = true)\n+ local features"]
    WS --> CONT["helix-container\n(workspace = true)\n+ local features"]
    WS --> DB["helix-db\n(workspace = true)\n+ local features"]
    WS --> HQL["hql-tests\n(workspace = true)"]
    WS --> MET["metrics\n(workspace = true)\n+ local features"]
    
    DB --> |"path dep"| MAC["helix-macros\n(not unified)"]
    DB --> |"path dep"| MET
    CLI --> |"path dep"| DB
    CLI --> |"path dep"| MET
    CONT --> |"path dep"| DB
    CONT --> |"path dep"| MAC

    style WS fill:#4a90d9,color:#fff
    style CLI fill:#50c878,color:#fff
    style CONT fill:#50c878,color:#fff
    style DB fill:#50c878,color:#fff
    style HQL fill:#50c878,color:#fff
    style MET fill:#50c878,color:#fff
    style MAC fill:#f0ad4e,color:#fff
```
</details>


<sub>Last reviewed commit: ec3ed9f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->