### PR TITLE
Update helix-cli version to 3.0.3 in Cargo.toml and Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helix-cli"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "base64",
  "chrono",

--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-cli"
-version = "3.0.2"
+version = "3.0.3"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `helix-cli` crate version from `3.0.2` to `3.0.3`, updating both `helix-cli/Cargo.toml` and the corresponding entry in `Cargo.lock`.

- **`helix-cli/Cargo.toml`**: `version` field changed from `3.0.2` to `3.0.3`.
- **`Cargo.lock`**: Lock file entry for `helix-cli` updated to reflect the new version; all dependencies and checksums remain unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-cli/Cargo.toml | Patch version bump from 3.0.2 to 3.0.3; no other changes. |
| Cargo.lock | Lock file updated to reflect the new helix-cli version; dependencies and checksums are unchanged. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[helix-cli/Cargo.toml\nversion = 3.0.2] -->|version bump| B[helix-cli/Cargo.toml\nversion = 3.0.3]
    C[Cargo.lock\nhelix-cli = 3.0.2] -->|lock update| D[Cargo.lock\nhelix-cli = 3.0.3]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Update helix-cli version to 3.0.3 in Car..."](https://github.com/helixdb/helix-db/commit/1c27a0474cc558033aca1ae6de9be06ba25eb141) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34418018)</sub>

<!-- /greptile_comment -->