### PR TITLE
Claude/merge memst memory management v eg pr

### DIFF
--- a/Dev-Manual.md
+++ b/Dev-Manual.md
@@ -1,0 +1,497 @@
+# Developer Manual
+
+This manual documents the day-to-day developer workflow for the HelixDB
+repository, with a focus on the harness engineering you need to know to
+build, test, and ship changes confidently. New contributors should read it
+end-to-end the first time and then use it as a reference.
+
+---
+
+## 1. Repository layout
+
+HelixDB is a Cargo workspace. Members are declared in the top-level
+`Cargo.toml`:
+
+| Path | Crate name | Purpose |
+|---|---|---|
+| `helix-db/` | `helix-db` | The core library: storage engine, gateway, query compiler, **memst integration** |
+| `helix-container/` | `helix-container` | Daemon / process boundary that ships HelixDB as a service |
+| `helix-cli/` | `helix-cli` | Command-line entry point |
+| `helix-macros/` | `helix-macros` | Procedural macros consumed by `helix-db` |
+| `metrics/` | `helix-metrics` | Lightweight metrics library |
+| `hql-tests/` | `hql-tests` | Black-box query-language tests |
+
+Everything new for memst lives under `helix-db/src/memst/`. See
+[`README-MEMST.md`](README-MEMST.md) for module-level details.
+
+---
+
+## 2. Toolchain prerequisites
+
+| Tool | Required version | Notes |
+|---|---|---|
+| Rust toolchain | latest stable | The crate uses `edition = "2024"`, so you need a recent rustc (>= 1.85). `rustup update stable` is the usual fix. |
+| `cargo` | bundled with Rust | |
+| C toolchain | system default | LMDB (`heed3`), `mimalloc`, and `blake3` ship a C implementation; on Linux install `build-essential`, on macOS `xcode-select --install`, on Windows MSVC build tools. |
+| `git` | any recent | |
+| `pkg-config` | recommended on Linux | Some transitive deps probe with `pkg-config`. |
+
+Optional but useful:
+
+- `cargo-nextest` - faster test runner, drop-in replacement for `cargo test`.
+- `cargo-watch` - re-run a command on file changes.
+- `cargo-deny` / `cargo-audit` - dependency scanning.
+
+Verify your toolchain:
+
+```bash
+rustc --version          # should print 1.85.x or newer
+cargo --version
+```
+
+---
+
+## 3. First-time setup
+
+```bash
+git clone https://github.com/yfyang86/helix-db.git
+cd helix-db
+
+# Fetch dependencies and confirm the workspace builds
+cargo check --workspace
+
+# (Optional) build everything, debug profile
+cargo build --workspace
+```
+
+Cold builds take a few minutes - `polars`, `axum`, `heed3`, and `mimalloc`
+are heavy. Subsequent builds are fast thanks to incremental compilation.
+
+> **Tip.** If you're on a constrained machine (CI runner, laptop on
+> battery), build only the crate you're touching:
+> `cargo check -p helix-db`.
+
+---
+
+## 4. Cargo features
+
+`helix-db/Cargo.toml` exposes a feature matrix. The relevant ones:
+
+| Feature | Default? | Pulls in |
+|---|---|---|
+| `compiler` | via `server` | HQL parser (`pest`, `pest_derive`, `ariadne`) |
+| `vectors` | via `server` | Cosine similarity + `url` |
+| `server` | **yes** | `compiler` + `vectors` + `reqwest` (full daemon) |
+| `dev` | no | `debug-output`, `server`, `bench` |
+| `bench` | no | `polars` for benchmarking |
+| `production` | no | `api-key` + `server` |
+| `debug-output` | no | Verbose `helix-macros` output |
+| `dev-instance` | no | Local-developer instance flag |
+
+Common build invocations:
+
+```bash
+# default profile (server enabled)
+cargo build -p helix-db
+
+# everything (compiler + vectors + server + bench)
+cargo build -p helix-db --features dev
+
+# minimal: storage core only, no compiler / no HTTP layer
+cargo build -p helix-db --no-default-features
+
+# release-tuned binary
+cargo build -p helix-db --release
+```
+
+The `[profile.release]` section of the workspace Cargo.toml uses
+`opt-level=2`, `lto=true`, `codegen-units=1`, `panic=abort`. That gives
+small fast binaries but slow builds - keep iteration on the dev profile.
+
+---
+
+## 5. Running tests
+
+### 5.1 Test taxonomy
+
+There are four kinds of tests in this repo and they are run differently:
+
+1. **Inline unit tests** - `#[cfg(test)] mod tests` inside source files.
+   Run by default with `cargo test`.
+2. **Integration tests** - files under `helix-db/tests/`. Each file is
+   compiled into its own binary, so they cannot share state but they can
+   reach the public crate API.
+3. **HQL tests** - under `hql-tests/`, exercise the query language end-to-end.
+4. **Doc tests** - anything inside ```rust``` blocks in module docs.
+
+The memst integration adds three integration test files:
+
+- `helix-db/tests/memst_unit.rs` - fine-grained unit tests
+- `helix-db/tests/memst_uat.rs` - Given/When/Then UATs
+- `helix-db/tests/memst_uat_multisession.rs` - multi-session UAT
+
+### 5.2 Environment variables
+
+Set these before invoking `cargo test`. None are required, but each unlocks
+something useful when you need it:
+
+| Variable | Effect |
+|---|---|
+| `RUST_BACKTRACE=1` | Prints a stack trace on panic. Set this first when debugging a failing test. |
+| `RUST_BACKTRACE=full` | Verbose backtrace including symbols. |
+| `RUST_LOG=debug` | Enables `tracing` logs (HelixDB uses the `tracing` crate). Filter by crate, e.g. `RUST_LOG=helix_db::memst=debug`. |
+| `RUST_TEST_THREADS=1` | Force serial execution. Use this when you suspect a race in test fixtures. |
+| `CARGO_TARGET_DIR=/tmp/helix-target` | Move the build cache off slow disks (CI / NFS / Docker bind mounts). Speeds builds dramatically. |
+| `RUSTFLAGS="-D warnings"` | Treat warnings as errors. Mirrors what CI does - recommended on PRs. |
+| `RUST_MIN_STACK=8388608` | Bump stack size if a test recurses deeply (rare). |
+
+Recommended baseline for local development:
+
+```bash
+export RUST_BACKTRACE=1
+export RUST_LOG=warn
+export CARGO_TARGET_DIR="$HOME/.cache/helix-target"
+```
+
+Add those to your shell rc once and forget about them.
+
+### 5.3 Common test commands
+
+```bash
+# Run every test in every workspace member (this is what CI does)
+cargo test --workspace
+
+# Run only helix-db tests
+cargo test -p helix-db
+
+# Run only the memst tests
+cargo test -p helix-db --test memst_unit
+cargo test -p helix-db --test memst_uat
+cargo test -p helix-db --test memst_uat_multisession
+
+# Run a single test by name
+cargo test -p helix-db --test memst_uat uat_18_session_persistence_across_reopen
+
+# Run only the inline unit tests inside the crate (lib tests, not integration)
+cargo test -p helix-db --lib
+
+# Run with output captured to stdout (useful for println! debugging)
+cargo test -p helix-db -- --nocapture
+
+# Run serially - fixes spurious failures in shared-state tests
+cargo test -p helix-db -- --test-threads=1
+```
+
+### 5.4 LMDB / `serial_test` gotcha
+
+HelixDB's storage engine sits on top of `heed3` (LMDB). Several stress
+tests are annotated with `#[serial]` from the `serial_test` crate to
+prevent two LMDB environments from racing on the same temp path. If you
+add a new test that touches `helix_engine::storage_core`, follow the
+existing pattern:
+
+```rust
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn my_lmdb_test() { /* ... */ }
+```
+
+If you forget the attribute and the test passes locally but flakes on
+CI, this is almost always the cause.
+
+### 5.5 memst-specific harness notes
+
+The memst integration uses two filesystem features that need attention:
+
+1. **Exclusive file lock (`fs2`).** `SessionStore::init` and
+   `SessionStore::open` take an `flock`-style exclusive lock on
+   `<base>/store.lock`. Two `SessionStore` instances on the **same** path
+   will deadlock - always drop the first one before re-opening. The
+   provided integration tests do this with a scoped block:
+
+   ```rust
+   let (alice_id, bob_id) = {
+       let store = SessionStore::init(dir.path())?;
+       // ... write data ...
+       (alice_id, bob_id)
+   };
+   let store = SessionStore::open(dir.path())?;  // lock released, reopen
+   ```
+
+2. **TempDir cleanup.** All memst tests use `tempfile::TempDir`, which
+   removes the directory when the value goes out of scope. Do **not**
+   `mem::forget` a TempDir - the lock file plus the `objects/` tree will
+   linger. If you see leftover directories under `$TMPDIR`, look for a
+   panicking test that bypassed Drop.
+
+### 5.6 Doc tests
+
+Doc tests are slow and easy to break. Run them only when you've changed
+docs:
+
+```bash
+cargo test -p helix-db --doc
+```
+
+If you add a runnable example to a doc comment, gate it with `no_run` or
+`ignore` if it relies on filesystem fixtures.
+
+### 5.7 Faster local cycles with nextest
+
+```bash
+cargo install cargo-nextest --locked
+cargo nextest run -p helix-db
+```
+
+Nextest fans out test binaries across cores aggressively and isolates
+panics. The downsides: it doesn't run doc tests, and `--test-threads=1`
+must become `--test-threads 1` (no equals sign).
+
+---
+
+## 6. Running the example demo
+
+The memst integration ships a runnable demo simulating three users:
+
+```bash
+cargo run -p helix-db --example memst_multi_session
+```
+
+It writes to a `TempDir`, prints a per-session summary, demonstrates
+budget-driven compaction, and verifies persistence by re-opening the
+store. Use it as a sanity check after touching `memst/store.rs` or
+`memst/memory.rs`.
+
+---
+
+## 7. Linting and formatting
+
+A pre-flight script lives at the repo root:
+
+```bash
+./clippy_check.sh
+```
+
+It runs `cargo clippy` with the project's chosen lint level. Run it
+before opening a PR - CI runs the same script.
+
+Format with rustfmt:
+
+```bash
+cargo fmt --all
+cargo fmt --all --check     # CI mode: fail if any file is unformatted
+```
+
+Recommended workflow per change:
+
+```bash
+cargo fmt --all
+./clippy_check.sh
+cargo test -p helix-db
+```
+
+If you treat warnings as errors locally, set this once:
+
+```bash
+export RUSTFLAGS="-D warnings"
+```
+
+---
+
+## 8. Tracing and runtime logs
+
+HelixDB uses the `tracing` crate. Enable logs with `RUST_LOG`:
+
+```bash
+# Top-level info
+RUST_LOG=info cargo run -p helix-db --example memst_multi_session
+
+# Drill into a specific module
+RUST_LOG=helix_db::memst::store=debug cargo test -p helix-db --test memst_uat -- --nocapture
+
+# Wide spread, useful when reproducing a CI failure
+RUST_LOG=helix_db=trace,heed3=info cargo test -p helix-db
+```
+
+`tracing-subscriber` is set up by `helix-container`; library tests do not
+configure a subscriber by default, so `info!()` calls in `helix-db` are
+silent unless your test installs one. The simplest pattern:
+
+```rust
+let _ = tracing_subscriber::fmt::try_init();
+```
+
+at the top of a test gives you formatted log output.
+
+---
+
+## 9. Working on the memst module
+
+`helix-db/src/memst/` is organized so each file owns one concern:
+
+```
+mod.rs       - re-exports (the `pub use` block is the public API contract)
+error.rs     - Error / Result
+types.rs     - Message, MemoryItem, MemoryTier, ...
+objects.rs   - ObjectId, Blob/Tree/Commit/Tag, ObjectStore (BLAKE3-backed)
+memory.rs    - MemoryLifecycle, checkpoints, token counters
+store.rs     - SessionStore (file/session management)
+```
+
+When adding a new public type:
+
+1. Define it in the most specific module (e.g. a new lifecycle trigger
+   goes in `memory.rs`).
+2. Add it to the `pub use` block in `mod.rs` so downstream users can
+   reach it via `helix_db::memst::NewType`.
+3. Write at least:
+   - one inline unit test next to the type (`#[cfg(test)] mod tests`),
+   - one fine-grained edge-case test in `tests/memst_unit.rs`,
+   - and if the type changes a user-visible behaviour, one BDD-style
+     scenario in `tests/memst_uat.rs`.
+
+If your change affects the on-disk layout, **bump the schema version**:
+
+```rust
+// in store.rs
+const SCHEMA_VERSION: &str = "1.1.0";  // was 1.0.0
+```
+
+...and write a migration path (or, at minimum, document in
+`README-MEMST.md` that an old store will refuse to open).
+
+---
+
+## 10. Branching, commits, and PRs
+
+- Develop on a feature branch named `claude/<short-topic>-<token>` (the
+  Claude Code harness uses this convention; manual branches can be
+  anything sensible).
+- Keep commits small and self-contained. Conventional commits are
+  preferred but not enforced.
+- Before pushing, the local checklist:
+
+  ```bash
+  cargo fmt --all
+  ./clippy_check.sh
+  cargo test -p helix-db
+  ```
+
+- Push with `git push -u origin <branch>`. The Claude Code harness
+  retries up to four times with exponential backoff on transient network
+  errors (2s / 4s / 8s / 16s); the same approach is fine for humans.
+- Open a PR via the GitHub UI or `gh pr create`. The PR for the memst
+  branch is **#1**.
+- Reviewers expect: changed-file scope <= ~500 LOC of net change; tests
+  covering new behaviour; CI green.
+
+---
+
+## 11. Continuous Integration
+
+The repo's CI (under `.github/workflows/`) runs the same commands listed
+above:
+
+1. `cargo fmt --all --check`
+2. `./clippy_check.sh`
+3. `cargo test --workspace`
+4. (Optional, on release tags) `cargo build --release`
+
+Common CI flake patterns and how to handle them:
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| LMDB test passes locally, flakes in CI | Missing `#[serial]` | Add `serial_test::serial` |
+| `error[E0308]` on stable but not nightly | Edition-2024-only construct | Stick to stable Rust 1.85+ syntax |
+| `linker not found` | C toolchain missing | Install build essentials in the runner |
+| Out-of-memory on the bench job | `polars` is heavy with all features | Drop `bench` from the failing job |
+
+---
+
+## 12. Releases (high-level)
+
+The crate version lives in `helix-db/Cargo.toml`'s `[package].version`.
+For a release:
+
+1. Update the version: `1.3.3` -> `1.3.4` (or `1.4.0` if the public API
+   changed).
+2. Update `CONTRIBUTORS.md` and any user-facing docs.
+3. Tag: `git tag v1.3.4 && git push --tags`.
+4. CI builds release binaries; manually trigger `cargo publish` only if
+   the crate is being published.
+
+> **Don't** run `cargo publish` from a developer machine without
+> explicit approval - once published, a version cannot be replaced, only
+> yanked.
+
+---
+
+## 13. Troubleshooting cookbook
+
+**Build fails with `failed to load source for dependency 'heed3'`.**
+Network or proxy. Try `cargo fetch --locked` and check `~/.cargo/config`
+for stale `[source.crates-io]` entries.
+
+**`cargo test` hangs forever.** Almost always two `SessionStore`s on the
+same directory deadlocking on the lock file. Add `RUST_LOG=trace`,
+re-run, and look for the test that initialized but didn't drop the
+store before re-opening. The fix is the scoped-block pattern in 5.5.
+
+**Test panics with `Failed to acquire lock: ...`.** Same root cause as
+above, but the second instance gave up immediately because some other
+process held the lock. Check for orphaned test processes:
+`pgrep -af helix-db`.
+
+**Linker error `undefined symbol: rust_eh_personality`.** Mismatch
+between profile `panic = "abort"` and a dependency built with `unwind`.
+`cargo clean -p <dep>` and rebuild.
+
+**`stack overflow` in a memst test.** A `MemoryItem` content blob got
+too large. The bincode-serialized message is read back as a single
+allocation; cap test inputs at a few MB.
+
+**`error: linking with cc failed: exit code: 1` on macOS.** Xcode CLI
+tools missing. `xcode-select --install`.
+
+**`bincode::Error: io error: unexpected end of file`.** A `messages.bin`
+or `*.bin` tier file is truncated. The tier reader handles this as
+end-of-stream, but if you see it inside a deserialize call, the file
+was corrupted by an unfinished write - investigate process kills, disk
+full, or buggy custom code that bypassed `OpenOptions::append(true)`.
+
+**Compile error referring to `serde_json` while building helix-db.** You
+removed the dep from `helix-db/Cargo.toml`. The memst module depends on
+`serde_json::Value` (operation payloads), so it must remain in the
+`[dependencies]` block.
+
+---
+
+## 14. Quick reference
+
+```bash
+# Setup once
+rustup update stable
+cargo check --workspace
+export RUST_BACKTRACE=1
+
+# Daily loop
+cargo fmt --all
+cargo test -p helix-db
+./clippy_check.sh
+
+# Memst-specific
+cargo test -p helix-db --test memst_unit
+cargo test -p helix-db --test memst_uat
+cargo test -p helix-db --test memst_uat_multisession
+cargo run  -p helix-db --example memst_multi_session
+
+# Drill into one failing test with logs
+RUST_LOG=helix_db::memst=debug \
+RUST_BACKTRACE=full \
+cargo test -p helix-db --test memst_uat <test_name> -- --nocapture --test-threads=1
+```
+
+If something here is wrong or out of date, please open a PR updating
+this file alongside the change.

