### PR TITLE
docs(ts-sdk): fix incorrect package name in README and examples

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -1,13 +1,13 @@
-# @helixdb/enterprise-ql
+# @helix-db/helix-db
 
-TypeScript query DSL for Helix Enterprise. This package builds the same JSON AST shape as the Rust `helix-enterprise-ql` crate.
+TypeScript query DSL for HelixDB. This package builds the same JSON AST shape as the Rust `helix-db` crate.
 
 The compatibility target is structural JSON equality with the Rust DSL. Object formatting and key order are not part of the contract, but enum tags, field names, omitted fields, explicit `null` fields, bundle metadata, and dynamic request payloads are intended to match Rust serde output.
 
 ## Quick Start
 
 ```ts
-import { defineParams, g, param, readBatch } from "@helixdb/enterprise-ql";
+import { defineParams, g, param, readBatch } from "@helix-db/helix-db";
 
 const params = defineParams({
   tenantId: param.string(),

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@helix-db/helix-db",
   "version": "2.0.0",
-  "description": "TypeScript library for working with  HelixDB",
+  "description": "TypeScript library for working with HelixDB",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Description
The TypeScript SDK README referenced `@helixdb/enterprise-ql`, but the
actual published package name (per package.json) is `@helix-db/helix-db`.
Users following the README would hit install/import errors.

Changes:
- README title, description, and import example updated to `@helix-db/helix-db`
- Rust crate name reference corrected (`helix-enterprise-ql` → `helix-db`)
- Double-space typo fixed in package.json description

## Related Issues
N/A

## Checklist when merging to main
- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt` (N/A — no Rust source modified)
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (N/A — docs only)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [x] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml` (N/A — docs only)

## Additional Notes
Documentation-only change (README.md + package.json description).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects stale package and crate name references in the TypeScript SDK documentation. The README previously referenced `@helixdb/enterprise-ql` (an old/incorrect name) while `package.json` already declared the package as `@helix-db/helix-db`, which would have caused install and import failures for users following the README.

- **`sdks/typescript/README.md`**: Title, description, and Quick Start import example updated from `@helixdb/enterprise-ql` to `@helix-db/helix-db`; Rust crate reference corrected from `helix-enterprise-ql` to `helix-db`.
- **`sdks/typescript/package.json`**: Double-space typo removed from the `description` field.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdks/typescript/README.md | Title, description, and import example corrected from `@helixdb/enterprise-ql` to `@helix-db/helix-db`; Rust crate reference updated from `helix-enterprise-ql` to `helix-db` |
| sdks/typescript/package.json | Double-space typo removed from the `description` field; no functional changes |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User reads README] --> B{Install package}
    B -->|Before PR: npm install @helixdb/enterprise-ql| C[❌ Package not found]
    B -->|After PR: npm install @helix-db/helix-db| D[✅ Package installed]
    D --> E{Import in code}
    E -->|import from '@helix-db/helix-db'| F[✅ Import resolves correctly]
    C --> G[Import fails]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix incorrect package name in Type..."](https://github.com/helixdb/helix-db/commit/0b0e469f2f753ff2e0b961f98bab58cc26bd46ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33758134)</sub>

<!-- /greptile_comment -->