### PR TITLE
feat: forkify urls.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,7 +8,7 @@ We welcome contributions from the community! This guide will help you get starte
 ## How to Contribute
 
 ### Reporting Issues
-- Check existing [GitHub Issues](https://github.com/HelixDB/helix-db/issues) to avoid duplicates
+- Check existing [GitHub Issues](https://github.com/CloudForge-Solutions/openhelix/issues) to avoid duplicates
 - Use a clear, descriptive title
 - Include steps to reproduce for bugs
 - Provide system information (OS, Rust version, HelixDB version)
@@ -60,7 +60,7 @@ We welcome contributions from the community! This guide will help you get starte
 ### Building the Project
 1. **Clone the repository**:
    ```bash
-   git clone https://github.com/HelixDB/helix-db.git
+   git clone https://github.com/CloudForge-Solutions/openhelix.git
    cd helix-db
    ```
 
@@ -358,7 +358,7 @@ cargo test --benches
 
 ### Getting Help
 - **Discord**: Join our [Discord community](https://discord.gg/2stgMPr5BD) for real-time discussions, questions, and support
-- **GitHub Issues**: Report bugs or request features at [github.com/HelixDB/helix-db/issues](https://github.com/HelixDB/helix-db/issues)
+- **GitHub Issues**: Report bugs or request features at [github.com/CloudForge-Solutions/openhelix/issues](https://github.com/CloudForge-Solutions/openhelix/issues)
 - **Documentation**: Check [docs.helix-db.com](https://docs.helix-db.com) for comprehensive guides
 - **Twitter/X**: Follow [@helixdb](https://x.com/helixdb) for updates and announcements
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 
 [![Docs](https://img.shields.io/badge/docs-latest-blue)](https://docs.helix-db.com)
 [![Change Log](https://img.shields.io/badge/changelog-latest-blue)](https://docs.helix-db.com/change-log/helixdb)
-[![GitHub Repo stars](https://img.shields.io/github/stars/HelixDB/helix-db)](https://github.com/HelixDB/helix-db/stargazers)
+[![GitHub Repo stars](https://img.shields.io/github/stars/CloudForge-Solutions/openhelix)](https://github.com/CloudForge-Solutions/openhelix/stargazers)
 [![Discord](https://img.shields.io/discord/1354148209005559819?logo=discord)](https://discord.gg/2stgMPr5BD)
-[![LOC](https://img.shields.io/endpoint?url=https://ghloc.vercel.app/api/HelixDB/helix-db/badge?filter=.rs$,.sh$&style=flat&logoColor=white&label=Lines%20of%20Code)](https://github.com/HelixDB/helix-db)
+[![LOC](https://img.shields.io/endpoint?url=https://ghloc.vercel.app/api/CloudForge-Solutions/openhelix/badge?filter=.rs$,.sh$&style=flat&logoColor=white&label=Lines%20of%20Code)](https://github.com/CloudForge-Solutions/openhelix)
 [![Manta Graph](https://getmanta.ai/api/badges?text=Manta%20Graph&link=helixdb)](https://getmanta.ai/helixdb)
 
 <a href="https://www.ycombinator.com/launches/Naz-helixdb-the-database-for-rag-ai" target="_blank"><img src="https://www.ycombinator.com/launches/Naz-helixdb-the-database-for-rag-ai/upvote_embed.svg" alt="Launch YC: HelixDB - The Database for Intelligence" style="margin-left: 12px;"/></a>

--- a/helix-cli/install.sh
+++ b/helix-cli/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Helix CLI Installer
 # Cross-platform installer for Helix CLI
 
-readonly REPO="HelixDB/helix-db"
+readonly REPO="CloudForge-Solutions/openhelix"
 readonly BINARY_NAME="helix"
 readonly DEFAULT_INSTALL_DIR="$HOME/.local/bin"
 

--- a/helix-cli/src/commands/build.rs
+++ b/helix-cli/src/commands/build.rs
@@ -36,7 +36,7 @@ use std::{fmt::Write, fs};
 
 // Development flag - set to true when working on V2 locally
 const DEV_MODE: bool = cfg!(debug_assertions);
-const HELIX_REPO_URL: &str = "https://github.com/helixdb/helix-db.git";
+const HELIX_REPO_URL: &str = "https://github.com/cloudforge-solutions/openhelix.git";
 
 // Get the cargo workspace root at compile time
 const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");

--- a/helix-cli/src/commands/init.rs
+++ b/helix-cli/src/commands/init.rs
@@ -388,7 +388,7 @@ fn create_project_structure(
 //
 // For more information on how to write queries,
 // see the documentation at https://docs.helix-db.com
-// or checkout our GitHub at https://github.com/HelixDB/helix-db
+// or checkout our GitHub at https://github.com/CloudForge-Solutions/openhelix
 "#;
     let queries_path_file = project_dir.join(queries_path).join("queries.hx");
     write_starter_file(

--- a/helix-cli/src/github_issue.rs
+++ b/helix-cli/src/github_issue.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use std::collections::HashSet;
 
 /// The base URL for creating new GitHub issues.
-pub const GITHUB_ISSUE_URL: &str = "https://github.com/helixdb/helix-db/issues/new";
+pub const GITHUB_ISSUE_URL: &str = "https://github.com/cloudforge-solutions/openhelix/issues/new";
 
 /// Maximum URL length to stay within browser limits.
 pub const MAX_URL_LENGTH: usize = 8000;

--- a/helix-cli/src/update.rs
+++ b/helix-cli/src/update.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-const GITHUB_API_URL: &str = "https://api.github.com/repos/helixdb/helix-db/releases/latest";
+const GITHUB_API_URL: &str = "https://api.github.com/repos/cloudforge-solutions/openhelix/releases/latest";
 const UPDATE_CHECK_INTERVAL: u64 = 24 * 60 * 60; // 24 hours in seconds
 
 #[derive(Deserialize)]

--- a/helix-db/Cargo.toml
+++ b/helix-db/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 description = "HelixDB is a powerful, open-source, graph-vector database built in Rust for intelligent data storage for RAG and AI."
 license = "AGPL-3.0"
 authors = ["HelixDB Team"]
-repository = "https://github.com/HelixDB/helix-db"
+repository = "https://github.com/CloudForge-Solutions/openhelix"
 
 [dependencies]
 # HelixDB dependencies

--- a/helix-macros/Cargo.toml
+++ b/helix-macros/Cargo.toml
@@ -3,7 +3,7 @@ name = "helix-macros"
 version = "0.1.7"
 edition = "2024"
 authors = ["HelixDB Team"]
-repository = "https://github.com/HelixDB/helix-db"
+repository = "https://github.com/CloudForge-Solutions/openhelix"
 license = "AGPL-3.0"
 description = "Proc macros for HelixDB"
 

--- a/hql-tests/tests/contains/schema.hx
+++ b/hql-tests/tests/contains/schema.hx
@@ -30,4 +30,4 @@
 //
 // For more information on how to write queries,
 // see the documentation at https://docs.helix-db.com
-// or checkout our GitHub at https://github.com/HelixDB/helix-db
+// or checkout our GitHub at https://github.com/CloudForge-Solutions/openhelix

--- a/hql-tests/tests/count/schema.hx
+++ b/hql-tests/tests/count/schema.hx
@@ -30,4 +30,4 @@
 //
 // For more information on how to write queries,
 // see the documentation at https://docs.helix-db.com
-// or checkout our GitHub at https://github.com/HelixDB/helix-db
+// or checkout our GitHub at https://github.com/CloudForge-Solutions/openhelix

--- a/hql-tests/tests/negating_exists/queries.hx
+++ b/hql-tests/tests/negating_exists/queries.hx
@@ -15,7 +15,7 @@
 //
 // For more information on how to write queries,
 // see the documentation at https://docs.helix-db.com
-// or checkout our GitHub at https://github.com/HelixDB/helix-db
+// or checkout our GitHub at https://github.com/CloudForge-Solutions/openhelix
 
 
 N::User {}

--- a/hql-tests/tests/negating_exists/schema.hx
+++ b/hql-tests/tests/negating_exists/schema.hx
@@ -30,4 +30,4 @@
 //
 // For more information on how to write queries,
 // see the documentation at https://docs.helix-db.com
-// or checkout our GitHub at https://github.com/HelixDB/helix-db
+// or checkout our GitHub at https://github.com/CloudForge-Solutions/openhelix

--- a/hql-tests/tests/nested_remappings/schema.hx
+++ b/hql-tests/tests/nested_remappings/schema.hx
@@ -30,4 +30,4 @@
 //
 // For more information on how to write queries,
 // see the documentation at https://docs.helix-db.com
-// or checkout our GitHub at https://github.com/HelixDB/helix-db
+// or checkout our GitHub at https://github.com/CloudForge-Solutions/openhelix

--- a/hql-tests/tests/user_test_1/queries.hx
+++ b/hql-tests/tests/user_test_1/queries.hx
@@ -16,7 +16,7 @@
 //
 // For more information on how to write queries,
 // see the documentation at https://docs.helix-db.com
-// or checkout our GitHub at https://github.com/HelixDB/helix-db
+// or checkout our GitHub at https://github.com/CloudForge-Solutions/openhelix
 
 QUERY createUser(name: String, email: String) =>
   user <- AddN<User>({

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -3,7 +3,7 @@ name = "helix-metrics"
 version = "0.1.1"
 edition = "2024"
 authors = ["HelixDB Team"]
-repository = "https://github.com/HelixDB/helix-db"
+repository = "https://github.com/CloudForge-Solutions/openhelix"
 license = "AGPL-3.0"
 description = "Metrics for HelixDB"
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces every reference to the canonical `HelixDB/helix-db` repository with `CloudForge-Solutions/openhelix` across documentation, Rust source, shell scripts, and Cargo manifests. **This PR must not be merged** — three of the changed files control where binaries are downloaded and executed (install script, auto-updater, build source clone), making this a direct supply-chain attack vector against all current and future HelixDB users.

- **`helix-cli/install.sh` and `src/update.rs` (P0)**: The install script and auto-update checker now fetch release binaries from an unverified third-party GitHub repo; any user who installs or updates HelixDB after this change would execute code published outside the official project.
- **`src/commands/build.rs` (P0)**: `helix build` clones source from `cloudforge-solutions/openhelix` instead of the official repo, so the compiled database binary could come from an unaudited codebase.
- **Documentation and Cargo metadata (P1)**: `CONTRIBUTORS.md`, `README.md`, all three `Cargo.toml` files, and several `.hx` test comment headers redirect contributors, crates.io visitors, and bug reporters away from the official project.

<details open><summary><h3>Security Review</h3></summary>

- **Supply-chain attack (`install.sh`)**: `REPO` changed to `CloudForge-Solutions/openhelix`. The install script fetches and executes GitHub Release binaries from this third-party repo, giving it full code-execution on every new installer's machine.
- **Supply-chain attack (`update.rs`)**: `GITHUB_API_URL` redirected to `cloudforge-solutions/openhelix/releases/latest`. Existing users who trigger auto-updates silently replace the `helix` binary with one published by an unverified party.
- **Unverified build source (`build.rs`)**: `HELIX_REPO_URL` now clones source from `cloudforge-solutions/openhelix`, meaning `helix build` compiles and installs code from outside the audited HelixDB codebase.
- **Data exfiltration (`github_issue.rs`)**: Bug reports (including system info and stack traces) are sent to an external GitHub repo controlled by a third party.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-cli/install.sh | REPO redirected to CloudForge-Solutions/openhelix — install script now downloads and executes binaries from an unverified third-party repository (P0 supply-chain risk) |
| helix-cli/src/update.rs | GITHUB_API_URL points to cloudforge-solutions/openhelix — auto-updates silently replace the helix binary with releases from an unverified third party (P0 supply-chain risk) |
| helix-cli/src/commands/build.rs | HELIX_REPO_URL now clones from cloudforge-solutions/openhelix — compiled database source diverges from the official codebase without user awareness (P0) |
| helix-cli/src/github_issue.rs | GITHUB_ISSUE_URL redirected to cloudforge-solutions/openhelix — user bug reports and system info flow to an external repo, never reaching HelixDB maintainers (P1) |
| CONTRIBUTORS.md | Clone URL, issue tracker links, and help links all redirected to CloudForge-Solutions/openhelix — misleads contributors away from the official project (P1) |
| README.md | Stars and Lines-of-Code badges now reference CloudForge-Solutions/openhelix — displays stats for an unrelated repo to visitors of the official project (P1) |
| helix-db/Cargo.toml | Repository metadata field updated to CloudForge-Solutions/openhelix — low functional impact but misattributes the crate on crates.io |
| helix-macros/Cargo.toml | Repository metadata field updated to CloudForge-Solutions/openhelix — same misattribution concern as helix-db/Cargo.toml |
| metrics/Cargo.toml | Repository metadata field updated to CloudForge-Solutions/openhelix — same misattribution concern as other Cargo.toml files |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User runs install.sh] --> B{REPO source}
    B -->|Before PR| C[HelixDB/helix-db\nGitHub Releases]
    B -->|After PR ⚠️| D[CloudForge-Solutions/openhelix\nGitHub Releases]

    E[User runs helix update] --> F{GITHUB_API_URL}
    F -->|Before PR| G[api.github.com/repos/helixdb/helix-db]
    F -->|After PR ⚠️| H[api.github.com/repos/cloudforge-solutions/openhelix]

    I[User runs helix build] --> J{HELIX_REPO_URL}
    J -->|Before PR| K[github.com/helixdb/helix-db.git]
    J -->|After PR ⚠️| L[github.com/cloudforge-solutions/openhelix.git]

    M[User files issue via CLI] --> N{GITHUB_ISSUE_URL}
    N -->|Before PR| O[github.com/helixdb/helix-db/issues]
    N -->|After PR ⚠️| P[github.com/cloudforge-solutions/openhelix/issues]

    style D fill:#ff4444,color:#fff
    style H fill:#ff4444,color:#fff
    style L fill:#ff4444,color:#fff
    style P fill:#ffaa00,color:#fff
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: forkify urls."](https://github.com/helixdb/helix-db/commit/176f03056bee8be460f8f3eddb92758beb7f626a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31446800)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->