--- a/README-MEMST.md
+++ b/README-MEMST.md
@@ -1,0 +1,304 @@
+# MemSt Integration
+
+`helix_db::memst` brings the core of the [memst](https://github.com/yfyang86/memst) crate
+into HelixDB: a Git-like memory architecture for LLM session management.
+
+It adds two capabilities that complement HelixDB's graph + vector engine:
+
+1. **Tiered memory management** — `Working` / `ShortTerm` / `LongTerm` tiers with
+   automatic promotion, demotion, token-budget tracking, and lossless compaction
+   checkpoints.
+2. **File and session management** — an on-disk session layout for chat
+   messages, operation logs, and per-tier memory persistence, with a global
+   manifest index and an exclusive process lock.
+
+A content-addressable object store (BLAKE3-hashed `Blob` / `Tree` / `Commit` /
+`Tag`) is also included as the persistent backbone for snapshots and history.
+
+> **Status.** This is a focused port of `memst-core`. Knowledge-graph, search,
+> vector, hybrid retrieval, and LLM-extraction modules from upstream `memst`
+> are intentionally **not** included — HelixDB already provides graph and
+> vector primitives, so they would conflict.
+
+---
+
+## Why this is here
+
+HelixDB stores graph and vector data extremely well, but a typical AI agent
+also needs:
+
+- A **conversation log** that grows append-only and can be read back in order.
+- An **operation log** of tool calls, web searches, retrievals, etc.
+- A pool of **distilled memories** at multiple lifetimes (hot / warm / cold).
+- A **budget** so the working set never explodes past the model's context.
+- A **commit history** so memories can be rewound when consolidation goes wrong.
+
+`memst` provides exactly that, with a small, dependency-light surface area.
+Merging it into HelixDB lets a downstream agent persist its full session
+state alongside the graph/vector data it queries — no second database.
+
+---
+
+## User story
+
+> *As an AI-agent backend, I want to remember the right things at the right
+> level of fidelity, with bounded context cost, and never lose history when
+> compacting.*
+
+A concrete walkthrough:
+
+1. **Alice**, a Rust developer, starts a session. The agent appends each
+   conversation turn to `messages.bin` and indexes it in `messages.idx`.
+2. The agent extracts a semantic memory ("user prefers Tokio") and stores it
+   in **working** memory with a token estimate.
+3. Each time Alice asks something Tokio-related, the agent calls
+   `access_memory`, bumping the access count.
+4. Once the access count crosses the configured threshold, the lifecycle's
+   `should_promote` returns `TransitionTrigger::AccessCount`, and the agent
+   moves the memory to **long-term**.
+5. As context fills up, `is_budget_exceeded(MemoryTier::Working)` flips to
+   `true`. The agent calls `select_for_compaction`, which returns the
+   lowest-importance / oldest items first.
+6. Before rewriting them, the agent opens a `CompactionCheckpoint` capturing
+   the pre-commit OID and original token count. Compaction summarises the
+   chosen memories into a single short-term entry; the checkpoint is
+   `finalize`d with the post-commit OID. If anything looks wrong later,
+   `restore_checkpoint` recovers the exact pre-state.
+7. Meanwhile **Bob** and **Carol** are running in their own sessions — the
+   per-session `memory/` directory keeps everyone isolated, and the manifest
+   tracks all of them centrally.
+8. Tomorrow Alice reopens her session: `SessionStore::open` loads the
+   manifest, the messages stream is replayed, and her long-term memories are
+   right where she left them.
+
+---
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────┐
+│                    helix_db::memst                         │
+├────────────────────────────────────────────────────────────┤
+│  store.rs        SessionStore                              │
+│                  ├── manifest.json     (global index)      │
+│                  ├── store.lock        (fs2 exclusive)     │
+│                  ├── sessions/<uuid>/                      │
+│                  │   ├── metadata.json                     │
+│                  │   ├── messages.bin  (append-only)       │
+│                  │   ├── messages.idx  (text index)        │
+│                  │   ├── operations.log (JSONL)            │
+│                  │   ├── memory/working.bin                │
+│                  │   ├── memory/short.bin                  │
+│                  │   └── memory/long.bin                   │
+│                  └── attachments/                          │
+│                                                            │
+│  memory.rs       MemoryLifecycle                           │
+│                  ├── HashMap<id, MemoryState>              │
+│                  ├── Vec<Transition>     (history)         │
+│                  ├── Vec<CompactionCheckpoint>             │
+│                  └── LifecycleConfig (budgets, TTLs)       │
+│                                                            │
+│  objects.rs      ObjectStore (content-addressable)         │
+│                  ├── Blob/Tree/Commit/Tag                  │
+│                  ├── BLAKE3-hashed paths                   │
+│                  └── automatic deduplication               │
+│                                                            │
+│  types.rs        Message · MemoryItem · Manifest · ...     │
+│  error.rs        Error / Result                            │
+└────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Quick start
+
+Add nothing — the module is part of the `helix-db` crate. From application
+code:
+
+```rust
+use helix_db::memst::{
+    MemoryItem, MemoryQuery, MemoryTier, MemoryType, Message,
+    SessionMetadata, SessionStore,
+};
+
+let dir = tempfile::TempDir::new()?;
+let store = SessionStore::init(dir.path())?;
+
+let session_id = store.create_session(SessionMetadata::new("alice", "gpt-4"))?;
+
+store.append_message(session_id, Message::user("Hello!"))?;
+store.append_message(session_id, Message::assistant("Hi there."))?;
+
+let mem = MemoryItem::new("user prefers Tokio", "extraction")
+    .with_memory_type(MemoryType::Semantic)
+    .with_tag("rust")
+    .with_token_estimate(7);
+store.add_memory(session_id, MemoryTier::Working, mem)?;
+
+let hits = store.retrieve_memories(
+    session_id,
+    MemoryQuery::new().with_keyword("tokio").with_tag("rust"),
+)?;
+assert_eq!(hits.len(), 1);
+```
+
+### Tiered lifecycle
+
+```rust
+use helix_db::memst::{LifecycleConfig, MemoryLifecycle, MemoryTier, TransitionTrigger};
+
+let mut lifecycle = MemoryLifecycle::new(LifecycleConfig::default());
+lifecycle.register(&mem.id.to_string(), MemoryTier::Working);
+
+// Decide if a memory should move tier:
+if let Some(trigger) = lifecycle.should_promote(&mem) {
+    match trigger {
+        TransitionTrigger::AccessCount(n)        => println!("hot: {n} accesses"),
+        TransitionTrigger::ImportanceThreshold(i) => println!("important: {i:.2}"),
+        _ => {}
+    }
+}
+
+// Detect budget pressure:
+if lifecycle.is_budget_exceeded(&memories, MemoryTier::Working) {
+    let to_compact = lifecycle.select_for_compaction(&memories, MemoryTier::Working, 10);
+    // ... summarise, write a Commit, move to ShortTerm ...
+}
+```
+
+### Compaction checkpoint
+
+```rust
+let pre = ObjectId::from_content(b"working tree before compaction");
+let cp = lifecycle.create_checkpoint(
+    Some(MemoryScope::Session(session_id.to_string())),
+    MemoryTier::Working,
+    MemoryTier::ShortTerm,
+    memory_ids,
+    pre,
+    /* original_tokens = */ 1_000,
+);
+
+// ... do the compaction work ...
+
+let post = ObjectId::from_content(b"compacted state");
+lifecycle.finalize_checkpoint(&cp.id, post, /* compacted_tokens = */ 250)?;
+
+// Lossless rewind, anytime later:
+let restored = lifecycle.restore_checkpoint(&cp.id);
+```
+
+---
+
+## Public API surface
+
+Re-exported from `helix_db::memst`:
+
+| Category | Types |
+|---|---|
+| Errors | `Error`, `Result` |
+| Messages | `Message`, `Role`, `Content`, `ContentPart` |
+| Sessions | `SessionStore`, `SessionMetadata`, `SessionSummary`, `Manifest`, `MessageIndexEntry`, `SessionId` |
+| Memories | `MemoryItem`, `MemoryTier`, `MemoryType`, `MemoryQuery`, `MemoryId` |
+| Operations | `Operation`, `OperationType`, `OperationQuery` |
+| Lifecycle | `MemoryLifecycle`, `LifecycleConfig`, `MemoryState`, `Transition`, `TransitionTrigger`, `CompactionCheckpoint` |
+| Token counters | `TokenCounter` (trait), `SimpleTokenCounter`, `ConfiguredTokenCounter` |
+| Object store | `ObjectStore`, `ObjectId`, `Blob`, `Tree`, `TreeEntry`, `Commit`, `CommitMetadata`, `CommitSource`, `Author`, `Tag`, `MemoryScope` |
+
+Submodules (`error`, `types`, `memory`, `objects`, `store`) remain `pub` so
+internal helpers like `ObjectHeader` are reachable when needed.
+
+---
+
+## On-disk layout
+
+```
+<base>/
+├── manifest.json          // global session index
+├── schema_version         // "1.0.0"
+├── store.lock             // fs2 exclusive lock
+├── attachments/           // out-of-band binary blobs
+└── sessions/
+    └── <session-uuid>/
+        ├── metadata.json   // SessionMetadata
+        ├── messages.bin    // bincode-packed Message stream
+        ├── messages.idx    // text index: id offset length ts role
+        ├── operations.log  // JSONL Operation entries
+        ├── memory/
+        │   ├── working.bin
+        │   ├── short.bin
+        │   └── long.bin
+        └── extractions/    // reserved for downstream extractors
+```
+
+The lock file ensures only one writer per store directory. Schema version
+bumps cause `SessionStore::open` to error out with `Error::VersionMismatch`.
+
+---
+
+## Testing
+
+The integration ships with three layers of coverage:
+
+| Layer | Location | Count |
+|---|---|---|
+| Module-level unit tests (happy path) | inline `#[cfg(test)] mod tests` in each `memst/*.rs` | ~15 |
+| Fine-grained unit tests (edge cases, builders, serde, errors) | `helix-db/tests/memst_unit.rs` | ~40 |
+| User Acceptance Tests (BDD-style end-to-end scenarios) | `helix-db/tests/memst_uat.rs`, `helix-db/tests/memst_uat_multisession.rs` | ~27 |
+
+Run all of them:
+
+```bash
+cargo test -p helix-db --tests
+```
+
+Run only the memst test files:
+
+```bash
+cargo test -p helix-db --test memst_unit
+cargo test -p helix-db --test memst_uat
+cargo test -p helix-db --test memst_uat_multisession
+```
+
+There's also a runnable demo that simulates three concurrent sessions:
+
+```bash
+cargo run -p helix-db --example memst_multi_session
+```
+
+---
+
+## Limitations and non-goals
+
+- **No knowledge-graph types.** Upstream `memst-core::types` exposes
+  `Entity`/`Relationship` plus a KG-evolution machinery; HelixDB has its own
+  graph engine, so those are not ported.
+- **No search/vector backends.** `memst-core::search`, `vector`, and `hybrid`
+  are dropped; use HelixDB's built-in `helix_engine` instead.
+- **No LLM extraction.** `memst-core::llm` and `extract` are dropped — feed
+  whatever extractor you like and call `add_memory` with the result.
+- **Single-process locking.** The `store.lock` file uses `fs2`'s POSIX/Windows
+  exclusive lock. It does not coordinate across machines.
+- **Bincode 1.x format.** Tied to HelixDB's existing bincode dependency. The
+  on-disk format will need a migration if HelixDB upgrades to bincode 2.
+
+---
+
+## File map
+
+```
+helix-db/
+├── src/memst/
+│   ├── mod.rs        re-exports
+│   ├── error.rs
+│   ├── types.rs      Message, MemoryItem, MemoryTier, ...
+│   ├── objects.rs    ObjectId, Blob/Tree/Commit/Tag, ObjectStore
+│   ├── memory.rs     MemoryLifecycle, checkpoints, token counters
+│   └── store.rs      SessionStore (file/session management)
+├── examples/
+│   └── memst_multi_session.rs   runnable demo
+└── tests/
+    ├── memst_unit.rs
+    ├── memst_uat.rs
+    └── memst_uat_multisession.rs
+```

--- a/helix-db/Cargo.toml
+++ b/helix-db/Cargo.toml
@@ -22,7 +22,7 @@ twox-hash = "2.1.0"
 heed3 = "0.22.0"
 uuid = { version = "1.12.1", features = ["serde", "v4", "v6", "fast-rng"] }
 rand = "0.9.0"
-chrono = "0.4.39"
+chrono = { version = "0.4.39", features = ["serde"] }
 flume = { version = "0.12.0", default-features = false, features = [
     "async",
     "select",
@@ -35,6 +35,10 @@ mimalloc = "0.1.48"
 bumpalo = { version = "3.19.0", features = ["collections", "boxed", "serde"] }
 bytemuck = "1.24.0"
 indexmap = { version = "2.7", features = ["serde"] }
+
+# memst integration: tiered memory management & file/session store
+blake3 = "1.5"
+fs2 = "0.4"
 
 # compiler dependencies
 pest = { version = "2.7", optional = true }

--- a/helix-db/Cargo.toml
+++ b/helix-db/Cargo.toml
@@ -39,6 +39,7 @@ indexmap = { version = "2.7", features = ["serde"] }
 # memst integration: tiered memory management & file/session store
 blake3 = "1.5"
 fs2 = "0.4"
+serde_json = "1.0"
 
 # compiler dependencies
 pest = { version = "2.7", optional = true }

--- a/helix-db/examples/memst_multi_session.rs
+++ b/helix-db/examples/memst_multi_session.rs
@@ -1,0 +1,298 @@
+//! Runnable demo: three concurrent sessions sharing one MemSt store.
+//!
+//! Each user has their own conversation, extracts a few memories at the
+//! `Working` tier, and the agent is configured with a small token budget so
+//! we can watch the lifecycle decide which memories to compact.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run -p helix-db --example memst_multi_session
+//! ```
+//!
+//! The demo writes everything to a temporary directory and prints a summary
+//! at the end; nothing is left on disk after the process exits.
+
+use helix_db::memst::{
+    ConfiguredTokenCounter, LifecycleConfig, MemoryItem, MemoryLifecycle, MemoryQuery, MemoryState,
+    MemoryTier, MemoryType, Message, Operation, OperationType, SessionMetadata, SessionStore,
+    TokenCounter, TransitionTrigger,
+};
+use std::error::Error;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    println!("=== MemSt multi-session demo ===\n");
+
+    // 1. Initialize a fresh store in a temporary directory.
+    let dir = TempDir::new()?;
+    let store = SessionStore::init(dir.path())?;
+    println!("store rooted at {}", dir.path().display());
+
+    // 2. Three users, three sessions, each on a different model.
+    let alice = create_session(&store, "alice", "claude-sonnet-4")?;
+    let bob = create_session(&store, "bob", "gpt-4o")?;
+    let carol = create_session(&store, "carol", "llama-3-70b")?;
+    println!("\ncreated 3 sessions:");
+    for s in store.list_sessions()? {
+        println!("  - {} ({}) -> {}", s.name, s.model, s.id);
+    }
+
+    // 3. Use a small working-memory budget so compaction triggers visibly.
+    let cfg = LifecycleConfig {
+        working_memory_max_tokens: 60,
+        promotion_access_threshold: 2,
+        ..LifecycleConfig::default()
+    };
+    let mut lifecycle = MemoryLifecycle::new(cfg);
+    let counter = ConfiguredTokenCounter::default();
+
+    // 4. Drive each session's conversation + memory extraction.
+    drive_alice(&store, &mut lifecycle, &counter, alice)?;
+    drive_bob(&store, &mut lifecycle, &counter, bob)?;
+    drive_carol(&store, &mut lifecycle, &counter, carol)?;
+
+    // 5. Show what each session has on disk.
+    println!("\n--- per-session summary ---");
+    for s in store.list_sessions()? {
+        let meta = store.get_session(s.id)?.unwrap();
+        let working = store.get_tier(s.id, MemoryTier::Working)?;
+        let short = store.get_tier(s.id, MemoryTier::ShortTerm)?;
+        let long = store.get_tier(s.id, MemoryTier::LongTerm)?;
+        let ops = store.get_operations(s.id)?;
+        println!(
+            "  {} : {} msg / {} tok | mem  W={}  S={}  L={} | ops={}",
+            meta.name,
+            meta.message_count,
+            meta.token_count,
+            working.len(),
+            short.len(),
+            long.len(),
+            ops.len()
+        );
+    }
+
+    // 6. Demonstrate budget pressure and lifecycle decisions for Alice.
+    let alice_working = store.get_tier(alice, MemoryTier::Working)?;
+    let usage = lifecycle.calculate_token_usage(&alice_working);
+    println!(
+        "\nalice working tokens: {}/{}",
+        usage.get(&MemoryTier::Working).copied().unwrap_or(0),
+        60
+    );
+    if lifecycle.is_budget_exceeded(&alice_working, MemoryTier::Working) {
+        println!("budget exceeded -> selecting compaction candidates");
+        let picked = lifecycle.select_for_compaction(&alice_working, MemoryTier::Working, 2);
+        for m in &picked {
+            println!(
+                "    candidate: \"{}\" (importance={:.2}, tokens={})",
+                truncate(&m.content, 40),
+                m.importance,
+                m.token_estimate.unwrap_or(0)
+            );
+        }
+        // Move the picked items down a tier and update the lifecycle state.
+        for m in picked {
+            store.promote_memory(alice, m.id, MemoryTier::ShortTerm)?;
+            lifecycle
+                .transition(
+                    &m.id.to_string(),
+                    MemoryState::ShortTerm,
+                    TransitionTrigger::TokenBudgetExceeded,
+                    -(m.token_estimate.unwrap_or(0) as i32),
+                )
+                .ok();
+        }
+        println!(
+            "    -> alice now has {} working / {} short-term",
+            store.get_tier(alice, MemoryTier::Working)?.len(),
+            store.get_tier(alice, MemoryTier::ShortTerm)?.len(),
+        );
+    }
+
+    // 7. Cross-session sanity: a query against alice never sees bob or carol.
+    println!("\n--- isolation check ---");
+    for (label, id) in [("alice", alice), ("bob", bob), ("carol", carol)] {
+        let hits = store.retrieve_memories(
+            id,
+            MemoryQuery::new().with_keyword("python"), // bob-specific keyword
+        )?;
+        println!(
+            "  {label}: {} memories matching 'python' (expected: only bob)",
+            hits.len()
+        );
+    }
+
+    // 8. Persistence check: drop the store and re-open from disk.
+    drop(store);
+    let store = SessionStore::open(dir.path())?;
+    let reopened = store.list_sessions()?;
+    println!(
+        "\nre-opened store sees {} sessions ({:?})",
+        reopened.len(),
+        reopened.iter().map(|s| s.name.as_str()).collect::<Vec<_>>()
+    );
+
+    println!("\n=== done ===");
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// per-user scripts
+// -----------------------------------------------------------------------------
+
+fn drive_alice<C: TokenCounter>(
+    store: &SessionStore,
+    lifecycle: &mut MemoryLifecycle,
+    counter: &C,
+    id: Uuid,
+) -> Result<(), Box<dyn Error>> {
+    let turns = [
+        Message::system("You help with Rust async."),
+        Message::user("How does Tokio's runtime schedule tasks?").with_token_count(8),
+        Message::assistant("Tokio uses a multi-threaded work-stealing scheduler...").with_token_count(60),
+        Message::user("Is it OK to mix tokio and async-std?").with_token_count(9),
+        Message::assistant("Generally avoid mixing runtimes...").with_token_count(40),
+    ];
+    append_turns(store, id, turns)?;
+
+    // Three working memories, each with a token estimate.
+    for content in [
+        "user prefers Tokio over async-std for async runtimes",
+        "user is comfortable with work-stealing schedulers",
+        "user wants idiomatic Rust async patterns",
+    ] {
+        let mem = MemoryItem::new(content, "extraction")
+            .with_memory_type(MemoryType::Semantic)
+            .with_tag("rust")
+            .with_token_estimate(counter.count(content));
+        lifecycle.register(&mem.id.to_string(), MemoryTier::Working);
+        store.add_memory(id, MemoryTier::Working, mem)?;
+    }
+
+    // Touch the Tokio memory twice -> crosses the access-count threshold.
+    let working = store.get_tier(id, MemoryTier::Working)?;
+    if let Some(tokio_mem) = working.iter().find(|m| m.content.contains("Tokio")) {
+        store.access_memory(id, tokio_mem.id)?;
+        store.access_memory(id, tokio_mem.id)?;
+        if let Some(updated) = store.get_memory(id, tokio_mem.id)? {
+            if let Some(trigger) = lifecycle.should_promote(&updated) {
+                println!(
+                    "alice: tokio memory should promote ({:?})",
+                    trigger
+                );
+                store.promote_memory(id, tokio_mem.id, MemoryTier::LongTerm)?;
+                lifecycle
+                    .transition(
+                        &tokio_mem.id.to_string(),
+                        MemoryState::LongTerm,
+                        trigger,
+                        0,
+                    )
+                    .ok();
+            }
+        }
+    }
+
+    log_op(store, id, OperationType::MemoryRetrieval, "tokio", 4)?;
+    Ok(())
+}
+
+fn drive_bob<C: TokenCounter>(
+    store: &SessionStore,
+    lifecycle: &mut MemoryLifecycle,
+    counter: &C,
+    id: Uuid,
+) -> Result<(), Box<dyn Error>> {
+    let turns = [
+        Message::system("You help with ML in Python."),
+        Message::user("How do I avoid GIL contention in PyTorch?").with_token_count(11),
+        Message::assistant("Use multiprocessing or move tensors to GPU...").with_token_count(35),
+    ];
+    append_turns(store, id, turns)?;
+
+    let content = "user uses Python and PyTorch; cares about GIL implications";
+    let mem = MemoryItem::new(content, "extraction")
+        .with_memory_type(MemoryType::Semantic)
+        .with_tag("python")
+        .with_tag("ml")
+        .with_token_estimate(counter.count(content));
+    lifecycle.register(&mem.id.to_string(), MemoryTier::Working);
+    store.add_memory(id, MemoryTier::Working, mem)?;
+
+    log_op(store, id, OperationType::WebSearch, "GIL pytorch", 12)?;
+    Ok(())
+}
+
+fn drive_carol<C: TokenCounter>(
+    store: &SessionStore,
+    lifecycle: &mut MemoryLifecycle,
+    counter: &C,
+    id: Uuid,
+) -> Result<(), Box<dyn Error>> {
+    let turns = [
+        Message::system("You help with Go infrastructure."),
+        Message::user("How do I tune GOMAXPROCS in Kubernetes?").with_token_count(12),
+        Message::assistant("Use the automaxprocs library or set it to the cgroup CPU limit.").with_token_count(45),
+    ];
+    append_turns(store, id, turns)?;
+
+    let content = "user runs Go services on Kubernetes; tuning GOMAXPROCS is recurring";
+    let mem = MemoryItem::new(content, "extraction")
+        .with_memory_type(MemoryType::Procedural)
+        .with_tag("go")
+        .with_tag("k8s")
+        .with_token_estimate(counter.count(content));
+    lifecycle.register(&mem.id.to_string(), MemoryTier::Working);
+    store.add_memory(id, MemoryTier::Working, mem)?;
+
+    log_op(store, id, OperationType::ToolCall { name: "kubectl".into() }, "describe pod", 30)?;
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// small helpers
+// -----------------------------------------------------------------------------
+
+fn create_session(
+    store: &SessionStore,
+    name: &str,
+    model: &str,
+) -> Result<Uuid, Box<dyn Error>> {
+    Ok(store.create_session(SessionMetadata::new(name, model).with_tag("demo"))?)
+}
+
+fn append_turns<I: IntoIterator<Item = Message>>(
+    store: &SessionStore,
+    id: Uuid,
+    turns: I,
+) -> Result<(), Box<dyn Error>> {
+    for m in turns {
+        store.append_message(id, m)?;
+    }
+    Ok(())
+}
+
+fn log_op(
+    store: &SessionStore,
+    id: Uuid,
+    op_type: OperationType,
+    detail: &str,
+    duration_ms: u64,
+) -> Result<(), Box<dyn Error>> {
+    store.append_operation(
+        id,
+        Operation::new(op_type, serde_json::json!({ "detail": detail }), duration_ms),
+    )?;
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let head: String = s.chars().take(max).collect();
+        format!("{head}...")
+    }
+}

--- a/helix-db/src/lib.rs
+++ b/helix-db/src/lib.rs
@@ -2,6 +2,7 @@ pub mod helix_engine;
 pub mod helix_gateway;
 #[cfg(feature = "compiler")]
 pub mod helixc;
+pub mod memst;
 pub mod protocol;
 pub mod utils;
 

--- a/helix-db/src/memst/error.rs
+++ b/helix-db/src/memst/error.rs
@@ -1,0 +1,83 @@
+//! Error types for the MemSt integration.
+//!
+//! Ported from `memst-core/src/error.rs`. Variants requiring external HTTP/LLM
+//! crates have been removed - HelixDB does not need the LLM extraction path of
+//! the upstream `memst-core` to integrate the memory and session subsystems.
+
+use std::io;
+use std::num::ParseIntError;
+use thiserror::Error;
+
+use super::objects::ObjectId;
+
+/// Result type alias with the MemSt integration error.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// MemSt integration error types.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// I/O error
+    #[error(transparent)]
+    Io(#[from] io::Error),
+
+    /// Bincode serialization error
+    #[error(transparent)]
+    Serialize(#[from] bincode::Error),
+
+    /// JSON serialization error
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    /// Session not found
+    #[error("Session not found: {0}")]
+    SessionNotFound(uuid::Uuid),
+
+    /// Message not found
+    #[error("Message not found: {0}")]
+    MessageNotFound(uuid::Uuid),
+
+    /// Lock error
+    #[error("Failed to acquire lock: {0}")]
+    LockError(String),
+
+    /// Index out of bounds
+    #[error("Index out of bounds: {0}")]
+    IndexOutOfBounds(String),
+
+    /// Corrupted data
+    #[error("Data corruption detected: {0}")]
+    Corruption(String),
+
+    /// Version mismatch
+    #[error("Version mismatch: expected {expected}, found {found}")]
+    VersionMismatch {
+        /// Expected version
+        expected: String,
+        /// Found version
+        found: String,
+    },
+
+    /// Invalid operation
+    #[error("Invalid operation: {0}")]
+    InvalidOperation(String),
+
+    /// UUID parsing error
+    #[error(transparent)]
+    UuidParse(#[from] uuid::Error),
+
+    /// Parse integer error
+    #[error(transparent)]
+    ParseInt(#[from] ParseIntError),
+
+    /// Object not found
+    #[error("Object not found: {0}")]
+    ObjectNotFound(ObjectId),
+
+    /// Invalid object ID
+    #[error("Invalid object ID: {0}")]
+    InvalidObjectId(String),
+
+    /// Invalid object format
+    #[error("Invalid object format")]
+    InvalidObjectFormat,
+}

--- a/helix-db/src/memst/memory.rs
+++ b/helix-db/src/memst/memory.rs
@@ -1,0 +1,508 @@
+//! Memory lifecycle management - tiered Working / ShortTerm / LongTerm flow.
+//!
+//! Port of `memst-core/src/memory/mod.rs`. The lifecycle controls how memories
+//! transition between tiers, when they get compacted, and how much token budget
+//! each tier may consume. This is the *different levels of memory management*
+//! capability requested when integrating MemSt into HelixDB.
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use super::error::{Error, Result};
+use super::objects::{MemoryScope, ObjectId};
+use super::types::{MemoryItem, MemoryTier};
+
+/// Memory lifecycle states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MemoryState {
+    /// Active in working memory
+    Active,
+    /// Marked for promotion
+    PendingPromotion,
+    /// Currently being compacted
+    Compacting,
+    /// In short-term storage
+    ShortTerm,
+    /// In long-term storage
+    LongTerm,
+    /// Archived (not in context)
+    Archived,
+    /// Tombstoned (deleted but preserved for history)
+    Tombstoned,
+}
+
+/// Trigger that caused a lifecycle transition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TransitionTrigger {
+    /// Token budget exceeded
+    TokenBudgetExceeded,
+    /// TTL expired
+    TtlExpired,
+    /// Access count threshold
+    AccessCount(u32),
+    /// Importance threshold crossed
+    ImportanceThreshold(f32),
+    /// Manually triggered
+    Manual,
+    /// Sleep-time consolidation
+    SleepConsolidation,
+    /// Conflict detected
+    ConflictDetected,
+}
+
+/// Record of a single state transition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Transition {
+    /// Origin state
+    pub from: MemoryState,
+    /// Destination state
+    pub to: MemoryState,
+    /// Cause
+    pub trigger: TransitionTrigger,
+    /// When the transition happened
+    pub timestamp: DateTime<Utc>,
+    /// Commit hash (if persisted)
+    pub commit_hash: Option<ObjectId>,
+    /// Token delta induced by the transition
+    pub token_delta: i32,
+}
+
+/// Lossless rewind point captured before a compaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompactionCheckpoint {
+    /// Checkpoint id
+    pub id: String,
+    /// When it was created
+    pub timestamp: DateTime<Utc>,
+    /// Optional scope of the checkpoint
+    pub scope: Option<MemoryScope>,
+    /// Source tier
+    pub source_tier: MemoryTier,
+    /// Destination tier
+    pub target_tier: MemoryTier,
+    /// Memory ids included
+    pub memory_ids: Vec<String>,
+    /// Commit hash before compaction
+    pub pre_commit: ObjectId,
+    /// Commit hash after compaction (set on finalize)
+    pub post_commit: Option<ObjectId>,
+    /// Original token count
+    pub original_tokens: u32,
+    /// Compacted token count
+    pub compacted_tokens: u32,
+}
+
+/// Configuration for [`MemoryLifecycle`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LifecycleConfig {
+    /// Maximum tokens in working memory
+    pub working_memory_max_tokens: u32,
+    /// Maximum tokens in short-term memory
+    pub short_term_max_tokens: u32,
+    /// Maximum tokens in long-term memory
+    pub long_term_max_tokens: u32,
+    /// Working-memory TTL in seconds
+    pub working_memory_ttl: u64,
+    /// Short-term TTL in seconds
+    pub short_term_ttl: u64,
+    /// Access count threshold for promotion
+    pub promotion_access_threshold: u32,
+    /// Importance threshold for long-term storage
+    pub long_term_importance_threshold: f32,
+    /// Whether to compact automatically when budgets are exceeded
+    pub auto_compact: bool,
+    /// Compaction batch size
+    pub compaction_batch_size: usize,
+}
+
+impl Default for LifecycleConfig {
+    fn default() -> Self {
+        Self {
+            working_memory_max_tokens: 4096,
+            short_term_max_tokens: 16384,
+            long_term_max_tokens: 1_048_576,
+            working_memory_ttl: 3_600,
+            short_term_ttl: 86_400,
+            promotion_access_threshold: 3,
+            long_term_importance_threshold: 0.7,
+            auto_compact: true,
+            compaction_batch_size: 100,
+        }
+    }
+}
+
+/// Memory lifecycle manager.
+///
+/// Tracks the current [`MemoryState`] of each memory id, records every
+/// transition, and exposes helpers for selecting candidates for promotion or
+/// compaction.
+pub struct MemoryLifecycle {
+    config: LifecycleConfig,
+    states: HashMap<String, MemoryState>,
+    transitions: Vec<Transition>,
+    checkpoints: Vec<CompactionCheckpoint>,
+}
+
+impl MemoryLifecycle {
+    /// Create a new lifecycle manager.
+    pub fn new(config: LifecycleConfig) -> Self {
+        Self {
+            config,
+            states: HashMap::new(),
+            transitions: Vec::new(),
+            checkpoints: Vec::new(),
+        }
+    }
+
+    /// Default lifecycle configuration.
+    pub fn default_config() -> LifecycleConfig {
+        LifecycleConfig::default()
+    }
+
+    /// Register a memory with an initial tier and return its computed state.
+    pub fn register(&mut self, memory_id: &str, initial_tier: MemoryTier) -> MemoryState {
+        let state = match initial_tier {
+            MemoryTier::Working => MemoryState::Active,
+            MemoryTier::ShortTerm => MemoryState::ShortTerm,
+            MemoryTier::LongTerm => MemoryState::LongTerm,
+        };
+        self.states.insert(memory_id.to_string(), state);
+        state
+    }
+
+    /// Look up the current state of a memory.
+    pub fn get_state(&self, memory_id: &str) -> Option<MemoryState> {
+        self.states.get(memory_id).copied()
+    }
+
+    /// Decide if a memory should be promoted, returning the trigger if so.
+    pub fn should_promote(&self, item: &MemoryItem) -> Option<TransitionTrigger> {
+        if item.access_count >= self.config.promotion_access_threshold {
+            return Some(TransitionTrigger::AccessCount(item.access_count));
+        }
+        if item.importance >= self.config.long_term_importance_threshold {
+            return Some(TransitionTrigger::ImportanceThreshold(item.importance));
+        }
+        None
+    }
+
+    /// Decide if a memory should be demoted/archived from `current_tier`.
+    pub fn should_demote(
+        &self,
+        item: &MemoryItem,
+        current_tier: MemoryTier,
+    ) -> Option<TransitionTrigger> {
+        let age = Utc::now() - item.last_accessed;
+        match current_tier {
+            MemoryTier::Working => {
+                if age > Duration::seconds(self.config.working_memory_ttl as i64) {
+                    Some(TransitionTrigger::TtlExpired)
+                } else {
+                    None
+                }
+            }
+            MemoryTier::ShortTerm => {
+                if age > Duration::seconds(self.config.short_term_ttl as i64) {
+                    Some(TransitionTrigger::TtlExpired)
+                } else {
+                    None
+                }
+            }
+            MemoryTier::LongTerm => None,
+        }
+    }
+
+    /// Apply a state transition and append it to the history.
+    pub fn transition(
+        &mut self,
+        memory_id: &str,
+        to_state: MemoryState,
+        trigger: TransitionTrigger,
+        token_delta: i32,
+    ) -> Result<Transition> {
+        let from_state = self
+            .states
+            .get(memory_id)
+            .copied()
+            .unwrap_or(MemoryState::Active);
+
+        let transition = Transition {
+            from: from_state,
+            to: to_state,
+            trigger,
+            timestamp: Utc::now(),
+            commit_hash: None,
+            token_delta,
+        };
+
+        self.states.insert(memory_id.to_string(), to_state);
+        self.transitions.push(transition.clone());
+        Ok(transition)
+    }
+
+    /// Open a compaction checkpoint.
+    pub fn create_checkpoint(
+        &mut self,
+        scope: Option<MemoryScope>,
+        source_tier: MemoryTier,
+        target_tier: MemoryTier,
+        memory_ids: Vec<String>,
+        pre_commit: ObjectId,
+        original_tokens: u32,
+    ) -> CompactionCheckpoint {
+        let checkpoint = CompactionCheckpoint {
+            id: format!(
+                "chk-{}-{}",
+                pre_commit.abbreviate(),
+                Utc::now().timestamp_millis()
+            ),
+            timestamp: Utc::now(),
+            scope,
+            source_tier,
+            target_tier,
+            memory_ids,
+            pre_commit,
+            post_commit: None,
+            original_tokens,
+            compacted_tokens: 0,
+        };
+        self.checkpoints.push(checkpoint.clone());
+        checkpoint
+    }
+
+    /// Finalize a checkpoint with the resulting commit and token count.
+    pub fn finalize_checkpoint(
+        &mut self,
+        checkpoint_id: &str,
+        post_commit: ObjectId,
+        compacted_tokens: u32,
+    ) -> Result<()> {
+        if let Some(cp) = self
+            .checkpoints
+            .iter_mut()
+            .find(|c| c.id == checkpoint_id)
+        {
+            cp.post_commit = Some(post_commit);
+            cp.compacted_tokens = compacted_tokens;
+            Ok(())
+        } else {
+            Err(Error::InvalidOperation(format!(
+                "Checkpoint {} not found",
+                checkpoint_id
+            )))
+        }
+    }
+
+    /// Look up a checkpoint by id (used for lossless rewind).
+    pub fn restore_checkpoint(&self, checkpoint_id: &str) -> Option<&CompactionCheckpoint> {
+        self.checkpoints.iter().find(|c| c.id == checkpoint_id)
+    }
+
+    /// Slice of all checkpoints.
+    pub fn list_checkpoints(&self) -> &[CompactionCheckpoint] {
+        &self.checkpoints
+    }
+
+    /// Slice of every transition recorded so far.
+    pub fn transitions(&self) -> &[Transition] {
+        &self.transitions
+    }
+
+    /// Sum of `token_estimate` per tier across the supplied memories.
+    pub fn calculate_token_usage(&self, memories: &[MemoryItem]) -> HashMap<MemoryTier, u32> {
+        let mut usage: HashMap<MemoryTier, u32> = HashMap::new();
+
+        for item in memories {
+            if let Some(state) = self.get_state(&item.id.to_string()) {
+                let tier = match state {
+                    MemoryState::Active
+                    | MemoryState::PendingPromotion
+                    | MemoryState::Compacting => MemoryTier::Working,
+                    MemoryState::ShortTerm => MemoryTier::ShortTerm,
+                    MemoryState::LongTerm
+                    | MemoryState::Archived
+                    | MemoryState::Tombstoned => MemoryTier::LongTerm,
+                };
+
+                *usage.entry(tier).or_insert(0) += item.token_estimate.unwrap_or(0);
+            }
+        }
+        usage
+    }
+
+    /// Whether `tier` is over its budget for the supplied memories.
+    pub fn is_budget_exceeded(&self, memories: &[MemoryItem], tier: MemoryTier) -> bool {
+        let usage = self.calculate_token_usage(memories);
+        let current = usage.get(&tier).copied().unwrap_or(0);
+        let limit = match tier {
+            MemoryTier::Working => self.config.working_memory_max_tokens,
+            MemoryTier::ShortTerm => self.config.short_term_max_tokens,
+            MemoryTier::LongTerm => self.config.long_term_max_tokens,
+        };
+        current > limit
+    }
+
+    /// Select up to `max_count` memories from `source_tier` for compaction,
+    /// preferring lower importance and older `last_accessed` first.
+    pub fn select_for_compaction<'a>(
+        &self,
+        memories: &'a [MemoryItem],
+        source_tier: MemoryTier,
+        max_count: usize,
+    ) -> Vec<&'a MemoryItem> {
+        let mut candidates: Vec<&'a MemoryItem> = memories
+            .iter()
+            .filter(|m| {
+                let state = self.get_state(&m.id.to_string());
+                match source_tier {
+                    MemoryTier::Working => {
+                        state == Some(MemoryState::Active)
+                            || state == Some(MemoryState::PendingPromotion)
+                    }
+                    MemoryTier::ShortTerm => state == Some(MemoryState::ShortTerm),
+                    MemoryTier::LongTerm => state == Some(MemoryState::LongTerm),
+                }
+            })
+            .collect();
+
+        candidates.sort_by(|a, b| {
+            let importance_cmp = a
+                .importance
+                .partial_cmp(&b.importance)
+                .unwrap_or(std::cmp::Ordering::Equal);
+            if importance_cmp == std::cmp::Ordering::Equal {
+                a.last_accessed.cmp(&b.last_accessed)
+            } else {
+                importance_cmp
+            }
+        });
+
+        candidates.into_iter().take(max_count).collect()
+    }
+}
+
+/// Pluggable token counter interface.
+pub trait TokenCounter: Send + Sync {
+    /// Count tokens in raw text.
+    fn count(&self, text: &str) -> u32;
+
+    /// Count tokens in a memory item (default: counts `item.content`).
+    fn count_memory(&self, item: &MemoryItem) -> u32 {
+        self.count(&item.content)
+    }
+}
+
+/// Whitespace-based token counter (fast approximation).
+pub struct SimpleTokenCounter;
+
+impl TokenCounter for SimpleTokenCounter {
+    fn count(&self, text: &str) -> u32 {
+        text.split_whitespace().count() as u32
+    }
+}
+
+/// Configuration-based token counter (English-tuned by default).
+pub struct ConfiguredTokenCounter {
+    tokens_per_word: f32,
+    overhead: u32,
+}
+
+impl ConfiguredTokenCounter {
+    /// Default English-tuned counter.
+    pub fn new() -> Self {
+        Self {
+            tokens_per_word: 1.3,
+            overhead: 3,
+        }
+    }
+
+    /// Customize the words->tokens ratio and per-message overhead.
+    pub fn with_ratio(tokens_per_word: f32, overhead: u32) -> Self {
+        Self {
+            tokens_per_word,
+            overhead,
+        }
+    }
+}
+
+impl Default for ConfiguredTokenCounter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TokenCounter for ConfiguredTokenCounter {
+    fn count(&self, text: &str) -> u32 {
+        let word_count = text.split_whitespace().count() as f32;
+        (word_count * self.tokens_per_word) as u32 + self.overhead
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mem(content: &str, importance: f32) -> MemoryItem {
+        MemoryItem::new(content, "test").with_confidence(importance)
+    }
+
+    #[test]
+    fn lifecycle_register_and_state() {
+        let mut lifecycle = MemoryLifecycle::new(LifecycleConfig::default());
+        let s = lifecycle.register("m1", MemoryTier::Working);
+        assert_eq!(s, MemoryState::Active);
+        assert_eq!(lifecycle.get_state("m1"), Some(MemoryState::Active));
+    }
+
+    #[test]
+    fn promotion_triggers_on_access_count() {
+        let lifecycle = MemoryLifecycle::new(LifecycleConfig::default());
+        let mut item = mem("x", 0.5);
+        item.access_count = 5;
+        assert!(lifecycle.should_promote(&item).is_some());
+    }
+
+    #[test]
+    fn demotion_triggers_on_ttl() {
+        let lifecycle = MemoryLifecycle::new(LifecycleConfig::default());
+        let mut item = mem("x", 0.5);
+        item.last_accessed = Utc::now() - Duration::hours(2);
+        assert!(lifecycle.should_demote(&item, MemoryTier::Working).is_some());
+    }
+
+    #[test]
+    fn transition_history_recorded() {
+        let mut lifecycle = MemoryLifecycle::new(LifecycleConfig::default());
+        lifecycle.register("m1", MemoryTier::Working);
+        let t = lifecycle
+            .transition("m1", MemoryState::ShortTerm, TransitionTrigger::TtlExpired, -100)
+            .unwrap();
+        assert_eq!(t.from, MemoryState::Active);
+        assert_eq!(t.to, MemoryState::ShortTerm);
+        assert_eq!(lifecycle.transitions().len(), 1);
+    }
+
+    #[test]
+    fn checkpoint_create_and_restore() {
+        let mut lifecycle = MemoryLifecycle::new(LifecycleConfig::default());
+        let pre = ObjectId::from_content(b"x");
+        let cp = lifecycle.create_checkpoint(
+            None,
+            MemoryTier::Working,
+            MemoryTier::ShortTerm,
+            vec!["m1".into(), "m2".into()],
+            pre,
+            500,
+        );
+        assert!(cp.id.starts_with("chk-"));
+        assert!(lifecycle.restore_checkpoint(&cp.id).is_some());
+    }
+
+    #[test]
+    fn token_counter_estimates() {
+        let counter = ConfiguredTokenCounter::new();
+        let n = counter.count("hello world this is a test");
+        assert!(n > 6 && n < 20);
+    }
+}

--- a/helix-db/src/memst/mod.rs
+++ b/helix-db/src/memst/mod.rs
@@ -26,11 +26,12 @@ pub use memory::{
     SimpleTokenCounter, TokenCounter, Transition, TransitionTrigger,
 };
 pub use objects::{
-    Author, Blob, Commit, CommitMetadata, CommitSource, MemoryScope, ObjectId, ObjectStore,
+    Author, Blob, Commit, CommitMetadata, CommitSource, MemoryScope, ObjectId, ObjectStore, Tag,
     Tree, TreeEntry,
 };
 pub use store::{MessageIndexEntry, SessionStore};
 pub use types::{
-    Content, ContentPart, Manifest, MemoryItem, MemoryQuery, MemoryTier, MemoryType, Message,
-    Operation, OperationQuery, OperationType, Role, SessionMetadata, SessionSummary,
+    Content, ContentPart, Manifest, MemoryId, MemoryItem, MemoryQuery, MemoryTier, MemoryType,
+    Message, Operation, OperationQuery, OperationType, Role, SessionId, SessionMetadata,
+    SessionSummary,
 };

--- a/helix-db/src/memst/mod.rs
+++ b/helix-db/src/memst/mod.rs
@@ -1,0 +1,36 @@
+//! MemSt integration: Git-like memory architecture for LLM session management.
+//!
+//! This module integrates the core of the [`memst`](https://github.com/yfyang86/memst)
+//! crate into HelixDB. It provides two main capabilities:
+//!
+//! 1. **Tiered memory management** ([`memory`]): Working / ShortTerm / LongTerm
+//!    lifecycle with promotion, demotion, compaction checkpoints and token budgets.
+//! 2. **File and session management** ([`store`]): on-disk session layout with
+//!    messages, operation logs, per-tier memory persistence and a manifest index.
+//!
+//! Supporting modules:
+//! - [`types`] - Message, Role, Content, MemoryItem, MemoryTier, SessionMetadata, ...
+//! - [`error`] - shared `Result` and `Error` types.
+//! - [`objects`] - content-addressable object store (BLAKE3-hashed blobs / trees /
+//!   commits / tags) used as the persistent backbone for sessions and memories.
+
+pub mod error;
+pub mod memory;
+pub mod objects;
+pub mod store;
+pub mod types;
+
+pub use error::{Error, Result};
+pub use memory::{
+    CompactionCheckpoint, ConfiguredTokenCounter, LifecycleConfig, MemoryLifecycle, MemoryState,
+    SimpleTokenCounter, TokenCounter, Transition, TransitionTrigger,
+};
+pub use objects::{
+    Author, Blob, Commit, CommitMetadata, CommitSource, MemoryScope, ObjectId, ObjectStore,
+    Tree, TreeEntry,
+};
+pub use store::{MessageIndexEntry, SessionStore};
+pub use types::{
+    Content, ContentPart, Manifest, MemoryItem, MemoryQuery, MemoryTier, MemoryType, Message,
+    Operation, OperationQuery, OperationType, Role, SessionMetadata, SessionSummary,
+};

--- a/helix-db/src/memst/objects.rs
+++ b/helix-db/src/memst/objects.rs
@@ -1,0 +1,647 @@
+//! Content-addressable object storage (Git-like).
+//!
+//! Focused port of `memst-core/src/objects/mod.rs` covering the building blocks
+//! used by HelixDB's MemSt integration:
+//! - [`ObjectId`] - BLAKE3 content hashes.
+//! - [`Blob`] / [`Tree`] / [`Commit`] / [`Tag`] - object kinds.
+//! - [`Author`], [`CommitMetadata`], [`CommitSource`], [`MemoryScope`].
+//! - [`ObjectStore`] - on-disk read/write of these objects.
+//!
+//! Skill, ContextFile, Entity and Relation upstream types are intentionally
+//! omitted: they belong to the knowledge-graph slice of `memst-core`, which is
+//! not part of the memory/session merge.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::path::PathBuf;
+
+use super::error::{Error, Result};
+
+/// BLAKE3 content hash (32 bytes, 64 hex characters).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ObjectId(pub [u8; 32]);
+
+impl ObjectId {
+    /// Create an `ObjectId` from raw bytes.
+    pub fn from_bytes(bytes: &[u8; 32]) -> Self {
+        Self(*bytes)
+    }
+
+    /// Create an `ObjectId` from a hex string.
+    pub fn from_hex(hex: &str) -> Result<Self> {
+        let bytes = hex_decode(hex)?;
+        Ok(Self::from_bytes(&bytes))
+    }
+
+    /// Compute an `ObjectId` from content using BLAKE3.
+    pub fn from_content(content: &[u8]) -> Self {
+        let hash = blake3::hash(content);
+        let mut bytes = [0u8; 32];
+        bytes.copy_from_slice(hash.as_bytes());
+        Self(bytes)
+    }
+
+    /// Render as a 64-character lowercase hex string.
+    pub fn to_hex(&self) -> String {
+        hex_encode(&self.0)
+    }
+
+    /// Abbreviated hash (first 7 hex chars), as in `git log --oneline`.
+    pub fn abbreviate(&self) -> String {
+        self.to_hex()[..7].to_string()
+    }
+
+    /// Whether this is the zero/nil OID.
+    pub fn is_nil(&self) -> bool {
+        self.0.iter().all(|&b| b == 0)
+    }
+
+    /// The nil OID constant.
+    pub const fn nil() -> Self {
+        Self([0u8; 32])
+    }
+}
+
+impl fmt::Debug for ObjectId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_hex())
+    }
+}
+
+impl fmt::Display for ObjectId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_hex())
+    }
+}
+
+/// Object kinds in the content-addressable store.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ObjectType {
+    /// Raw data (messages, memories)
+    Blob,
+    /// Directory structure
+    Tree,
+    /// Snapshot with metadata
+    Commit,
+    /// Annotated tag
+    Tag,
+}
+
+impl ObjectType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ObjectType::Blob => "blob",
+            ObjectType::Tree => "tree",
+            ObjectType::Commit => "commit",
+            ObjectType::Tag => "tag",
+        }
+    }
+}
+
+impl std::str::FromStr for ObjectType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "blob" => Ok(ObjectType::Blob),
+            "tree" => Ok(ObjectType::Tree),
+            "commit" => Ok(ObjectType::Commit),
+            "tag" => Ok(ObjectType::Tag),
+            _ => Err(Error::InvalidObjectFormat),
+        }
+    }
+}
+
+/// On-disk header preceding object content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObjectHeader {
+    /// Object kind
+    pub object_type: ObjectType,
+    /// Content size in bytes
+    pub size: u64,
+}
+
+impl ObjectHeader {
+    /// Serialize header and content together (`<type> <size>\0<content>`).
+    pub fn serialize(&self, content: &[u8]) -> Result<Vec<u8>> {
+        let header_str = format!("{} {}\0", self.object_type.as_str(), self.size);
+        let mut result = Vec::with_capacity(header_str.len() + content.len());
+        result.extend_from_slice(header_str.as_bytes());
+        result.extend_from_slice(content);
+        Ok(result)
+    }
+
+    /// Parse an object from on-disk bytes, returning the header and content slice.
+    pub fn deserialize(data: &[u8]) -> Result<(Self, &[u8])> {
+        let null_pos = data
+            .iter()
+            .position(|&b| b == 0)
+            .ok_or(Error::InvalidObjectFormat)?;
+        let header_str =
+            std::str::from_utf8(&data[..null_pos]).map_err(|_| Error::InvalidObjectFormat)?;
+        let parts: Vec<&str> = header_str.splitn(2, ' ').collect();
+        if parts.len() != 2 {
+            return Err(Error::InvalidObjectFormat);
+        }
+        let object_type: ObjectType = parts[0].parse()?;
+        let size = parts[1].parse().map_err(|_| Error::InvalidObjectFormat)?;
+        Ok((Self { object_type, size }, &data[null_pos + 1..]))
+    }
+}
+
+/// Blob object - raw content storage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Blob {
+    /// Raw content bytes
+    pub content: Vec<u8>,
+}
+
+impl Blob {
+    /// Wrap a byte slice as a blob.
+    pub fn new(content: &[u8]) -> Self {
+        Self {
+            content: content.to_vec(),
+        }
+    }
+
+    /// Length in bytes.
+    pub fn size(&self) -> u64 {
+        self.content.len() as u64
+    }
+
+    /// Try to interpret content as UTF-8 text.
+    pub fn to_text(&self) -> Option<&str> {
+        std::str::from_utf8(&self.content).ok()
+    }
+}
+
+/// Tree entry - a reference to a child object.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TreeEntry {
+    /// POSIX mode (100644 for file, 040000 for subtree)
+    pub mode: u32,
+    /// Object id of the child
+    pub oid: ObjectId,
+    /// Name of the entry
+    pub name: String,
+}
+
+impl TreeEntry {
+    /// Create a tree entry.
+    pub fn new(mode: u32, oid: ObjectId, name: &str) -> Self {
+        Self {
+            mode,
+            oid,
+            name: name.to_string(),
+        }
+    }
+
+    /// File mode for blobs.
+    pub const MODE_FILE: u32 = 0o100644;
+    /// Directory mode for subtrees.
+    pub const MODE_DIR: u32 = 0o040000;
+    /// Executable mode.
+    pub const MODE_EXECUTABLE: u32 = 0o100755;
+}
+
+/// Tree object - directory structure.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Tree {
+    /// Entries in the tree
+    pub entries: Vec<TreeEntry>,
+}
+
+impl Tree {
+    /// Create a new empty tree.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Push an entry.
+    pub fn add_entry(&mut self, entry: TreeEntry) {
+        self.entries.push(entry);
+    }
+
+    /// Lookup an entry by name.
+    pub fn get_entry(&self, name: &str) -> Option<&TreeEntry> {
+        self.entries.iter().find(|e| e.name == name)
+    }
+
+    /// Remove an entry by name.
+    pub fn remove_entry(&mut self, name: &str) -> Option<TreeEntry> {
+        self.entries
+            .iter()
+            .position(|e| e.name == name)
+            .map(|i| self.entries.remove(i))
+    }
+}
+
+/// Author / committer information.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Author {
+    /// Human-readable name.
+    pub name: String,
+    /// Email address.
+    pub email: String,
+    /// Timestamp associated with the author/committer.
+    pub timestamp: DateTime<Utc>,
+}
+
+impl Author {
+    /// Create an author with `Utc::now()` timestamp.
+    pub fn new(name: &str, email: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            email: email.to_string(),
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create an author with an explicit timestamp.
+    pub fn with_timestamp(name: &str, email: &str, timestamp: DateTime<Utc>) -> Self {
+        Self {
+            name: name.to_string(),
+            email: email.to_string(),
+            timestamp,
+        }
+    }
+}
+
+/// Commit source classification (where the commit originated).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommitSource {
+    /// Manually triggered by a user
+    UserExplicit,
+    /// Written inline by the agent
+    AgentInline,
+    /// Async consolidation job
+    SleepConsolidation,
+    /// Skill extracted from conversation
+    SkillLearning,
+    /// Imported from external format
+    ImportExternal,
+    /// Three-way semantic merge
+    Merge,
+}
+
+/// Memory scope for multi-agent isolation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MemoryScope {
+    /// User-scoped memory
+    User(String),
+    /// Project-scoped memory
+    Project(String),
+    /// Organization-scoped memory
+    Org(String),
+    /// Session-scoped memory
+    Session(String),
+    /// Agent-scoped memory
+    Agent(String),
+}
+
+/// Commit metadata extensions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitMetadata {
+    /// Token budget change introduced by this commit
+    pub token_delta: i32,
+    /// Confidence score in `[0.0, 1.0]`
+    pub confidence: f32,
+    /// Source classification
+    pub source: CommitSource,
+    /// Optional scope of the memory
+    pub scope: Option<MemoryScope>,
+}
+
+impl Default for CommitMetadata {
+    fn default() -> Self {
+        Self {
+            token_delta: 0,
+            confidence: 1.0,
+            source: CommitSource::UserExplicit,
+            scope: None,
+        }
+    }
+}
+
+/// Commit object - snapshot with metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Commit {
+    /// Tree object id
+    pub tree_oid: ObjectId,
+    /// Parent commit ids
+    pub parent_oids: Vec<ObjectId>,
+    /// Author information
+    pub author: Author,
+    /// Committer information
+    pub committer: Author,
+    /// Commit message
+    pub message: String,
+    /// Optional signature (PGP/GPG)
+    pub signature: Option<String>,
+    /// MemSt metadata extensions
+    pub metadata: CommitMetadata,
+}
+
+impl Commit {
+    /// Create a new commit (committer defaults to the author).
+    pub fn new(tree_oid: ObjectId, author: Author, message: &str) -> Self {
+        Self {
+            tree_oid,
+            parent_oids: Vec::new(),
+            author: author.clone(),
+            committer: author,
+            message: message.to_string(),
+            signature: None,
+            metadata: CommitMetadata::default(),
+        }
+    }
+
+    /// Create a commit with explicit metadata.
+    pub fn with_metadata(
+        tree_oid: ObjectId,
+        author: Author,
+        message: &str,
+        metadata: CommitMetadata,
+    ) -> Self {
+        Self {
+            tree_oid,
+            parent_oids: Vec::new(),
+            author: author.clone(),
+            committer: author,
+            message: message.to_string(),
+            signature: None,
+            metadata,
+        }
+    }
+
+    /// Add a parent commit.
+    pub fn add_parent(&mut self, parent_oid: ObjectId) {
+        self.parent_oids.push(parent_oid);
+    }
+
+    /// Whether this commit has more than one parent.
+    pub fn is_merge(&self) -> bool {
+        self.parent_oids.len() > 1
+    }
+
+    /// First parent (used for fast-forward detection).
+    pub fn first_parent(&self) -> Option<ObjectId> {
+        self.parent_oids.first().copied()
+    }
+}
+
+/// Tag object - annotated tag for marking commits.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tag {
+    /// Tagged object oid
+    pub target_oid: ObjectId,
+    /// Tag name
+    pub name: String,
+    /// Tagger information
+    pub tagger: Author,
+    /// Tag message
+    pub message: String,
+    /// Optional signature
+    pub signature: Option<String>,
+    /// Whether this is a lightweight tag
+    pub is_lightweight: bool,
+}
+
+impl Tag {
+    /// Create an annotated tag.
+    pub fn new(target_oid: ObjectId, name: &str, tagger: Author, message: &str) -> Self {
+        Self {
+            target_oid,
+            name: name.to_string(),
+            tagger,
+            message: message.to_string(),
+            signature: None,
+            is_lightweight: false,
+        }
+    }
+
+    /// Create a lightweight tag (no tagger metadata, no message).
+    pub fn lightweight(target_oid: ObjectId, name: &str) -> Self {
+        Self {
+            target_oid,
+            name: name.to_string(),
+            tagger: Author::new("memst", "memst@local"),
+            message: String::new(),
+            signature: None,
+            is_lightweight: true,
+        }
+    }
+}
+
+/// Object store - on-disk content-addressable storage.
+pub struct ObjectStore {
+    base_path: PathBuf,
+}
+
+impl ObjectStore {
+    /// Open or create an object store at `base_path`.
+    pub fn new(base_path: &PathBuf) -> Result<Self> {
+        std::fs::create_dir_all(base_path)?;
+        Ok(Self {
+            base_path: base_path.clone(),
+        })
+    }
+
+    fn object_path(&self, oid: &ObjectId) -> PathBuf {
+        let hex = oid.to_hex();
+        let dir = &hex[..2];
+        let file = &hex[2..];
+        self.base_path.join("objects").join(dir).join(file)
+    }
+
+    /// Write a blob, returning its content hash.
+    pub fn write_blob(&mut self, blob: &Blob) -> Result<ObjectId> {
+        let content = bincode::serialize(blob)?;
+        let oid = ObjectId::from_content(&content);
+        if self.object_path(&oid).exists() {
+            return Ok(oid);
+        }
+        self.write_object(oid, ObjectType::Blob, &content)
+    }
+
+    /// Write a tree.
+    pub fn write_tree(&mut self, tree: &Tree) -> Result<ObjectId> {
+        let content = bincode::serialize(tree)?;
+        let oid = ObjectId::from_content(&content);
+        if self.object_path(&oid).exists() {
+            return Ok(oid);
+        }
+        self.write_object(oid, ObjectType::Tree, &content)
+    }
+
+    /// Write a commit.
+    pub fn write_commit(&mut self, commit: &Commit) -> Result<ObjectId> {
+        let content = bincode::serialize(commit)?;
+        let oid = ObjectId::from_content(&content);
+        if self.object_path(&oid).exists() {
+            return Ok(oid);
+        }
+        self.write_object(oid, ObjectType::Commit, &content)
+    }
+
+    /// Write an annotated/lightweight tag.
+    pub fn write_tag(&mut self, tag: &Tag) -> Result<ObjectId> {
+        let content = bincode::serialize(tag)?;
+        let oid = ObjectId::from_content(&content);
+        if self.object_path(&oid).exists() {
+            return Ok(oid);
+        }
+        self.write_object(oid, ObjectType::Tag, &content)
+    }
+
+    fn write_object(
+        &self,
+        oid: ObjectId,
+        object_type: ObjectType,
+        data: &[u8],
+    ) -> Result<ObjectId> {
+        let path = self.object_path(&oid);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let header = ObjectHeader {
+            object_type,
+            size: data.len() as u64,
+        };
+        let serialized = header.serialize(data)?;
+        let temp_path = path.with_extension("tmp");
+        std::fs::write(&temp_path, &serialized)?;
+        std::fs::rename(&temp_path, &path)?;
+        Ok(oid)
+    }
+
+    fn read_object_data(&self, oid: &ObjectId, expected_type: ObjectType) -> Result<Vec<u8>> {
+        let path = self.object_path(oid);
+        if !path.exists() {
+            return Err(Error::ObjectNotFound(*oid));
+        }
+        let content = std::fs::read(&path)?;
+        let (header, data) = ObjectHeader::deserialize(&content)?;
+        if header.object_type != expected_type {
+            return Err(Error::InvalidObjectFormat);
+        }
+        Ok(data.to_vec())
+    }
+
+    /// Read a blob by id.
+    pub fn read_blob(&self, oid: &ObjectId) -> Result<Blob> {
+        let data = self.read_object_data(oid, ObjectType::Blob)?;
+        Ok(bincode::deserialize(&data)?)
+    }
+
+    /// Read a tree by id.
+    pub fn read_tree(&self, oid: &ObjectId) -> Result<Tree> {
+        let data = self.read_object_data(oid, ObjectType::Tree)?;
+        Ok(bincode::deserialize(&data)?)
+    }
+
+    /// Read a commit by id.
+    pub fn read_commit(&self, oid: &ObjectId) -> Result<Commit> {
+        let data = self.read_object_data(oid, ObjectType::Commit)?;
+        Ok(bincode::deserialize(&data)?)
+    }
+
+    /// Read a tag by id.
+    pub fn read_tag(&self, oid: &ObjectId) -> Result<Tag> {
+        let data = self.read_object_data(oid, ObjectType::Tag)?;
+        Ok(bincode::deserialize(&data)?)
+    }
+
+    /// Whether the store contains the given object.
+    pub fn exists(&self, oid: &ObjectId) -> bool {
+        self.object_path(oid).exists()
+    }
+
+    /// List every object id present in the store.
+    pub fn list_objects(&self) -> Result<Vec<ObjectId>> {
+        let mut oids = Vec::new();
+        let objects_dir = self.base_path.join("objects");
+        if !objects_dir.exists() {
+            return Ok(oids);
+        }
+        for entry in std::fs::read_dir(&objects_dir)? {
+            let dir = entry?;
+            for subentry in std::fs::read_dir(dir.path())? {
+                let file = subentry?;
+                let file_name = file.file_name().to_string_lossy().to_string();
+                let hex = format!("{}{}", dir.file_name().to_string_lossy(), file_name);
+                if let Ok(oid) = ObjectId::from_hex(&hex) {
+                    oids.push(oid);
+                }
+            }
+        }
+        Ok(oids)
+    }
+
+    /// Number of objects in the store.
+    pub fn count(&self) -> Result<usize> {
+        Ok(self.list_objects()?.len())
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+fn hex_decode(hex: &str) -> Result<[u8; 32]> {
+    if hex.len() != 64 {
+        return Err(Error::InvalidObjectId(format!(
+            "Expected 64 hex chars, got {}",
+            hex.len()
+        )));
+    }
+    let mut bytes = [0u8; 32];
+    for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+        let s = std::str::from_utf8(chunk)
+            .map_err(|_| Error::InvalidObjectId(format!("Invalid hex at position {}", i)))?;
+        bytes[i] = u8::from_str_radix(s, 16)
+            .map_err(|_| Error::InvalidObjectId(format!("Invalid hex at position {}", i)))?;
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn object_id_blake3() {
+        let oid = ObjectId::from_content(b"hello");
+        assert_eq!(oid.to_hex().len(), 64);
+        assert_eq!(oid.abbreviate().len(), 7);
+    }
+
+    #[test]
+    fn blob_roundtrip() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut store = ObjectStore::new(&dir.path().to_path_buf()).unwrap();
+        let oid = store.write_blob(&Blob::new(b"abc")).unwrap();
+        let blob = store.read_blob(&oid).unwrap();
+        assert_eq!(blob.content, b"abc");
+    }
+
+    #[test]
+    fn commit_with_metadata() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut store = ObjectStore::new(&dir.path().to_path_buf()).unwrap();
+        let tree_oid = store.write_tree(&Tree::new()).unwrap();
+        let author = Author::new("test", "test@example.com");
+        let metadata = CommitMetadata {
+            token_delta: 42,
+            confidence: 0.9,
+            source: CommitSource::AgentInline,
+            scope: Some(MemoryScope::Session("abc".to_string())),
+        };
+        let commit = Commit::with_metadata(tree_oid, author, "msg", metadata);
+        let oid = store.write_commit(&commit).unwrap();
+        let read = store.read_commit(&oid).unwrap();
+        assert_eq!(read.metadata.token_delta, 42);
+        assert!(matches!(read.metadata.source, CommitSource::AgentInline));
+    }
+}

