### PR TITLE
fix(upsert): skip redundant writes on idempotent upsert_e and upsert_v

### DIFF
--- a/helix-db/src/helix_engine/tests/traversal_tests/upsert_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/upsert_tests.rs
@@ -541,6 +541,112 @@ fn test_upsert_e_updates_existing_edge_with_properties() {
 }
 
 #[test]
+fn test_upsert_e_noop_when_all_properties_identical() {
+    let (_temp_dir, storage) = setup_test_db();
+    let arena = Bump::new();
+    let mut txn = storage.graph_env.write_txn().unwrap();
+
+    let node1 = G::new_mut(&storage, &arena, &mut txn)
+        .add_n("person", None, None)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()[0]
+        .id();
+    let node2 = G::new_mut(&storage, &arena, &mut txn)
+        .add_n("person", None, None)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()[0]
+        .id();
+
+    let existing_edge = G::new_mut(&storage, &arena, &mut txn)
+        .add_edge(
+            "relates",
+            props_option(&arena, props!("kind" => "friend", "weight" => 2)),
+            node1,
+            node2,
+            false,
+            false,
+        )
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+
+    let edge_id = if let TraversalValue::Edge(ref e) = existing_edge {
+        e.id
+    } else {
+        panic!("Expected edge");
+    };
+
+    let result = G::new_mut_from_iter(&storage, &mut txn, std::iter::once(existing_edge), &arena)
+        .upsert_e(
+            "relates",
+            node1,
+            node2,
+            &[("kind", Value::from("friend")), ("weight", Value::from(2))],
+        )
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    if let TraversalValue::Edge(edge) = &result[0] {
+        assert_eq!(edge.id, edge_id);
+        assert_eq!(edge.label, "relates");
+        assert_eq!(edge.get_property("kind").unwrap(), &Value::from("friend"));
+        assert_eq!(edge.get_property("weight").unwrap(), &Value::from(2));
+    } else {
+        panic!("Expected edge");
+    }
+    txn.commit().unwrap();
+}
+
+#[test]
+fn test_upsert_e_noop_when_no_properties_and_empty_props() {
+    let (_temp_dir, storage) = setup_test_db();
+    let arena = Bump::new();
+    let mut txn = storage.graph_env.write_txn().unwrap();
+
+    let node1 = G::new_mut(&storage, &arena, &mut txn)
+        .add_n("person", None, None)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()[0]
+        .id();
+    let node2 = G::new_mut(&storage, &arena, &mut txn)
+        .add_n("person", None, None)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()[0]
+        .id();
+
+    let existing_edge = G::new_mut(&storage, &arena, &mut txn)
+        .add_edge("plain", None, node1, node2, false, false)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+
+    let edge_id = if let TraversalValue::Edge(ref e) = existing_edge {
+        e.id
+    } else {
+        panic!("Expected edge");
+    };
+
+    let result = G::new_mut_from_iter(&storage, &mut txn, std::iter::once(existing_edge), &arena)
+        .upsert_e("plain", node1, node2, &[])
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    if let TraversalValue::Edge(edge) = &result[0] {
+        assert_eq!(edge.id, edge_id);
+        assert!(edge.properties.is_none());
+    } else {
+        panic!("Expected edge");
+    }
+    txn.commit().unwrap();
+}
+
+#[test]
 fn test_upsert_e_with_defaults_applies_on_create_and_explicit_wins() {
     let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
@@ -890,6 +996,87 @@ fn test_upsert_v_updates_existing_vector_with_properties() {
             vector.get_property("timestamp").unwrap(),
             &Value::from(1640995200)
         );
+    } else {
+        panic!("Expected vector");
+    }
+    txn.commit().unwrap();
+}
+
+#[test]
+fn test_upsert_v_noop_when_all_properties_identical() {
+    let (_temp_dir, storage) = setup_test_db();
+    let arena = Bump::new();
+    let mut txn = storage.graph_env.write_txn().unwrap();
+
+    let query = [0.1_f64, 0.2, 0.3];
+    let existing_vector = G::new_mut(&storage, &arena, &mut txn)
+        .insert_v::<Filter>(
+            &query,
+            "embedding",
+            props_option(
+                &arena,
+                props!("model" => "gpt3", "version" => 1, "accuracy" => 0.95),
+            ),
+        )
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+
+    let vector_id = existing_vector.id();
+
+    let result = G::new_mut_from_iter(&storage, &mut txn, std::iter::once(existing_vector), &arena)
+        .upsert_v(
+            &query,
+            "embedding",
+            &[
+                ("model", Value::from("gpt3")),
+                ("version", Value::from(1)),
+                ("accuracy", Value::from(0.95)),
+            ],
+        )
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    if let TraversalValue::Vector(vector) = &result[0] {
+        assert_eq!(vector.id, vector_id);
+        assert_eq!(vector.get_property("model").unwrap(), &Value::from("gpt3"));
+        assert_eq!(vector.get_property("version").unwrap(), &Value::from(1));
+        assert_eq!(vector.get_property("accuracy").unwrap(), &Value::from(0.95));
+    } else {
+        panic!("Expected vector");
+    }
+    txn.commit().unwrap();
+}
+
+#[test]
+fn test_upsert_v_noop_when_no_properties_and_empty_props() {
+    let (_temp_dir, storage) = setup_test_db();
+    let arena = Bump::new();
+    let mut txn = storage.graph_env.write_txn().unwrap();
+
+    let query = [0.5_f64, 0.6, 0.7];
+    let existing_vector = G::new_mut(&storage, &arena, &mut txn)
+        .insert_v::<Filter>(&query, "embedding", None)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+
+    let vector_id = existing_vector.id();
+
+    let result = G::new_mut_from_iter(&storage, &mut txn, std::iter::once(existing_vector), &arena)
+        .upsert_v(&query, "embedding", &[])
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    if let TraversalValue::Vector(vector) = &result[0] {
+        assert_eq!(vector.id, vector_id);
+        assert!(vector.properties.is_none());
     } else {
         panic!("Expected vector");
     }

--- a/helix-db/src/helix_engine/traversal_core/ops/util/upsert.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/util/upsert.rs
@@ -766,135 +766,141 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
 
                     match vector.properties {
                         None => {
-                            // Insert secondary indices
-                            for (k, v) in props.iter() {
-                                let Some((db, secondary_index)) =
-                                    self.storage.secondary_indices.get(*k)
-                                else {
-                                    continue;
-                                };
+                            if !props.is_empty() {
+                                // Insert secondary indices
+                                for (k, v) in props.iter() {
+                                    let Some((db, secondary_index)) =
+                                        self.storage.secondary_indices.get(*k)
+                                    else {
+                                        continue;
+                                    };
 
-                                let v_serialized = bincode::serialize(v)?;
-                                match secondary_index {
-                                    crate::helix_engine::types::SecondaryIndex::Unique(_) => db
-                                        .put_with_flags(
-                                            self.txn,
-                                            PutFlags::NO_OVERWRITE,
-                                            &v_serialized,
-                                            &vector.id,
-                                        )
-                                        .map_err(|_| GraphError::DuplicateKey(k.to_string()))?,
-                                    crate::helix_engine::types::SecondaryIndex::Index(_) => {
-                                        db.put(self.txn, &v_serialized, &vector.id)?
-                                    }
-                                    crate::helix_engine::types::SecondaryIndex::None => {
-                                        unreachable!()
+                                    let v_serialized = bincode::serialize(v)?;
+                                    match secondary_index {
+                                        crate::helix_engine::types::SecondaryIndex::Unique(_) => db
+                                            .put_with_flags(
+                                                self.txn,
+                                                PutFlags::NO_OVERWRITE,
+                                                &v_serialized,
+                                                &vector.id,
+                                            )
+                                            .map_err(|_| GraphError::DuplicateKey(k.to_string()))?,
+                                        crate::helix_engine::types::SecondaryIndex::Index(_) => {
+                                            db.put(self.txn, &v_serialized, &vector.id)?
+                                        }
+                                        crate::helix_engine::types::SecondaryIndex::None => {
+                                            unreachable!()
+                                        }
                                     }
                                 }
+
+                                // Create properties map and insert node
+                                let map = ImmutablePropertiesMap::new(
+                                    props.len(),
+                                    props.iter().map(|(k, v)| (*k, v.clone())),
+                                    self.arena,
+                                );
+
+                                vector.properties = Some(map);
                             }
-
-                            // Create properties map and insert node
-                            let map = ImmutablePropertiesMap::new(
-                                props.len(),
-                                props.iter().map(|(k, v)| (*k, v.clone())),
-                                self.arena,
-                            );
-
-                            vector.properties = Some(map);
                         }
                         Some(old) => {
-                            for (k, v) in props.iter() {
-                                let Some((db, secondary_index)) =
-                                    self.storage.secondary_indices.get(*k)
-                                else {
-                                    continue;
-                                };
+                            if !props.iter().all(|(k, v)| old.get(k) == Some(v)) {
+                                for (k, v) in props.iter() {
+                                    let Some((db, secondary_index)) =
+                                        self.storage.secondary_indices.get(*k)
+                                    else {
+                                        continue;
+                                    };
 
-                                // delete secondary indexes for the props changed
-                                let Some(old_value) = old.get(k) else {
-                                    continue;
-                                };
+                                    // delete secondary indexes for the props changed
+                                    let Some(old_value) = old.get(k) else {
+                                        continue;
+                                    };
 
-                                let old_serialized = bincode::serialize(old_value)?;
-                                db.delete_one_duplicate(self.txn, &old_serialized, &vector.id)?;
+                                    let old_serialized = bincode::serialize(old_value)?;
+                                    db.delete_one_duplicate(self.txn, &old_serialized, &vector.id)?;
 
-                                // create new secondary indexes for the props changed
-                                let v_serialized = bincode::serialize(v)?;
-                                match secondary_index {
-                                    crate::helix_engine::types::SecondaryIndex::Unique(_) => db
-                                        .put_with_flags(
-                                            self.txn,
-                                            PutFlags::NO_OVERWRITE,
-                                            &v_serialized,
-                                            &vector.id,
-                                        )
-                                        .map_err(|_| GraphError::DuplicateKey(k.to_string()))?,
-                                    crate::helix_engine::types::SecondaryIndex::Index(_) => {
-                                        db.put(self.txn, &v_serialized, &vector.id)?
-                                    }
-                                    crate::helix_engine::types::SecondaryIndex::None => {
-                                        unreachable!()
-                                    }
-                                }
-                            }
-
-                            let diff: Vec<_> = props
-                                .iter()
-                                .filter(|(k, _)| !old.iter().map(|(old_k, _)| old_k).contains(k))
-                                .cloned()
-                                .collect();
-
-                            // Add secondary indices for NEW properties (not in old)
-                            for (k, v) in &diff {
-                                let Some((db, secondary_index)) =
-                                    self.storage.secondary_indices.get(*k)
-                                else {
-                                    continue;
-                                };
-
-                                let v_serialized = bincode::serialize(v)?;
-                                match secondary_index {
-                                    crate::helix_engine::types::SecondaryIndex::Unique(_) => db
-                                        .put_with_flags(
-                                            self.txn,
-                                            PutFlags::NO_OVERWRITE,
-                                            &v_serialized,
-                                            &vector.id,
-                                        )
-                                        .map_err(|_| GraphError::DuplicateKey(k.to_string()))?,
-                                    crate::helix_engine::types::SecondaryIndex::Index(_) => {
-                                        db.put(self.txn, &v_serialized, &vector.id)?
-                                    }
-                                    crate::helix_engine::types::SecondaryIndex::None => {
-                                        unreachable!()
+                                    // create new secondary indexes for the props changed
+                                    let v_serialized = bincode::serialize(v)?;
+                                    match secondary_index {
+                                        crate::helix_engine::types::SecondaryIndex::Unique(_) => db
+                                            .put_with_flags(
+                                                self.txn,
+                                                PutFlags::NO_OVERWRITE,
+                                                &v_serialized,
+                                                &vector.id,
+                                            )
+                                            .map_err(|_| GraphError::DuplicateKey(k.to_string()))?,
+                                        crate::helix_engine::types::SecondaryIndex::Index(_) => {
+                                            db.put(self.txn, &v_serialized, &vector.id)?
+                                        }
+                                        crate::helix_engine::types::SecondaryIndex::None => {
+                                            unreachable!()
+                                        }
                                     }
                                 }
+
+                                let diff: Vec<_> = props
+                                    .iter()
+                                    .filter(|(k, _)| {
+                                        !old.iter().map(|(old_k, _)| old_k).contains(k)
+                                    })
+                                    .cloned()
+                                    .collect();
+
+                                // Add secondary indices for NEW properties (not in old)
+                                for (k, v) in &diff {
+                                    let Some((db, secondary_index)) =
+                                        self.storage.secondary_indices.get(*k)
+                                    else {
+                                        continue;
+                                    };
+
+                                    let v_serialized = bincode::serialize(v)?;
+                                    match secondary_index {
+                                        crate::helix_engine::types::SecondaryIndex::Unique(_) => db
+                                            .put_with_flags(
+                                                self.txn,
+                                                PutFlags::NO_OVERWRITE,
+                                                &v_serialized,
+                                                &vector.id,
+                                            )
+                                            .map_err(|_| GraphError::DuplicateKey(k.to_string()))?,
+                                        crate::helix_engine::types::SecondaryIndex::Index(_) => {
+                                            db.put(self.txn, &v_serialized, &vector.id)?
+                                        }
+                                        crate::helix_engine::types::SecondaryIndex::None => {
+                                            unreachable!()
+                                        }
+                                    }
+                                }
+
+                                // find out how many new properties we'll need space for
+                                let len_diff = diff.len();
+
+                                let merged = old
+                                    .iter()
+                                    .map(|(old_k, old_v)| {
+                                        props
+                                            .iter()
+                                            .find_map(|(k, v)| old_k.eq(*k).then_some(v))
+                                            .map_or_else(
+                                                || (old_k, old_v.clone()),
+                                                |v| (old_k, v.clone()),
+                                            )
+                                    })
+                                    .chain(diff);
+
+                                // make new props, updated by current props
+                                let new_map = ImmutablePropertiesMap::new(
+                                    old.len() + len_diff,
+                                    merged,
+                                    self.arena,
+                                );
+
+                                vector.properties = Some(new_map);
                             }
-
-                            // find out how many new properties we'll need space for
-                            let len_diff = diff.len();
-
-                            let merged = old
-                                .iter()
-                                .map(|(old_k, old_v)| {
-                                    props
-                                        .iter()
-                                        .find_map(|(k, v)| old_k.eq(*k).then_some(v))
-                                        .map_or_else(
-                                            || (old_k, old_v.clone()),
-                                            |v| (old_k, v.clone()),
-                                        )
-                                })
-                                .chain(diff);
-
-                            // make new props, updated by current props
-                            let new_map = ImmutablePropertiesMap::new(
-                                old.len() + len_diff,
-                                merged,
-                                self.arena,
-                            );
-
-                            vector.properties = Some(new_map);
                         }
                     }
 

--- a/helix-db/src/helix_engine/traversal_core/ops/util/upsert.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/util/upsert.rs
@@ -228,7 +228,9 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
                                             &old_serialized,
                                             &node.id,
                                         )?;
-                                        if let Err(e) = update_secondary_index(index, self.txn, k, node.id, v) {
+                                        if let Err(e) =
+                                            update_secondary_index(index, self.txn, k, node.id, v)
+                                        {
                                             // Restore the old index entry since the new one failed
                                             let _ = db.put(self.txn, &old_serialized, &node.id);
                                             return Err(e);
@@ -420,6 +422,10 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
                     // Update existing edge - merge properties
                     match edge.properties {
                         None => {
+                            if props.is_empty() {
+                                return Ok(TraversalValue::Edge(edge));
+                            }
+
                             let map = ImmutablePropertiesMap::new(
                                 props.len(),
                                 props.iter().map(|(k, v)| (*k, v.clone())),
@@ -428,6 +434,10 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
                             edge.properties = Some(map);
                         }
                         Some(old) => {
+                            if props.iter().all(|(k, v)| old.get(k) == Some(v)) {
+                                return Ok(TraversalValue::Edge(edge));
+                            }
+
                             let diff: Vec<_> = props
                                 .iter()
                                 .filter(|(k, _)| !old.iter().map(|(old_k, _)| old_k).contains(k))
@@ -553,6 +563,10 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
                 Some(Ok(TraversalValue::Vector(mut vector))) => {
                     match vector.properties {
                         None => {
+                            if props.is_empty() {
+                                return Ok(TraversalValue::Vector(vector));
+                            }
+
                             // Insert secondary indices
                             for (k, v) in props.iter() {
                                 let Some((db, secondary_index)) =
@@ -590,6 +604,10 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
                             vector.properties = Some(map);
                         }
                         Some(old) => {
+                            if props.iter().all(|(k, v)| old.get(k) == Some(v)) {
+                                return Ok(TraversalValue::Vector(vector));
+                            }
+
                             for (k, v) in props.iter() {
                                 let Some((db, secondary_index)) =
                                     self.storage.secondary_indices.get(*k)


### PR DESCRIPTION
## Description
upsert_n already skips the write when properties haven't changed. upsert_e and upsert_v were missing the same check, so repeated upserts with identical data still wrote to disk every time, bloating the database file over time.

This PR adds the same property-equality check to all upsert paths:

- upsert_e: skip the write entirely when nothing changed.
- upsert_v (Vector): same — skip the write entirely.
- upsert_v (VectorNodeWithoutVectorData): skip the property merge, but still write because the vector data itself is being updated.

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [X] No compiler warnings (if applicable)
- [X] Code is formatted with `rustfmt`
- [X] No useless or dead code (if applicable)
- [X] Code is easy to understand
- [X] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [X] All tests pass
- [X] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes

This PR adds the same property-equality check to all upsert paths:

- upsert_e: skip the write entirely when nothing changed.
- upsert_v (Vector): same — skip the write entirely.
- upsert_v (VectorNodeWithoutVectorData): skip the property merge, but still write because the vector data itself is being updated.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the idempotent-write optimisation (already present in `upsert_n`) to `upsert_e` and `upsert_v`, short-circuiting redundant LMDB writes when an upsert's incoming properties are identical to what is already stored. The logic is correct for the edge and the full-vector paths, but there is a meaningful asymmetry in how the three `upsert_v` variants handle embedding data that is worth resolving.

- **`upsert_e`** — two new early returns: one for `edge.properties == None && props.is_empty()`, one for `Some(old)` when all incoming props already match `old`. Both correctly skip the `edges_db.put` call.
- **`upsert_v` (Vector)** — mirrors the above for vectors. However, the `Vector` branch never sets `vector.data = query`, so a caller that passes a different embedding vector but unchanged properties will hit the early return and silently lose the embedding update. The `VectorNodeWithoutVectorData` branch avoids this by always writing (it sets `vector.data = query` first), which highlights the inconsistency.
- **`upsert_v` (VectorNodeWithoutVectorData)** — correctly wraps only the property-merge logic in the skip guard, but unconditionally calls `put_vector` to persist updated embedding data.
- **Tests** — four new tests cover the primary noop paths for edges and vectors. Missing: a test for `VectorNodeWithoutVectorData` (noop merge but still writes), and for `Some(old)` + empty `props` (vacuous-truth early return).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-db/src/helix_engine/traversal_core/ops/util/upsert.rs | Adds early-return guards to `upsert_e` and `upsert_v` (Vector) to skip redundant LMDB writes when properties are unchanged; the `VectorNodeWithoutVectorData` path correctly skips only the property merge but still writes for vector data. Main concern: the `Vector` variant early return silently skips `put_vector` even when `query` (new embedding data) differs from the stored `vector.data`, because `vector.data = query` is never set in that branch. |
| helix-db/src/helix_engine/tests/traversal_tests/upsert_tests.rs | Adds four new tests covering the noop paths for `upsert_e` (identical props, empty props) and `upsert_v` (identical props, empty props). Tests are well-structured and correctly assert identity and property preservation. Missing coverage for: `VectorNodeWithoutVectorData` noop-property-merge-but-still-writes path, and `Some(old)` + empty props edge case for both ops. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[upsert_e / upsert_v called] --> B{Existing record found?}
    B -- No --> C[Create new record + write to LMDB]
    B -- Yes: Vector case --> D{vector.properties?}
    B -- Yes: Edge case --> E{edge.properties?}
    B -- Yes: VectorNodeWithoutVectorData --> VND[Set vector.data = query]

    D -- None --> D1{props.is_empty?}
    D1 -- Yes --> SKIP1[⏭ Early return — skip put_vector]
    D1 -- No --> D2[Add secondary indices + create props map]
    D2 --> WRITE1[put_vector]

    D -- Some old --> D3{all props match old?}
    D3 -- Yes --> SKIP2[⏭ Early return — skip put_vector]
    D3 -- No --> D4[Update secondary indices + merge props]
    D4 --> WRITE2[put_vector]

    E -- None --> E1{props.is_empty?}
    E1 -- Yes --> SKIP3[⏭ Early return — skip edges_db.put]
    E1 -- No --> E2[Create new props map]
    E2 --> WRITE3[edges_db.put]

    E -- Some old --> E3{all props match old?}
    E3 -- Yes --> SKIP4[⏭ Early return — skip edges_db.put]
    E3 -- No --> E4[Merge props]
    E4 --> WRITE4[edges_db.put]

    VND --> VND2{vector.properties?}
    VND2 -- None --> VND3{props.is_empty?}
    VND3 -- Yes --> VND_WRITE[put_vector — always writes]
    VND3 -- No --> VND4[Add secondary indices + create props map]
    VND4 --> VND_WRITE
    VND2 -- Some old --> VND5{all props match old?}
    VND5 -- Yes --> VND_WRITE
    VND5 -- No --> VND6[Update secondary indices + merge props]
    VND6 --> VND_WRITE

    style SKIP1 fill:#ffd700
    style SKIP2 fill:#ffd700
    style SKIP3 fill:#ffd700
    style SKIP4 fill:#ffd700
    style VND_WRITE fill:#90EE90
    style WRITE1 fill:#90EE90
    style WRITE2 fill:#90EE90
    style WRITE3 fill:#90EE90
    style WRITE4 fill:#90EE90
```
</details>

<sub>Last reviewed commit: ["fix(upsert): skip re..."](https://github.com/helixdb/helix-db/commit/855d1e4f2ed0d054c403c68f44a761dc7fd1780d)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->