### PR TITLE
Remove Manta Graph badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 [![GitHub Repo stars](https://img.shields.io/github/stars/HelixDB/helix-db)](https://github.com/HelixDB/helix-db/stargazers)
 [![Discord](https://img.shields.io/discord/1354148209005559819?logo=discord)](https://discord.gg/2stgMPr5BD)
 [![LOC](https://img.shields.io/endpoint?url=https://ghloc.vercel.app/api/HelixDB/helix-db/badge?filter=.rs$,.sh$&style=flat&logoColor=white&label=Lines%20of%20Code)](https://github.com/HelixDB/helix-db)
-[![Manta Graph](https://getmanta.ai/api/badges?text=Manta%20Graph&link=helixdb)](https://getmanta.ai/helixdb)
 
 <a href="https://www.ycombinator.com/launches/Naz-helixdb-the-database-for-rag-ai" target="_blank"><img src="https://www.ycombinator.com/launches/Naz-helixdb-the-database-for-rag-ai/upvote_embed.svg" alt="Launch YC: HelixDB - The Database for Intelligence" style="margin-left: 12px;"/></a>
 


### PR DESCRIPTION
Service is no longer supported

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the Manta Graph badge from the `README.md` shields row because the service is no longer supported. It is a minimal, low-risk documentation change with no impact on code or functionality.

- Removes one badge line (`[![Manta Graph](...)](...)`) from the badge row in `README.md`
- No code, configuration, or logic is affected
- The remaining badges (GitHub stars, Discord, Lines of Code, YC upvote embed) are untouched

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Removes the deprecated Manta Graph badge link; clean and straightforward documentation update with no other changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    README["README.md Badge Row"]
    README --> B1["GitHub Repo Stars Badge"]
    README --> B2["Discord Badge"]
    README --> B3["Lines of Code Badge"]
    README --> B4["~~Manta Graph Badge~~ (removed)"]
    README --> B5["YC Upvote Embed"]

    style B4 fill:#ffcccc,stroke:#cc0000,color:#cc0000
```
</details>

<sub>Last reviewed commit: ["Remove Manta Graph b..."](https://github.com/helixdb/helix-db/commit/c1b6cbf81324a933dd6449face8e5c19741821c2)</sub>

<!-- /greptile_comment -->