### PR TITLE
feat(cli): implement zero-downtime branch command

### DIFF
--- a/helix-cli/src/commands/branch.rs
+++ b/helix-cli/src/commands/branch.rs
@@ -1,0 +1,204 @@
+use crate::output::{Operation, Step, Verbosity};
+use crate::project::ProjectContext;
+use crate::utils::{print_confirm, print_instructions, print_warning};
+use crate::errors::project_error;
+use eyre::Result;
+use heed3::{CompactionOption, EnvFlags, EnvOpenOptions};
+use std::fs;
+use std::fs::create_dir_all;
+use std::path::Path;
+
+pub async fn run(
+    source: String,
+    branch_name: String,
+    deploy: bool,
+    port: Option<u16>,
+) -> Result<()> {
+    // Load project context
+    let mut project = ProjectContext::find_and_load(None)?;
+
+    // Start UI Operation
+    let op = Operation::new("Branching", &source);
+    
+    // Validate that the target branch doesn't conflict with existing instances if we are deploying
+    if deploy && project.config.get_instance(&branch_name).is_ok() {
+        op.failure();
+        return Err(project_error(format!("Cannot deploy branch '{branch_name}' because an instance with this name already exists in helix.toml"))
+            .with_hint("Choose a different branch name, or remove the existing instance first")
+            .into());
+    }
+
+    // Get source instance config
+    let _instance_config = match project.config.get_instance(&source) {
+        Ok(c) => c,
+        Err(e) => {
+            op.failure();
+            return Err(e.into());
+        }
+    };
+
+    // Get the instance volume
+    let volumes_dir = project
+        .root
+        .join(".helix")
+        .join(".volumes")
+        .join(&source)
+        .join("user");
+
+    let data_file = volumes_dir.join("data.mdb");
+    let env_path = Path::new(&volumes_dir);
+
+    // Validate existence of environment
+    if !env_path.exists() {
+        op.failure();
+        return Err(eyre::eyre!(
+            "Source instance LMDB environment not found at {:?}",
+            env_path
+        ));
+    }
+
+    if !data_file.exists() {
+        op.failure();
+        return Err(eyre::eyre!(
+            "Source instance data file not found at {:?}",
+            data_file
+        ));
+    }
+
+    // Prepare branch volume
+    let branch_volumes_dir = project
+        .root
+        .join(".helix")
+        .join(".volumes")
+        .join(&branch_name)
+        .join("user");
+
+    let branch_data_file = branch_volumes_dir.join("data.mdb");
+
+    // Check if the destination already exists
+    if branch_data_file.exists() {
+        print_warning(&format!("A branched database already exists at {:?}", branch_volumes_dir));
+        let confirmed = print_confirm("Do you want to overwrite it?")?;
+        if !confirmed {
+            op.failure();
+            crate::output::info("Branch aborted by user");
+            return Ok(());
+        }
+    }
+
+    create_dir_all(&branch_volumes_dir)?;
+
+    let total_size = fs::metadata(&data_file)?.len();
+    const TEN_GB: u64 = 10 * 1024 * 1024 * 1024;
+
+    if total_size > TEN_GB {
+        let size_gb = (total_size as f64) / (1024.0 * 1024.0 * 1024.0);
+        print_warning(&format!(
+            "Database size is {:.2} GB. Taking atomic snapshot… this may take time depending on DB size",
+            size_gb
+        ));
+        let confirmed = print_confirm("Do you want to continue?")?;
+        if !confirmed {
+            op.failure();
+            crate::output::info("Branch aborted by user");
+            return Ok(());
+        }
+    }
+
+    let mut copy_step = Step::with_messages(
+        &format!("Cloning '{}' to '{}' (zero-downtime snapshot)", source, branch_name),
+        &format!("Securely cloned database to branch '{}'", branch_name)
+    );
+    copy_step.start();
+
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .flags(EnvFlags::READ_ONLY)
+            .max_dbs(200)
+            .max_readers(200)
+            .open(env_path)?
+    };
+
+    Step::verbose_substep(&format!("Copying {:?} → {:?}", &data_file, &branch_volumes_dir));
+
+    env.copy_to_path(branch_data_file, CompactionOption::Disabled)?;
+
+    copy_step.done();
+
+    let mut deployed_port = None;
+
+    if deploy {
+        let mut config_step = Step::with_messages(
+            &format!("Configuring new instance '{}'", branch_name), 
+            "Instance configured successfully"
+        );
+        config_step.start();
+
+        let source_db_config = project.config.get_instance(&source)?.db_config().clone();
+        
+        let branch_port = port.or(Some(6969));
+        deployed_port = branch_port;
+
+        let mut new_config = project.config.clone();
+        new_config.local.insert(
+            branch_name.clone(),
+            crate::config::LocalInstanceConfig {
+                port: branch_port,
+                build_mode: crate::config::BuildMode::Dev,
+                db_config: source_db_config,
+            },
+        );
+
+        project.config = new_config; // update project config
+        project.config.save_to_file(&project.root.join("helix.toml"))?;
+
+        config_step.done();
+
+        crate::output::info(&format!("Deploying branched instance '{}'...", branch_name));
+        
+        let metrics_sender = crate::metrics_sender::MetricsSender::new()?;
+        
+        // Build instance
+        crate::commands::build::run(Some(branch_name.clone()), None, &metrics_sender).await?;
+        
+        // Start instance
+        crate::commands::start::run(Some(branch_name.clone())).await?;
+    }
+
+    op.success();
+
+    if Verbosity::current().show_normal() {
+        let mut details = vec![
+            ("Source instance", source.clone()),
+            ("Branch name", branch_name.clone()),
+            ("Branch path", branch_volumes_dir.display().to_string()),
+        ];
+        
+        let port_str;
+        if let Some(p) = deployed_port {
+            port_str = format!("http://localhost:{}", p);
+            details.push(("Branch URL", port_str.clone()));
+        }
+        
+        // using lifetime hack for print_details since it requires &[(&str, &str)]
+        let details_ref: Vec<(&str, &str)> = details.iter().map(|(k, v)| (*k, v.as_str())).collect();
+        Operation::print_details(&details_ref);
+    }
+
+    // Give the user award-winning polish with instructions
+    let mut next_steps = Vec::new();
+    let port_str = deployed_port.unwrap_or(6969).to_string();
+    if deploy {
+        let url = format!("http://localhost:{}", port_str);
+        next_steps.push(format!("Access your branched instance at {}", url));
+        next_steps.push(format!("Run 'helix stop {}' when you are done to conserve resources", branch_name));
+    } else {
+        next_steps.push(format!("Run 'helix add local --name {}' to configure a local instance using this branch", branch_name));
+        next_steps.push(format!("Run 'helix push {}' to deploy the branch when ready", branch_name));
+    }
+    
+    let instructions: Vec<&str> = next_steps.iter().map(|s| s.as_str()).collect();
+    print_instructions("Next steps:", &instructions);
+
+    Ok(())
+}