--- a/helix-db/src/memst/store.rs
+++ b/helix-db/src/memst/store.rs
@@ -1,0 +1,717 @@
+//! File and session management.
+//!
+//! Port of the search-independent core of `memst-core/src/store/mod.rs`. The
+//! upstream module has both a path-based session/messages/memory layout and a
+//! search-index integration; here we keep only the layout and file APIs since
+//! HelixDB already provides its own indexing/search via its query engine.
+//!
+//! On-disk layout managed by [`SessionStore`]:
+//!
+//! ```text
+//! <base>/
+//!   manifest.json
+//!   schema_version
+//!   store.lock
+//!   sessions/
+//!     <session-uuid>/
+//!       metadata.json
+//!       messages.bin
+//!       messages.idx
+//!       operations.log
+//!       memory/
+//!         working.bin
+//!         short.bin
+//!         long.bin
+//!       extractions/
+//!   attachments/
+//! ```
+
+use bincode::Options;
+use chrono::Utc;
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+use super::error::{Error, Result};
+use super::types::{
+    Manifest, MemoryItem, MemoryQuery, MemoryTier, Message, Operation, OperationQuery,
+    OperationType, Role, SessionMetadata, SessionSummary,
+};
+
+const SCHEMA_VERSION: &str = "1.0.0";
+
+/// Index entry for message lookup.
+///
+/// Each entry corresponds to a line in `messages.idx` and points at a record
+/// inside `messages.bin`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageIndexEntry {
+    /// Message UUID
+    pub message_id: Uuid,
+    /// Byte offset in `messages.bin`
+    pub byte_offset: u64,
+    /// Byte length of the message record
+    pub byte_length: u64,
+    /// Timestamp
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    /// Role for quick filtering
+    pub role: Role,
+}
+
+impl MessageIndexEntry {
+    /// Create a new index entry.
+    pub fn new(
+        message_id: Uuid,
+        byte_offset: u64,
+        byte_length: u64,
+        timestamp: chrono::DateTime<chrono::Utc>,
+        role: Role,
+    ) -> Self {
+        Self {
+            message_id,
+            byte_offset,
+            byte_length,
+            timestamp,
+            role,
+        }
+    }
+}
+
+/// Session storage with the file-based layout described in the module docs.
+///
+/// Holds an exclusive file lock on `store.lock` for the lifetime of the
+/// instance, ensuring only one process mutates a given store at a time.
+pub struct SessionStore {
+    base_path: PathBuf,
+    manifest_path: PathBuf,
+    sessions_dir: PathBuf,
+    attachments_dir: PathBuf,
+    _lock_file: File,
+}
+
+impl SessionStore {
+    /// Initialize a fresh session store at `base_path`.
+    pub fn init(base_path: &Path) -> Result<Self> {
+        fs::create_dir_all(base_path)?;
+        fs::create_dir_all(base_path.join("sessions"))?;
+        fs::create_dir_all(base_path.join("attachments"))?;
+
+        fs::write(base_path.join("schema_version"), SCHEMA_VERSION)?;
+
+        let manifest = Manifest::new();
+        let manifest_path = base_path.join("manifest.json");
+        fs::write(&manifest_path, serde_json::to_string_pretty(&manifest)?)?;
+
+        let lock_path = base_path.join("store.lock");
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        // Use UFCS so this resolves to fs2's trait method even on Rust >=1.89
+        // where `std::fs::File::lock_exclusive` is also stable.
+        FileExt::lock_exclusive(&lock_file)
+            .map_err(|e| Error::LockError(e.to_string()))?;
+
+        Ok(Self {
+            base_path: base_path.to_path_buf(),
+            manifest_path,
+            sessions_dir: base_path.join("sessions"),
+            attachments_dir: base_path.join("attachments"),
+            _lock_file: lock_file,
+        })
+    }
+
+    /// Open an existing session store.
+    pub fn open(base_path: &Path) -> Result<Self> {
+        let schema_version = fs::read_to_string(base_path.join("schema_version"))?;
+        if schema_version.trim() != SCHEMA_VERSION {
+            return Err(Error::VersionMismatch {
+                expected: SCHEMA_VERSION.to_string(),
+                found: schema_version,
+            });
+        }
+
+        let lock_path = base_path.join("store.lock");
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&lock_path)?;
+        FileExt::lock_exclusive(&lock_file)
+            .map_err(|e| Error::LockError(e.to_string()))?;
+
+        Ok(Self {
+            base_path: base_path.to_path_buf(),
+            manifest_path: base_path.join("manifest.json"),
+            sessions_dir: base_path.join("sessions"),
+            attachments_dir: base_path.join("attachments"),
+            _lock_file: lock_file,
+        })
+    }
+
+    /// The store's base directory.
+    pub fn base_path(&self) -> &Path {
+        &self.base_path
+    }
+
+    /// Directory housing attachments.
+    pub fn attachments_dir(&self) -> &Path {
+        &self.attachments_dir
+    }
+
+    /// Path of a session directory (does not check existence).
+    pub fn session_path(&self, session_id: Uuid) -> PathBuf {
+        self.sessions_dir.join(session_id.to_string())
+    }
+
+    fn read_manifest(&self) -> Result<Manifest> {
+        let content = fs::read_to_string(&self.manifest_path)?;
+        Ok(serde_json::from_str(&content)?)
+    }
+
+    fn write_manifest(&self, manifest: &Manifest) -> Result<()> {
+        fs::write(&self.manifest_path, serde_json::to_string_pretty(manifest)?)?;
+        Ok(())
+    }
+
+    /// Create a new session and return its id.
+    pub fn create_session(&self, metadata: SessionMetadata) -> Result<Uuid> {
+        let session_id = Uuid::new_v4();
+        let session_path = self.session_path(session_id);
+
+        fs::create_dir_all(&session_path)?;
+        fs::write(
+            session_path.join("metadata.json"),
+            serde_json::to_string_pretty(&metadata)?,
+        )?;
+        fs::write(session_path.join("messages.bin"), "")?;
+        fs::write(
+            session_path.join("messages.idx"),
+            "# message_id byte_offset byte_length timestamp role\n",
+        )?;
+        fs::write(session_path.join("operations.log"), "")?;
+        fs::create_dir_all(session_path.join("memory"))?;
+        fs::create_dir_all(session_path.join("extractions"))?;
+
+        let mut manifest = self.read_manifest()?;
+        manifest.upsert_session(SessionSummary {
+            id: session_id,
+            name: metadata.name.clone(),
+            model: metadata.model.clone(),
+            tags: metadata.tags.clone(),
+            created_at: metadata.created_at,
+            last_activity: metadata.last_activity,
+            message_count: 0,
+        });
+        self.write_manifest(&manifest)?;
+
+        Ok(session_id)
+    }
+
+    /// Load metadata for a session.
+    pub fn get_session(&self, session_id: Uuid) -> Result<Option<SessionMetadata>> {
+        let metadata_path = self.session_path(session_id).join("metadata.json");
+        if !metadata_path.exists() {
+            return Ok(None);
+        }
+        let content = fs::read_to_string(&metadata_path)?;
+        Ok(Some(serde_json::from_str(&content)?))
+    }
+
+    /// List every known session summary.
+    pub fn list_sessions(&self) -> Result<Vec<SessionSummary>> {
+        let manifest = self.read_manifest()?;
+        Ok(manifest.sessions.values().cloned().collect())
+    }
+
+    /// Delete a session and remove it from the manifest.
+    pub fn delete_session(&self, session_id: Uuid) -> Result<()> {
+        let session_path = self.session_path(session_id);
+        if !session_path.exists() {
+            return Err(Error::SessionNotFound(session_id));
+        }
+        fs::remove_dir_all(&session_path)?;
+        let mut manifest = self.read_manifest()?;
+        manifest.remove_session(&session_id);
+        self.write_manifest(&manifest)?;
+        Ok(())
+    }
+
+    /// Append a message to a session, updating both the binary log and the
+    /// text index.
+    pub fn append_message(&self, session_id: Uuid, message: Message) -> Result<()> {
+        let session_path = self.session_path(session_id);
+        let messages_path = session_path.join("messages.bin");
+        let index_path = session_path.join("messages.idx");
+
+        let byte_offset = fs::metadata(&messages_path)?.len();
+
+        let options = bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes();
+        let encoded = options.serialize(&message)?;
+
+        let mut file = OpenOptions::new().append(true).open(&messages_path)?;
+        file.write_all(&encoded)?;
+        file.flush()?;
+        drop(file);
+
+        let index_entry = format!(
+            "{} {} {} {} {}\n",
+            message.id,
+            byte_offset,
+            encoded.len(),
+            message.timestamp.format("%Y-%m-%dT%H:%M:%SZ"),
+            message.role
+        );
+        let mut index_file = OpenOptions::new().append(true).open(&index_path)?;
+        index_file.write_all(index_entry.as_bytes())?;
+        index_file.flush()?;
+        drop(index_file);
+
+        let mut metadata = self
+            .get_session(session_id)?
+            .ok_or(Error::SessionNotFound(session_id))?;
+        metadata.message_count += 1;
+        metadata.last_activity = Utc::now();
+        if let Some(count) = message.token_count {
+            metadata.token_count += count as u64;
+        }
+        fs::write(
+            session_path.join("metadata.json"),
+            serde_json::to_string_pretty(&metadata)?,
+        )?;
+
+        let mut manifest = self.read_manifest()?;
+        if let Some(summary) = manifest.sessions.get_mut(&session_id) {
+            summary.message_count = metadata.message_count;
+            summary.last_activity = metadata.last_activity;
+        }
+        self.write_manifest(&manifest)?;
+
+        Ok(())
+    }
+
+    /// Read every message in a session (in append order).
+    pub fn get_messages(&self, session_id: Uuid) -> Result<Vec<Message>> {
+        let messages_path = self.session_path(session_id).join("messages.bin");
+        if !messages_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let file = File::open(&messages_path)?;
+        let mut reader = BufReader::new(file);
+        let options = bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes();
+
+        let mut messages = Vec::new();
+        loop {
+            match options.deserialize_from(&mut reader) {
+                Ok(msg) => messages.push(msg),
+                Err(e) => {
+                    let err_kind: &bincode::ErrorKind = Box::as_ref(&e);
+                    if let bincode::ErrorKind::Io(io_err) = err_kind {
+                        if io_err.kind() == io::ErrorKind::UnexpectedEof {
+                            break;
+                        }
+                    }
+                    return Err(Error::from(e));
+                }
+            }
+        }
+        Ok(messages)
+    }
+
+    /// Read messages in the half-open range `[start, end)`.
+    pub fn get_messages_range(
+        &self,
+        session_id: Uuid,
+        start: usize,
+        end: usize,
+    ) -> Result<Vec<Message>> {
+        let all = self.get_messages(session_id)?;
+        Ok(all
+            .into_iter()
+            .skip(start)
+            .take(end.saturating_sub(start))
+            .collect())
+    }
+
+    /// Read the message index for a session.
+    pub fn read_message_index(&self, session_id: Uuid) -> Result<Vec<MessageIndexEntry>> {
+        let index_path = self.session_path(session_id).join("messages.idx");
+        if !index_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let content = fs::read_to_string(&index_path)?;
+        let mut entries = Vec::new();
+
+        for line in content.lines().skip(1) {
+            if line.trim().is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 5 {
+                let entry = MessageIndexEntry {
+                    message_id: Uuid::parse_str(parts[0])?,
+                    byte_offset: parts[1].parse::<u64>()?,
+                    byte_length: parts[2].parse::<u64>()?,
+                    timestamp: chrono::DateTime::parse_from_rfc3339(parts[3])
+                        .map(|d| d.with_timezone(&chrono::Utc))
+                        .unwrap_or_else(|_| chrono::Utc::now()),
+                    role: match parts[4] {
+                        "system" => Role::System,
+                        "user" => Role::User,
+                        "assistant" => Role::Assistant,
+                        "tool" => Role::Tool,
+                        _ => Role::User,
+                    },
+                };
+                entries.push(entry);
+            }
+        }
+        Ok(entries)
+    }
+
+    /// Append an operation entry to `operations.log`.
+    pub fn append_operation(&self, session_id: Uuid, operation: Operation) -> Result<()> {
+        let ops_path = self.session_path(session_id).join("operations.log");
+        let json_line = serde_json::to_string(&operation)?;
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&ops_path)?
+            .write_all(format!("{}\n", json_line).as_bytes())?;
+        Ok(())
+    }
+
+    /// Read every operation logged for a session.
+    pub fn get_operations(&self, session_id: Uuid) -> Result<Vec<Operation>> {
+        let ops_path = self.session_path(session_id).join("operations.log");
+        if !ops_path.exists() {
+            return Ok(Vec::new());
+        }
+        let content = fs::read_to_string(&ops_path)?;
+        let mut operations = Vec::new();
+        for line in content.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            operations.push(serde_json::from_str(line)?);
+        }
+        Ok(operations)
+    }
+
+    /// Filter operations using `query`.
+    pub fn query_operations(
+        &self,
+        session_id: Uuid,
+        query: OperationQuery,
+    ) -> Result<Vec<Operation>> {
+        let mut filtered: Vec<_> = self
+            .get_operations(session_id)?
+            .into_iter()
+            .filter(|op| {
+                if !query.op_types.is_empty() && !query.op_types.contains(&op.op_type) {
+                    return false;
+                }
+                if let Some(from) = query.from {
+                    if op.timestamp < from {
+                        return false;
+                    }
+                }
+                if let Some(to) = query.to {
+                    if op.timestamp > to {
+                        return false;
+                    }
+                }
+                true
+            })
+            .collect();
+
+        if query.limit > 0 && filtered.len() > query.limit {
+            filtered.truncate(query.limit);
+        }
+        Ok(filtered)
+    }
+
+    /// Convenience helper - filter operations by type.
+    pub fn get_operations_by_type(
+        &self,
+        session_id: Uuid,
+        op_type: OperationType,
+    ) -> Result<Vec<Operation>> {
+        self.query_operations(session_id, OperationQuery::new().by_type(op_type))
+    }
+
+    fn memory_tier_path(&self, session_id: Uuid, tier: MemoryTier) -> PathBuf {
+        let tier_name = match tier {
+            MemoryTier::Working => "working.bin",
+            MemoryTier::ShortTerm => "short.bin",
+            MemoryTier::LongTerm => "long.bin",
+        };
+        self.session_path(session_id).join("memory").join(tier_name)
+    }
+
+    /// Add a memory item to a tier file.
+    pub fn add_memory(
+        &self,
+        session_id: Uuid,
+        tier: MemoryTier,
+        item: MemoryItem,
+    ) -> Result<MemoryItem> {
+        let tier_path = self.memory_tier_path(session_id, tier);
+        if let Some(parent) = tier_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let mut memories = self.load_memories(&tier_path)?;
+        memories.push(item.clone());
+        self.save_memories(&tier_path, &memories)?;
+        Ok(item)
+    }
+
+    /// Load every memory in a tier file.
+    pub fn get_tier(
+        &self,
+        session_id: Uuid,
+        tier: MemoryTier,
+    ) -> Result<Vec<MemoryItem>> {
+        self.load_memories(&self.memory_tier_path(session_id, tier))
+    }
+
+    /// Find a memory by id, searching every tier.
+    pub fn get_memory(
+        &self,
+        session_id: Uuid,
+        memory_id: Uuid,
+    ) -> Result<Option<MemoryItem>> {
+        for tier in [MemoryTier::Working, MemoryTier::ShortTerm, MemoryTier::LongTerm] {
+            if let Some(memory) = self
+                .get_tier(session_id, tier)?
+                .into_iter()
+                .find(|m| m.id == memory_id)
+            {
+                return Ok(Some(memory));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Record an access to a memory and persist the updated counters.
+    pub fn access_memory(&self, session_id: Uuid, memory_id: Uuid) -> Result<bool> {
+        for tier in [MemoryTier::Working, MemoryTier::ShortTerm, MemoryTier::LongTerm] {
+            let tier_path = self.memory_tier_path(session_id, tier);
+            if !tier_path.exists() {
+                continue;
+            }
+            let mut memories = self.load_memories(&tier_path)?;
+            if let Some(pos) = memories.iter().position(|m| m.id == memory_id) {
+                memories[pos].record_access();
+                self.save_memories(&tier_path, &memories)?;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Retrieve memories matching `query`. Searches across all three tiers.
+    pub fn retrieve_memories(
+        &self,
+        session_id: Uuid,
+        query: MemoryQuery,
+    ) -> Result<Vec<MemoryItem>> {
+        let mut results = Vec::new();
+        for tier in [MemoryTier::Working, MemoryTier::ShortTerm, MemoryTier::LongTerm] {
+            for memory in self.get_tier(session_id, tier)? {
+                if !query.keywords.is_empty() {
+                    let lower = memory.content.to_lowercase();
+                    if !query.keywords.iter().all(|kw| lower.contains(&kw.to_lowercase())) {
+                        continue;
+                    }
+                }
+                if !query.tags.is_empty()
+                    && !query.tags.iter().all(|tag| memory.tags.contains(tag))
+                {
+                    continue;
+                }
+                if let Some(min_conf) = query.min_confidence {
+                    if memory.confidence < min_conf {
+                        continue;
+                    }
+                }
+                results.push(memory);
+            }
+        }
+        results.sort_by(|a, b| {
+            b.importance
+                .partial_cmp(&a.importance)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        if query.limit > 0 && results.len() > query.limit {
+            results.truncate(query.limit);
+        }
+        Ok(results)
+    }
+
+    /// Move a memory from its current tier into `to_tier`.
+    pub fn promote_memory(
+        &self,
+        session_id: Uuid,
+        memory_id: Uuid,
+        to_tier: MemoryTier,
+    ) -> Result<bool> {
+        for tier in [MemoryTier::Working, MemoryTier::ShortTerm, MemoryTier::LongTerm] {
+            let tier_path = self.memory_tier_path(session_id, tier);
+            if !tier_path.exists() {
+                continue;
+            }
+            let mut memories = self.load_memories(&tier_path)?;
+            if let Some(pos) = memories.iter().position(|m| m.id == memory_id) {
+                let memory = memories.remove(pos);
+                self.save_memories(&tier_path, &memories)?;
+                self.add_memory(session_id, to_tier, memory)?;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn load_memories(&self, path: &Path) -> Result<Vec<MemoryItem>> {
+        if !path.exists() {
+            return Ok(Vec::new());
+        }
+        let file = File::open(path)?;
+        let mut reader = BufReader::new(file);
+        let options = bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes();
+
+        let mut memories = Vec::new();
+        loop {
+            match options.deserialize_from(&mut reader) {
+                Ok(memory) => memories.push(memory),
+                Err(e) => {
+                    let err_kind: &bincode::ErrorKind = Box::as_ref(&e);
+                    if let bincode::ErrorKind::Io(io_err) = err_kind {
+                        if io_err.kind() == io::ErrorKind::UnexpectedEof {
+                            break;
+                        }
+                    }
+                    return Err(Error::from(e));
+                }
+            }
+        }
+        Ok(memories)
+    }
+
+    fn save_memories(&self, path: &Path, memories: &[MemoryItem]) -> Result<()> {
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
+        let mut writer = BufWriter::new(file);
+        let options = bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes();
+        for memory in memories {
+            options.serialize_into(&mut writer, memory)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memst::types::{Content, MemoryType};
+
+    #[test]
+    fn init_and_open_roundtrip() {
+        let dir = tempfile::TempDir::new().unwrap();
+        {
+            let _store = SessionStore::init(dir.path()).unwrap();
+        }
+        let _store = SessionStore::open(dir.path()).unwrap();
+    }
+
+    #[test]
+    fn create_and_list_sessions() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = SessionStore::init(dir.path()).unwrap();
+        let id = store
+            .create_session(SessionMetadata::new("s1", "gpt-4"))
+            .unwrap();
+        assert!(store.get_session(id).unwrap().is_some());
+        assert_eq!(store.list_sessions().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn append_and_read_messages() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = SessionStore::init(dir.path()).unwrap();
+        let id = store
+            .create_session(SessionMetadata::new("s1", "gpt-4"))
+            .unwrap();
+
+        store
+            .append_message(id, Message::new(Role::User, Content::Text("hi".into())))
+            .unwrap();
+        store
+            .append_message(
+                id,
+                Message::new(Role::Assistant, Content::Text("hello".into())),
+            )
+            .unwrap();
+
+        let msgs = store.get_messages(id).unwrap();
+        assert_eq!(msgs.len(), 2);
+        let idx = store.read_message_index(id).unwrap();
+        assert_eq!(idx.len(), 2);
+    }
+
+    #[test]
+    fn memory_tiers_and_retrieval() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = SessionStore::init(dir.path()).unwrap();
+        let id = store
+            .create_session(SessionMetadata::new("s1", "gpt-4"))
+            .unwrap();
+
+        let m = MemoryItem::new("user prefers tokio", "test")
+            .with_memory_type(MemoryType::Semantic)
+            .with_tag("rust");
+        store.add_memory(id, MemoryTier::Working, m.clone()).unwrap();
+
+        let q = MemoryQuery::new().with_keyword("tokio").with_tag("rust");
+        let hits = store.retrieve_memories(id, q).unwrap();
+        assert_eq!(hits.len(), 1);
+
+        assert!(store.promote_memory(id, m.id, MemoryTier::LongTerm).unwrap());
+        assert!(store.get_tier(id, MemoryTier::Working).unwrap().is_empty());
+        assert_eq!(store.get_tier(id, MemoryTier::LongTerm).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn operations_log_roundtrip() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = SessionStore::init(dir.path()).unwrap();
+        let id = store
+            .create_session(SessionMetadata::new("s1", "gpt-4"))
+            .unwrap();
+        store
+            .append_operation(
+                id,
+                Operation::tool_call("search", serde_json::json!({"q": "x"}), 50),
+            )
+            .unwrap();
+        let ops = store.get_operations(id).unwrap();
+        assert_eq!(ops.len(), 1);
+    }
+}

--- a/helix-db/src/memst/types.rs
+++ b/helix-db/src/memst/types.rs
@@ -1,0 +1,593 @@
+//! Core data types for MemSt session and memory management.
+//!
+//! This is a focused port of `memst-core/src/types/mod.rs` covering only the
+//! types required for the [`super::memory`] and [`super::store`] modules:
+//! messages, sessions, operations, and memory items. Knowledge-graph types
+//! (entities/relationships) and KG-evolution types live in upstream `memst`
+//! and are not part of the HelixDB integration.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// Represents the role of a message in a conversation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Role {
+    /// System prompt that defines the assistant's behavior
+    System,
+    /// User's input message
+    User,
+    /// Assistant's response message
+    Assistant,
+    /// Message from a tool execution
+    Tool,
+}
+
+impl std::fmt::Display for Role {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Role::System => write!(f, "system"),
+            Role::User => write!(f, "user"),
+            Role::Assistant => write!(f, "assistant"),
+            Role::Tool => write!(f, "tool"),
+        }
+    }
+}
+
+/// Content part types for multipart messages.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ContentPart {
+    /// Plain text content
+    Text(String),
+    /// Image content with data and mime type
+    Image {
+        /// Image binary data
+        data: Vec<u8>,
+        /// MIME type (e.g., "image/png")
+        mime_type: String,
+    },
+    /// File reference
+    File {
+        /// Content hash of the file
+        hash: String,
+        /// Original filename
+        filename: String,
+    },
+}
+
+/// Message content - either plain text or multipart.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Content {
+    /// Plain text message
+    Text(String),
+    /// Multipart message with multiple content parts
+    MultiPart(Vec<ContentPart>),
+}
+
+impl Default for Content {
+    fn default() -> Self {
+        Content::Text(String::new())
+    }
+}
+
+impl From<String> for Content {
+    fn from(s: String) -> Self {
+        Content::Text(s)
+    }
+}
+
+impl From<&str> for Content {
+    fn from(s: &str) -> Self {
+        Content::Text(s.to_string())
+    }
+}
+
+/// A single message in a conversation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Message {
+    /// Unique message identifier
+    pub id: Uuid,
+    /// Role of the message sender
+    pub role: Role,
+    /// Message content
+    pub content: Content,
+    /// Timestamp when the message was created
+    pub timestamp: DateTime<Utc>,
+    /// Optional metadata (model name, token usage, etc.)
+    pub metadata: HashMap<String, serde_json::Value>,
+    /// Optional token count for this message
+    pub token_count: Option<u32>,
+}
+
+impl Message {
+    /// Create a new message with the given role and content.
+    pub fn new(role: Role, content: impl Into<Content>) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            role,
+            content: content.into(),
+            timestamp: Utc::now(),
+            metadata: HashMap::new(),
+            token_count: None,
+        }
+    }
+
+    /// Create a user message.
+    pub fn user(content: impl Into<Content>) -> Self {
+        Self::new(Role::User, content)
+    }
+
+    /// Create an assistant message.
+    pub fn assistant(content: impl Into<Content>) -> Self {
+        Self::new(Role::Assistant, content)
+    }
+
+    /// Create a system message.
+    pub fn system(content: impl Into<Content>) -> Self {
+        Self::new(Role::System, content)
+    }
+
+    /// Set the token count for this message.
+    pub fn with_token_count(mut self, count: u32) -> Self {
+        self.token_count = Some(count);
+        self
+    }
+
+    /// Add metadata to this message.
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Serialize) -> Self {
+        self.metadata
+            .insert(key.into(), serde_json::to_value(value).unwrap());
+        self
+    }
+}
+
+impl Default for Message {
+    fn default() -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            role: Role::User,
+            content: Content::Text(String::new()),
+            timestamp: Utc::now(),
+            metadata: HashMap::new(),
+            token_count: None,
+        }
+    }
+}
+
+/// Session metadata stored in `metadata.json`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SessionMetadata {
+    /// Human-readable session name
+    pub name: String,
+    /// Model used for this session
+    pub model: String,
+    /// Tags for categorization
+    pub tags: Vec<String>,
+    /// Creation timestamp
+    pub created_at: DateTime<Utc>,
+    /// Last activity timestamp
+    pub last_activity: DateTime<Utc>,
+    /// Total message count
+    pub message_count: u32,
+    /// Total token count
+    pub token_count: u64,
+}
+
+impl SessionMetadata {
+    /// Create new session metadata with default values.
+    pub fn new(name: impl Into<String>, model: impl Into<String>) -> Self {
+        let now = Utc::now();
+        Self {
+            name: name.into(),
+            model: model.into(),
+            tags: Vec::new(),
+            created_at: now,
+            last_activity: now,
+            message_count: 0,
+            token_count: 0,
+        }
+    }
+
+    /// Add a tag to this session.
+    pub fn with_tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.push(tag.into());
+        self
+    }
+
+    /// Set multiple tags on this session.
+    pub fn with_tags(mut self, tags: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.tags = tags.into_iter().map(|t| t.into()).collect();
+        self
+    }
+}
+
+/// Summary information for session listing.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionSummary {
+    /// Session ID
+    pub id: Uuid,
+    /// Human-readable name
+    pub name: String,
+    /// Model name
+    pub model: String,
+    /// Tags
+    pub tags: Vec<String>,
+    /// Creation timestamp
+    pub created_at: DateTime<Utc>,
+    /// Last activity timestamp
+    pub last_activity: DateTime<Utc>,
+    /// Message count
+    pub message_count: u32,
+}
+
+/// Global store manifest containing the session index.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Manifest {
+    /// Store version
+    pub version: String,
+    /// Schema version
+    pub schema_version: String,
+    /// Last compaction timestamp
+    pub last_compaction: Option<DateTime<Utc>>,
+    /// Session index: session_id -> session summary
+    pub sessions: indexmap::IndexMap<Uuid, SessionSummary>,
+}
+
+impl Manifest {
+    /// Create a new manifest.
+    pub fn new() -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            schema_version: "1.0.0".to_string(),
+            last_compaction: None,
+            sessions: indexmap::IndexMap::new(),
+        }
+    }
+
+    /// Insert or update a session summary.
+    pub fn upsert_session(&mut self, summary: SessionSummary) {
+        self.sessions.insert(summary.id, summary);
+    }
+
+    /// Remove a session from the index.
+    pub fn remove_session(&mut self, id: &Uuid) {
+        self.sessions.swap_remove(id);
+    }
+
+    /// Look up a session summary by id.
+    pub fn get_session(&self, id: &Uuid) -> Option<&SessionSummary> {
+        self.sessions.get(id)
+    }
+}
+
+/// Types of operations that can be logged.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OperationType {
+    /// A tool call (web_search, file_read, etc.)
+    ToolCall {
+        /// Name of the tool
+        name: String,
+    },
+    /// A function call
+    FunctionCall {
+        /// Name of the function
+        name: String,
+    },
+    /// Web search operation
+    WebSearch,
+    /// Reasoning/thinking step
+    ThinkingStep,
+    /// Memory retrieval operation
+    MemoryRetrieval,
+    /// Knowledge graph query
+    KnowledgeGraphQuery,
+    /// Custom operation type
+    Custom(String),
+}
+
+impl std::fmt::Display for OperationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OperationType::ToolCall { name } => write!(f, "tool_call:{}", name),
+            OperationType::FunctionCall { name } => write!(f, "function_call:{}", name),
+            OperationType::WebSearch => write!(f, "web_search"),
+            OperationType::ThinkingStep => write!(f, "thinking_step"),
+            OperationType::MemoryRetrieval => write!(f, "memory_retrieval"),
+            OperationType::KnowledgeGraphQuery => write!(f, "knowledge_graph_query"),
+            OperationType::Custom(name) => write!(f, "custom:{}", name),
+        }
+    }
+}
+
+/// An operation log entry for tracking tool calls, searches, etc.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Operation {
+    /// Unique operation ID
+    pub id: Uuid,
+    /// Timestamp of the operation
+    pub timestamp: DateTime<Utc>,
+    /// Type of operation
+    pub op_type: OperationType,
+    /// Input parameters (JSON)
+    pub input: serde_json::Value,
+    /// Output result (JSON)
+    pub output: Option<serde_json::Value>,
+    /// Duration in milliseconds
+    pub duration_ms: u64,
+    /// Token usage (optional)
+    pub tokens_used: Option<u32>,
+}
+
+impl Operation {
+    /// Create a new operation entry.
+    pub fn new(op_type: OperationType, input: serde_json::Value, duration_ms: u64) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            op_type,
+            input,
+            output: None,
+            duration_ms,
+            tokens_used: None,
+        }
+    }
+
+    /// Helper to construct a tool-call operation.
+    pub fn tool_call(name: impl Into<String>, input: serde_json::Value, duration_ms: u64) -> Self {
+        Self::new(
+            OperationType::ToolCall { name: name.into() },
+            input,
+            duration_ms,
+        )
+    }
+
+    /// Attach output payload.
+    pub fn with_output(mut self, output: serde_json::Value) -> Self {
+        self.output = Some(output);
+        self
+    }
+
+    /// Attach token usage information.
+    pub fn with_tokens(mut self, tokens: u32) -> Self {
+        self.tokens_used = Some(tokens);
+        self
+    }
+}
+
+/// Query options for filtering operations.
+#[derive(Debug, Clone, Default)]
+pub struct OperationQuery {
+    /// Filter by operation types (empty = all)
+    pub op_types: Vec<OperationType>,
+    /// Start time filter (inclusive)
+    pub from: Option<DateTime<Utc>>,
+    /// End time filter (inclusive)
+    pub to: Option<DateTime<Utc>>,
+    /// Maximum results (0 = unlimited)
+    pub limit: usize,
+}
+
+impl OperationQuery {
+    /// Create an empty query.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Filter by operation type.
+    pub fn by_type(mut self, op_type: OperationType) -> Self {
+        self.op_types.push(op_type);
+        self
+    }
+
+    /// Restrict to a time range.
+    pub fn with_time_range(mut self, from: DateTime<Utc>, to: DateTime<Utc>) -> Self {
+        self.from = Some(from);
+        self.to = Some(to);
+        self
+    }
+
+    /// Cap maximum results.
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = limit;
+        self
+    }
+}
+
+/// Memory categories following MIRIX taxonomy.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MemoryType {
+    /// "What happened" - conversation turns, event summaries
+    Episodic,
+    /// "What is true" - facts, preferences, world knowledge
+    Semantic,
+    /// "How to do X" - learned workflows, tool usage patterns
+    Procedural,
+    /// File paths, URLs, external references
+    Resource,
+    /// Agent's beliefs about its own knowledge quality
+    MetaCognitive,
+}
+
+/// Memory tier levels for automatic promotion/demotion.
+///
+/// This is the *different levels of memory management* surface area requested
+/// when integrating MemSt into HelixDB:
+/// - [`MemoryTier::Working`] - hot, in-context memories.
+/// - [`MemoryTier::ShortTerm`] - retained for moderate periods.
+/// - [`MemoryTier::LongTerm`] - persistent important memories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum MemoryTier {
+    /// Working memory - most recent / frequently accessed.
+    Working,
+    /// Short-term memory - retained for moderate periods.
+    ShortTerm,
+    /// Long-term memory - persistent important memories.
+    LongTerm,
+}
+
+impl std::fmt::Display for MemoryTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MemoryTier::Working => write!(f, "working"),
+            MemoryTier::ShortTerm => write!(f, "short_term"),
+            MemoryTier::LongTerm => write!(f, "long_term"),
+        }
+    }
+}
+
+/// A memory item stored in memory tiers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryItem {
+    /// Unique memory ID
+    pub id: Uuid,
+    /// Memory content
+    pub content: String,
+    /// Source (e.g., message_id, extraction)
+    pub source: String,
+    /// When the memory was created
+    pub created_at: DateTime<Utc>,
+    /// When the memory was last accessed
+    pub last_accessed: DateTime<Utc>,
+    /// Number of times this memory was accessed
+    pub access_count: u32,
+    /// Optional embedding vector for similarity search
+    pub embedding: Option<Vec<f32>>,
+    /// Tags for categorization
+    pub tags: Vec<String>,
+    /// Confidence score (0.0 - 1.0)
+    pub confidence: f32,
+    /// Importance score (derived from access count and confidence)
+    pub importance: f32,
+    /// Memory type
+    pub memory_type: MemoryType,
+    /// Token estimate
+    pub token_estimate: Option<u32>,
+    /// Superseded memory ID (if this memory replaces another)
+    pub supersedes: Option<Uuid>,
+}
+
+impl MemoryItem {
+    /// Create a new memory item.
+    pub fn new(content: impl Into<String>, source: impl Into<String>) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4(),
+            content: content.into(),
+            source: source.into(),
+            created_at: now,
+            last_accessed: now,
+            access_count: 0,
+            embedding: None,
+            tags: Vec::new(),
+            confidence: 1.0,
+            importance: 0.0,
+            memory_type: MemoryType::Semantic,
+            token_estimate: None,
+            supersedes: None,
+        }
+    }
+
+    /// Add a tag.
+    pub fn with_tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.push(tag.into());
+        self
+    }
+
+    /// Set tags.
+    pub fn with_tags(mut self, tags: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.tags = tags.into_iter().map(|t| t.into()).collect();
+        self
+    }
+
+    /// Set the confidence score, clamped into [0, 1].
+    pub fn with_confidence(mut self, confidence: f32) -> Self {
+        self.confidence = confidence.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Attach an embedding vector.
+    pub fn with_embedding(mut self, embedding: Vec<f32>) -> Self {
+        self.embedding = Some(embedding);
+        self
+    }
+
+    /// Override the memory type.
+    pub fn with_memory_type(mut self, memory_type: MemoryType) -> Self {
+        self.memory_type = memory_type;
+        self
+    }
+
+    /// Set a token estimate.
+    pub fn with_token_estimate(mut self, tokens: u32) -> Self {
+        self.token_estimate = Some(tokens);
+        self
+    }
+
+    /// Record an access (bumps `access_count`, updates recency, recomputes importance).
+    pub fn record_access(&mut self) {
+        self.access_count += 1;
+        self.last_accessed = Utc::now();
+        self.recalculate_importance();
+    }
+
+    fn recalculate_importance(&mut self) {
+        let access_factor = (self.access_count as f32 + 1.0).ln();
+        let recency_factor =
+            (Utc::now() - self.last_accessed).num_seconds() as f32 / 86400.0; // days
+        self.importance = 0.5 * self.confidence
+            + 0.3 * access_factor.min(3.0) / 3.0
+            + 0.2 * (-recency_factor).exp();
+    }
+}
+
+/// Query for memory retrieval.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryQuery {
+    /// Keywords to search for (case-insensitive substring match)
+    pub keywords: Vec<String>,
+    /// Required tags
+    pub tags: Vec<String>,
+    /// Minimum confidence
+    pub min_confidence: Option<f32>,
+    /// Maximum results (0 = unlimited)
+    pub limit: usize,
+    /// Include embeddings in returned results
+    pub include_embeddings: bool,
+}
+
+impl MemoryQuery {
+    /// Create an empty query.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a keyword filter.
+    pub fn with_keyword(mut self, keyword: impl Into<String>) -> Self {
+        self.keywords.push(keyword.into());
+        self
+    }
+
+    /// Add a tag filter.
+    pub fn with_tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.push(tag.into());
+        self
+    }
+
+    /// Set minimum confidence.
+    pub fn with_min_confidence(mut self, confidence: f32) -> Self {
+        self.min_confidence = Some(confidence);
+        self
+    }
+
+    /// Cap maximum results.
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = limit;
+        self
+    }
+}
+
+/// Convenience alias for memory IDs.
+pub type MemoryId = Uuid;
+/// Convenience alias for session IDs.
+pub type SessionId = Uuid;

