### PR TITLE
feat: add MiniMax as embedding provider

### DIFF
--- a/helix-db/src/helix_engine/tests/README.md
+++ b/helix-db/src/helix_engine/tests/README.md
@@ -143,6 +143,8 @@
 - `test_openai_embedding_success` - Tests OpenAI embedding success
 - `test_gemini_embedding_success` - Tests Gemini embedding success
 - `test_gemini_embedding_with_task_type` - Tests Gemini embedding with task types
+- `test_minimax_embedding_success` - Tests MiniMax embedding success
+- `test_minimax_embedding_with_query_type` - Tests MiniMax embedding with query type
 - `test_local_embedding_success` - Tests local embedding success
 - `test_local_embedding_invalid_url` - Tests invalid URL handling for local embeddings
 

--- a/helix-db/src/helix_gateway/embedding_providers/mod.rs
+++ b/helix-db/src/helix_gateway/embedding_providers/mod.rs
@@ -45,6 +45,9 @@ pub enum EmbeddingProvider {
         resource_name: String,
         deployment_id: String,
     },
+    MiniMax {
+        embedding_type: String,
+    },
     Local,
 }
 
@@ -83,6 +86,13 @@ impl EmbeddingModelImpl {
                     .map(String::from)
                     .or_else(|| env::var("AZURE_OPENAI_API_KEY").ok())
                     .ok_or_else(|| GraphError::from("AZURE_OPENAI_API_KEY not set"))?;
+                Some(key)
+            }
+            EmbeddingProvider::MiniMax { .. } => {
+                let key = api_key
+                    .map(String::from)
+                    .or_else(|| env::var("MINIMAX_API_KEY").ok())
+                    .ok_or_else(|| GraphError::from("MINIMAX_API_KEY not set"))?;
                 Some(key)
             }
             EmbeddingProvider::Local => None,
@@ -157,6 +167,21 @@ impl EmbeddingModelImpl {
                     },
                     model_name.to_string(),
                 ))
+            }
+            Some(m) if m.starts_with("minimax:") => {
+                let parts: Vec<&str> = m.splitn(2, ':').collect();
+                let model_and_type = parts.get(1).unwrap_or(&"embo-01");
+                let (model_name, embedding_type) = if model_and_type.contains(':') {
+                    let type_parts: Vec<&str> = model_and_type.splitn(2, ':').collect();
+                    (
+                        type_parts[0].to_string(),
+                        type_parts.get(1).unwrap_or(&"db").to_string(),
+                    )
+                } else {
+                    (model_and_type.to_string(), "db".to_string())
+                };
+
+                Ok((EmbeddingProvider::MiniMax { embedding_type }, model_name))
             }
             Some("local") => Ok((EmbeddingProvider::Local, "local".to_string())),
 
@@ -365,6 +390,79 @@ impl EmbeddingModel for EmbeddingModelImpl {
                 Ok(embedding)
             }
 