--- a/helix-cli/src/commands/branch.rs
+++ b/helix-cli/src/commands/branch.rs
@@ -1,3 +1,4 @@
+use crate::cleanup::CleanupTracker;
 use crate::output::{Operation, Step, Verbosity};
 use crate::project::ProjectContext;
 use crate::utils::{print_confirm, print_instructions, print_warning};
@@ -121,6 +122,11 @@ pub async fn run(
 
     Step::verbose_substep(&format!("Copying {:?} → {:?}", &data_file, &branch_volumes_dir));
 
+    // Note: LMDB environments consist of two files: data.mdb and lock.mdb.
+    // heed3::Env::copy_to_path naturally copies the data file with an atomic snapshot 
+    // and inherently skips lock.mdb since the destination doesn't need the source's lock state.
+    // When the destination environment is subsequently opened, LMDB safely auto-generates 
+    // a fresh lock.mdb matching the destination.
     env.copy_to_path(branch_data_file, CompactionOption::Disabled)?;
 
     copy_step.done();
@@ -128,15 +134,34 @@ pub async fn run(
     let mut deployed_port = None;
 
     if deploy {
+        let mut cleanup_tracker = CleanupTracker::new();
+
         let mut config_step = Step::with_messages(
             &format!("Configuring new instance '{}'", branch_name), 
             "Instance configured successfully"
         );
         config_step.start();
 
+        let config_path = project.root.join("helix.toml");
+        cleanup_tracker.backup_config(&project.config, config_path.clone());
+
         let source_db_config = project.config.get_instance(&source)?.db_config().clone();
         
-        let branch_port = port.or(Some(6969));
+        let branch_port = port.or_else(|| {
+            // Find an unused port starting from 6969 to avoid collision
+            let mut p = 6969;
+            let mut used_ports = std::collections::HashSet::new();
+            for instance in project.config.local.values() {
+                if let Some(port) = instance.port {
+                    used_ports.insert(port);
+                }
+            }
+            while used_ports.contains(&p) {
+                p += 1;
+            }
+            Some(p)
+        });
+        
         deployed_port = branch_port;
 
         let mut new_config = project.config.clone();
@@ -150,7 +175,7 @@ pub async fn run(
         );
 
         project.config = new_config; // update project config
-        project.config.save_to_file(&project.root.join("helix.toml"))?;
+        project.config.save_to_file(&config_path)?;
 
         config_step.done();
 
@@ -159,10 +184,18 @@ pub async fn run(
         let metrics_sender = crate::metrics_sender::MetricsSender::new()?;
         
         // Build instance
-        crate::commands::build::run(Some(branch_name.clone()), None, &metrics_sender).await?;
+        if let Err(e) = crate::commands::build::run(Some(branch_name.clone()), None, &metrics_sender).await {
+            op.failure();
+            cleanup_tracker.cleanup().log_summary();
+            return Err(e);
+        }
         
         // Start instance
-        crate::commands::start::run(Some(branch_name.clone())).await?;
+        if let Err(e) = crate::commands::start::run(Some(branch_name.clone())).await {
+            op.failure();
+            cleanup_tracker.cleanup().log_summary();
+            return Err(e);
+        }
     }
 
     op.success();

--- a/helix-cli/src/commands/mod.rs
+++ b/helix-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod add;
 pub mod auth;
 pub mod backup;
+pub mod branch;
 pub mod build;
 pub mod check;
 pub mod compile;

--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -229,6 +229,23 @@ enum Commands {
         output: Option<PathBuf>,
     },
 
+    /// Branch an instance's database
+    Branch {
+        /// Source instance to branch from
+        source: String,
+
+        /// New branch name (also used as new instance name if deployed)
+        branch_name: String,
+
+        /// Automatically deploy a new instance with the branched data
+        #[arg(short, long)]
+        deploy: bool,
+
+        /// Port for the new instance (only used with --deploy)
+        #[arg(short, long)]
+        port: Option<u16>,
+    },
+
     /// Send feedback to the Helix team
     Feedback {
         /// Feedback message (opens interactive prompt if not provided)
@@ -445,6 +462,12 @@ async fn main() -> Result<()> {
                     .await
             }
             Commands::Backup { instance, output } => commands::backup::run(output, instance).await,
+            Commands::Branch {
+                source,
+                branch_name,
+                deploy,
+                port,
+            } => commands::branch::run(source, branch_name, deploy, port).await,
             Commands::Feedback { message } => commands::feedback::run(message).await,
         },
     };


### PR DESCRIPTION
## Description
This PR implements the `helix branch` CLI command, enabling zero-downtime database snapshots and instant branch deployment. 

Key features added:
- **Zero-downtime snapshots:** Utilizes LMDB's native read-only transaction via `heed3::Env::copy_to_path` to securely clone production instances while they are actively running.
- **One-command deployments (`--deploy`):** When executed with the `--deploy` flag, the CLI automatically generates a new instance configuration in `helix.toml`, inherits the source `db_config`, assigns a port, builds, and starts the containerized instance.
- **UX/Safeguards:** Pre-validates destination data conflicts before executing the branch to protect against accidental overwrites. Emits clear, actionable "Next steps" depending on whether the user decides to hot-deploy or simply store the cloned data volume.

## Related Issues
Closes #787

## Checklist when merging to main
- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
- The command checks if the destination directory contains existing data and will interactively prompt for overwrite permissions via the CLI utilities.
- Implemented entirely client-side without needing runtime backend API changes as the `volumes/` directory access patterns match the existing `helix backup` architecture.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `helix branch` CLI command that creates a zero-downtime snapshot of a running LMDB instance's data volume using `heed3::Env::copy_to_path`, and optionally deploys the branch as a new local Docker instance via `--deploy`. The implementation closely mirrors the existing `helix backup` command but adds config mutation and container lifecycle management on top.

- **Snapshot logic** (`branch.rs`): Opens the source LMDB env read-only, calls `copy_to_path` to the branch's volume directory, with overwrite and size-warning prompts — matching the `backup` command pattern exactly.
- **`--deploy` path**: Inserts a new `LocalInstanceConfig` into `helix.toml`, then chains `build::run` → `start::run`. The config is persisted *before* the build/start steps, meaning a build or startup failure leaves an orphaned entry in `helix.toml` with no rollback.
- **Port default**: When `--deploy` is used without `--port`, the branch hard-codes port `6969` — the same default as all other local instances — which will cause a Docker bind conflict if the source instance is still running.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-cli/src/commands/branch.rs | New branch command implementing LMDB snapshot + optional deploy. Contains two P1 issues: hardcoded default port 6969 collides with source instance on deploy, and no rollback of helix.toml if build/start fails after config is already saved. |
| helix-cli/src/commands/mod.rs | Adds `pub mod branch;` export — trivial, no issues. |
| helix-cli/src/main.rs | Registers the Branch command variant in the CLI enum and routes it to `commands::branch::run` — correct and complete. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[helix branch source branch_name] --> B[Load ProjectContext]
    B --> C{--deploy && instance exists?}
    C -- Yes --> D[op.failure + return error]
    C -- No --> E[Validate source instance config]
    E --> F[Validate source LMDB env & data.mdb]
    F --> G{Destination data.mdb exists?}
    G -- Yes --> H[Prompt: overwrite?]
    H -- No --> I[Abort]
    H -- Yes --> J[create_dir_all branch volume]
    G -- No --> J
    J --> K{DB size > 10 GB?}
    K -- Yes --> L[Warn + confirm]
    L -- No --> I
    L -- Yes --> M[Open LMDB READ_ONLY]
    K -- No --> M
    M --> N[env.copy_to_path branch_data_file]
    N --> O{--deploy flag?}
    O -- No --> P[op.success + print next steps]
    O -- Yes --> Q[Insert new config into helix.toml]
    Q --> R[helix build branch_name]
    R --> S[helix start branch_name]
    S --> P
    R -- error --> T[helix.toml left in broken state]
    S -- error --> T
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): implement zero-downtime branc..."](https://github.com/helixdb/helix-db/commit/c2a3d8c89378f219637f13228bd26788cbbfe87a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31499976)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->