--- a/helix-db/tests/memst_uat.rs
+++ b/helix-db/tests/memst_uat.rs
@@ -1,0 +1,667 @@
+//! User Acceptance Tests for the MemSt integration in HelixDB.
+//!
+//! These exercise end-to-end scenarios that a downstream user of
+//! `helix_db::memst` is expected to rely on. They are written in
+//! Given/When/Then style and prefer the public API surface (re-exports
+//! from [`helix_db::memst`]) over module internals.
+//!
+//! Coverage map:
+//! - UAT-01..03  Session + message lifecycle (file/session management).
+//! - UAT-04..07  Memory tiers, querying, promotion (memory management).
+//! - UAT-08..09  Lifecycle promotion / demotion triggers.
+//! - UAT-10..12  Token-budget aware compaction.
+//! - UAT-13..14  Operation log filtering.
+//! - UAT-15..16  Content-addressable object store.
+//! - UAT-17..18  Persistence and isolation invariants.
+//! - UAT-19..21  Composed end-to-end workflows.
+
+use chrono::{Duration, Utc};
+use helix_db::memst::{
+    Author, Blob, Commit, CommitMetadata, CommitSource, ConfiguredTokenCounter, LifecycleConfig,
+    MemoryItem, MemoryLifecycle, MemoryQuery, MemoryScope, MemoryState, MemoryTier, MemoryType,
+    Message, ObjectId, ObjectStore, Operation, OperationQuery, OperationType, Role,
+    SessionMetadata, SessionStore, Tag, TokenCounter, TransitionTrigger, Tree, TreeEntry,
+};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+fn store() -> (TempDir, SessionStore) {
+    let dir = TempDir::new().unwrap();
+    let store = SessionStore::init(dir.path()).unwrap();
+    (dir, store)
+}
+
+fn session(store: &SessionStore, name: &str) -> Uuid {
+    store
+        .create_session(SessionMetadata::new(name, "gpt-4"))
+        .unwrap()
+}
+
+fn working_memory(content: &str, tag: &str, tokens: u32) -> MemoryItem {
+    MemoryItem::new(content, "uat")
+        .with_tag(tag)
+        .with_token_estimate(tokens)
+        .with_memory_type(MemoryType::Semantic)
+}
+
+// -----------------------------------------------------------------------------
+// UAT-01..03: Session + message lifecycle
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_01_session_lifecycle_create_list_get_delete() {
+    // Given a freshly initialized store
+    let (_dir, store) = store();
+
+    // When a session is created with metadata
+    let id = store
+        .create_session(SessionMetadata::new("UAT", "gpt-4").with_tag("test"))
+        .unwrap();
+
+    // Then it shows up in list_sessions
+    let sessions = store.list_sessions().unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].id, id);
+    assert_eq!(sessions[0].name, "UAT");
+    assert_eq!(sessions[0].tags, vec!["test".to_string()]);
+
+    // And get_session returns matching metadata
+    let meta = store.get_session(id).unwrap().expect("session exists");
+    assert_eq!(meta.model, "gpt-4");
+    assert_eq!(meta.message_count, 0);
+    assert_eq!(meta.token_count, 0);
+
+    // When deleted
+    store.delete_session(id).unwrap();
+
+    // Then list is empty and the session can no longer be retrieved
+    assert_eq!(store.list_sessions().unwrap().len(), 0);
+    assert!(store.get_session(id).unwrap().is_none());
+}
+
+#[test]
+fn uat_02_message_conversation_round_trip() {
+    // Given a session
+    let (_dir, store) = store();
+    let id = session(&store, "chat");
+
+    // When a 3-turn conversation is appended
+    store
+        .append_message(id, Message::system("You are a helpful assistant."))
+        .unwrap();
+    store
+        .append_message(id, Message::user("hello").with_token_count(2))
+        .unwrap();
+    store
+        .append_message(
+            id,
+            Message::assistant("hi! how can I help?").with_token_count(7),
+        )
+        .unwrap();
+
+    // Then messages come back in order
+    let msgs = store.get_messages(id).unwrap();
+    assert_eq!(msgs.len(), 3);
+    assert_eq!(msgs[0].role, Role::System);
+    assert_eq!(msgs[1].role, Role::User);
+    assert_eq!(msgs[2].role, Role::Assistant);
+
+    // And metadata reflects message + token counts
+    let meta = store.get_session(id).unwrap().unwrap();
+    assert_eq!(meta.message_count, 3);
+    assert_eq!(meta.token_count, 9);
+
+    // And a range query returns the correct slice
+    let middle = store.get_messages_range(id, 1, 2).unwrap();
+    assert_eq!(middle.len(), 1);
+    assert_eq!(middle[0].role, Role::User);
+}
+
+#[test]
+fn uat_03_message_index_offsets_match_binary_layout() {
+    // Given a session with three messages
+    let (_dir, store) = store();
+    let id = session(&store, "index");
+    for i in 0..3 {
+        store
+            .append_message(id, Message::user(format!("msg {}", i)))
+            .unwrap();
+    }
+
+    // When the index is read
+    let idx = store.read_message_index(id).unwrap();
+
+    // Then there is one entry per message and offsets are strictly increasing
+    assert_eq!(idx.len(), 3);
+    let mut prev = 0u64;
+    for entry in &idx {
+        assert!(entry.byte_offset >= prev);
+        prev = entry.byte_offset + entry.byte_length;
+        assert_eq!(entry.role, Role::User);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// UAT-04..07: Memory tiers, querying, retrieval ordering
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_04_tiered_memory_promotion_working_to_long_term() {
+    // Given a session with a working-tier memory
+    let (_dir, store) = store();
+    let id = session(&store, "tiers");
+    let mem = working_memory("user prefers tokio for async", "rust", 7);
+    store.add_memory(id, MemoryTier::Working, mem.clone()).unwrap();
+    assert_eq!(store.get_tier(id, MemoryTier::Working).unwrap().len(), 1);
+    assert_eq!(store.get_tier(id, MemoryTier::LongTerm).unwrap().len(), 0);
+
+    // When the memory is promoted to LongTerm
+    let promoted = store.promote_memory(id, mem.id, MemoryTier::LongTerm).unwrap();
+    assert!(promoted);
+
+    // Then it lives only in LongTerm
+    assert!(store.get_tier(id, MemoryTier::Working).unwrap().is_empty());
+    let long = store.get_tier(id, MemoryTier::LongTerm).unwrap();
+    assert_eq!(long.len(), 1);
+    assert_eq!(long[0].id, mem.id);
+
+    // And get_memory finds it across tiers
+    let found = store.get_memory(id, mem.id).unwrap().unwrap();
+    assert_eq!(found.id, mem.id);
+}
+
+#[test]
+fn uat_05_memory_query_filters_by_keyword_and_tag() {
+    // Given a session with memories at different tiers and tags
+    let (_dir, store) = store();
+    let id = session(&store, "query");
+    store
+        .add_memory(id, MemoryTier::Working, working_memory("Rust uses Tokio for async", "rust", 5))
+        .unwrap();
+    store
+        .add_memory(id, MemoryTier::ShortTerm, working_memory("Go uses goroutines", "go", 4))
+        .unwrap();
+    store
+        .add_memory(id, MemoryTier::LongTerm, working_memory("User likes async/await", "rust", 3))
+        .unwrap();
+
+    // When querying for keyword "async" and tag "rust"
+    let q = MemoryQuery::new()
+        .with_keyword("async")
+        .with_tag("rust");
+    let hits = store.retrieve_memories(id, q).unwrap();
+
+    // Then only the rust-tagged "async" memories match
+    assert_eq!(hits.len(), 2);
+    for hit in hits {
+        assert!(hit.tags.contains(&"rust".to_string()));
+        assert!(hit.content.to_lowercase().contains("async"));
+    }
+}
+
+#[test]
+fn uat_06_memory_query_respects_min_confidence() {
+    let (_dir, store) = store();
+    let id = session(&store, "conf");
+    store
+        .add_memory(
+            id,
+            MemoryTier::Working,
+            working_memory("low conf", "x", 1).with_confidence(0.2),
+        )
+        .unwrap();
+    store
+        .add_memory(
+            id,
+            MemoryTier::Working,
+            working_memory("high conf", "x", 1).with_confidence(0.9),
+        )
+        .unwrap();
+
+    let hits = store
+        .retrieve_memories(id, MemoryQuery::new().with_min_confidence(0.5))
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].content, "high conf");
+}
+
+#[test]
+fn uat_07_memory_query_limits_results() {
+    let (_dir, store) = store();
+    let id = session(&store, "limit");
+    for i in 0..10 {
+        store
+            .add_memory(
+                id,
+                MemoryTier::Working,
+                working_memory(&format!("note {}", i), "x", 1),
+            )
+            .unwrap();
+    }
+
+    let hits = store
+        .retrieve_memories(id, MemoryQuery::new().with_limit(3))
+        .unwrap();
+    assert_eq!(hits.len(), 3);
+}
+
+// -----------------------------------------------------------------------------
+// UAT-08..09: Lifecycle promotion / demotion triggers
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_08_lifecycle_promotion_triggered_by_access_count() {
+    let lifecycle = MemoryLifecycle::new(LifecycleConfig::default());
+
+    let mut item = MemoryItem::new("cool fact", "uat").with_confidence(0.4);
+    assert!(lifecycle.should_promote(&item).is_none());
+
+    // After enough accesses, the access-count threshold fires.
+    for _ in 0..3 {
+        item.record_access();
+    }
+    let trigger = lifecycle.should_promote(&item).expect("should fire");
+    assert!(matches!(trigger, TransitionTrigger::AccessCount(n) if n >= 3));
+}
+
+#[test]
+fn uat_09_lifecycle_demotion_triggered_by_ttl() {
+    let lifecycle = MemoryLifecycle::new(LifecycleConfig::default());
+
+    let mut item = MemoryItem::new("stale", "uat");
+    item.last_accessed = Utc::now() - Duration::hours(48);
+
+    // Working memory expires after 1h by default; 48h is way past TTL.
+    assert!(matches!(
+        lifecycle.should_demote(&item, MemoryTier::Working),
+        Some(TransitionTrigger::TtlExpired)
+    ));
+    // ShortTerm expires after 24h by default.
+    assert!(matches!(
+        lifecycle.should_demote(&item, MemoryTier::ShortTerm),
+        Some(TransitionTrigger::TtlExpired)
+    ));
+    // LongTerm never demotes by TTL.
+    assert!(lifecycle.should_demote(&item, MemoryTier::LongTerm).is_none());
+}
+
+// -----------------------------------------------------------------------------
+// UAT-10..12: Token-budget aware compaction
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_10_compaction_checkpoint_create_finalize_restore() {
+    let mut lifecycle = MemoryLifecycle::new(LifecycleConfig::default());
+    let pre = ObjectId::from_content(b"pre-commit");
+    let post = ObjectId::from_content(b"post-commit");
+
+    let cp = lifecycle.create_checkpoint(
+        Some(MemoryScope::Session("s1".into())),
+        MemoryTier::Working,
+        MemoryTier::ShortTerm,
+        vec!["m1".into(), "m2".into()],
+        pre,
+        1_000,
+    );
+    let cp_id = cp.id.clone();
+    assert!(cp_id.starts_with("chk-"));
+    assert!(cp.post_commit.is_none());
+
+    // Finalize updates the checkpoint with post-commit and compacted tokens.
+    lifecycle
+        .finalize_checkpoint(&cp_id, post, 250)
+        .expect("finalize should succeed");
+
+    // Restore looks up the checkpoint by id.
+    let restored = lifecycle.restore_checkpoint(&cp_id).unwrap();
+    assert_eq!(restored.post_commit, Some(post));
+    assert_eq!(restored.compacted_tokens, 250);
+
+    // Listing returns at least the one checkpoint we created.
+    assert!(!lifecycle.list_checkpoints().is_empty());
+}
+
+#[test]
+fn uat_11_token_budget_exceeded_when_over_limit() {
+    // Working budget defaults to 4096 tokens.
+    let mut lifecycle = MemoryLifecycle::new(LifecycleConfig::default());
+
+    let mut memories = Vec::new();
+    for _ in 0..10 {
+        let m = MemoryItem::new("x", "uat").with_token_estimate(500);
+        lifecycle.register(&m.id.to_string(), MemoryTier::Working);
+        memories.push(m);
+    }
+
+    // 10 * 500 = 5000 > 4096, budget should be exceeded.
+    assert!(lifecycle.is_budget_exceeded(&memories, MemoryTier::Working));
+    // ShortTerm has a higher budget and we registered everything to Working,
+    // so ShortTerm usage is 0 and not exceeded.
+    assert!(!lifecycle.is_budget_exceeded(&memories, MemoryTier::ShortTerm));
+}
+
+#[test]
+fn uat_12_select_for_compaction_picks_low_importance_oldest_first() {
+    let mut lifecycle = MemoryLifecycle::new(LifecycleConfig::default());
+
+    let mut high = MemoryItem::new("important", "uat");
+    high.importance = 0.9;
+    high.last_accessed = Utc::now();
+    lifecycle.register(&high.id.to_string(), MemoryTier::Working);
+
+    let mut low_recent = MemoryItem::new("low recent", "uat");
+    low_recent.importance = 0.1;
+    low_recent.last_accessed = Utc::now();
+    lifecycle.register(&low_recent.id.to_string(), MemoryTier::Working);
+
+    let mut low_old = MemoryItem::new("low old", "uat");
+    low_old.importance = 0.1;
+    low_old.last_accessed = Utc::now() - Duration::days(7);
+    lifecycle.register(&low_old.id.to_string(), MemoryTier::Working);
+
+    let memories = vec![high.clone(), low_recent.clone(), low_old.clone()];
+    let picked = lifecycle.select_for_compaction(&memories, MemoryTier::Working, 2);
+
+    // The two lowest-importance items are picked, with the older one first.
+    assert_eq!(picked.len(), 2);
+    assert_eq!(picked[0].id, low_old.id);
+    assert_eq!(picked[1].id, low_recent.id);
+}
+
+// -----------------------------------------------------------------------------
+// UAT-13..14: Operation log filtering
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_13_operations_log_filter_by_type() {
+    let (_dir, store) = store();
+    let id = session(&store, "ops");
+    store
+        .append_operation(id, Operation::tool_call("search", serde_json::json!({}), 10))
+        .unwrap();
+    store
+        .append_operation(
+            id,
+            Operation::new(OperationType::WebSearch, serde_json::json!({}), 20),
+        )
+        .unwrap();
+    store
+        .append_operation(id, Operation::tool_call("fetch", serde_json::json!({}), 5))
+        .unwrap();
+
+    let only_web = store
+        .get_operations_by_type(id, OperationType::WebSearch)
+        .unwrap();
+    assert_eq!(only_web.len(), 1);
+    assert!(matches!(only_web[0].op_type, OperationType::WebSearch));
+}
+
+#[test]
+fn uat_14_operations_log_filter_by_time_range_and_limit() {
+    let (_dir, store) = store();
+    let id = session(&store, "ops-range");
+    let t0 = Utc::now() - Duration::hours(2);
+    let t1 = Utc::now() - Duration::hours(1);
+    let t2 = Utc::now() + Duration::hours(1);
+
+    let mut op_old = Operation::new(OperationType::WebSearch, serde_json::json!({}), 1);
+    op_old.timestamp = t0 - Duration::minutes(1);
+    let mut op_mid = Operation::new(OperationType::WebSearch, serde_json::json!({}), 1);
+    op_mid.timestamp = t0 + Duration::minutes(30);
+    let mut op_new = Operation::new(OperationType::WebSearch, serde_json::json!({}), 1);
+    op_new.timestamp = t1 + Duration::minutes(30);
+    for op in [op_old, op_mid, op_new] {
+        store.append_operation(id, op).unwrap();
+    }
+
+    let q = OperationQuery::new()
+        .with_time_range(t0, t2)
+        .with_limit(2);
+    let hits = store.query_operations(id, q).unwrap();
+    assert!(hits.len() <= 2);
+    for op in &hits {
+        assert!(op.timestamp >= t0);
+        assert!(op.timestamp <= t2);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// UAT-15..16: Object store
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_15_object_store_commit_chain_traversal() {
+    let dir = TempDir::new().unwrap();
+    let mut os = ObjectStore::new(&dir.path().to_path_buf()).unwrap();
+
+    // Build a parent commit
+    let mut tree = Tree::new();
+    let blob_oid = os.write_blob(&Blob::new(b"data v1")).unwrap();
+    tree.add_entry(TreeEntry::new(TreeEntry::MODE_FILE, blob_oid, "file.txt"));
+    let tree1 = os.write_tree(&tree).unwrap();
+    let author = Author::new("uat", "uat@example.com");
+    let parent = Commit::with_metadata(
+        tree1,
+        author.clone(),
+        "init",
+        CommitMetadata {
+            token_delta: 100,
+            confidence: 1.0,
+            source: CommitSource::UserExplicit,
+            scope: None,
+        },
+    );
+    let parent_oid = os.write_commit(&parent).unwrap();
+
+    // Build a child commit pointing at parent
+    let blob2 = os.write_blob(&Blob::new(b"data v2")).unwrap();
+    let mut tree2 = Tree::new();
+    tree2.add_entry(TreeEntry::new(TreeEntry::MODE_FILE, blob2, "file.txt"));
+    let tree2_oid = os.write_tree(&tree2).unwrap();
+    let mut child = Commit::new(tree2_oid, author.clone(), "update");
+    child.add_parent(parent_oid);
+    let child_oid = os.write_commit(&child).unwrap();
+
+    // Read back and verify the parent linkage
+    let read = os.read_commit(&child_oid).unwrap();
+    assert_eq!(read.first_parent(), Some(parent_oid));
+    assert!(!read.is_merge());
+
+    // Tagging the parent and reading it back works
+    let tag = Tag::new(parent_oid, "v1.0", author, "first release");
+    let tag_oid = os.write_tag(&tag).unwrap();
+    let read_tag = os.read_tag(&tag_oid).unwrap();
+    assert_eq!(read_tag.target_oid, parent_oid);
+    assert_eq!(read_tag.name, "v1.0");
+}
+
+#[test]
+fn uat_16_object_store_dedupes_identical_blobs() {
+    let dir = TempDir::new().unwrap();
+    let mut os = ObjectStore::new(&dir.path().to_path_buf()).unwrap();
+
+    let oid1 = os.write_blob(&Blob::new(b"same content")).unwrap();
+    let oid2 = os.write_blob(&Blob::new(b"same content")).unwrap();
+    let oid3 = os.write_blob(&Blob::new(b"different")).unwrap();
+
+    assert_eq!(oid1, oid2);
+    assert_ne!(oid1, oid3);
+    // Dedup means the store contains only 2 distinct objects.
+    assert_eq!(os.count().unwrap(), 2);
+}
+
+// -----------------------------------------------------------------------------
+// UAT-17..18: Persistence and isolation
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_17_multi_session_isolation_no_cross_contamination() {
+    let (_dir, store) = store();
+    let a = session(&store, "alice");
+    let b = session(&store, "bob");
+
+    store
+        .add_memory(a, MemoryTier::Working, working_memory("alice secret", "private", 1))
+        .unwrap();
+    store
+        .add_memory(b, MemoryTier::Working, working_memory("bob fact", "public", 1))
+        .unwrap();
+
+    let alice = store.get_tier(a, MemoryTier::Working).unwrap();
+    let bob = store.get_tier(b, MemoryTier::Working).unwrap();
+    assert_eq!(alice.len(), 1);
+    assert_eq!(bob.len(), 1);
+    assert_ne!(alice[0].content, bob[0].content);
+}
+
+#[test]
+fn uat_18_session_persistence_across_reopen() {
+    let dir = TempDir::new().unwrap();
+
+    // First session: write data, then drop the store (releases lock).
+    let id = {
+        let store = SessionStore::init(dir.path()).unwrap();
+        let id = session(&store, "persistent");
+        store
+            .append_message(id, Message::user("first message"))
+            .unwrap();
+        store
+            .add_memory(id, MemoryTier::LongTerm, working_memory("learned fact", "x", 5))
+            .unwrap();
+        id
+    };
+
+    // Re-open and verify everything is intact.
+    let store = SessionStore::open(dir.path()).unwrap();
+    let summaries = store.list_sessions().unwrap();
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].id, id);
+
+    let msgs = store.get_messages(id).unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].role, Role::User);
+
+    let lt = store.get_tier(id, MemoryTier::LongTerm).unwrap();
+    assert_eq!(lt.len(), 1);
+    assert_eq!(lt[0].content, "learned fact");
+}
+
+// -----------------------------------------------------------------------------
+// UAT-19..21: End-to-end composed workflows
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_19_full_chat_extract_store_retrieve_workflow() {
+    // A realistic workflow: chat -> extract memories -> persist -> retrieve.
+    let (_dir, store) = store();
+    let id = session(&store, "e2e");
+
+    // 1. Chat turns are appended.
+    let turns = [
+        Message::system("You are helpful."),
+        Message::user("I prefer Rust over Python for systems work."),
+        Message::assistant("Got it - I'll keep that in mind."),
+    ];
+    for m in turns {
+        store.append_message(id, m).unwrap();
+    }
+
+    // 2. The agent extracts a semantic memory and tags it.
+    let counter = ConfiguredTokenCounter::new();
+    let extracted = MemoryItem::new(
+        "User prefers Rust over Python for systems-programming work",
+        "extraction",
+    )
+    .with_memory_type(MemoryType::Semantic)
+    .with_tag("preference")
+    .with_tag("language");
+    let token_estimate = counter.count(&extracted.content);
+    let extracted = extracted.with_token_estimate(token_estimate);
+    store
+        .add_memory(id, MemoryTier::ShortTerm, extracted.clone())
+        .unwrap();
+
+    // 3. The retrieval API surfaces it again on a relevant query.
+    let q = MemoryQuery::new()
+        .with_keyword("rust")
+        .with_tag("preference");
+    let hits = store.retrieve_memories(id, q).unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].id, extracted.id);
+
+    // 4. Operation log records the retrieval.
+    store
+        .append_operation(
+            id,
+            Operation::new(
+                OperationType::MemoryRetrieval,
+                serde_json::json!({ "query": "rust preference" }),
+                3,
+            ),
+        )
+        .unwrap();
+    let ops = store
+        .get_operations_by_type(id, OperationType::MemoryRetrieval)
+        .unwrap();
+    assert_eq!(ops.len(), 1);
+}
+
+#[test]
+fn uat_20_memory_access_increments_count_and_recency() {
+    let (_dir, store) = store();
+    let id = session(&store, "access");
+    let mem = working_memory("hot fact", "x", 1);
+    store.add_memory(id, MemoryTier::Working, mem.clone()).unwrap();
+
+    let before = store.get_memory(id, mem.id).unwrap().unwrap();
+    assert_eq!(before.access_count, 0);
+
+    let touched = store.access_memory(id, mem.id).unwrap();
+    assert!(touched);
+
+    let after = store.get_memory(id, mem.id).unwrap().unwrap();
+    assert_eq!(after.access_count, 1);
+    assert!(after.last_accessed >= before.last_accessed);
+    // Importance is recomputed on access.
+    assert!(after.importance > 0.0);
+
+    // Accessing a non-existent memory id returns false, not an error.
+    let missing = store.access_memory(id, Uuid::new_v4()).unwrap();
+    assert!(!missing);
+}
+
+#[test]
+fn uat_21_state_transition_history_is_preserved() {
+    let mut lifecycle = MemoryLifecycle::new(LifecycleConfig::default());
+    lifecycle.register("m1", MemoryTier::Working);
+
+    lifecycle
+        .transition(
+            "m1",
+            MemoryState::ShortTerm,
+            TransitionTrigger::TtlExpired,
+            -50,
+        )
+        .unwrap();
+    lifecycle
+        .transition(
+            "m1",
+            MemoryState::LongTerm,
+            TransitionTrigger::ImportanceThreshold(0.8),
+            20,
+        )
+        .unwrap();
+
+    let history = lifecycle.transitions();
+    assert_eq!(history.len(), 2);
+    assert_eq!(history[0].to, MemoryState::ShortTerm);
+    assert_eq!(history[1].from, MemoryState::ShortTerm);
+    assert_eq!(history[1].to, MemoryState::LongTerm);
+
+    // Final state matches the last transition.
+    assert_eq!(lifecycle.get_state("m1"), Some(MemoryState::LongTerm));
+}

