### PR TITLE
fix(vector-core): harden cosine similarity with input validation, zero-magnitude handling, and edge case tests

### DIFF
--- a/helix-db/src/helix_engine/tests/traversal_tests/upsert_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/upsert_tests.rs
@@ -530,7 +530,7 @@ fn test_upsert_v_creates_new_vector_when_none_exists() {
 }
 
 #[test]
-fn test_upsert_v_creates_vector_with_default_data_when_none_provided() {
+fn test_upsert_v_rejects_empty_vector_data() {
     let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
@@ -542,21 +542,9 @@ fn test_upsert_v_creates_vector_with_default_data_when_none_provided() {
         &arena,
     )
     .upsert_v(&[], "placeholder", &[("status", Value::from("pending"))])
-    .collect::<Result<Vec<_>, _>>()
-    .unwrap();
+    .collect::<Result<Vec<_>, _>>();
 
-    assert_eq!(result.len(), 1);
-    if let TraversalValue::Vector(vector) = &result[0] {
-        assert_eq!(vector.label, "placeholder");
-        assert!(vector.data.is_empty()); // Default empty data
-        assert_eq!(
-            vector.get_property("status").unwrap(),
-            &Value::from("pending")
-        );
-    } else {
-        panic!("Expected vector");
-    }
-    txn.commit().unwrap();
+    assert!(result.is_err());
 }
 
 #[test]

--- a/helix-db/src/helix_engine/tests/vector_tests.rs
+++ b/helix-db/src/helix_engine/tests/vector_tests.rs
@@ -173,3 +173,10 @@ fn test_hvector_distance_zero_vector_returns_error() {
     let v2 = alloc_vector(&arena, &[3.0, 4.0]);
     assert!(v1.distance_to(&v2).is_err());
 }
+
+#[test]
+fn test_cosine_similarity_near_zero_magnitude_returns_error() {
+    let tiny = f64::EPSILON * 0.1;
+    let result = cosine_similarity(&[tiny, 0.0], &[1.0, 2.0]);
+    assert!(result.is_err());
+}

--- a/helix-db/src/helix_engine/tests/vector_tests.rs
+++ b/helix-db/src/helix_engine/tests/vector_tests.rs
@@ -1,4 +1,6 @@
-use crate::helix_engine::vector_core::vector_distance::{MAX_DISTANCE, MIN_DISTANCE, ORTHOGONAL};
+use crate::helix_engine::vector_core::vector_distance::{
+    cosine_similarity, MAX_DISTANCE, MIN_DISTANCE, ORTHOGONAL,
+};
 
 use crate::helix_engine::vector_core::vector::HVector;
 use bumpalo::Bump;
@@ -36,8 +38,8 @@ fn test_hvector_distance_min() {
 #[test]
 fn test_hvector_distance_max() {
     let arena = Bump::new();
-    let v1 = alloc_vector(&arena, &[0.0, 0.0]);
-    let v2 = alloc_vector(&arena, &[3.0, 4.0]);
+    let v1 = alloc_vector(&arena, &[-1.0, -2.0, -3.0]);
+    let v2 = alloc_vector(&arena, &[1.0, 2.0, 3.0]);
     let distance = v1.distance_to(&v2).unwrap();
     assert_eq!(distance, MAX_DISTANCE);
 }
@@ -98,4 +100,76 @@ fn test_hvector_cosine_similarity() {
     let v2 = alloc_vector(&arena2, &[4.0, 5.0, 6.0]);
     let similarity = v1.distance_to(&v2).unwrap();
     assert!((similarity - (1.0 - 0.9746318461970762)).abs() < 1e-9);
+}
+
+#[test]
+fn test_cosine_similarity_zero_vector_returns_error() {
+    let result = cosine_similarity(&[0.0, 0.0, 0.0], &[1.0, 2.0, 3.0]);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_cosine_similarity_both_zero_vectors_returns_error() {
+    let result = cosine_similarity(&[0.0, 0.0], &[0.0, 0.0]);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_cosine_similarity_empty_vectors_returns_error() {
+    let result = cosine_similarity(&[], &[]);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_cosine_similarity_one_empty_vector_returns_error() {
+    let result = cosine_similarity(&[], &[1.0, 2.0]);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_cosine_similarity_dimension_mismatch_returns_error() {
+    let result = cosine_similarity(&[1.0, 2.0], &[1.0, 2.0, 3.0]);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_cosine_similarity_identical_vectors() {
+    let result = cosine_similarity(&[1.0, 2.0, 3.0], &[1.0, 2.0, 3.0]);
+    assert!((result.unwrap() - 1.0).abs() < 1e-10);
+}
+
+#[test]
+fn test_cosine_similarity_opposite_vectors() {
+    let result = cosine_similarity(&[1.0, 2.0, 3.0], &[-1.0, -2.0, -3.0]);
+    assert!((result.unwrap() - (-1.0)).abs() < 1e-10);
+}
+
+#[test]
+fn test_cosine_similarity_orthogonal_vectors() {
+    let result = cosine_similarity(&[1.0, 0.0], &[0.0, 1.0]);
+    assert!(result.unwrap().abs() < 1e-10);
+}
+
+#[test]
+fn test_cosine_similarity_single_element() {
+    let result = cosine_similarity(&[5.0], &[3.0]);
+    assert!((result.unwrap() - 1.0).abs() < 1e-10);
+}
+
+#[test]
+fn test_cosine_similarity_large_dimensions() {
+    let a: Vec<f64> = (0..1024).map(|i| (i as f64).sin()).collect();
+    let b: Vec<f64> = (0..1024).map(|i| (i as f64).cos()).collect();
+    let result = cosine_similarity(&a, &b);
+    assert!(result.is_ok());
+    let sim = result.unwrap();
+    assert!(sim >= -1.0 && sim <= 1.0);
+}
+
+#[test]
+fn test_hvector_distance_zero_vector_returns_error() {
+    let arena = Bump::new();
+    let v1 = alloc_vector(&arena, &[0.0, 0.0]);
+    let v2 = alloc_vector(&arena, &[3.0, 4.0]);
+    assert!(v1.distance_to(&v2).is_err());
 }

--- a/helix-db/src/helix_engine/vector_core/vector_core.rs
+++ b/helix-db/src/helix_engine/vector_core/vector_core.rs
@@ -288,18 +288,10 @@ impl VectorCore {
 
                 neighbor.set_distance(neighbor.distance_to(query)?);
 
-                /*
-                let passes_filters = match filter {
-                    Some(filter_slice) => filter_slice.iter().all(|f| f(&neighbor, txn)),
-                    None => true,
-                };
-
-                if passes_filters {
-                    result.push(neighbor);
-                }
-                */
-
-                if filter.is_none() || filter.unwrap().iter().all(|f| f(&neighbor, txn)) {
+                if filter
+                    .as_ref()
+                    .map_or(true, |f| f.iter().all(|f| f(&neighbor, txn)))
+                {
                     result.push(neighbor);
                 }
             }
@@ -458,7 +450,7 @@ impl VectorCore {
             let (key, _) = result?;
 
             // Extract id from the key: v: (2 bytes) + id (16 bytes) + level (8 bytes)
-            if key.len() < VECTOR_PREFIX.len() + 16 {
+            if key.len() < VECTOR_PREFIX.len() + 16 + 8 {
                 continue; // Skip malformed keys
             }
 
@@ -505,6 +497,10 @@ impl HNSW for VectorCore {
         'db: 'arena,
         'arena: 'txn,
     {
+        if query.is_empty() {
+            return Err(VectorError::InvalidVectorData);
+        }
+
         let query = HVector::from_slice(label, 0, query);
         // let temp_arena = bumpalo::Bump::new();
 
@@ -572,6 +568,10 @@ impl HNSW for VectorCore {
         'db: 'arena,
         'arena: 'txn,
     {
+        if data.is_empty() {
+            return Err(VectorError::InvalidVectorData);
+        }
+
         let new_level = self.get_new_level();
 
         let mut query = HVector::from_slice(label, 0, data);
@@ -597,7 +597,7 @@ impl HNSW for VectorCore {
             let mut nearest =
                 self.search_level::<F>(txn, label, &query, &mut curr_ep, 1, level, None, arena)?;
             curr_ep = nearest.pop().ok_or(VectorError::VectorCoreError(
-                "emtpy search result".to_string(),
+                "empty search result".to_string(),
             ))?;
         }
 
@@ -613,7 +613,7 @@ impl HNSW for VectorCore {
                 arena,
             )?;
             curr_ep = *nearest.peek().ok_or(VectorError::VectorCoreError(
-                "emtpy search result".to_string(),
+                "empty search result".to_string(),
             ))?;
 
             let neighbors =

--- a/helix-db/src/helix_engine/vector_core/vector_distance.rs
+++ b/helix-db/src/helix_engine/vector_core/vector_distance.rs
@@ -28,11 +28,13 @@ pub fn cosine_similarity(from: &[f64], to: &[f64]) -> Result<f64, VectorError> {
     let len = from.len();
     let other_len = to.len();
 
+    if len == 0 || other_len == 0 {
+        return Err(VectorError::InvalidVectorData);
+    }
+
     if len != other_len {
-        println!("mis-match in vector dimensions!\n{len} != {other_len}");
         return Err(VectorError::InvalidVectorLength);
     }
-    //debug_assert_eq!(len, other.data.len(), "Vectors must have the same length");
 
     #[cfg(target_feature = "avx2")]
     {
@@ -78,11 +80,17 @@ pub fn cosine_similarity(from: &[f64], to: &[f64]) -> Result<f64, VectorError> {
         magnitude_b += b_val * b_val;
     }
 
-    if magnitude_a.abs() == 0.0 || magnitude_b.abs() == 0.0 {
-        return Ok(-1.0);
+    if magnitude_a == 0.0 || magnitude_b == 0.0 {
+        return Err(VectorError::InvalidVectorData);
     }
 
-    Ok(dot_product / (magnitude_a.sqrt() * magnitude_b.sqrt()))
+    let similarity = dot_product / (magnitude_a.sqrt() * magnitude_b.sqrt());
+
+    if similarity.is_nan() || similarity.is_infinite() {
+        return Err(VectorError::InvalidVectorData);
+    }
+
+    Ok(similarity)
 }
 
 // SIMD implementation using AVX2 (256-bit vectors)

--- a/helix-db/src/helix_engine/vector_core/vector_distance.rs
+++ b/helix-db/src/helix_engine/vector_core/vector_distance.rs
@@ -96,7 +96,7 @@ pub fn cosine_similarity(from: &[f64], to: &[f64]) -> Result<f64, VectorError> {
 // SIMD implementation using AVX2 (256-bit vectors)
 #[cfg(target_feature = "avx2")]
 #[inline(always)]
-pub fn cosine_similarity_avx2(a: &[f64], b: &[f64]) -> f64 {
+pub fn cosine_similarity_avx2(a: &[f64], b: &[f64]) -> Result<f64, VectorError> {
     use std::arch::x86_64::*;
 
     let len = a.len();
@@ -141,10 +141,20 @@ pub fn cosine_similarity_avx2(a: &[f64], b: &[f64]) -> f64 {
 
         // Combine SIMD and scalar results
         let dot_product_total = dot_sum + dot_remainder;
-        let magnitude_a_total = (mag_a_sum + mag_a_remainder).sqrt();
-        let magnitude_b_total = (mag_b_sum + mag_b_remainder).sqrt();
+        let mag_a_total = mag_a_sum + mag_a_remainder;
+        let mag_b_total = mag_b_sum + mag_b_remainder;
 
-        dot_product_total / (magnitude_a_total * magnitude_b_total)
+        if mag_a_total < f64::EPSILON || mag_b_total < f64::EPSILON {
+            return Err(VectorError::InvalidVectorData);
+        }
+
+        let similarity = dot_product_total / (mag_a_total.sqrt() * mag_b_total.sqrt());
+
+        if similarity.is_nan() || similarity.is_infinite() {
+            return Err(VectorError::InvalidVectorData);
+        }
+
+        Ok(similarity)
     }
 }
 

--- a/helix-db/src/helix_engine/vector_core/vector_distance.rs
+++ b/helix-db/src/helix_engine/vector_core/vector_distance.rs
@@ -80,7 +80,7 @@ pub fn cosine_similarity(from: &[f64], to: &[f64]) -> Result<f64, VectorError> {
         magnitude_b += b_val * b_val;
     }
 
-    if magnitude_a == 0.0 || magnitude_b == 0.0 {
+    if magnitude_a < f64::EPSILON || magnitude_b < f64::EPSILON {
         return Err(VectorError::InvalidVectorData);
     }
 


### PR DESCRIPTION
## Summary

Hardens the vector core module with input validation, proper error handling for edge cases, and bug fixes that prevent silent data corruption and misleading results in cosine similarity calculations.

## Problem

The vector core had several correctness issues:

1. **Zero-magnitude vectors silently returned `-1.0`** from `cosine_similarity()` — this is mathematically undefined and misleading (treated as "most dissimilar" instead of signaling an error)
2. **Empty vectors could be inserted** into the HNSW index and used in search queries, causing NaN propagation in downstream distance calculations
3. **No NaN/Infinity guards** on the computed similarity output
4. **Stale `println!` in production path** — `println!("mis-match in vector dimensions!")` was left in `cosine_similarity()`
5. **`is_none() || unwrap()` anti-pattern** in `select_neighbors` — logically correct but fragile and non-idiomatic
6. **Incomplete boundary check** in `get_all_vectors` — checked `prefix + 16` bytes but key format requires `prefix + 16 + 8`
7. **Typo** — `"emtpy search result"` in two error messages

## Changes

### `vector_distance.rs` — Cosine similarity hardening
- Empty vectors → `Err(InvalidVectorData)` (was: proceed to divide-by-zero)
- Zero/near-zero magnitude → `Err(InvalidVectorData)` using `f64::EPSILON` threshold (was: `Ok(-1.0)`)
- Added NaN/Infinity guard on result
- Removed stale `println!`

### `vector_core.rs` — Structural improvements
- Added empty vector validation in both `insert()` and `search()` entry points
- Fixed `"emtpy"` → `"empty"` in 2 error messages
- Replaced `filter.is_none() || filter.unwrap()...` with idiomatic `filter.as_ref().map_or(true, ...)`
- Removed dead commented-out code block in `select_neighbors`
- Fixed `get_all_vectors` key length check: `prefix + 16` → `prefix + 16 + 8`

### Tests — 12 new edge case tests
- Zero-magnitude, near-zero magnitude, empty, both-empty, one-empty vectors → error
- Dimension mismatch → error
- Identical, opposite, orthogonal, single-element, large-dimension (1024-d) vectors → correct results
- Updated `test_hvector_distance_max` to use opposite vectors (was using zero-magnitude)
- Updated `test_upsert_v` to expect error on empty vector data

## Test Results

All **1228 tests pass** (0 failures), verified with:

cargo test --lib -p helix-db -- --skip concurrency_tests --skip hnsw_tests --skip worker_pool_tests


---



## Summary of What Changed (4 files)

| File | What Changed |
|------|-------------|
| **`vector_distance.rs`** | Empty/zero-magnitude vectors now return `Err` instead of `-1.0`; removed `println!`; added NaN guard |
| **`vector_core.rs`** | Added empty data validation in `insert()` & `search()`; fixed typo "emtpy"→"empty"; fixed key length check; idiomatic filter pattern |
| **`vector_tests.rs`** | Added 12 new edge case tests for cosine similarity |
| **`upsert_tests.rs`** | Updated test to expect error on empty vector data |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the vector core module by adding input validation and proper error handling to `cosine_similarity` and the HNSW insert/search entry points, replacing a silent incorrect return value (`Ok(-1.0)` for zero-magnitude vectors) with explicit errors, and adding 12 new edge-case tests.

**Key changes:**
- `vector_distance.rs`: Adds empty-vector, zero-magnitude (`< f64::EPSILON`), and NaN/Inf guards to the scalar cosine similarity path; removes the stale `println!`
- `vector_core.rs`: Empty data validation added in `insert()` and `search()`; fixes boundary check in `get_all_vectors` (`+16` → `+16+8`); fixes two "emtpy" typos; replaces `is_none() || unwrap()` anti-pattern with idiomatic `map_or`
- `vector_tests.rs`: 12 new tests for edge cases; `test_hvector_distance_max` updated to use valid opposite vectors
- `upsert_tests.rs`: Test updated to assert that empty vector data now returns an error

**Issue found:**
- The new zero-magnitude check and NaN guard in `vector_distance.rs` are placed **after** the `#[cfg(target_feature = "avx2")]` early return, meaning they are completely bypassed on AVX2 targets. Additionally, `cosine_similarity_avx2` still has a return type of `f64` rather than `Result<f64, VectorError>`, which would produce a compile error on any AVX2-capable build. The empty-vector and dimension-mismatch guards are correctly placed before the AVX2 branch, but the magnitude and NaN protections need to be replicated inside the AVX2 path (or the function signature updated) to make the fix complete.

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["cosine_similarity(from, to)"] --> B{Either input empty?}
    B -- Yes --> C["Err(InvalidVectorData)"]
    B -- No --> D{Lengths equal?}
    D -- No --> E["Err(InvalidVectorLength)"]
    D -- Yes --> F{AVX2 feature enabled?}
    F -- Yes --> G["cosine_similarity_avx2(from, to)\nreturns f64 ⚠️\nNo magnitude/NaN guard"]
    F -- No --> H["Scalar loop:\ncompute dot_product,\nmagnitude_a, magnitude_b"]
    H --> I{"magnitude_a < ε\nor magnitude_b < ε?"}
    I -- Yes --> J["Err(InvalidVectorData)"]
    I -- No --> K["similarity = dot / (√mag_a × √mag_b)"]
    K --> L{NaN or Infinite?}
    L -- Yes --> M["Err(InvalidVectorData)"]
    L -- No --> N["Ok(similarity)"]

    style G fill:#ffcccc,stroke:#cc0000
    style C fill:#ffe0e0
    style E fill:#ffe0e0
    style J fill:#ffe0e0
    style M fill:#ffe0e0
    style N fill:#ccffcc,stroke:#00aa00
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `helix-db/src/helix_engine/vector_core/vector_distance.rs`, line 39-42 ([link](https://github.com/helixdb/helix-db/blob/02b8a11d76fe36ca31fba6197b6bbefd1b7a70fb/helix-db/src/helix_engine/vector_core/vector_distance.rs#L39-L42)) 

   **New guards bypass AVX2 path**

   The zero-magnitude check (line 83) and NaN/Inf guard (line 89) added by this PR are placed **after** the `#[cfg(target_feature = "avx2")]` early return on line 42. When compiled with AVX2 support enabled, `cosine_similarity_avx2` is called instead, which has no magnitude check or NaN guard — a zero-magnitude vector on an AVX2 target would still produce a `NaN` or `inf` result rather than `Err(InvalidVectorData)`.

   Additionally, `cosine_similarity_avx2` returns `f64`, not `Result<f64, VectorError>`, so `return cosine_similarity_avx2(from, to)` would be a **compile error** on any AVX2 target. Both the empty-vector and dimension-mismatch guards are correctly placed before this branch, but the new magnitude/NaN protections need to be applied inside `cosine_similarity_avx2` (or it should be changed to return `Result<f64, VectorError>`) for the fix to be complete.

   ```rust
   #[cfg(target_feature = "avx2")]
   {
       return cosine_similarity_avx2(from, to);
       // ^^^ Returns f64, not Result<f64, VectorError> — compile error on AVX2 targets
       //     Also: no zero-magnitude or NaN guard in cosine_similarity_avx2
   }
   ```

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 02b8a11</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->