### PR TITLE
feat(mcp): improve VFromType with filter support

### DIFF
--- a/helix-db/src/helix_gateway/mcp/tools.rs
+++ b/helix-db/src/helix_gateway/mcp/tools.rs
@@ -6,7 +6,7 @@ use crate::{
                 g::G,
                 in_::{in_::InAdapter, in_e::InEdgesAdapter},
                 out::{out::OutAdapter, out_e::OutEdgesAdapter},
-                source::{e_from_type::EFromTypeAdapter, n_from_type::NFromTypeAdapter},
+                source::{e_from_type::EFromTypeAdapter, n_from_type::NFromTypeAdapter, v_from_type::VFromTypeAdapter},
                 util::{order::OrderByAdapter, range::RangeAdapter},
             },
             traversal_iter::RoTraversalIterator,
@@ -55,6 +55,10 @@ pub enum ToolArgs {
     },
     EFromType {
         edge_type: String,
+    },
+    VFromType {
+        vector_type: String,
+        filter: Option<FilterTraversal>,
     },
     FilterItems {
         #[serde(default)]
@@ -301,6 +305,17 @@ where
             Ok(TraversalStream::from_ro_iterator(
                 G::new(storage, txn, arena).e_from_type(label),
             ))
+        }
+        ToolArgs::VFromType { vector_type, filter } => {
+            let label = arena.alloc_str(vector_type);
+            let transformed = TraversalStream::from_ro_iterator(
+                G::new(storage, txn, arena).v_from_type(label, true),
+            );
+            if let Some(filter) = filter.clone() {
+                apply_filter(transformed, filter)
+            } else {
+                Ok(transformed)
+            }
         }
         ToolArgs::OutStep {
             edge_label,

--- a/helix-db/src/helix_gateway/mcp/tools.rs
+++ b/helix-db/src/helix_gateway/mcp/tools.rs
@@ -6,7 +6,10 @@ use crate::{
                 g::G,
                 in_::{in_::InAdapter, in_e::InEdgesAdapter},
                 out::{out::OutAdapter, out_e::OutEdgesAdapter},
-                source::{e_from_type::EFromTypeAdapter, n_from_type::NFromTypeAdapter, v_from_type::VFromTypeAdapter},
+                source::{
+                    e_from_type::EFromTypeAdapter, n_from_type::NFromTypeAdapter,
+                    v_from_type::VFromTypeAdapter,
+                },
                 util::{order::OrderByAdapter, range::RangeAdapter},
             },
             traversal_iter::RoTraversalIterator,
@@ -306,7 +309,10 @@ where
                 G::new(storage, txn, arena).e_from_type(label),
             ))
         }
-        ToolArgs::VFromType { vector_type, filter } => {
+        ToolArgs::VFromType {
+            vector_type,
+            filter,
+        } => {
             let label = arena.alloc_str(vector_type);
             let transformed = TraversalStream::from_ro_iterator(
                 G::new(storage, txn, arena).v_from_type(label, true),


### PR DESCRIPTION
## Description
This PR enhances the MCP toolset by improving the `VFromType` tool and removing redundant functionality:
- VFromType Improvement: Added optional filter: Option<FilterTraversal> support. This allows for metadata-based filtering of vectors during initial retrieval, consistently aligning with the functionality of `NFromType` and `EFromType`.

## Checklist when merging to main

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `VFromType` MCP tool that retrieves vectors by type label with optional metadata filtering support. The implementation follows the existing pattern used by `OutStep`, `InStep`, and other tools that support optional filters by wrapping the base traversal with `apply_filter` when a filter is provided. The code is well-structured and integrates cleanly with the existing traversal system.

Key changes:
- Added `VFromTypeAdapter` import from the source module
- Added `VFromType` variant to the `ToolArgs` enum with `vector_type: String` and `filter: Option<FilterTraversal>` fields
- Implemented the `VFromType` case in `apply_step` that calls `v_from_type(label, true)` to retrieve vector data and conditionally applies filtering

The implementation is correct and follows established patterns in the codebase.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/src/helix_gateway/mcp/tools.rs | Adds `VFromType` tool with optional filter support for retrieving vectors by type |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[VFromType Tool Args] --> B{Parse vector_type and filter}
    B --> C[Allocate label in arena]
    C --> D[Call G.v_from_type with label and get_vector_data=true]
    D --> E[Create TraversalStream from iterator]
    E --> F{Filter provided?}
    F -->|Yes| G[apply_filter with FilterTraversal]
    F -->|No| H[Return unfiltered stream]
    G --> I[Filter by properties and/or sub-traversals]
    I --> J[Return filtered TraversalStream]
    H --> J
    J --> K[Results ready for consumption]
```
</details>


<sub>Last reviewed commit: dbcdf25</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->