--- a/helix-db/tests/memst_uat_multisession.rs
+++ b/helix-db/tests/memst_uat_multisession.rs
@@ -1,0 +1,397 @@
+//! Multi-session UAT mirroring the `memst_multi_session` example.
+//!
+//! These tests assert the same invariants the demo exercises: per-session
+//! isolation, per-tier accounting, lifecycle decisions under a tight token
+//! budget, and persistence across reopen. They are meant to ride along with
+//! the demo - if you change the demo's behaviour, update these accordingly.
+
+use helix_db::memst::{
+    ConfiguredTokenCounter, LifecycleConfig, MemoryItem, MemoryLifecycle, MemoryQuery, MemoryState,
+    MemoryTier, MemoryType, Message, Operation, OperationType, SessionMetadata, SessionStore,
+    TokenCounter, TransitionTrigger,
+};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+// -----------------------------------------------------------------------------
+// scenario setup helpers (mirror examples/memst_multi_session.rs)
+// -----------------------------------------------------------------------------
+
+struct UserScript {
+    name: &'static str,
+    model: &'static str,
+    messages: Vec<Message>,
+    memories: Vec<(&'static str, MemoryType, &'static [&'static str])>,
+}
+
+fn alice() -> UserScript {
+    UserScript {
+        name: "alice",
+        model: "claude-sonnet-4",
+        messages: vec![
+            Message::system("You help with Rust async."),
+            Message::user("How does Tokio's runtime schedule tasks?").with_token_count(8),
+            Message::assistant("Tokio uses a multi-threaded work-stealing scheduler.")
+                .with_token_count(60),
+            Message::user("Is it OK to mix tokio and async-std?").with_token_count(9),
+            Message::assistant("Generally avoid mixing runtimes.").with_token_count(40),
+        ],
+        memories: vec![
+            (
+                "user prefers Tokio over async-std for async runtimes",
+                MemoryType::Semantic,
+                &["rust"],
+            ),
+            (
+                "user is comfortable with work-stealing schedulers",
+                MemoryType::Semantic,
+                &["rust"],
+            ),
+            (
+                "user wants idiomatic Rust async patterns",
+                MemoryType::Semantic,
+                &["rust"],
+            ),
+        ],
+    }
+}
+
+fn bob() -> UserScript {
+    UserScript {
+        name: "bob",
+        model: "gpt-4o",
+        messages: vec![
+            Message::system("You help with ML in Python."),
+            Message::user("How do I avoid GIL contention in PyTorch?").with_token_count(11),
+            Message::assistant("Use multiprocessing or move tensors to GPU.").with_token_count(35),
+        ],
+        memories: vec![(
+            "user uses Python and PyTorch; cares about GIL implications",
+            MemoryType::Semantic,
+            &["python", "ml"],
+        )],
+    }
+}
+
+fn carol() -> UserScript {
+    UserScript {
+        name: "carol",
+        model: "llama-3-70b",
+        messages: vec![
+            Message::system("You help with Go infrastructure."),
+            Message::user("How do I tune GOMAXPROCS in Kubernetes?").with_token_count(12),
+            Message::assistant("Use the automaxprocs library.").with_token_count(45),
+        ],
+        memories: vec![(
+            "user runs Go services on Kubernetes; tuning GOMAXPROCS is recurring",
+            MemoryType::Procedural,
+            &["go", "k8s"],
+        )],
+    }
+}
+
+fn run_script<C: TokenCounter>(
+    store: &SessionStore,
+    lifecycle: &mut MemoryLifecycle,
+    counter: &C,
+    script: UserScript,
+) -> Uuid {
+    let id = store
+        .create_session(SessionMetadata::new(script.name, script.model).with_tag("uat"))
+        .unwrap();
+    for m in script.messages {
+        store.append_message(id, m).unwrap();
+    }
+    for (content, ty, tags) in script.memories {
+        let mut mem = MemoryItem::new(content, "extraction")
+            .with_memory_type(ty)
+            .with_token_estimate(counter.count(content));
+        for t in tags {
+            mem = mem.with_tag(*t);
+        }
+        lifecycle.register(&mem.id.to_string(), MemoryTier::Working);
+        store.add_memory(id, MemoryTier::Working, mem).unwrap();
+    }
+    id
+}
+
+// -----------------------------------------------------------------------------
+// UAT-MS-01: each session gets its own state and they don't bleed
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_ms_01_three_sessions_remain_isolated() {
+    let dir = TempDir::new().unwrap();
+    let store = SessionStore::init(dir.path()).unwrap();
+    let mut lc = MemoryLifecycle::new(LifecycleConfig::default());
+    let counter = ConfiguredTokenCounter::default();
+
+    let alice_id = run_script(&store, &mut lc, &counter, alice());
+    let bob_id = run_script(&store, &mut lc, &counter, bob());
+    let carol_id = run_script(&store, &mut lc, &counter, carol());
+
+    // Three sessions are listed.
+    let sessions = store.list_sessions().unwrap();
+    assert_eq!(sessions.len(), 3);
+    let names: Vec<_> = sessions.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains(&"alice"));
+    assert!(names.contains(&"bob"));
+    assert!(names.contains(&"carol"));
+
+    // Per-session memory counts match the scripts.
+    assert_eq!(
+        store.get_tier(alice_id, MemoryTier::Working).unwrap().len(),
+        3
+    );
+    assert_eq!(
+        store.get_tier(bob_id, MemoryTier::Working).unwrap().len(),
+        1
+    );
+    assert_eq!(
+        store
+            .get_tier(carol_id, MemoryTier::Working)
+            .unwrap()
+            .len(),
+        1
+    );
+
+    // A query for "python" only matches Bob's memories.
+    for (id, expected) in [(alice_id, 0), (bob_id, 1), (carol_id, 0)] {
+        let hits = store
+            .retrieve_memories(id, MemoryQuery::new().with_keyword("python"))
+            .unwrap();
+        assert_eq!(
+            hits.len(),
+            expected,
+            "session {id} should have {expected} python hits"
+        );
+    }
+
+    // A query for "go" only matches Carol's memories.
+    let hits = store
+        .retrieve_memories(carol_id, MemoryQuery::new().with_tag("go"))
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+}
+
+// -----------------------------------------------------------------------------
+// UAT-MS-02: per-session message + token accounting
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_ms_02_message_and_token_counts_are_per_session() {
+    let dir = TempDir::new().unwrap();
+    let store = SessionStore::init(dir.path()).unwrap();
+    let mut lc = MemoryLifecycle::new(LifecycleConfig::default());
+    let counter = ConfiguredTokenCounter::default();
+
+    let alice_id = run_script(&store, &mut lc, &counter, alice());
+    let bob_id = run_script(&store, &mut lc, &counter, bob());
+    let carol_id = run_script(&store, &mut lc, &counter, carol());
+
+    // alice: 5 messages, token sum = 8 + 60 + 9 + 40 = 117 (system has none).
+    let alice_meta = store.get_session(alice_id).unwrap().unwrap();
+    assert_eq!(alice_meta.message_count, 5);
+    assert_eq!(alice_meta.token_count, 117);
+
+    // bob: 3 messages, token sum = 11 + 35 = 46.
+    let bob_meta = store.get_session(bob_id).unwrap().unwrap();
+    assert_eq!(bob_meta.message_count, 3);
+    assert_eq!(bob_meta.token_count, 46);
+
+    // carol: 3 messages, token sum = 12 + 45 = 57.
+    let carol_meta = store.get_session(carol_id).unwrap().unwrap();
+    assert_eq!(carol_meta.message_count, 3);
+    assert_eq!(carol_meta.token_count, 57);
+}
+
+// -----------------------------------------------------------------------------
+// UAT-MS-03: tight budget triggers compaction selection
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_ms_03_budget_pressure_triggers_compaction_candidates() {
+    let dir = TempDir::new().unwrap();
+    let store = SessionStore::init(dir.path()).unwrap();
+
+    // A small working budget so even Alice's three semantic memories overflow.
+    let cfg = LifecycleConfig {
+        working_memory_max_tokens: 60,
+        promotion_access_threshold: 2,
+        ..LifecycleConfig::default()
+    };
+    let mut lc = MemoryLifecycle::new(cfg);
+    let counter = ConfiguredTokenCounter::default();
+    let alice_id = run_script(&store, &mut lc, &counter, alice());
+
+    let working = store.get_tier(alice_id, MemoryTier::Working).unwrap();
+    let total: u32 = working.iter().filter_map(|m| m.token_estimate).sum();
+    assert!(
+        total > 60,
+        "alice's three memories should add up to more than the 60-token budget; got {total}"
+    );
+    assert!(lc.is_budget_exceeded(&working, MemoryTier::Working));
+
+    // select_for_compaction should pick at most 2 lowest-importance items.
+    let picked = lc.select_for_compaction(&working, MemoryTier::Working, 2);
+    assert_eq!(picked.len(), 2);
+
+    // Move them to ShortTerm and update the lifecycle.
+    for m in picked {
+        store
+            .promote_memory(alice_id, m.id, MemoryTier::ShortTerm)
+            .unwrap();
+        lc.transition(
+            &m.id.to_string(),
+            MemoryState::ShortTerm,
+            TransitionTrigger::TokenBudgetExceeded,
+            -(m.token_estimate.unwrap_or(0) as i32),
+        )
+        .unwrap();
+    }
+
+    let working_after = store.get_tier(alice_id, MemoryTier::Working).unwrap();
+    let short_after = store.get_tier(alice_id, MemoryTier::ShortTerm).unwrap();
+    assert_eq!(working_after.len(), 1);
+    assert_eq!(short_after.len(), 2);
+}
+
+// -----------------------------------------------------------------------------
+// UAT-MS-04: hot memory crosses access threshold and promotes to long-term
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_ms_04_repeated_access_promotes_to_long_term() {
+    let dir = TempDir::new().unwrap();
+    let store = SessionStore::init(dir.path()).unwrap();
+    let cfg = LifecycleConfig {
+        promotion_access_threshold: 2,
+        ..LifecycleConfig::default()
+    };
+    let mut lc = MemoryLifecycle::new(cfg);
+    let counter = ConfiguredTokenCounter::default();
+    let alice_id = run_script(&store, &mut lc, &counter, alice());
+
+    // Find the Tokio memory and access it twice.
+    let working = store.get_tier(alice_id, MemoryTier::Working).unwrap();
+    let tokio_mem = working
+        .iter()
+        .find(|m| m.content.contains("Tokio"))
+        .expect("alice has a Tokio memory")
+        .clone();
+
+    for _ in 0..2 {
+        assert!(store.access_memory(alice_id, tokio_mem.id).unwrap());
+    }
+    let updated = store.get_memory(alice_id, tokio_mem.id).unwrap().unwrap();
+    assert_eq!(updated.access_count, 2);
+
+    // The lifecycle should now flag promotion.
+    let trigger = lc.should_promote(&updated).expect("should fire");
+    assert!(matches!(
+        trigger,
+        TransitionTrigger::AccessCount(n) if n >= 2
+    ));
+
+    // Apply the promotion.
+    store
+        .promote_memory(alice_id, tokio_mem.id, MemoryTier::LongTerm)
+        .unwrap();
+    lc.transition(
+        &tokio_mem.id.to_string(),
+        MemoryState::LongTerm,
+        trigger,
+        0,
+    )
+    .unwrap();
+
+    // The Tokio memory now lives only in long-term.
+    let long = store.get_tier(alice_id, MemoryTier::LongTerm).unwrap();
+    assert!(long.iter().any(|m| m.id == tokio_mem.id));
+    let working_after = store.get_tier(alice_id, MemoryTier::Working).unwrap();
+    assert!(working_after.iter().all(|m| m.id != tokio_mem.id));
+    assert_eq!(lc.get_state(&tokio_mem.id.to_string()), Some(MemoryState::LongTerm));
+}
+
+// -----------------------------------------------------------------------------
+// UAT-MS-05: operation logs are per-session and surviving reopen
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_ms_05_operations_isolated_and_persistent() {
+    let dir = TempDir::new().unwrap();
+    let alice_id;
+    let bob_id;
+
+    {
+        let store = SessionStore::init(dir.path()).unwrap();
+        let mut lc = MemoryLifecycle::new(LifecycleConfig::default());
+        let counter = ConfiguredTokenCounter::default();
+        alice_id = run_script(&store, &mut lc, &counter, alice());
+        bob_id = run_script(&store, &mut lc, &counter, bob());
+
+        store
+            .append_operation(
+                alice_id,
+                Operation::new(
+                    OperationType::MemoryRetrieval,
+                    serde_json::json!({"q": "tokio"}),
+                    4,
+                ),
+            )
+            .unwrap();
+        store
+            .append_operation(
+                bob_id,
+                Operation::new(OperationType::WebSearch, serde_json::json!({"q": "GIL"}), 12),
+            )
+            .unwrap();
+    }
+
+    // Re-open and verify everything is still there and isolated.
+    let store = SessionStore::open(dir.path()).unwrap();
+    let alice_ops = store.get_operations(alice_id).unwrap();
+    let bob_ops = store.get_operations(bob_id).unwrap();
+    assert_eq!(alice_ops.len(), 1);
+    assert_eq!(bob_ops.len(), 1);
+    assert!(matches!(alice_ops[0].op_type, OperationType::MemoryRetrieval));
+    assert!(matches!(bob_ops[0].op_type, OperationType::WebSearch));
+}
+
+// -----------------------------------------------------------------------------
+// UAT-MS-06: full round-trip - 3 sessions, persistence, retrieval all intact
+// -----------------------------------------------------------------------------
+
+#[test]
+fn uat_ms_06_full_multi_session_persistence() {
+    let dir = TempDir::new().unwrap();
+
+    let (alice_id, bob_id, carol_id) = {
+        let store = SessionStore::init(dir.path()).unwrap();
+        let mut lc = MemoryLifecycle::new(LifecycleConfig::default());
+        let counter = ConfiguredTokenCounter::default();
+        let a = run_script(&store, &mut lc, &counter, alice());
+        let b = run_script(&store, &mut lc, &counter, bob());
+        let c = run_script(&store, &mut lc, &counter, carol());
+        (a, b, c)
+    };
+
+    let store = SessionStore::open(dir.path()).unwrap();
+    let summaries = store.list_sessions().unwrap();
+    assert_eq!(summaries.len(), 3);
+
+    let messages_total: u32 = summaries.iter().map(|s| s.message_count).sum();
+    assert_eq!(messages_total, 5 + 3 + 3);
+
+    // Spot-check that each user's first memory survived.
+    let alice_w = store.get_tier(alice_id, MemoryTier::Working).unwrap();
+    assert!(alice_w
+        .iter()
+        .any(|m| m.content.contains("Tokio") || m.content.contains("Rust")));
+
+    let bob_w = store.get_tier(bob_id, MemoryTier::Working).unwrap();
+    assert!(bob_w.iter().any(|m| m.content.contains("Python")));
+
+    let carol_w = store.get_tier(carol_id, MemoryTier::Working).unwrap();
+    assert!(carol_w.iter().any(|m| m.content.contains("Kubernetes")));
+}

--- a/helix-db/tests/memst_unit.rs
+++ b/helix-db/tests/memst_unit.rs
@@ -1,0 +1,582 @@
+//! Fine-grained unit tests for the MemSt integration.
+//!
+//! Module-level inline tests cover the primary happy paths; these tests focus
+//! on edge cases and small contracts: hex / serialization round-trips, default
+//! impls, builder methods, error branches, and helpers that don't need a full
+//! filesystem store.
+
+use chrono::{Duration, Utc};
+use helix_db::memst::{
+    Author, Blob, Commit, CommitMetadata, CommitSource, ConfiguredTokenCounter, Content,
+    ContentPart, LifecycleConfig, Manifest, MemoryItem, MemoryLifecycle, MemoryQuery, MemoryScope,
+    MemoryState, MemoryTier, MemoryType, Message, ObjectId, ObjectStore, Operation,
+    OperationQuery, OperationType, Role, SessionMetadata, SessionSummary, SimpleTokenCounter,
+    Tag, TokenCounter, TransitionTrigger, Tree, TreeEntry,
+};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+// -----------------------------------------------------------------------------
+// ObjectId
+// -----------------------------------------------------------------------------
+
+#[test]
+fn object_id_hex_round_trip() {
+    let oid = ObjectId::from_content(b"hello world");
+    let hex = oid.to_hex();
+    assert_eq!(hex.len(), 64);
+    let parsed = ObjectId::from_hex(&hex).unwrap();
+    assert_eq!(oid, parsed);
+}
+
+#[test]
+fn object_id_blake3_is_deterministic() {
+    let a = ObjectId::from_content(b"abc");
+    let b = ObjectId::from_content(b"abc");
+    let c = ObjectId::from_content(b"abd");
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+}
+
+#[test]
+fn object_id_nil_and_abbreviate() {
+    let nil = ObjectId::nil();
+    assert!(nil.is_nil());
+    assert_eq!(nil.to_hex(), "0".repeat(64));
+
+    let oid = ObjectId::from_content(b"x");
+    assert!(!oid.is_nil());
+    assert_eq!(oid.abbreviate().len(), 7);
+    assert_eq!(oid.abbreviate(), &oid.to_hex()[..7]);
+}
+
+#[test]
+fn object_id_from_hex_rejects_wrong_length() {
+    assert!(ObjectId::from_hex("abc").is_err());
+    assert!(ObjectId::from_hex(&"f".repeat(63)).is_err());
+    assert!(ObjectId::from_hex(&"f".repeat(65)).is_err());
+}
+
+#[test]
+fn object_id_display_uses_hex() {
+    let oid = ObjectId::from_content(b"x");
+    assert_eq!(format!("{}", oid), oid.to_hex());
+    assert_eq!(format!("{:?}", oid), oid.to_hex());
+}
+
+// -----------------------------------------------------------------------------
+// Tree / TreeEntry / Author / Tag
+// -----------------------------------------------------------------------------
+
+#[test]
+fn tree_default_is_empty() {
+    let t = Tree::default();
+    assert!(t.entries.is_empty());
+    assert!(t.get_entry("anything").is_none());
+}
+
+#[test]
+fn tree_add_get_remove_entries() {
+    let mut t = Tree::new();
+    let oid = ObjectId::from_content(b"x");
+    t.add_entry(TreeEntry::new(TreeEntry::MODE_FILE, oid, "a.txt"));
+    t.add_entry(TreeEntry::new(TreeEntry::MODE_DIR, oid, "subdir"));
+
+    assert!(t.get_entry("a.txt").is_some());
+    let removed = t.remove_entry("a.txt").unwrap();
+    assert_eq!(removed.name, "a.txt");
+    assert!(t.get_entry("a.txt").is_none());
+    assert_eq!(t.entries.len(), 1);
+}
+
+#[test]
+fn tree_entry_modes_are_octal() {
+    assert_eq!(TreeEntry::MODE_FILE, 0o100644);
+    assert_eq!(TreeEntry::MODE_DIR, 0o040000);
+    assert_eq!(TreeEntry::MODE_EXECUTABLE, 0o100755);
+}
+
+#[test]
+fn author_with_explicit_timestamp() {
+    let ts = Utc::now() - Duration::days(30);
+    let a = Author::with_timestamp("alice", "alice@example.com", ts);
+    assert_eq!(a.name, "alice");
+    assert_eq!(a.email, "alice@example.com");
+    assert_eq!(a.timestamp, ts);
+}
+
+#[test]
+fn tag_lightweight_has_default_tagger_and_no_signature() {
+    let oid = ObjectId::from_content(b"x");
+    let tag = Tag::lightweight(oid, "v1");
+    assert!(tag.is_lightweight);
+    assert!(tag.signature.is_none());
+    assert_eq!(tag.message, "");
+    assert_eq!(tag.tagger.name, "memst");
+}
+
+#[test]
+fn tag_annotated_has_message_and_no_signature_initially() {
+    let oid = ObjectId::from_content(b"x");
+    let tag = Tag::new(oid, "v2", Author::new("a", "a@x"), "release notes");
+    assert!(!tag.is_lightweight);
+    assert_eq!(tag.message, "release notes");
+    assert!(tag.signature.is_none());
+    assert_eq!(tag.target_oid, oid);
+}
+
+// -----------------------------------------------------------------------------
+// Commit
+// -----------------------------------------------------------------------------
+
+#[test]
+fn commit_is_merge_when_multiple_parents() {
+    let tree = ObjectId::from_content(b"tree");
+    let mut c = Commit::new(tree, Author::new("a", "a@x"), "msg");
+    assert!(!c.is_merge());
+
+    c.add_parent(ObjectId::from_content(b"p1"));
+    assert!(!c.is_merge());
+
+    c.add_parent(ObjectId::from_content(b"p2"));
+    assert!(c.is_merge());
+    assert_eq!(c.first_parent(), Some(ObjectId::from_content(b"p1")));
+}
+
+#[test]
+fn commit_metadata_default_values() {
+    let m = CommitMetadata::default();
+    assert_eq!(m.token_delta, 0);
+    assert_eq!(m.confidence, 1.0);
+    assert!(matches!(m.source, CommitSource::UserExplicit));
+    assert!(m.scope.is_none());
+}
+
+#[test]
+fn commit_with_metadata_round_trips_via_object_store() {
+    let dir = TempDir::new().unwrap();
+    let mut os = ObjectStore::new(&dir.path().to_path_buf()).unwrap();
+    let tree = os.write_tree(&Tree::new()).unwrap();
+    let metadata = CommitMetadata {
+        token_delta: -5,
+        confidence: 0.42,
+        source: CommitSource::SleepConsolidation,
+        scope: Some(MemoryScope::User("alice".into())),
+    };
+    let commit = Commit::with_metadata(tree, Author::new("a", "a@x"), "test", metadata);
+    let oid = os.write_commit(&commit).unwrap();
+    let read = os.read_commit(&oid).unwrap();
+    assert_eq!(read.metadata.token_delta, -5);
+    assert!((read.metadata.confidence - 0.42).abs() < 1e-6);
+    assert!(matches!(read.metadata.source, CommitSource::SleepConsolidation));
+    assert!(matches!(read.metadata.scope, Some(MemoryScope::User(ref s)) if s == "alice"));
+}
+
+// -----------------------------------------------------------------------------
+// Manifest
+// -----------------------------------------------------------------------------
+
+fn summary(name: &str) -> SessionSummary {
+    SessionSummary {
+        id: Uuid::new_v4(),
+        name: name.into(),
+        model: "gpt-4".into(),
+        tags: vec![],
+        created_at: Utc::now(),
+        last_activity: Utc::now(),
+        message_count: 0,
+    }
+}
+
+#[test]
+fn manifest_upsert_replaces_existing() {
+    let mut m = Manifest::new();
+    let mut s = summary("first");
+    let id = s.id;
+    m.upsert_session(s.clone());
+    assert_eq!(m.sessions.len(), 1);
+
+    s.name = "renamed".into();
+    m.upsert_session(s);
+    assert_eq!(m.sessions.len(), 1);
+    assert_eq!(m.get_session(&id).unwrap().name, "renamed");
+}
+
+#[test]
+fn manifest_remove_session() {
+    let mut m = Manifest::new();
+    let s = summary("only");
+    let id = s.id;
+    m.upsert_session(s);
+    m.remove_session(&id);
+    assert!(m.get_session(&id).is_none());
+    assert_eq!(m.sessions.len(), 0);
+}
+
+#[test]
+fn manifest_default_schema_version() {
+    let m = Manifest::new();
+    assert_eq!(m.schema_version, "1.0.0");
+    assert!(m.last_compaction.is_none());
+}
+
+// -----------------------------------------------------------------------------
+// MemoryItem
+// -----------------------------------------------------------------------------
+
+#[test]
+fn memory_item_record_access_increments_and_updates_recency() {
+    let mut m = MemoryItem::new("x", "test");
+    assert_eq!(m.access_count, 0);
+    let before = m.last_accessed;
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    m.record_access();
+    assert_eq!(m.access_count, 1);
+    assert!(m.last_accessed >= before);
+    assert!(m.importance > 0.0);
+}
+
+#[test]
+fn memory_item_with_confidence_clamps() {
+    let m = MemoryItem::new("x", "test").with_confidence(2.5);
+    assert_eq!(m.confidence, 1.0);
+    let m2 = MemoryItem::new("x", "test").with_confidence(-0.5);
+    assert_eq!(m2.confidence, 0.0);
+}
+
+#[test]
+fn memory_item_builders_set_fields() {
+    let m = MemoryItem::new("hello", "src")
+        .with_tag("a")
+        .with_tag("b")
+        .with_tags(["c", "d"])
+        .with_embedding(vec![1.0, 2.0])
+        .with_memory_type(MemoryType::Procedural)
+        .with_token_estimate(42);
+    // with_tags replaces, not appends.
+    assert_eq!(m.tags, vec!["c".to_string(), "d".to_string()]);
+    assert_eq!(m.embedding.as_ref().unwrap().len(), 2);
+    assert!(matches!(m.memory_type, MemoryType::Procedural));
+    assert_eq!(m.token_estimate, Some(42));
+}
+
+// -----------------------------------------------------------------------------
+// Content / Message / Role
+// -----------------------------------------------------------------------------
+
+#[test]
+fn content_from_string_and_str() {
+    let from_str: Content = "hi".into();
+    assert!(matches!(from_str, Content::Text(ref s) if s == "hi"));
+
+    let owned = String::from("hello");
+    let from_string: Content = owned.into();
+    assert!(matches!(from_string, Content::Text(ref s) if s == "hello"));
+}
+
+#[test]
+fn content_default_is_empty_text() {
+    match Content::default() {
+        Content::Text(s) => assert!(s.is_empty()),
+        _ => panic!("expected text default"),
+    }
+}
+
+#[test]
+fn content_multipart_holds_mixed_parts() {
+    let c = Content::MultiPart(vec![
+        ContentPart::Text("hello".into()),
+        ContentPart::Image {
+            data: vec![0xff, 0xd8],
+            mime_type: "image/jpeg".into(),
+        },
+        ContentPart::File {
+            hash: "abc".into(),
+            filename: "x.txt".into(),
+        },
+    ]);
+    if let Content::MultiPart(parts) = c {
+        assert_eq!(parts.len(), 3);
+    } else {
+        panic!("expected multipart");
+    }
+}
+
+#[test]
+fn message_user_assistant_system_helpers() {
+    let u = Message::user("hi");
+    assert_eq!(u.role, Role::User);
+    let a = Message::assistant("hello");
+    assert_eq!(a.role, Role::Assistant);
+    let s = Message::system("be nice");
+    assert_eq!(s.role, Role::System);
+}
+
+#[test]
+fn message_with_metadata_and_tokens() {
+    let m = Message::user("hi")
+        .with_token_count(10)
+        .with_metadata("model", "gpt-4")
+        .with_metadata("temperature", 0.5);
+    assert_eq!(m.token_count, Some(10));
+    assert_eq!(m.metadata.len(), 2);
+    assert_eq!(m.metadata.get("model").unwrap(), "gpt-4");
+}
+
+#[test]
+fn role_display_is_lowercase() {
+    assert_eq!(Role::System.to_string(), "system");
+    assert_eq!(Role::User.to_string(), "user");
+    assert_eq!(Role::Assistant.to_string(), "assistant");
+    assert_eq!(Role::Tool.to_string(), "tool");
+}
+
+#[test]
+fn memory_tier_display() {
+    assert_eq!(MemoryTier::Working.to_string(), "working");
+    assert_eq!(MemoryTier::ShortTerm.to_string(), "short_term");
+    assert_eq!(MemoryTier::LongTerm.to_string(), "long_term");
+}
+
+// -----------------------------------------------------------------------------
+// Operations
+// -----------------------------------------------------------------------------
+
+#[test]
+fn operation_type_display_includes_name() {
+    let t = OperationType::ToolCall {
+        name: "search".into(),
+    };
+    assert_eq!(t.to_string(), "tool_call:search");
+    assert_eq!(OperationType::WebSearch.to_string(), "web_search");
+    assert_eq!(
+        OperationType::Custom("xyz".into()).to_string(),
+        "custom:xyz"
+    );
+}
+
+#[test]
+fn operation_builders_attach_output_and_tokens() {
+    let op = Operation::tool_call("read", serde_json::json!({"path": "/x"}), 5)
+        .with_output(serde_json::json!({"ok": true}))
+        .with_tokens(15);
+    assert!(op.output.is_some());
+    assert_eq!(op.tokens_used, Some(15));
+}
+
+#[test]
+fn operation_query_default_is_empty() {
+    let q = OperationQuery::default();
+    assert!(q.op_types.is_empty());
+    assert_eq!(q.limit, 0);
+}
+
+#[test]
+fn operation_serialization_round_trip() {
+    let op = Operation::new(
+        OperationType::KnowledgeGraphQuery,
+        serde_json::json!({"q": 1}),
+        12,
+    )
+    .with_tokens(7);
+    let s = serde_json::to_string(&op).unwrap();
+    let back: Operation = serde_json::from_str(&s).unwrap();
+    assert_eq!(back.id, op.id);
+    assert_eq!(back.duration_ms, 12);
+    assert_eq!(back.tokens_used, Some(7));
+}
+
+// -----------------------------------------------------------------------------
+// Token counters
+// -----------------------------------------------------------------------------
+
+#[test]
+fn simple_token_counter_counts_whitespace_separated() {
+    let c = SimpleTokenCounter;
+    assert_eq!(c.count(""), 0);
+    assert_eq!(c.count("one"), 1);
+    assert_eq!(c.count("a b c"), 3);
+}
+
+#[test]
+fn configured_token_counter_default_includes_overhead() {
+    let c = ConfiguredTokenCounter::default();
+    let n = c.count("a b c d");
+    // 4 words * 1.3 = 5.2 truncated to 5, + 3 overhead = 8.
+    assert_eq!(n, 8);
+}
+
+#[test]
+fn configured_token_counter_with_ratio_is_configurable() {
+    let c = ConfiguredTokenCounter::with_ratio(2.0, 0);
+    assert_eq!(c.count("one two"), 4);
+}
+
+#[test]
+fn token_counter_count_memory_default_uses_content() {
+    let item = MemoryItem::new("hello world from memst", "uat");
+    let c = SimpleTokenCounter;
+    assert_eq!(c.count_memory(&item), 4);
+}
+
+// -----------------------------------------------------------------------------
+// Lifecycle: edge cases
+// -----------------------------------------------------------------------------
+
+#[test]
+fn lifecycle_register_long_term_starts_in_long_term_state() {
+    let mut lc = MemoryLifecycle::new(LifecycleConfig::default());
+    assert_eq!(lc.register("m", MemoryTier::LongTerm), MemoryState::LongTerm);
+    assert_eq!(lc.get_state("m"), Some(MemoryState::LongTerm));
+}
+
+#[test]
+fn lifecycle_should_not_promote_below_threshold() {
+    let lc = MemoryLifecycle::new(LifecycleConfig::default());
+    let item = MemoryItem::new("x", "uat").with_confidence(0.1);
+    assert!(lc.should_promote(&item).is_none());
+}
+
+#[test]
+fn lifecycle_should_not_demote_long_term_by_ttl() {
+    let lc = MemoryLifecycle::new(LifecycleConfig::default());
+    let mut item = MemoryItem::new("x", "uat");
+    item.last_accessed = Utc::now() - Duration::days(365);
+    assert!(lc.should_demote(&item, MemoryTier::LongTerm).is_none());
+}
+
+#[test]
+fn lifecycle_finalize_unknown_checkpoint_errors() {
+    let mut lc = MemoryLifecycle::new(LifecycleConfig::default());
+    let result = lc.finalize_checkpoint("does-not-exist", ObjectId::nil(), 0);
+    assert!(result.is_err());
+}
+
+#[test]
+fn lifecycle_default_config_values() {
+    let cfg = LifecycleConfig::default();
+    assert_eq!(cfg.working_memory_max_tokens, 4096);
+    assert_eq!(cfg.short_term_max_tokens, 16_384);
+    assert_eq!(cfg.long_term_max_tokens, 1_048_576);
+    assert_eq!(cfg.promotion_access_threshold, 3);
+}
+
+#[test]
+fn lifecycle_calculate_token_usage_groups_by_state() {
+    let mut lc = MemoryLifecycle::new(LifecycleConfig::default());
+    let working = MemoryItem::new("w", "uat").with_token_estimate(100);
+    let short = MemoryItem::new("s", "uat").with_token_estimate(200);
+    let long = MemoryItem::new("l", "uat").with_token_estimate(400);
+    lc.register(&working.id.to_string(), MemoryTier::Working);
+    lc.register(&short.id.to_string(), MemoryTier::ShortTerm);
+    lc.register(&long.id.to_string(), MemoryTier::LongTerm);
+
+    let usage = lc.calculate_token_usage(&[working, short, long]);
+    assert_eq!(usage.get(&MemoryTier::Working), Some(&100));
+    assert_eq!(usage.get(&MemoryTier::ShortTerm), Some(&200));
+    assert_eq!(usage.get(&MemoryTier::LongTerm), Some(&400));
+}
+
+// -----------------------------------------------------------------------------
+// SessionMetadata helpers
+// -----------------------------------------------------------------------------
+
+#[test]
+fn session_metadata_with_tag_appends() {
+    let m = SessionMetadata::new("s", "gpt-4")
+        .with_tag("a")
+        .with_tag("b");
+    assert_eq!(m.tags, vec!["a".to_string(), "b".to_string()]);
+}
+
+#[test]
+fn session_metadata_with_tags_replaces() {
+    let m = SessionMetadata::new("s", "gpt-4")
+        .with_tag("old")
+        .with_tags(["x", "y"]);
+    assert_eq!(m.tags, vec!["x".to_string(), "y".to_string()]);
+}
+
+// -----------------------------------------------------------------------------
+// MemoryQuery builder
+// -----------------------------------------------------------------------------
+
+#[test]
+fn memory_query_builder_sets_fields() {
+    let q = MemoryQuery::new()
+        .with_keyword("foo")
+        .with_keyword("bar")
+        .with_tag("t1")
+        .with_min_confidence(0.5)
+        .with_limit(7);
+    assert_eq!(q.keywords, vec!["foo", "bar"]);
+    assert_eq!(q.tags, vec!["t1"]);
+    assert_eq!(q.min_confidence, Some(0.5));
+    assert_eq!(q.limit, 7);
+}
+
+// -----------------------------------------------------------------------------
+// Object store: error path
+// -----------------------------------------------------------------------------
+
+#[test]
+fn object_store_read_missing_object_returns_not_found() {
+    let dir = TempDir::new().unwrap();
+    let os = ObjectStore::new(&dir.path().to_path_buf()).unwrap();
+    let unknown = ObjectId::from_content(b"never written");
+    let err = os.read_blob(&unknown).err().expect("expected error");
+    let msg = err.to_string();
+    assert!(msg.contains("Object not found"), "msg={msg}");
+}
+
+#[test]
+fn object_store_blob_to_text_handles_utf8_and_binary() {
+    let dir = TempDir::new().unwrap();
+    let mut os = ObjectStore::new(&dir.path().to_path_buf()).unwrap();
+    let text_oid = os.write_blob(&Blob::new(b"hello")).unwrap();
+    let text = os.read_blob(&text_oid).unwrap();
+    assert_eq!(text.to_text(), Some("hello"));
+
+    let bin_oid = os.write_blob(&Blob::new(&[0xff, 0xfe, 0x00, 0x80])).unwrap();
+    let bin = os.read_blob(&bin_oid).unwrap();
+    assert!(bin.to_text().is_none());
+    assert_eq!(bin.size(), 4);
+}
+
+// -----------------------------------------------------------------------------
+// Sanity: TransitionTrigger pattern matching
+// -----------------------------------------------------------------------------
+
+#[test]
+fn transition_trigger_variants_round_trip_via_serde() {
+    for trig in [
+        TransitionTrigger::TokenBudgetExceeded,
+        TransitionTrigger::TtlExpired,
+        TransitionTrigger::AccessCount(7),
+        TransitionTrigger::ImportanceThreshold(0.9),
+        TransitionTrigger::Manual,
+        TransitionTrigger::SleepConsolidation,
+        TransitionTrigger::ConflictDetected,
+    ] {
+        let s = serde_json::to_string(&trig).unwrap();
+        let back: TransitionTrigger = serde_json::from_str(&s).unwrap();
+        // pattern equality (the type doesn't derive PartialEq).
+        match (trig, back) {
+            (TransitionTrigger::TokenBudgetExceeded, TransitionTrigger::TokenBudgetExceeded) => {}
+            (TransitionTrigger::TtlExpired, TransitionTrigger::TtlExpired) => {}
+            (TransitionTrigger::AccessCount(a), TransitionTrigger::AccessCount(b)) => {
+                assert_eq!(a, b);
+            }
+            (
+                TransitionTrigger::ImportanceThreshold(a),
+                TransitionTrigger::ImportanceThreshold(b),
+            ) => {
+                assert!((a - b).abs() < 1e-6);
+            }
+            (TransitionTrigger::Manual, TransitionTrigger::Manual) => {}
+            (TransitionTrigger::SleepConsolidation, TransitionTrigger::SleepConsolidation) => {}
+            (TransitionTrigger::ConflictDetected, TransitionTrigger::ConflictDetected) => {}
+            (a, b) => panic!("variant mismatch: {:?} vs {:?}", a, b),
+        }
+    }
+}


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR integrates the `memst` crate into `helix-db` as `helix_db::memst`, adding a Git-like three-tier memory management system (Working / ShortTerm / LongTerm) with BLAKE3-backed content-addressable storage, token-budget tracking, and an on-disk session/message layout with exclusive file locking. The overall architecture is well-designed with thorough test coverage, but `store.rs` has a cluster of data-integrity issues that should be addressed before merging.

- **`helix-db/src/memst/`** — five new modules (`store`, `memory`, `objects`, `types`, `error`) plus a `mod.rs` re-export facade; `store.rs` contains several data-integrity issues (see inline comments).
- **Tests and docs** — three integration test files, a runnable multi-session example, `README-MEMST.md`, and `Dev-Manual.md` are added; coverage is broad and the documentation is thorough.
- **`helix-db/Cargo.toml`** — three new dependencies (`blake3`, `fs2`, `serde_json`) and a new `serde` feature on `chrono`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-db/src/memst/store.rs | Core session/memory file manager — contains three data-integrity bugs: BufWriter not flushed in save_memories, non-atomic truncate-then-write pattern in save_memories, and non-atomic promote_memory that can permanently lose a memory item if the destination write fails after the source is already removed. |
| helix-db/src/memst/types.rs | Core data types (Message, MemoryItem, SessionMetadata, etc.) — well-structured; minor issue: with_metadata panics on unserializable values instead of failing gracefully. |
| helix-db/src/memst/memory.rs | MemoryLifecycle manager with tiered promotion/demotion, checkpointing, and token-budget tracking — logic is sound; importance scores stored on disk can become stale between accesses, which may skew compaction ranking. |
| helix-db/src/memst/objects.rs | BLAKE3-backed content-addressable object store (Blob/Tree/Commit/Tag) — correctly uses write-to-temp + rename for atomic writes; solid implementation. |
| helix-db/src/memst/error.rs | Error enum with thiserror-derived variants — straightforward, well-covered. |
| helix-db/src/memst/mod.rs | Re-export facade for the memst module — all new public types are correctly re-exported. |
| helix-db/examples/memst_multi_session.rs | Runnable demo showing three concurrent sessions with lifecycle, budget pressure, and persistence check — well-structured example. |
| helix-db/Cargo.toml | Adds blake3, fs2, and serde_json dependencies for the memst integration; chrono updated to include serde feature. |
| helix-db/tests/memst_uat.rs | BDD-style UAT scenarios covering session lifecycle, memory tiers, compaction checkpoints, and persistence — good coverage. |
| helix-db/tests/memst_unit.rs | Fine-grained unit tests for builders, serde, index parsing, and edge cases — comprehensive. |
| helix-db/tests/memst_uat_multisession.rs | Multi-session isolation UAT — verifies that memories and messages from one session never leak into another. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SessionStore::init / open\nfs2 exclusive lock] --> B[create_session\nmetadata.json + messages.bin/idx\noperations.log + memory/]
    B --> C[append_message\nappend → messages.bin\ntext line → messages.idx\nmetadata.json updated\nmanifest.json updated]
    B --> D[add_memory\nload_memories → mutate → save_memories\ntruncate-then-write ⚠️\nno flush ⚠️]
    D --> E{access_memory\nrecord_access → recalculate_importance\nsave_memories ⚠️}
    D --> F[promote_memory\nremove from src → save src ⚠️\nadd to dst]
    B --> G[append_operation\nJSONL append → operations.log]
    H[MemoryLifecycle] --> I[should_promote / should_demote\naccess_count / TTL checks]
    H --> J[create_checkpoint\npre_commit ObjectId]
    H --> K[finalize_checkpoint\npost_commit ObjectId]
    H --> L[select_for_compaction\nsort by importance ASC]
    M[ObjectStore BLAKE3] --> N[write_blob/tree/commit/tag\nwrite-to-tmp + rename ✅]
    M --> O[read_blob/tree/commit/tag]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Dev-Manual.md covering build, test h..."](https://github.com/helixdb/helix-db/commit/80a9f15d63ef817110e0a821e23b36483c67659a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31435678)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->