+            EmbeddingProvider::MiniMax { embedding_type } => {
+                let api_key = self.api_key.as_ref().ok_or_else(|| {
+                    GraphError::EmbeddingError("MiniMax API key not set".to_string())
+                })?;
+
+                let response = self
+                    .client
+                    .post("https://api.minimax.io/v1/embeddings")
+                    .header("Authorization", format!("Bearer {api_key}"))
+                    .header("Content-Type", "application/json")
+                    .json(&json!({
+                        "model": &self.model,
+                        "texts": [text],
+                        "type": embedding_type
+                    }))
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        GraphError::EmbeddingError(format!(
+                            "Failed to send request to MiniMax: {e}"
+                        ))
+                    })?;
+
+                let status = response.status();
+                let text_response = response.text().await.map_err(|e| {
+                    GraphError::EmbeddingError(format!("Failed to read MiniMax response: {e}"))
+                })?;
+
+                if !status.is_success() {
+                    return Err(parse_api_error("MiniMax", status.as_u16(), &text_response));
+                }
+
+                let response =
+                    sonic_rs::from_str::<sonic_rs::Value>(&text_response).map_err(|e| {
+                        GraphError::EmbeddingError(format!(
+                            "Failed to parse MiniMax response: {e}"
+                        ))
+                    })?;
+
+                // MiniMax returns HTTP 200 even for errors (e.g. rate limits);
+                // check base_resp.status_code for the real status.
+                if let Some(code) = response["base_resp"]["status_code"].as_i64() {
+                    if code != 0 {
+                        let msg = response["base_resp"]["status_msg"]
+                            .as_str()
+                            .unwrap_or("unknown error");
+                        return Err(GraphError::EmbeddingError(format!(
+                            "MiniMax embedding API error ({}): {}",
+                            code, msg
+                        )));
+                    }
+                }
+
+                let embedding = response["vectors"][0]
+                    .as_array()
+                    .ok_or_else(|| {
+                        GraphError::EmbeddingError(
+                            "Invalid embedding format in MiniMax response".to_string(),
+                        )
+                    })?
+                    .iter()
+                    .map(|v| {
+                        v.as_f64().ok_or_else(|| {
+                            GraphError::EmbeddingError(
+                                "Invalid float value in embedding".to_string(),
+                            )
+                        })
+                    })
+                    .collect::<Result<Vec<f64>, GraphError>>()?;
+
+                Ok(embedding)
+            }
+
             EmbeddingProvider::Local => {
                 let url = self.url.as_ref().ok_or_else(|| {
                     GraphError::EmbeddingError("Local embedding URL not set".to_string())
@@ -451,6 +549,7 @@ pub fn get_embedding_model(
 /// let query = embed!("Hello, world!");
 /// let embedding = embed!("Hello, world!", "text-embedding-ada-002");
 /// let embedding = embed!("Hello, world!", "gemini:gemini-embedding-001:SEMANTIC_SIMILARITY");
+/// let embedding = embed!("Hello, world!", "minimax:embo-01");
 /// let embedding = embed!("Hello, world!", "text-embedding-ada-002", "http://localhost:8699/embed");
 /// ```
 macro_rules! embed {

--- a/helix-db/src/helix_gateway/embedding_providers/mod.rs
+++ b/helix-db/src/helix_gateway/embedding_providers/mod.rs
@@ -424,9 +424,7 @@ impl EmbeddingModel for EmbeddingModelImpl {
 
                 let response =
                     sonic_rs::from_str::<sonic_rs::Value>(&text_response).map_err(|e| {
-                        GraphError::EmbeddingError(format!(
-                            "Failed to parse MiniMax response: {e}"
-                        ))
+                        GraphError::EmbeddingError(format!("Failed to parse MiniMax response: {e}"))
                     })?;
 
                 // MiniMax returns HTTP 200 even for errors (e.g. rate limits);

--- a/helix-db/src/helix_gateway/tests/embedding_providers.rs
+++ b/helix-db/src/helix_gateway/tests/embedding_providers.rs
@@ -66,7 +66,11 @@ fn test_local_embedding_success() {
 async fn test_minimax_embedding_success() {
     let model = get_embedding_model(None, Some("minimax:embo-01"), None).unwrap();
     let result = model.fetch_embedding_async("test text").await;
-    assert!(result.is_ok(), "MiniMax embedding failed: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "MiniMax embedding failed: {:?}",
+        result.err()
+    );
     let embedding = result.unwrap();
     assert_eq!(embedding.len(), 1536); // embo-01 produces 1536-dimensional embeddings
     println!("embedding: {embedding:?}");

--- a/helix-db/src/helix_gateway/tests/embedding_providers.rs
+++ b/helix-db/src/helix_gateway/tests/embedding_providers.rs
@@ -61,6 +61,28 @@ fn test_local_embedding_success() {
     println!("embedding: {:?}", embedding);
 }
 
+#[tokio::test]
+#[ignore] // Requires API key and network
+async fn test_minimax_embedding_success() {
+    let model = get_embedding_model(None, Some("minimax:embo-01"), None).unwrap();
+    let result = model.fetch_embedding_async("test text").await;
+    assert!(result.is_ok(), "MiniMax embedding failed: {:?}", result.err());
+    let embedding = result.unwrap();
+    assert_eq!(embedding.len(), 1536); // embo-01 produces 1536-dimensional embeddings
+    println!("embedding: {embedding:?}");
+}
+
+#[tokio::test]
+#[ignore] // Requires API key and network
+async fn test_minimax_embedding_with_query_type() {
+    let model = get_embedding_model(None, Some("minimax:embo-01:query"), None).unwrap();
+    let result = model.fetch_embedding_async("search query text").await;
+    assert!(result.is_ok());
+    let embedding = result.unwrap();
+    assert_eq!(embedding.len(), 1536);
+    println!("embedding: {embedding:?}");
+}
+
 #[test]
 fn test_local_embedding_invalid_url() {
     let model = get_embedding_model(None, Some("local"), Some("invalid_url"));
@@ -161,6 +183,66 @@ fn test_parse_gemini_provider_empty_model() {
         _ => panic!("Expected Gemini provider"),
     }
     assert_eq!(model, ""); // Returns empty string when no model specified after colon
+}
+
+#[test]
+fn test_parse_minimax_provider_with_model() {
+    let result = EmbeddingModelImpl::parse_provider_and_model(Some("minimax:embo-01"));
+    assert!(result.is_ok());
+    let (provider, model) = result.unwrap();
+    match provider {
+        EmbeddingProvider::MiniMax { embedding_type } => {
+            assert_eq!(embedding_type, "db");
+        }
+        _ => panic!("Expected MiniMax provider"),
+    }
+    assert_eq!(model, "embo-01");
+}
+
+#[test]
+fn test_parse_minimax_provider_with_type() {
+    let result = EmbeddingModelImpl::parse_provider_and_model(Some("minimax:embo-01:query"));
+    assert!(result.is_ok());
+    let (provider, model) = result.unwrap();
+    match provider {
+        EmbeddingProvider::MiniMax { embedding_type } => {
+            assert_eq!(embedding_type, "query");
+        }
+        _ => panic!("Expected MiniMax provider"),
+    }
+    assert_eq!(model, "embo-01");
+}
+
+#[test]
+fn test_parse_minimax_provider_empty_model() {
+    let result = EmbeddingModelImpl::parse_provider_and_model(Some("minimax:"));
+    assert!(result.is_ok());
+    let (provider, model) = result.unwrap();
+    match provider {
+        EmbeddingProvider::MiniMax { embedding_type } => {
+            assert_eq!(embedding_type, "db");
+        }
+        _ => panic!("Expected MiniMax provider"),
+    }
+    assert_eq!(model, "");
+}
+
+#[test]
+fn test_new_minimax_without_api_key_fails() {
+    unsafe {
+        std::env::remove_var("MINIMAX_API_KEY");
+    }
+    let result = EmbeddingModelImpl::new(None, Some("minimax:embo-01"), None);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_new_minimax_with_api_key() {
+    let result = EmbeddingModelImpl::new(Some("test-key"), Some("minimax:embo-01"), None);
+    assert!(result.is_ok());
+    let model = result.unwrap();
+    assert!(matches!(model.provider, EmbeddingProvider::MiniMax { .. }));
+    assert_eq!(model.model, "embo-01");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add [MiniMax AI](https://www.minimaxi.com) as a built-in embedding provider, supporting the `embo-01` model (1536 dimensions)
- Implement native MiniMax embedding API format (`texts` array + `type` field for db/query distinction, `vectors` response)
- Handle MiniMax's HTTP 200 error responses by checking `base_resp.status_code` in the response body

## Usage

```rust
// Storage embeddings (type defaults to "db")
embed!("Hello, world!", "minimax:embo-01");

// Search query embeddings
embed!("search query", "minimax:embo-01:query");
```

Requires `MINIMAX_API_KEY` environment variable (or pass key directly).

## Changes

| File | Change |
|------|--------|
| `helix-db/src/helix_gateway/embedding_providers/mod.rs` | Add `MiniMax` variant to `EmbeddingProvider` enum, `minimax:` prefix parsing, API key resolution, and `fetch_embedding_async()` implementation |
| `helix-db/src/helix_gateway/tests/embedding_providers.rs` | Add 5 unit tests (parsing, API key validation) + 2 integration tests |
| `helix-db/src/helix_engine/tests/README.md` | Document new MiniMax embedding tests |

## MiniMax API Details

- **Endpoint**: `POST https://api.minimax.io/v1/embeddings`
- **Model**: `embo-01` (1536 dimensions)
- **Request**: `{"model": "embo-01", "texts": ["text"], "type": "db"}`
- **Response**: `{"vectors": [[...]], "base_resp": {"status_code": 0}}`
- **Type parameter**: `"db"` for storage, `"query"` for search queries

## Test plan

- [x] All 25 existing + new unit tests pass (`cargo test embedding_providers`)
- [x] New MiniMax parsing tests: model, type, empty model
- [x] New MiniMax initialization tests: missing key fails, explicit key succeeds
- [x] Integration tests added (ignored by default, require `MINIMAX_API_KEY`)
- [x] Full project build succeeds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds MiniMax as a new embedding provider following the existing pattern for OpenAI, Gemini, and Azure OpenAI, including proper API key resolution, a custom request/response format (`texts` array + `type` field + `vectors` response), and handling of MiniMax's HTTP-200-for-errors behaviour via `base_resp.status_code`.

Key points:
- The implementation is structurally sound and correctly mirrors the conventions used by other providers.
- **Dead default fallback**: `parts.get(1).unwrap_or(&"embo-01")` on the model-parsing path (line 173) is unreachable — `splitn(2, ':')` always produces `Some("")` when the user writes `"minimax:"`, so the intended default `"embo-01"` is never applied and an empty model string is forwarded to the API. The accompanying test documents this broken behaviour by asserting `model == ""`.
- **No `embedding_type` validation**: The `type` field forwarded to MiniMax is not checked against the two accepted values (`"db"`, `"query"`); invalid types will only fail at runtime with an opaque API error.
- **Integration test inconsistency**: New MiniMax integration tests use `#[tokio::test]` + `fetch_embedding_async`, while all existing integration tests use plain `#[test]` + the synchronous `fetch_embedding` wrapper.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-db/src/helix_gateway/embedding_providers/mod.rs | Adds MiniMax to EmbeddingProvider enum and implements full parse + fetch logic; has a dead `unwrap_or(&"embo-01")` default that never fires, causing `"minimax:"` to silently send an empty model name to the API. |
| helix-db/src/helix_gateway/tests/embedding_providers.rs | Adds 5 unit tests and 2 integration tests for MiniMax; the empty-model unit test asserts the buggy behaviour (`""` instead of `"embo-01"`), and integration tests use `#[tokio::test]` inconsistently with the rest of the test suite. |
| helix-db/src/helix_engine/tests/README.md | Documentation-only addition of two new MiniMax integration test names; no issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant embed_macro as embed! macro
    participant Parser as parse_provider_and_model
    participant EmbeddingModelImpl
    participant MiniMaxAPI as MiniMax API (api.minimax.io)

    User->>embed_macro: embed!(text, "minimax:embo-01[:query]")
    embed_macro->>Parser: parse_provider_and_model(Some("minimax:embo-01"))
    Parser-->>EmbeddingModelImpl: (MiniMax { embedding_type: "db" }, "embo-01")
    embed_macro->>EmbeddingModelImpl: fetch_embedding(text)
    EmbeddingModelImpl->>MiniMaxAPI: POST /v1/embeddings\n{model, texts:[text], type:"db"}
    MiniMaxAPI-->>EmbeddingModelImpl: HTTP 200 {vectors:[[...]], base_resp:{status_code:0}}
    Note over EmbeddingModelImpl: Check base_resp.status_code != 0\n(MiniMax returns HTTP 200 even for errors)
    EmbeddingModelImpl-->>embed_macro: Vec<f64> (1536 dims)
    embed_macro-->>User: embedding vector
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add MiniMax as embedding provider"](https://github.com/helixdb/helix-db/commit/bc497d24e77b95a4e31ee645e9ca5a718e095a71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25963099)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->