### PR TITLE
fix(ci): make cli_tests.yml a valid workflow

### DIFF
--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -1,58 +1,12 @@
-# name: CLI Tests
+name: CLI Tests
 
-# on:
-#   pull_request:
-#     branches: [main, dev]
-#     paths:
-#       - 'helix-cli/**'
-#       - 'helix-macros/**'
-#       - 'helix-container/**'
-#       - 'helix-db/**'
-#       - 'Cargo.toml'
-#       - 'Cargo.lock'
+on:
+  workflow_dispatch:
 
-# env:
-#   CARGO_TERM_COLOR: always
-#   RUST_BACKTRACE: 1
-
-# jobs:
-#   test:
-#     name: Test (${{ matrix.os }})
-#     runs-on: ${{ matrix.os }}
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         os: [ubuntu-latest, macos-latest, windows-latest]
-
-#     steps:
-#       - name: Checkout repository
-#         uses: actions/checkout@v4
-
-#       - name: Setup Rust toolchain
-#         uses: dtolnay/rust-toolchain@stable
-
-#       - name: Cache cargo registry
-#         uses: actions/cache@v4
-#         with:
-#           path: |
-#             ~/.cargo/registry
-#             ~/.cargo/git
-#             target
-#           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-#           restore-keys: |
-#             ${{ runner.os }}-cargo-
-
-#       - name: Run helix-cli unit tests
-#         run: cargo test --release --package helix-cli
-#         env:
-#           # Use a unique temp directory for test isolation
-#           HELIX_CACHE_DIR: ${{ runner.temp }}/helix-test-cache-${{ github.run_id }}
-
-#       - name: Run helix-macros tests
-#         run: cargo test --release --package helix-macros
-
-#       # Integration tests that require repo cloning run serially
-#       - name: Run helix-cli integration tests (ignored tests)
-#         run: cargo test --release --package helix-cli -- --ignored --test-threads=1
-#         env:
-#           HELIX_CACHE_DIR: ${{ runner.temp }}/helix-test-cache-ignored-${{ github.run_id }}
+jobs:
+  noop:
+    name: Workflow Placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "CLI tests workflow is valid and can be enabled for pull_request when ready."


### PR DESCRIPTION
## Summary
- replace the invalid/commented `cli_tests.yml` workflow with a valid workflow definition
- use `workflow_dispatch` + a placeholder job so GitHub no longer reports parser failures like `No event triggers defined in on`

## Why
PRs were receiving workflow failure notifications even when no jobs could run because the workflow file had no valid `on` section.

## Note
This intentionally keeps CLI tests disabled for automatic PR triggers; it only fixes workflow validity/noise.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a GitHub Actions parser failure caused by `cli_tests.yml` being entirely commented out, leaving no valid `on:` trigger. The file is replaced with a minimal valid workflow (`workflow_dispatch` + a no-op placeholder job) so GitHub no longer reports parse errors on PRs, while keeping CLI tests disabled for automatic triggers.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/cli_tests.yml | Replaces an entirely commented-out (invalid) workflow file with a minimal valid workflow using `workflow_dispatch` and a placeholder no-op job to silence GitHub Actions parser errors. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub detects cli_tests.yml] --> B{Valid on: trigger?}
    B -- "Before (all commented out)" --> C[Parser Error: No event triggers defined]
    C --> D[Workflow failure notification on PRs]
    B -- "After (workflow_dispatch)" --> E[Workflow is valid]
    E --> F{Triggered manually?}
    F -- Yes --> G[Run noop placeholder job]
    G --> H[echo message and exit]
    F -- No --> I[Workflow not triggered on PRs]
    I --> J[No spurious failure notifications]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): make cli\_tests workflow valid t..."](https://github.com/helixdb/helix-db/commit/f16f76be0b8b3154462818c1c71d9e423f03fb8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27936121)</sub>

<!-- /greptile_comment -->