### PR TITLE
docs: add cargo-rail change-detection config

### DIFF
--- a/.config/cargo-rail-planning-intergation.md
+++ b/.config/cargo-rail-planning-intergation.md
@@ -1,0 +1,38 @@
+# cargo-rail Planning Integration
+
+## Intent
+This repo uses `cargo rail run` with workflow/profile mapping.
+The `.config/rail.toml` keeps DB/HQL lanes explicit via workflow + custom surface mapping.
+
+## Local developer flow
+```bash
+cargo rail config validate --strict
+cargo rail plan --merge-base --explain
+cargo rail run --merge-base --profile ci
+```
+
+## GitHub Actions integration (cargo-rail-action)
+Use planner outputs for core and HQL lanes.
+
+```yaml
+- uses: loadingalias/cargo-rail-action@v3
+  id: rail
+
+- name: Core lane
+  if: steps.rail.outputs.build == 'true' || steps.rail.outputs.test == 'true'
+  run: cargo rail run --since "${{ steps.rail.outputs.base-ref }}" --profile ci
+
+- name: HQL lane
+  if: steps.rail.outputs.hql == 'true'
+  run: cargo rail run --since "${{ steps.rail.outputs.base-ref }}" --profile hql
+```
+
+## UI output that teams should read
+- action summary surface table + reasons
+- `steps.rail.outputs.plan-json` for custom branching
+- `cargo rail plan --explain` for local reproducibility
+
+## Measured impact (last 20 commits)
+- Could skip build: 10%
+- Could skip tests: 10%
+- Targeted (not full run): 75%

--- a/.config/rail.toml
+++ b/.config/rail.toml
@@ -1,0 +1,108 @@
+# cargo-rail configuration
+# Documentation: https://github.com/loadingalias/cargo-rail
+
+# Targets for multi-platform validation (runs `cargo metadata --filter-platform <target>` per target)
+targets = [
+  "aarch64-apple-darwin",
+  "aarch64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+  "x86_64-unknown-linux-gnu",
+]
+
+[unify]
+include_paths = true
+include_renamed = false
+
+pin_transitives = false  # enable for hakari/workspace-hack users
+transitive_host = "root"  # only used if pin_transitives = true
+
+strict_version_compat = true
+exact_pin_handling = "warn"
+major_version_conflict = "warn"  # warn = skip, bump = force highest
+
+msrv = true
+msrv_source = "max"  # deps | workspace | max
+enforce_msrv_inheritance = false  # Ensure members inherit workspace rust-version
+
+detect_unused = true
+remove_unused = true  # requires detect_unused = true
+
+prune_dead_features = true
+preserve_features = []  # glob patterns to keep from pruning
+detect_undeclared_features = true
+fix_undeclared_features = true  # requires detect_undeclared_features = true
+skip_undeclared_patterns = [
+  "default",
+  "std",
+  "alloc",
+  "*_backend",
+  "*_impl",
+]
+
+exclude = []  # excluding one workspace member excludes its whole member cohort
+include = []  # workspace-member cohorts are auto-included
+max_backups = 3
+sort_dependencies = true  # false to preserve existing order
+
+
+[release]
+tag_prefix = "v"
+tag_format = "{crate}-{prefix}{version}"  # e.g. my-crate-v1.0.0 (with tag_prefix = "v")
+require_clean = true
+publish_delay = 5  # seconds between publishes
+create_github_release = false
+sign_tags = false
+changelog_path = "CHANGELOG.md"
+changelog_relative_to = "crate"  # crate = per-crate, workspace = single file
+skip_changelog_for = []
+require_changelog_entries = false
+
+
+[change-detection]
+# helix-db has specialized DB/HQL workflows; keep workflow mapping explicit.
+infrastructure = [
+  ".github/**",
+  "clippy_check.sh",
+  "Cargo.toml",
+  "Cargo.lock",
+]
+conservative_unclassified_owner_fallback = true
+confidence_profile = "balanced"
+bot_pr_confidence_profile = "strict"
+
+[change-detection.custom]
+hql = ["hql-tests/**"]
+assets = ["assets/**"]
+
+[run]
+default_profile = "local"
+
+[run.workflow]
+commit = "ci"
+ci = "ci"
+db_tests = "ci"
+hql_tests = "hql"
+clippy_check = "ci"
+
+[run.profile.local]
+surfaces = ["test"]
+merge_base = true
+
+[run.profile.ci]
+surfaces = ["build", "test"]
+run_args = ["--workspace", "{cargo_args}"]
+merge_base = true
+
+[run.profile.hql]
+surfaces = ["test"]
+run_args = ["-p", "hql-tests", "{cargo_args}"]
+merge_base = true
+
+
+# Per-crate configuration: run 'cargo rail split init <crate>' to generate
+# [crates.my-crate.split]
+# remote = "git@github.com:org/my-crate.git"
+# branch = "main"
+# mode = "single"
+# paths = [{ crate = "crates/my-crate" }]


### PR DESCRIPTION
Adds two files only:
- `.config/rail.toml`
- `.config/cargo-rail-planning-intergation.md`

Config maps core + HQL workflow lanes with deterministic planner output (`cargo rail plan --merge-base --explain`, `loadingalias/cargo-rail-action@v3`).

Measured on recent history (20 commits): build skip 10%, test skip 10%, targeted/non-full runs 75% - give or take.

No Rust source changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds cargo-rail configuration to enable intelligent CI/CD change detection and targeted test execution for the helix-db workspace. The configuration defines workflow profiles for core database tests (`ci` profile) and HQL tests (`hql` profile), with custom change detection mapping that aligns with the repository's existing GitHub Actions workflows (`db_tests`, `hql_tests`, `clippy_check`).

**Key additions:**
- Multi-platform target validation (Linux, macOS, Windows on x86_64 and ARM64)
- Change detection for infrastructure files (`.github/**`, `Cargo.{toml,lock}`, `clippy_check.sh`)
- Custom surface mappings for `hql` (targeting `hql-tests/**`) and `assets` directories
- Workflow-to-profile mappings that integrate with existing CI lanes
- Documentation showing expected 10% build/test skip rate and 75% targeted run rate

**Issue found:**
- Documentation filename has typo: `cargo-rail-planning-intergation.md` should be `cargo-rail-planning-integration.md`

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .config/rail.toml | Adds cargo-rail configuration with change detection, workflow profiles (ci/hql/local), and multi-platform targets |
| .config/cargo-rail-planning-intergation.md | Documents cargo-rail integration for CI/CD optimization; filename has typo ("intergation" vs "integration") |

</details>


</details>


<sub>Last reviewed commit: c390a91</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->