### PR TITLE
Update helix-cli version to 3.0.0 in Cargo.toml and Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helix-cli"
-version = "2.3.5"
+version = "3.0.0"
 dependencies = [
  "base64",
  "chrono",

--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-cli"
-version = "2.3.5"
+version = "3.0.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `helix-cli` package version from `2.3.5` to `3.0.0`, updating both `helix-cli/Cargo.toml` and the corresponding `Cargo.lock` entry. This is a major version release, and the existing `update.rs` already has supporting logic (`is_v3_update`, `V1_TARGET_VERSION`) in place to handle the migration warning and `--v1` downgrade path.

- **`helix-cli/Cargo.toml`**: Version field updated from `"2.3.5"` to `"3.0.0"`.
- **`Cargo.lock`**: Lock file entry for `helix-cli` updated to match the new version; all other fields unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-cli/Cargo.toml | Major version bump from 2.3.5 to 3.0.0; no other changes to dependencies or configuration. |
| Cargo.lock | Lock file entry for helix-cli updated to 3.0.0 to match Cargo.toml; consistent with the version bump. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User runs 'helix update'] --> B{--v1 flag?}
    B -- Yes --> C[Target: V1_TARGET_TAG = v2.3.5]
    B -- No --> D[Target: Latest GitHub Release]
    C --> E{is_v3_update?\ncurrent vs latest}
    D --> E
    E -- true --> F[Print v3 breaking-change warning]
    E -- false --> G[Skip warning]
    F --> H[Download & install target version]
    G --> H
    H --> I[Done]

    style F fill:#f90,color:#000
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Update helix-cli version to 3.0.0 in Car..."](https://github.com/helixdb/helix-db/commit/5dea0e2cd69edbb289a2a97e3c4a4f3e6b2028d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32354960)</sub>

<!-- /greptile_comment -->