### PR TITLE
feat: remove Docker/Podman dependency with native runtime support

### DIFF
--- a/helix-cli/src/commands/dashboard.rs
+++ b/helix-cli/src/commands/dashboard.rs
@@ -7,6 +7,8 @@ use crate::utils::command_exists;
 use eyre::{Result, eyre};
 use std::process::{Command, Stdio};
 
+// The dashboard is always a container (Docker/Podman), never native.
+
 const DASHBOARD_IMAGE: &str = "public.ecr.aws/p8l2s5f1/helix-dashboard:latest";
 const DASHBOARD_CONTAINER_NAME: &str = "helix-dashboard";
 
@@ -43,6 +45,7 @@ async fn start(
         match runtime {
             ContainerRuntime::Docker => "host.docker.internal".to_string(),
             ContainerRuntime::Podman => "host.containers.internal".to_string(),
+            ContainerRuntime::Native => "localhost".to_string(),
         }
     } else {
         host

--- a/helix-cli/src/commands/dashboard.rs
+++ b/helix-cli/src/commands/dashboard.rs
@@ -7,8 +7,6 @@ use crate::utils::command_exists;
 use eyre::{Result, eyre};
 use std::process::{Command, Stdio};
 
-// The dashboard is always a container (Docker/Podman), never native.
-
 const DASHBOARD_IMAGE: &str = "public.ecr.aws/p8l2s5f1/helix-dashboard:latest";
 const DASHBOARD_CONTAINER_NAME: &str = "helix-dashboard";
 
@@ -45,6 +43,7 @@ async fn start(
         match runtime {
             ContainerRuntime::Docker => "host.docker.internal".to_string(),
             ContainerRuntime::Podman => "host.containers.internal".to_string(),
+            // detect_runtime never returns Native; fallback for completeness
             ContainerRuntime::Native => "localhost".to_string(),
         }
     } else {

--- a/helix-cli/src/commands/delete.rs
+++ b/helix-cli/src/commands/delete.rs
@@ -1,5 +1,5 @@
 use crate::config::InstanceInfo;
-use crate::local_runtime::LocalRuntime;
+use crate::local_runtime::Runtime;
 use crate::output::Operation;
 use crate::project::ProjectContext;
 use crate::utils::{print_confirm, print_warning};
@@ -24,7 +24,7 @@ pub async fn run(instance: String, yes: bool) -> Result<()> {
 
     let op = Operation::new("Deleting", &instance);
     if matches!(info, InstanceInfo::Local(_)) {
-        let _ = LocalRuntime::new(&project).prune_instance(&instance);
+        let _ = Runtime::for_project(&project).prune(&instance);
     }
 
     project.config.local.remove(&instance);

--- a/helix-cli/src/commands/logs/mod.rs
+++ b/helix-cli/src/commands/logs/mod.rs
@@ -1,7 +1,7 @@
 use crate::commands::auth::require_auth;
 use crate::config::InstanceInfo;
 use crate::enterprise_cloud::cloud_base_url;
-use crate::local_runtime::LocalRuntime;
+use crate::local_runtime::Runtime;
 use crate::project::ProjectContext;
 use crate::prompts;
 use chrono::{DateTime, Duration, Utc};
@@ -34,7 +34,7 @@ pub async fn run(
                     "--range, --start, and --end are only supported for Enterprise logs; local logs use docker/podman logs"
                 ));
             }
-            LocalRuntime::new(&project).logs(&instance, follow)?;
+            Runtime::for_project(&project).logs(&instance, follow)?;
         }
         InstanceInfo::Enterprise(config) => {
             if follow {

--- a/helix-cli/src/commands/prune.rs
+++ b/helix-cli/src/commands/prune.rs
@@ -1,4 +1,4 @@
-use crate::local_runtime::LocalRuntime;
+use crate::local_runtime::Runtime;
 use crate::output::Operation;
 use crate::project::ProjectContext;
 use crate::prompts::{self, PruneSelection};
@@ -26,7 +26,7 @@ pub async fn run(instance: Option<String>, all: bool, yes: bool) -> Result<()> {
 
 async fn prune_one(project: &ProjectContext, instance: &str) -> Result<()> {
     let op = Operation::new("Pruning", instance);
-    let removed_container = LocalRuntime::new(project).prune_instance(instance)?;
+    let removed_container = Runtime::for_project(project).prune(instance)?;
     let workspace = project.instance_workspace(instance);
     let removed_workspace = workspace.exists();
     if workspace.exists() {

--- a/helix-cli/src/commands/restart.rs
+++ b/helix-cli/src/commands/restart.rs
@@ -1,5 +1,5 @@
 use crate::config::InstanceInfo;
-use crate::local_runtime::LocalRuntime;
+use crate::local_runtime::Runtime;
 use crate::output::Operation;
 use crate::project::ProjectContext;
 use crate::prompts;
@@ -12,7 +12,7 @@ pub async fn run(instance: Option<String>) -> Result<()> {
         return Err(eyre!("'{instance}' is not a local v2 instance"));
     };
     let op = Operation::new("Restarting", &instance);
-    LocalRuntime::new(&project).restart(&instance, config)?;
+    Runtime::for_project(&project).restart(&instance, config)?;
     op.success();
     Ok(())
 }

--- a/helix-cli/src/commands/run.rs
+++ b/helix-cli/src/commands/run.rs
@@ -1,5 +1,5 @@
 use crate::config::{InstanceInfo, LocalStorageMode};
-use crate::local_runtime::LocalRuntime;
+use crate::local_runtime::Runtime;
 use crate::output::{Operation, Verbosity};
 use crate::project::ProjectContext;
 use crate::prompts;
@@ -36,18 +36,18 @@ pub async fn run(
     }
 
     project.ensure_instance_dir(&instance)?;
-    let runtime = LocalRuntime::new(&project);
+    let runtime = Runtime::for_project(&project);
     if foreground {
         crate::output::info("Running in foreground. Press Ctrl-C to stop.");
-        runtime.run_foreground(&instance, &config).await?;
+        runtime.start_foreground(&instance, &config).await?;
         op.success();
     } else {
-        runtime.run_detached(&instance, &config)?;
+        runtime.start(&instance, &config)?;
         op.success();
         if Verbosity::current().show_normal() {
             Operation::print_details(&[
                 ("URL", &format!("http://localhost:{}", config.port)),
-                ("Container", &runtime.container_name(&instance)),
+                ("Container", &runtime.display_name(&instance)),
             ]);
         }
     }

--- a/helix-cli/src/commands/status.rs
+++ b/helix-cli/src/commands/status.rs
@@ -1,5 +1,5 @@
 use crate::config::InstanceInfo;
-use crate::local_runtime::LocalRuntime;
+use crate::local_runtime::Runtime;
 use crate::project::ProjectContext;
 use crate::prompts::{self, StatusSelection};
 use crate::utils::{print_field, print_header, print_newline};
@@ -13,7 +13,7 @@ pub async fn run(instance: Option<String>) -> Result<()> {
     print_field("Root", &project.root.display().to_string());
     print_newline();
 
-    let runtime = LocalRuntime::new(&project);
+    let runtime = Runtime::for_project(&project);
     print_header("Instances");
     match resolve_status_selection(&project, instance)? {
         StatusSelection::All => {
@@ -21,7 +21,9 @@ pub async fn run(instance: Option<String>) -> Result<()> {
                 print_instance(&project, &runtime, name)?;
             }
         }
-        StatusSelection::Instance(instance) => print_instance(&project, &runtime, &instance)?,
+        StatusSelection::Instance(instance) => {
+            print_instance(&project, &runtime, &instance)?
+        }
     }
 
     Ok(())
@@ -41,7 +43,7 @@ fn resolve_status_selection(
     Ok(StatusSelection::All)
 }
 
-fn print_instance(project: &ProjectContext, runtime: &LocalRuntime, name: &str) -> Result<()> {
+fn print_instance(project: &ProjectContext, runtime: &Runtime, name: &str) -> Result<()> {
     match project.config.get_instance(name)? {
         InstanceInfo::Local(config) => {
             let status = runtime.status(name)?;

--- a/helix-cli/src/commands/stop.rs
+++ b/helix-cli/src/commands/stop.rs
@@ -1,5 +1,5 @@
 use crate::config::InstanceInfo;
-use crate::local_runtime::LocalRuntime;
+use crate::local_runtime::Runtime;
 use crate::output::Operation;
 use crate::project::ProjectContext;
 use crate::prompts;
@@ -15,7 +15,7 @@ pub async fn run(instance: Option<String>) -> Result<()> {
         return Err(eyre!("'{instance}' is not a local v2 instance"));
     }
     let op = Operation::new("Stopping", &instance);
-    if LocalRuntime::new(&project).stop(&instance)? {
+    if Runtime::for_project(&project).stop(&instance)? {
         op.success();
     } else {
         crate::output::info(&format!("Instance '{instance}' was not running"));

--- a/helix-cli/src/config.rs
+++ b/helix-cli/src/config.rs
@@ -86,6 +86,7 @@ pub enum ContainerRuntime {
     #[default]
     Docker,
     Podman,
+    Native,
 }
 
 impl ContainerRuntime {
@@ -93,6 +94,7 @@ impl ContainerRuntime {
         match self {
             Self::Docker => "docker",
             Self::Podman => "podman",
+            Self::Native => "native",
         }
     }
 
@@ -100,7 +102,12 @@ impl ContainerRuntime {
         match self {
             Self::Docker => "Docker",
             Self::Podman => "Podman",
+            Self::Native => "Native",
         }
+    }
+
+    pub const fn is_native(&self) -> bool {
+        matches!(self, Self::Native)
     }
 }
 

--- a/helix-cli/src/local_runtime.rs
+++ b/helix-cli/src/local_runtime.rs
@@ -5,8 +5,9 @@ use crate::project::ProjectContext;
 use eyre::{Result, eyre};
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::process::{Command, Output, Stdio};
-use std::thread;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::{fs, thread};
 use std::time::{Duration, Instant};
 use tokio::process::Command as TokioCommand;
 
@@ -20,17 +21,100 @@ const LOCAL_S3_REGION: &str = "us-east-1";
 const LOCAL_DB_PATH: &str = "db/";
 
 #[derive(Debug, Clone)]
-pub struct LocalRuntime {
-    runtime: ContainerRuntime,
-    project_name: String,
-}
-
-#[derive(Debug, Clone)]
 pub struct LocalStatus {
     pub instance_name: String,
     pub container_name: String,
     pub status: String,
     pub ports: String,
+}
+
+// ---------------------------------------------------------------------------
+// Enum-based runtime dispatch
+// ---------------------------------------------------------------------------
+
+pub enum Runtime<'a> {
+    Container(LocalRuntime),
+    Native(NativeManager<'a>),
+}
+
+impl<'a> Runtime<'a> {
+    pub fn for_project(project: &'a ProjectContext) -> Self {
+        if project.config.project.container_runtime.is_native() {
+            Self::Native(NativeManager::new(project))
+        } else {
+            Self::Container(LocalRuntime::new(project))
+        }
+    }
+
+    pub async fn start_foreground(
+        &self,
+        instance_name: &str,
+        config: &LocalInstanceConfig,
+    ) -> Result<()> {
+        match self {
+            Self::Container(r) => r.start_foreground(instance_name, config).await,
+            Self::Native(r) => r.start_foreground(instance_name, config).await,
+        }
+    }
+
+    pub fn start(&self, instance_name: &str, config: &LocalInstanceConfig) -> Result<()> {
+        match self {
+            Self::Container(r) => r.start(instance_name, config),
+            Self::Native(r) => r.start(instance_name, config),
+        }
+    }
+
+    pub fn stop(&self, instance_name: &str) -> Result<bool> {
+        match self {
+            Self::Container(r) => r.stop(instance_name),
+            Self::Native(r) => r.stop(instance_name),
+        }
+    }
+
+    pub fn restart(&self, instance_name: &str, config: &LocalInstanceConfig) -> Result<()> {
+        match self {
+            Self::Container(r) => r.restart(instance_name, config),
+            Self::Native(r) => r.restart(instance_name, config),
+        }
+    }
+
+    pub fn logs(&self, instance_name: &str, follow: bool) -> Result<()> {
+        match self {
+            Self::Container(r) => r.logs(instance_name, follow),
+            Self::Native(r) => r.logs(instance_name, follow),
+        }
+    }
+
+    pub fn status(&self, instance_name: &str) -> Result<Option<LocalStatus>> {
+        match self {
+            Self::Container(r) => r.status(instance_name),
+            Self::Native(r) => r.status(instance_name),
+        }
+    }
+
+    pub fn prune(&self, instance_name: &str) -> Result<bool> {
+        match self {
+            Self::Container(r) => r.prune(instance_name),
+            Self::Native(r) => r.prune(instance_name),
+        }
+    }
+
+    pub fn display_name(&self, instance_name: &str) -> String {
+        match self {
+            Self::Container(r) => r.display_name(instance_name),
+            Self::Native(r) => r.display_name(instance_name),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Container-based runtime (Docker / Podman)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct LocalRuntime {
+    runtime: ContainerRuntime,
+    project_name: String,
 }
 
 #[derive(Debug, Clone)]
@@ -76,7 +160,7 @@ impl LocalRuntime {
         format!("helix-{}-{}", self.project_name, instance_name)
     }
 
-    pub fn pull_image(&self, config: &LocalInstanceConfig) -> Result<()> {
+    fn pull_image(&self, config: &LocalInstanceConfig) -> Result<()> {
         self.pull_image_ref(&config.image_ref())
     }
 
@@ -105,201 +189,6 @@ impl LocalRuntime {
             .output()
             .map(|output| output.status.success())
             .unwrap_or(false)
-    }
-
-    pub fn run_detached(&self, instance_name: &str, config: &LocalInstanceConfig) -> Result<()> {
-        Self::check_available(self.runtime)?;
-        self.pull_image(config)?;
-
-        let name = self.container_name(instance_name);
-        let image = config.image_ref();
-        let _ = self.remove_container(&name);
-        let disk_resources = if config.storage.is_disk() {
-            Some(self.start_disk_dependencies(instance_name)?)
-        } else {
-            let _ = self.remove_disk_resources(instance_name, false);
-            None
-        };
-
-        let args = helix_run_args(&name, &image, config.port, true, disk_resources.as_ref());
-        let output = Command::new(self.runtime.binary())
-            .args(&args)
-            .output()
-            .map_err(|e| eyre!("Failed to start {name}: {e}"))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(eyre!("Failed to start {name}:\n{stderr}"));
-        }
-
-        self.wait_ready(config.port)?;
-        Ok(())
-    }
-
-    pub async fn run_foreground(
-        &self,
-        instance_name: &str,
-        config: &LocalInstanceConfig,
-    ) -> Result<()> {
-        Self::check_available(self.runtime)?;
-        self.pull_image(config)?;
-
-        let name = self.container_name(instance_name);
-        let image = config.image_ref();
-        let _ = self.remove_container(&name);
-        let disk_resources = if config.storage.is_disk() {
-            Some(self.start_disk_dependencies(instance_name)?)
-        } else {
-            let _ = self.remove_disk_resources(instance_name, false);
-            None
-        };
-        let args = helix_run_args(&name, &image, config.port, false, disk_resources.as_ref());
-
-        let mut child = TokioCommand::new(self.runtime.binary())
-            .args(&args)
-            .stdin(Stdio::inherit())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .spawn()
-            .map_err(|e| eyre!("Failed to run {name}: {e}"))?;
-
-        let mut wait = Box::pin(child.wait());
-        tokio::select! {
-            status = &mut wait => {
-                let status = status?;
-                if !status.success() {
-                    if config.storage.is_disk() {
-                        let _ = self.remove_disk_resources(instance_name, false);
-                    }
-                    return Err(eyre!("{name} exited with status {status}"));
-                }
-            }
-            signal = tokio::signal::ctrl_c() => {
-                signal?;
-                crate::output::info("Stopping foreground local Helix instance");
-                let _ = self.remove_container(&name);
-                if config.storage.is_disk() {
-                    let _ = self.remove_disk_resources(instance_name, false);
-                }
-                match tokio::time::timeout(Duration::from_secs(10), &mut wait).await {
-                    Ok(Ok(_)) => {}
-                    Ok(Err(e)) => return Err(eyre!("Failed to wait for {name} to stop: {e}")),
-                    Err(_) => return Err(eyre!("Timed out waiting for {name} to stop")),
-                }
-            }
-        }
-
-        if config.storage.is_disk() {
-            let _ = self.remove_disk_resources(instance_name, false);
-        }
-
-        Ok(())
-    }
-
-    pub fn stop(&self, instance_name: &str) -> Result<bool> {
-        let name = self.container_name(instance_name);
-        let removed_helix = self.remove_container(&name)?;
-        let removed_disk_resources = self.remove_disk_resources(instance_name, false)?;
-        Ok(removed_helix || removed_disk_resources)
-    }
-
-    pub fn restart(&self, instance_name: &str, config: &LocalInstanceConfig) -> Result<()> {
-        if config.storage.is_disk() {
-            return self.run_detached(instance_name, config);
-        }
-
-        let name = self.container_name(instance_name);
-        let output = Command::new(self.runtime.binary())
-            .args(["restart", &name])
-            .output()
-            .map_err(|e| eyre!("Failed to restart {name}: {e}"))?;
-
-        if output.status.success() {
-            self.wait_ready(config.port)?;
-            return Ok(());
-        }
-
-        self.run_detached(instance_name, config)
-    }
-
-    pub fn logs(&self, instance_name: &str, follow: bool) -> Result<()> {
-        let name = self.container_name(instance_name);
-        let mut command = Command::new(self.runtime.binary());
-        command.arg("logs");
-        if follow {
-            command.arg("-f");
-        }
-        command.arg(&name);
-        let status = command
-            .stdin(Stdio::inherit())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .status()
-            .map_err(|e| eyre!("Failed to read logs for {name}: {e}"))?;
-
-        if !status.success() {
-            return Err(eyre!(
-                "{} logs exited with status {status}",
-                self.runtime.binary()
-            ));
-        }
-        Ok(())
-    }
-
-    pub fn status(&self, instance_name: &str) -> Result<Option<LocalStatus>> {
-        let name = self.container_name(instance_name);
-        let output = Command::new(self.runtime.binary())
-            .args([
-                "ps",
-                "-a",
-                "--format",
-                "{{.Names}}\t{{.Status}}\t{{.Ports}}",
-                "--filter",
-                &format!("name=^{name}$"),
-            ])
-            .output()
-            .map_err(|e| eyre!("Failed to inspect {name}: {e}"))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(eyre!("Failed to inspect {name}:\n{stderr}"));
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let Some(line) = stdout.lines().find(|line| !line.trim().is_empty()) else {
-            return Ok(None);
-        };
-        let parts: Vec<&str> = line.split('\t').collect();
-        if parts.len() < 3 {
-            return Ok(None);
-        }
-
-        Ok(Some(LocalStatus {
-            instance_name: instance_name.to_string(),
-            container_name: parts[0].to_string(),
-            status: parts[1].to_string(),
-            ports: parts[2].to_string(),
-        }))
-    }
-
-    pub fn prune_instance(&self, instance_name: &str) -> Result<bool> {
-        let name = self.container_name(instance_name);
-        let removed_helix = self.remove_container(&name)?;
-        let removed_disk_resources = self.remove_disk_resources(instance_name, true)?;
-        Ok(removed_helix || removed_disk_resources)
-    }
-
-    pub fn run_command(&self, args: &[&str]) -> Result<Output> {
-        Command::new(self.runtime.binary())
-            .args(args)
-            .output()
-            .map_err(|e| {
-                eyre!(
-                    "Failed to run {} {}: {e}",
-                    self.runtime.binary(),
-                    args.join(" ")
-                )
-            })
     }
 
     fn disk_resources(&self, instance_name: &str) -> DiskRuntimeResources {
@@ -468,48 +357,541 @@ impl LocalRuntime {
     }
 
     fn wait_ready(&self, port: u16) -> Result<()> {
-        let deadline = Instant::now() + Duration::from_secs(30);
-        while Instant::now() < deadline {
-            if self.query_endpoint_ready(port) {
-                return Ok(());
-            }
-            thread::sleep(Duration::from_millis(250));
-        }
-
-        Err(CliError::new("local Helix did not become ready in time")
-            .with_hint(format!(
-                "check logs with 'helix logs' or verify port {port} is reachable"
-            ))
-            .into())
+        wait_ready(port)
     }
 
-    fn query_endpoint_ready(&self, port: u16) -> bool {
-        let Ok(mut stream) = TcpStream::connect_timeout(
-            &(std::net::Ipv4Addr::LOCALHOST, port).into(),
-            Duration::from_millis(500),
-        ) else {
-            return false;
+    fn start(&self, instance_name: &str, config: &LocalInstanceConfig) -> Result<()> {
+        Self::check_available(self.runtime)?;
+        self.pull_image(config)?;
+
+        let name = self.container_name(instance_name);
+        let image = config.image_ref();
+        let _ = self.remove_container(&name);
+        let disk_resources = if config.storage.is_disk() {
+            Some(self.start_disk_dependencies(instance_name)?)
+        } else {
+            let _ = self.remove_disk_resources(instance_name, false);
+            None
         };
-        let _ = stream.set_read_timeout(Some(Duration::from_millis(750)));
-        let _ = stream.set_write_timeout(Some(Duration::from_millis(750)));
 
-        let body = r#"{"request_type":"read","query":{"queries":[{"Query":{"name":"readiness","steps":[{"NWhere":{"Eq":["$label",{"String":"__HelixReadiness__"}]}},"Count"],"condition":null}}],"returns":["readiness"]},"parameters":{}}"#;
-        let request = format!(
-            "POST /v1/query HTTP/1.1\r\nHost: localhost:{port}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-            body.len()
-        );
+        let args = helix_run_args(&name, &image, config.port, true, disk_resources.as_ref());
+        let output = Command::new(self.runtime.binary())
+            .args(&args)
+            .output()
+            .map_err(|e| eyre!("Failed to start {name}: {e}"))?;
 
-        if stream.write_all(request.as_bytes()).is_err() {
-            return false;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(eyre!("Failed to start {name}:\n{stderr}"));
         }
 
-        let mut response = String::new();
-        if stream.read_to_string(&mut response).is_err() {
-            return false;
-        }
-
-        response.starts_with("HTTP/1.1 2") || response.starts_with("HTTP/1.0 2")
+        self.wait_ready(config.port)?;
+        Ok(())
     }
+
+    async fn start_foreground(
+        &self,
+        instance_name: &str,
+        config: &LocalInstanceConfig,
+    ) -> Result<()> {
+        Self::check_available(self.runtime)?;
+        self.pull_image(config)?;
+
+        let name = self.container_name(instance_name);
+        let image = config.image_ref();
+        let _ = self.remove_container(&name);
+        let disk_resources = if config.storage.is_disk() {
+            Some(self.start_disk_dependencies(instance_name)?)
+        } else {
+            let _ = self.remove_disk_resources(instance_name, false);
+            None
+        };
+        let args = helix_run_args(&name, &image, config.port, false, disk_resources.as_ref());
+
+        let mut child = TokioCommand::new(self.runtime.binary())
+            .args(&args)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|e| eyre!("Failed to run {name}: {e}"))?;
+
+        let mut wait = Box::pin(child.wait());
+        tokio::select! {
+            status = &mut wait => {
+                let status = status?;
+                if !status.success() {
+                    if config.storage.is_disk() {
+                        let _ = self.remove_disk_resources(instance_name, false);
+                    }
+                    return Err(eyre!("{name} exited with status {status}"));
+                }
+            }
+            signal = tokio::signal::ctrl_c() => {
+                signal?;
+                crate::output::info("Stopping foreground local Helix instance");
+                let _ = self.remove_container(&name);
+                if config.storage.is_disk() {
+                    let _ = self.remove_disk_resources(instance_name, false);
+                }
+                match tokio::time::timeout(Duration::from_secs(10), &mut wait).await {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => return Err(eyre!("Failed to wait for {name} to stop: {e}")),
+                    Err(_) => return Err(eyre!("Timed out waiting for {name} to stop")),
+                }
+            }
+        }
+
+        if config.storage.is_disk() {
+            let _ = self.remove_disk_resources(instance_name, false);
+        }
+
+        Ok(())
+    }
+
+    fn stop(&self, instance_name: &str) -> Result<bool> {
+        let name = self.container_name(instance_name);
+        let removed_helix = self.remove_container(&name)?;
+        let removed_disk_resources = self.remove_disk_resources(instance_name, false)?;
+        Ok(removed_helix || removed_disk_resources)
+    }
+
+    fn restart(&self, instance_name: &str, config: &LocalInstanceConfig) -> Result<()> {
+        if config.storage.is_disk() {
+            return self.start(instance_name, config);
+        }
+
+        let name = self.container_name(instance_name);
+        let output = Command::new(self.runtime.binary())
+            .args(["restart", &name])
+            .output()
+            .map_err(|e| eyre!("Failed to restart {name}: {e}"))?;
+
+        if output.status.success() {
+            self.wait_ready(config.port)?;
+            return Ok(());
+        }
+
+        self.start(instance_name, config)
+    }
+
+    fn logs(&self, instance_name: &str, follow: bool) -> Result<()> {
+        let name = self.container_name(instance_name);
+        let mut command = Command::new(self.runtime.binary());
+        command.arg("logs");
+        if follow {
+            command.arg("-f");
+        }
+        command.arg(&name);
+        let status = command
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+            .map_err(|e| eyre!("Failed to read logs for {name}: {e}"))?;
+
+        if !status.success() {
+            return Err(eyre!(
+                "{} logs exited with status {status}",
+                self.runtime.binary()
+            ));
+        }
+        Ok(())
+    }
+
+    fn status(&self, instance_name: &str) -> Result<Option<LocalStatus>> {
+        let name = self.container_name(instance_name);
+        let output = Command::new(self.runtime.binary())
+            .args([
+                "ps",
+                "-a",
+                "--format",
+                "{{.Names}}\t{{.Status}}\t{{.Ports}}",
+                "--filter",
+                &format!("name=^{name}$"),
+            ])
+            .output()
+            .map_err(|e| eyre!("Failed to inspect {name}: {e}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(eyre!("Failed to inspect {name}:\n{stderr}"));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let Some(line) = stdout.lines().find(|line| !line.trim().is_empty()) else {
+            return Ok(None);
+        };
+        let parts: Vec<&str> = line.split('\t').collect();
+        if parts.len() < 3 {
+            return Ok(None);
+        }
+
+        Ok(Some(LocalStatus {
+            instance_name: instance_name.to_string(),
+            container_name: parts[0].to_string(),
+            status: parts[1].to_string(),
+            ports: parts[2].to_string(),
+        }))
+    }
+
+    fn prune(&self, instance_name: &str) -> Result<bool> {
+        let name = self.container_name(instance_name);
+        let removed_helix = self.remove_container(&name)?;
+        let removed_disk_resources = self.remove_disk_resources(instance_name, true)?;
+        Ok(removed_helix || removed_disk_resources)
+    }
+
+    fn display_name(&self, instance_name: &str) -> String {
+        self.container_name(instance_name)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Native process-based runtime
+// ---------------------------------------------------------------------------
+
+pub struct NativeManager<'a> {
+    project: &'a ProjectContext,
+}
+
+impl<'a> NativeManager<'a> {
+    pub fn new(project: &'a ProjectContext) -> Self {
+        Self { project }
+    }
+
+    fn pid_file(&self, instance_name: &str) -> PathBuf {
+        self.project
+            .instance_workspace(instance_name)
+            .join("helix.pid")
+    }
+
+    fn log_file(&self, instance_name: &str) -> PathBuf {
+        self.project
+            .instance_workspace(instance_name)
+            .join("helix.log")
+    }
+
+    fn binary_path(&self, instance_name: &str) -> PathBuf {
+        self.project
+            .instance_workspace(instance_name)
+            .join("helix-container")
+            .join("target")
+            .join("release")
+            .join("helix-container")
+    }
+
+    fn save_pid(&self, instance_name: &str, pid: u32) -> Result<()> {
+        let pid_file = self.pid_file(instance_name);
+        if let Some(parent) = pid_file.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&pid_file, pid.to_string())
+            .map_err(|e| eyre!("Failed to write PID file: {e}"))
+    }
+
+    fn read_pid(&self, instance_name: &str) -> Result<Option<u32>> {
+        let pid_file = self.pid_file(instance_name);
+        if !pid_file.exists() {
+            return Ok(None);
+        }
+        let content = fs::read_to_string(&pid_file)
+            .map_err(|e| eyre!("Failed to read PID file: {e}"))?;
+        let pid = content
+            .trim()
+            .parse::<u32>()
+            .map_err(|e| eyre!("Invalid PID in file: {e}"))?;
+        Ok(Some(pid))
+    }
+
+    fn remove_pid_file(&self, instance_name: &str) {
+        let _ = fs::remove_file(self.pid_file(instance_name));
+    }
+
+    fn remove_log_file(&self, instance_name: &str) {
+        let _ = fs::remove_file(self.log_file(instance_name));
+    }
+
+    fn is_process_running(pid: u32) -> bool {
+        #[cfg(target_os = "linux")]
+        {
+            PathBuf::from(format!("/proc/{pid}")).exists()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Command::new("kill")
+                .args(["-0", &pid.to_string()])
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        }
+    }
+
+    fn stop_process(&self, instance_name: &str) -> Result<bool> {
+        let Some(pid) = self.read_pid(instance_name)? else {
+            return Ok(false);
+        };
+
+        if !Self::is_process_running(pid) {
+            self.remove_pid_file(instance_name);
+            return Ok(false);
+        }
+
+        let output = Command::new("kill")
+            .args(["-TERM", &pid.to_string()])
+            .output()
+            .map_err(|e| eyre!("Failed to send SIGTERM to process {pid}: {e}"))?;
+
+        if !output.status.success() {
+            self.remove_pid_file(instance_name);
+            return Ok(false);
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if !Self::is_process_running(pid) {
+                self.remove_pid_file(instance_name);
+                return Ok(true);
+            }
+            thread::sleep(Duration::from_millis(200));
+        }
+
+        let _ = Command::new("kill")
+            .args(["-KILL", &pid.to_string()])
+            .output();
+        self.remove_pid_file(instance_name);
+        Ok(true)
+    }
+
+    fn start(&self, instance_name: &str, config: &LocalInstanceConfig) -> Result<()> {
+        let binary = self.binary_path(instance_name);
+        if !binary.exists() {
+            return Err(CliError::new(format!(
+                "native binary not found at {}",
+                binary.display()
+            ))
+            .with_hint(format!(
+                "run 'helix build {instance_name}' first to compile the instance"
+            ))
+            .into());
+        }
+
+        let data_dir = self.project.instance_volume(instance_name);
+        fs::create_dir_all(&data_dir)?;
+        let port = config.port;
+
+        let log_file = self.log_file(instance_name);
+        if let Some(parent) = log_file.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let log = fs::File::create(&log_file)
+            .map_err(|e| eyre!("Failed to create log file: {e}"))?;
+
+        let mut cmd = Command::new(&binary);
+        cmd.env("HELIX_PORT", port.to_string())
+            .env("HELIX_DATA_DIR", &data_dir)
+            .current_dir(&data_dir)
+            .stdout(Stdio::from(log.try_clone()?))
+            .stderr(Stdio::from(log));
+
+        if config.storage.is_disk() {
+            cmd.env("S3_BUCKET", LOCAL_S3_BUCKET)
+                .env("S3_REGION", LOCAL_S3_REGION)
+                .env("DB_PATH", LOCAL_DB_PATH);
+        }
+
+        let child = cmd
+            .spawn()
+            .map_err(|e| eyre!("Failed to start native process: {e}"))?;
+
+        self.save_pid(instance_name, child.id())?;
+
+        wait_ready(port)?;
+        Ok(())
+    }
+
+    async fn start_foreground(
+        &self,
+        instance_name: &str,
+        config: &LocalInstanceConfig,
+    ) -> Result<()> {
+        let binary = self.binary_path(instance_name);
+        if !binary.exists() {
+            return Err(CliError::new(format!(
+                "native binary not found at {}",
+                binary.display()
+            ))
+            .with_hint(format!(
+                "run 'helix build {instance_name}' first to compile the instance"
+            ))
+            .into());
+        }
+
+        let data_dir = self.project.instance_volume(instance_name);
+        fs::create_dir_all(&data_dir)?;
+        let port = config.port;
+
+        let mut cmd = TokioCommand::new(&binary);
+        cmd.env("HELIX_PORT", port.to_string())
+            .env("HELIX_DATA_DIR", &data_dir)
+            .current_dir(&data_dir)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit());
+
+        if config.storage.is_disk() {
+            cmd.env("S3_BUCKET", LOCAL_S3_BUCKET)
+                .env("S3_REGION", LOCAL_S3_REGION)
+                .env("DB_PATH", LOCAL_DB_PATH);
+        }
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| eyre!("Failed to start native process: {e}"))?;
+
+        let mut wait = Box::pin(child.wait());
+        tokio::select! {
+            status = &mut wait => {
+                let status = status?;
+                if !status.success() {
+                    return Err(eyre!("Native process exited with status {status}"));
+                }
+            }
+            signal = tokio::signal::ctrl_c() => {
+                signal?;
+                crate::output::info("Stopping foreground local Helix instance");
+                match tokio::time::timeout(Duration::from_secs(10), &mut wait).await {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => return Err(eyre!("Failed to wait for process to stop: {e}")),
+                    Err(_) => return Err(eyre!("Timed out waiting for process to stop")),
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn stop(&self, instance_name: &str) -> Result<bool> {
+        self.stop_process(instance_name)
+    }
+
+    fn restart(&self, instance_name: &str, config: &LocalInstanceConfig) -> Result<()> {
+        let _ = self.stop_process(instance_name);
+        self.start(instance_name, config)
+    }
+
+    fn logs(&self, instance_name: &str, follow: bool) -> Result<()> {
+        let log_file = self.log_file(instance_name);
+        if !log_file.exists() {
+            return Err(eyre!("No log file found for instance '{instance_name}'"));
+        }
+
+        if follow {
+            let status = Command::new("tail")
+                .args(["-f", &log_file.to_string_lossy()])
+                .stdin(Stdio::inherit())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .status()
+                .map_err(|e| eyre!("Failed to follow logs: {e}"))?;
+
+            if !status.success() {
+                return Err(eyre!("tail exited with status {status}"));
+            }
+        } else {
+            let content = fs::read_to_string(&log_file)
+                .map_err(|e| eyre!("Failed to read log file: {e}"))?;
+            print!("{content}");
+        }
+        Ok(())
+    }
+
+    fn status(&self, instance_name: &str) -> Result<Option<LocalStatus>> {
+        let Some(pid) = self.read_pid(instance_name)? else {
+            return Ok(None);
+        };
+
+        if Self::is_process_running(pid) {
+            let port = self
+                .project
+                .config
+                .local
+                .get(instance_name)
+                .map(|c| c.port)
+                .unwrap_or(0);
+            Ok(Some(LocalStatus {
+                instance_name: instance_name.to_string(),
+                container_name: format!("native-{pid}"),
+                status: "Up (native)".to_string(),
+                ports: format!("0.0.0.0:{port}->8080/tcp"),
+            }))
+        } else {
+            self.remove_pid_file(instance_name);
+            Ok(None)
+        }
+    }
+
+    fn prune(&self, instance_name: &str) -> Result<bool> {
+        let removed = self.stop_process(instance_name)?;
+        self.remove_pid_file(instance_name);
+        self.remove_log_file(instance_name);
+        Ok(removed)
+    }
+
+    fn display_name(&self, instance_name: &str) -> String {
+        match self.read_pid(instance_name) {
+            Ok(Some(pid)) => format!("native process {pid}"),
+            _ => format!("native:{instance_name}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn wait_ready(port: u16) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if query_endpoint_ready(port) {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+
+    Err(CliError::new("local Helix did not become ready in time")
+        .with_hint(format!(
+            "check logs with 'helix logs' or verify port {port} is reachable"
+        ))
+        .into())
+}
+
+fn query_endpoint_ready(port: u16) -> bool {
+    let Ok(mut stream) = TcpStream::connect_timeout(
+        &(std::net::Ipv4Addr::LOCALHOST, port).into(),
+        Duration::from_millis(500),
+    ) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(750)));
+    let _ = stream.set_write_timeout(Some(Duration::from_millis(750)));
+
+    let body = r#"{"request_type":"read","query":{"queries":[{"Query":{"name":"readiness","steps":[{"NWhere":{"Eq":["$label",{"String":"__HelixReadiness__"}]}},"Count"],"condition":null}}],"returns":["readiness"]},"parameters":{}}"#;
+    let request = format!(
+        "POST /v1/query HTTP/1.1\r\nHost: localhost:{port}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+
+    if stream.write_all(request.as_bytes()).is_err() {
+        return false;
+    }
+
+    let mut response = String::new();
+    if stream.read_to_string(&mut response).is_err() {
+        return false;
+    }
+
+    response.starts_with("HTTP/1.1 2") || response.starts_with("HTTP/1.0 2")
 }
 
 fn helix_run_args(

--- a/helix-cli/src/local_runtime.rs
+++ b/helix-cli/src/local_runtime.rs
@@ -586,22 +586,32 @@ impl<'a> NativeManager<'a> {
         if let Some(parent) = pid_file.parent() {
             fs::create_dir_all(parent)?;
         }
-        fs::write(&pid_file, pid.to_string())
+        let start_time = Self::process_start_time(pid).unwrap_or(0);
+        fs::write(&pid_file, format!("{pid}\n{start_time}\n"))
             .map_err(|e| eyre!("Failed to write PID file: {e}"))
     }
 
-    fn read_pid(&self, instance_name: &str) -> Result<Option<u32>> {
+    fn read_pid(&self, instance_name: &str) -> Result<Option<(u32, u64)>> {
         let pid_file = self.pid_file(instance_name);
         if !pid_file.exists() {
             return Ok(None);
         }
         let content = fs::read_to_string(&pid_file)
             .map_err(|e| eyre!("Failed to read PID file: {e}"))?;
-        let pid = content
+        let mut lines = content.lines();
+        let pid = lines
+            .next()
+            .unwrap_or("")
             .trim()
             .parse::<u32>()
             .map_err(|e| eyre!("Invalid PID in file: {e}"))?;
-        Ok(Some(pid))
+        let start_time = lines
+            .next()
+            .unwrap_or("0")
+            .trim()
+            .parse::<u64>()
+            .unwrap_or(0);
+        Ok(Some((pid, start_time)))
     }
 
     fn remove_pid_file(&self, instance_name: &str) {
@@ -627,12 +637,41 @@ impl<'a> NativeManager<'a> {
         }
     }
 
+    /// Returns the process start time as jiffies since boot (Linux) or 0 on other platforms.
+    fn process_start_time(pid: u32) -> Option<u64> {
+        #[cfg(target_os = "linux")]
+        {
+            let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+            // Field 22 (0-indexed: 21) is starttime in jiffies since boot
+            let fields: Vec<&str> = stat.splitn(22, ' ').collect();
+            let start_str = fields.get(21)?;
+            start_str.trim().parse::<u64>().ok()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = pid;
+            None
+        }
+    }
+
+    /// Verify that the PID still refers to the same process we started.
+    fn verify_pid(&self, _instance_name: &str, pid: u32, saved_start_time: u64) -> bool {
+        if !Self::is_process_running(pid) {
+            return false;
+        }
+        if saved_start_time == 0 {
+            // Can't verify on this platform; assume it's the same process
+            return true;
+        }
+        Self::process_start_time(pid) == Some(saved_start_time)
+    }
+
     fn stop_process(&self, instance_name: &str) -> Result<bool> {
-        let Some(pid) = self.read_pid(instance_name)? else {
+        let Some((pid, start_time)) = self.read_pid(instance_name)? else {
             return Ok(false);
         };
 
-        if !Self::is_process_running(pid) {
+        if !self.verify_pid(instance_name, pid, start_time) {
             self.remove_pid_file(instance_name);
             return Ok(false);
         }
@@ -700,11 +739,15 @@ impl<'a> NativeManager<'a> {
                 .env("DB_PATH", LOCAL_DB_PATH);
         }
 
-        let child = cmd
+        let mut child = cmd
             .spawn()
             .map_err(|e| eyre!("Failed to start native process: {e}"))?;
 
-        self.save_pid(instance_name, child.id())?;
+        if let Err(e) = self.save_pid(instance_name, child.id()) {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(e);
+        }
 
         wait_ready(port)?;
         Ok(())
@@ -749,9 +792,9 @@ impl<'a> NativeManager<'a> {
             .spawn()
             .map_err(|e| eyre!("Failed to start native process: {e}"))?;
 
-        let mut wait = Box::pin(child.wait());
+        let pid = child.id();
         tokio::select! {
-            status = &mut wait => {
+            status = child.wait() => {
                 let status = status?;
                 if !status.success() {
                     return Err(eyre!("Native process exited with status {status}"));
@@ -760,10 +803,18 @@ impl<'a> NativeManager<'a> {
             signal = tokio::signal::ctrl_c() => {
                 signal?;
                 crate::output::info("Stopping foreground local Helix instance");
-                match tokio::time::timeout(Duration::from_secs(10), &mut wait).await {
+                match tokio::time::timeout(Duration::from_secs(10), child.wait()).await {
                     Ok(Ok(_)) => {}
                     Ok(Err(e)) => return Err(eyre!("Failed to wait for process to stop: {e}")),
-                    Err(_) => return Err(eyre!("Timed out waiting for process to stop")),
+                    Err(_) => {
+                        // Timeout expired — force-kill by PID
+                        if let Some(pid) = pid {
+                            let _ = Command::new("kill")
+                                .args(["-KILL", &pid.to_string()])
+                                .output();
+                        }
+                        return Err(eyre!("Timed out waiting for process to stop"));
+                    }
                 }
             }
         }
@@ -807,11 +858,11 @@ impl<'a> NativeManager<'a> {
     }
 
     fn status(&self, instance_name: &str) -> Result<Option<LocalStatus>> {
-        let Some(pid) = self.read_pid(instance_name)? else {
+        let Some((pid, start_time)) = self.read_pid(instance_name)? else {
             return Ok(None);
         };
 
-        if Self::is_process_running(pid) {
+        if self.verify_pid(instance_name, pid, start_time) {
             let port = self
                 .project
                 .config
@@ -840,7 +891,7 @@ impl<'a> NativeManager<'a> {
 
     fn display_name(&self, instance_name: &str) -> String {
         match self.read_pid(instance_name) {
-            Ok(Some(pid)) => format!("native process {pid}"),
+            Ok(Some((pid, _))) => format!("native process {pid}"),
             _ => format!("native:{instance_name}"),
         }
     }

--- a/helix-cli/src/project.rs
+++ b/helix-cli/src/project.rs
@@ -33,6 +33,14 @@ impl ProjectContext {
         self.helix_dir.join(instance_name)
     }
 
+    pub fn volumes_dir(&self) -> PathBuf {
+        self.helix_dir.join(".volumes")
+    }
+
+    pub fn instance_volume(&self, instance_name: &str) -> PathBuf {
+        self.volumes_dir().join(instance_name)
+    }
+
     pub fn ensure_instance_dir(&self, instance_name: &str) -> Result<(), ProjectError> {
         let workspace = self.instance_workspace(instance_name);
         std::fs::create_dir_all(&workspace).map_err(|source| ProjectError::CreateDir {

--- a/sdks/rust/helix-dsl-macros/src/lib.rs
+++ b/sdks/rust/helix-dsl-macros/src/lib.rs
@@ -294,13 +294,12 @@ fn parse_param_type(ty: &Type) -> syn::Result<ParamTypeSpec> {
         }
         "Vec" => {
             let inner = single_type_arg(segment, ty)?;
-            if let Type::Path(inner_path) = inner {
-                if let Some(inner_seg) = inner_path.path.segments.last() {
-                    if inner_seg.ident == "u8" && matches!(inner_seg.arguments, PathArguments::None)
-                    {
-                        return Ok(ParamTypeSpec::Bytes);
-                    }
-                }
+            if let Type::Path(inner_path) = inner
+                && let Some(inner_seg) = inner_path.path.segments.last()
+                && inner_seg.ident == "u8"
+                && matches!(inner_seg.arguments, PathArguments::None)
+            {
+                return Ok(ParamTypeSpec::Bytes);
             }
             Ok(ParamTypeSpec::Array(Box::new(parse_param_type(inner)?)))
         }

--- a/sdks/rust/src/dsl.rs
+++ b/sdks/rust/src/dsl.rs
@@ -1431,21 +1431,25 @@ impl Expr {
     }
 
     /// Addition: self + other
+    #[allow(clippy::should_implement_trait)]
     pub fn add(self, other: Expr) -> Self {
         Expr::Add(Box::new(self), Box::new(other))
     }
 
     /// Subtraction: self - other
+    #[allow(clippy::should_implement_trait)]
     pub fn sub(self, other: Expr) -> Self {
         Expr::Sub(Box::new(self), Box::new(other))
     }
 
     /// Multiplication: self * other
+    #[allow(clippy::should_implement_trait)]
     pub fn mul(self, other: Expr) -> Self {
         Expr::Mul(Box::new(self), Box::new(other))
     }
 
     /// Division: self / other
+    #[allow(clippy::should_implement_trait)]
     pub fn div(self, other: Expr) -> Self {
         Expr::Div(Box::new(self), Box::new(other))
     }
@@ -1456,6 +1460,7 @@ impl Expr {
     }
 
     /// Negation: -self
+    #[allow(clippy::should_implement_trait)]
     pub fn neg(self) -> Self {
         Expr::Neg(Box::new(self))
     }
@@ -1914,6 +1919,7 @@ impl Predicate {
     }
 
     /// Negate a predicate
+    #[allow(clippy::should_implement_trait)]
     pub fn not(predicate: Predicate) -> Self {
         Predicate::Not(Box::new(predicate))
     }
@@ -2046,24 +2052,20 @@ impl From<ExprProjection> for Projection {
 }
 
 /// Sort order for ordering steps
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Order {
     /// Ascending order (smallest first)
+    #[default]
     Asc,
     /// Descending order (largest first)
     Desc,
 }
 
-impl Default for Order {
-    fn default() -> Self {
-        Order::Asc
-    }
-}
-
 /// Emit behavior for repeat steps
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EmitBehavior {
     /// Don't emit intermediate results.
+    #[default]
     None,
     /// Emit the current node stream before each repeat iteration.
     Before,
@@ -2071,12 +2073,6 @@ pub enum EmitBehavior {
     After,
     /// Emit both before and after each repeat iteration.
     All,
-}
-
-impl Default for EmitBehavior {
-    fn default() -> Self {
-        EmitBehavior::None
-    }
 }
 
 /// Aggregation function for reduce operations


### PR DESCRIPTION
## Summary

Adds a native process-based runtime that runs HelixDB without Docker or Podman, enabling bare-metal execution. This is the foundation for future in-memory database features that need direct process control.

## Changes

- **`ContainerRuntime::Native`** — new variant in config.rs with `is_native()`, `binary()="native"`, `label()="Native"`
- **`Runtime` enum** — dispatches between `Container(LocalRuntime)` and `Native(NativeManager)` via `Runtime::for_project()`
- **`NativeManager`** — process lifecycle via PID files, SIGTERM/SIGKILL, log file output, TCP readiness probe
- **`ProjectContext`** — added `volumes_dir()` and `instance_volume()` helpers
- **All commands updated** — run, stop, restart, status, logs, prune, delete use `Runtime::for_project()`
- **Clippy fixes** — collapsible_if, derivable_impls, should_implement_trait in sdks

## Usage

```toml
# helix.toml
[project]
name = "myproject"
container_runtime = "native"
```

Then `helix run dev` runs the binary directly instead of in a container.

## Backward Compatibility

Docker and Podman runtimes remain the default. `container_runtime = "docker"` (the default) works exactly as before.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `ContainerRuntime::Native` variant that bypasses Docker/Podman entirely, spawning the HelixDB binary as a plain OS process managed via PID files, SIGTERM/SIGKILL, and a log file. All CLI commands are updated to dispatch through a new `Runtime` enum routing to either `LocalRuntime` or the new `NativeManager`. The SDK changes are unrelated Clippy fixes.

- **`NativeManager`** manages process lifecycle: spawns the native binary with `HELIX_PORT`/`HELIX_DATA_DIR`, writes a PID file, probes TCP readiness, and stops via SIGTERM → SIGKILL.
- **`Runtime` enum** dispatches all CLI operations; all command files now use `Runtime::for_project()` instead of constructing `LocalRuntime` directly.
- **Two correctness gaps in `NativeManager`**: if `save_pid` fails after a successful `spawn`, the process leaks with no CLI-visible handle; and in `start_foreground`, if the process doesn't exit within 10 seconds of Ctrl-C, the CLI returns an error but sends no SIGKILL, leaving the process running.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-cli/src/local_runtime.rs | Adds NativeManager for process-based runtime; two correctness gaps: orphan process if save_pid fails after spawn, and no SIGKILL fallback in start_foreground on Ctrl-C timeout. |
| helix-cli/src/config.rs | Adds ContainerRuntime::Native variant with is_native(), binary(), label(); clean backward-compatible change with Docker as default. |
| helix-cli/src/project.rs | Adds volumes_dir() and instance_volume() helpers to ProjectContext; straightforward path helpers. |
| helix-cli/src/commands/dashboard.rs | Adds Native arm returning localhost for dashboard host resolution; will fail on macOS/Windows where container localhost does not equal host. |
| helix-cli/src/commands/logs/mod.rs | Switches to Runtime::for_project; error message still references docker/podman when native runtime is in use. |
| sdks/rust/src/dsl.rs | Clippy fixes: derives Default for Order and EmitBehavior instead of manual impls, adds allow(clippy::should_implement_trait) on arithmetic methods. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[helix run / stop / restart / status / logs / prune] --> B[Runtime::for_project]
    B --> C{container_runtime in helix.toml}
    C -- docker / podman --> D[LocalRuntime]
    C -- native --> E[NativeManager]
    D --> F[docker/podman run / rm / ps / logs]
    E --> G[spawn binary HELIX_PORT + HELIX_DATA_DIR]
    G --> H[save_pid to .helix/name/helix.pid]
    H -->|save_pid fails| I[process leaks no PID file]
    H -->|success| J[TCP readiness probe :port]
    J -->|ready| K[instance running]
    K --> L{helix stop}
    L --> M[read_pid SIGTERM wait 10s SIGKILL]
    M --> N[remove PID file]
    E --> O[start_foreground: inherit stdio]
    O --> P{Ctrl-C}
    P --> Q[wait 10s for exit]
    Q -->|timeout| R[returns error process still running]
    Q -->|exited| S[done]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: remove Docker/Podman dependency wi..."](https://github.com/helixdb/helix-db/commit/ce150874049a158664d1c2d9dbd65f3700a73c77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34819010)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->