### PR TITLE
Add v1 gRPC protocol crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +169,53 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -475,6 +550,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +630,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -730,12 +817,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -820,6 +913,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "helix-protocol"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "protoc-bin-vendored",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +987,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -901,6 +1011,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -937,7 +1060,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1115,12 +1238,22 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1188,6 +1321,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1320,6 +1462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,6 +1505,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.61.1",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "munge"
@@ -1554,6 +1708,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.10.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,6 +1771,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +1788,122 @@ checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "ptr_meta"
@@ -1637,7 +1947,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1654,7 +1964,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.1",
  "lru-slab",
- "rand",
+ "rand 0.9.1",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1675,7 +1985,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1700,12 +2010,33 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1715,7 +2046,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.1",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1840,7 +2180,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -1880,7 +2220,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -1926,8 +2266,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
 dependencies = [
  "bytes",
- "hashbrown",
- "indexmap",
+ "hashbrown 0.15.2",
+ "indexmap 2.10.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -2308,6 +2648,16 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
@@ -2544,7 +2894,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.1",
 ]
@@ -2581,6 +2931,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,7 +2960,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
- "indexmap",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2633,6 +2994,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,7 +3084,7 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "url",
@@ -2684,7 +3109,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2809,7 +3246,7 @@ checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.1",
  "js-sys",
- "rand",
+ "rand 0.9.1",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "helix-cli",
+    "helix-protocol",
     "metrics",
     "sdks/rust",
 ]

--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-cli"
-version = "3.0.5"
+version = "3.0.6"
 edition = "2024"
 
 [dependencies]

--- a/helix-protocol/Cargo.toml
+++ b/helix-protocol/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "helix-protocol"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.75"
+description = "Protobuf and gRPC contract for HelixDB"
+license = "Apache-2.0"
+repository = "https://github.com/helixdb/helix-db"
+readme = "README.md"
+keywords = ["helixdb", "grpc", "protobuf", "database"]
+categories = ["database", "network-programming"]
+
+[dependencies]
+prost = "0.13"
+tonic = { version = "0.12", default-features = false, features = ["codegen", "prost"] }
+
+[features]
+default = ["transport"]
+transport = ["tonic/transport"]
+
+[build-dependencies]
+protoc-bin-vendored = "3.1"
+tonic-build = "0.12"

--- a/helix-protocol/README.md
+++ b/helix-protocol/README.md
@@ -1,0 +1,28 @@
+# helix-protocol
+
+`helix-protocol` defines the versioned Protobuf and gRPC contract for HelixDB.
+
+The crate generates Rust client and server bindings for `helix.v1.Helix` with Tonic. Other SDKs can generate their native clients from `proto/helix/v1/helix.proto`.
+
+## API Surface
+
+- `Query`: unary query execution for dynamic and stored queries.
+- `QueryStream`: server-side streaming for large results and long-running graph traversals.
+- `Insert`: document/record insertion with mutation metadata.
+- `Search`: server-side streaming vector search results.
+- `Health`: readiness/status probe for clients and load balancers.
+
+JSON fields are represented as `bytes` so the gRPC API remains lossless with the existing `/v1/query` HTTP contract while SDKs get generated, type-safe transport code.
+
+## Rust Usage
+
+```rust,no_run
+use helix_protocol::v1::helix_client::HelixClient;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let mut client = HelixClient::connect("http://localhost:6970").await?;
+let health = client.health(helix_protocol::v1::HealthRequest {}).await?;
+println!("{:?}", health.into_inner());
+# Ok(())
+# }
+```

--- a/helix-protocol/build.rs
+++ b/helix-protocol/build.rs
@@ -1,0 +1,13 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=proto/helix/v1/helix.proto");
+
+    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    std::env::set_var("PROTOC", protoc);
+
+    tonic_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .compile_protos(&["proto/helix/v1/helix.proto"], &["proto"])?;
+
+    Ok(())
+}

--- a/helix-protocol/proto/helix/v1/helix.proto
+++ b/helix-protocol/proto/helix/v1/helix.proto
@@ -2,6 +2,11 @@ syntax = "proto3";
 
 package helix.v1;
 
+option go_package = "github.com/HelixDB/helix-db/helix-protocol/gen/go/helix/v1;helixv1";
+option java_multiple_files = true;
+option java_outer_classname = "HelixProto";
+option java_package = "com.helixdb.helix.v1";
+
 // Helix exposes the database's primary query, mutation, and vector-search
 // operations over HTTP/2. JSON payload fields intentionally preserve parity
 // with the existing /v1/query HTTP contract while giving SDKs a stable typed
@@ -26,6 +31,8 @@ service Helix {
 }
 
 message QueryRequest {
+  reserved 3 to 9;
+
   oneof target {
     DynamicQuery dynamic = 1;
     StoredQuery stored = 2;
@@ -43,15 +50,15 @@ message StoredQuery {
   string name = 1;
 
   // Optional UTF-8 JSON parameters/body for the stored query.
-  bytes parameters_json = 2;
+  optional bytes parameters_json = 2;
 }
 
 message RequestOptions {
-  // Mirrors x-helix-require-writer.
-  bool require_writer = 1;
+  // Mirrors x-helix-require-writer. Absence lets the server use its default.
+  optional bool require_writer = 1;
 
-  // Mirrors x-helix-warm.
-  bool warm_only = 2;
+  // Mirrors x-helix-warm. Absence lets the server use its default.
+  optional bool warm_only = 2;
 
   // Mirrors x-helix-await-durable. Absence lets the server use its default.
   optional bool await_durability = 3;
@@ -63,17 +70,18 @@ message QueryResponse {
 }
 
 message QueryChunk {
+  reserved 3;
+
   // Monotonic sequence number assigned by the server.
   uint64 sequence = 1;
 
   // UTF-8 JSON fragment or row payload.
   bytes json = 2;
-
-  // True when this is the final chunk for the stream.
-  bool terminal = 3;
 }
 
 message InsertRequest {
+  reserved 3 to 9;
+
   // Logical collection, label, or table name chosen by the server runtime.
   string collection = 1;
 
@@ -91,10 +99,12 @@ message MutationResponse {
   uint64 affected = 2;
 
   // Optional UTF-8 JSON payload with server-specific mutation details.
-  bytes json = 3;
+  optional bytes json = 3;
 }
 
 message SearchRequest {
+  reserved 5 to 9;
+
   // Logical vector index or collection/label to search.
   string index = 1;
 
@@ -106,7 +116,7 @@ message SearchRequest {
   uint32 limit = 3;
 
   // Optional UTF-8 JSON filter expression.
-  bytes filter_json = 4;
+  optional bytes filter_json = 4;
 
   RequestOptions options = 10;
 }

--- a/helix-protocol/proto/helix/v1/helix.proto
+++ b/helix-protocol/proto/helix/v1/helix.proto
@@ -1,0 +1,136 @@
+syntax = "proto3";
+
+package helix.v1;
+
+// Helix exposes the database's primary query, mutation, and vector-search
+// operations over HTTP/2. JSON payload fields intentionally preserve parity
+// with the existing /v1/query HTTP contract while giving SDKs a stable typed
+// transport surface.
+service Helix {
+  // Query executes either an inline dynamic query or a named stored query and
+  // returns the complete JSON response body.
+  rpc Query(QueryRequest) returns (QueryResponse);
+
+  // QueryStream executes a query and streams ordered JSON chunks. Servers can
+  // use this for large result sets and long-running graph traversals.
+  rpc QueryStream(QueryRequest) returns (stream QueryChunk);
+
+  // Insert writes a JSON document into a logical collection/label.
+  rpc Insert(InsertRequest) returns (MutationResponse);
+
+  // Search performs vector search and streams ranked matches in score order.
+  rpc Search(SearchRequest) returns (stream SearchResult);
+
+  // Health gives clients and load balancers a cheap readiness probe.
+  rpc Health(HealthRequest) returns (HealthResponse);
+}
+
+message QueryRequest {
+  oneof target {
+    DynamicQuery dynamic = 1;
+    StoredQuery stored = 2;
+  }
+
+  RequestOptions options = 10;
+}
+
+message DynamicQuery {
+  // UTF-8 JSON matching the current DynamicQueryRequest HTTP payload.
+  bytes json = 1;
+}
+
+message StoredQuery {
+  string name = 1;
+
+  // Optional UTF-8 JSON parameters/body for the stored query.
+  bytes parameters_json = 2;
+}
+
+message RequestOptions {
+  // Mirrors x-helix-require-writer.
+  bool require_writer = 1;
+
+  // Mirrors x-helix-warm.
+  bool warm_only = 2;
+
+  // Mirrors x-helix-await-durable. Absence lets the server use its default.
+  optional bool await_durability = 3;
+}
+
+message QueryResponse {
+  // UTF-8 JSON response body.
+  bytes json = 1;
+}
+
+message QueryChunk {
+  // Monotonic sequence number assigned by the server.
+  uint64 sequence = 1;
+
+  // UTF-8 JSON fragment or row payload.
+  bytes json = 2;
+
+  // True when this is the final chunk for the stream.
+  bool terminal = 3;
+}
+
+message InsertRequest {
+  // Logical collection, label, or table name chosen by the server runtime.
+  string collection = 1;
+
+  // UTF-8 JSON document body.
+  bytes document_json = 2;
+
+  RequestOptions options = 10;
+}
+
+message MutationResponse {
+  // Server-assigned primary identifier when one is available.
+  string id = 1;
+
+  // Number of records/nodes/edges affected by the mutation.
+  uint64 affected = 2;
+
+  // Optional UTF-8 JSON payload with server-specific mutation details.
+  bytes json = 3;
+}
+
+message SearchRequest {
+  // Logical vector index or collection/label to search.
+  string index = 1;
+
+  // Query vector. float is the common embedding precision and maps cleanly to
+  // SDK types across Rust, Go, Python, Java, and TypeScript.
+  repeated float vector = 2;
+
+  // Maximum number of results. Zero lets the server choose its default.
+  uint32 limit = 3;
+
+  // Optional UTF-8 JSON filter expression.
+  bytes filter_json = 4;
+
+  RequestOptions options = 10;
+}
+
+message SearchResult {
+  string id = 1;
+  float score = 2;
+
+  // UTF-8 JSON document or projection payload.
+  bytes json = 3;
+
+  uint64 sequence = 4;
+}
+
+message HealthRequest {}
+
+message HealthResponse {
+  HealthStatus status = 1;
+  string version = 2;
+  string message = 3;
+}
+
+enum HealthStatus {
+  HEALTH_STATUS_UNSPECIFIED = 0;
+  HEALTH_STATUS_SERVING = 1;
+  HEALTH_STATUS_NOT_SERVING = 2;
+}

--- a/helix-protocol/src/lib.rs
+++ b/helix-protocol/src/lib.rs
@@ -1,0 +1,67 @@
+//! Protobuf and gRPC contract for HelixDB.
+//!
+//! This crate owns the generated Rust types for the public `helix.v1` service.
+//! The `.proto` file is included in the repository so other SDKs can generate
+//! their native clients from the same source of truth.
+
+/// Default local gRPC port reserved for HelixDB.
+pub const DEFAULT_GRPC_PORT: u16 = 6970;
+
+/// Versioned HelixDB gRPC API.
+pub mod v1 {
+    tonic::include_proto!("helix.v1");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::v1::{
+        query_request, DynamicQuery, HealthResponse, HealthStatus, QueryRequest, RequestOptions,
+        SearchRequest,
+    };
+
+    #[test]
+    fn dynamic_query_preserves_json_payload_and_options() {
+        let request = QueryRequest {
+            target: Some(query_request::Target::Dynamic(DynamicQuery {
+                json: br#"{"request_type":"read"}"#.to_vec(),
+            })),
+            options: Some(RequestOptions {
+                require_writer: true,
+                warm_only: false,
+                await_durability: Some(true),
+            }),
+        };
+
+        let Some(query_request::Target::Dynamic(dynamic)) = request.target else {
+            panic!("expected dynamic query target");
+        };
+        assert_eq!(dynamic.json.as_slice(), br#"{"request_type":"read"}"#);
+        assert_eq!(request.options.unwrap().await_durability, Some(true));
+    }
+
+    #[test]
+    fn search_request_uses_cross_language_vector_shape() {
+        let request = SearchRequest {
+            index: "Document".to_string(),
+            vector: vec![0.25, -0.5, 0.75],
+            limit: 10,
+            filter_json: br#"{"tenant":"acme"}"#.to_vec(),
+            options: None,
+        };
+
+        assert_eq!(request.index, "Document");
+        assert_eq!(request.vector, vec![0.25, -0.5, 0.75]);
+        assert_eq!(request.limit, 10);
+    }
+
+    #[test]
+    fn health_status_round_trips_as_enum_value() {
+        let response = HealthResponse {
+            status: HealthStatus::Serving.into(),
+            version: "dev".to_string(),
+            message: "ready".to_string(),
+        };
+
+        assert_eq!(response.status(), HealthStatus::Serving);
+    }
+}

--- a/helix-protocol/src/lib.rs
+++ b/helix-protocol/src/lib.rs
@@ -26,8 +26,8 @@ mod tests {
                 json: br#"{"request_type":"read"}"#.to_vec(),
             })),
             options: Some(RequestOptions {
-                require_writer: true,
-                warm_only: false,
+                require_writer: Some(true),
+                warm_only: Some(false),
                 await_durability: Some(true),
             }),
         };
@@ -45,7 +45,7 @@ mod tests {
             index: "Document".to_string(),
             vector: vec![0.25, -0.5, 0.75],
             limit: 10,
-            filter_json: br#"{"tenant":"acme"}"#.to_vec(),
+            filter_json: Some(br#"{"tenant":"acme"}"#.to_vec()),
             options: None,
         };
 

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-db"
-version = "2.0.4"
+version = "2.0.5"
 edition = "2021"
 rust-version = "1.75"
 description = "Library for working with HelixDB"

--- a/sdks/rust/helix-dsl-macros/src/lib.rs
+++ b/sdks/rust/helix-dsl-macros/src/lib.rs
@@ -294,13 +294,12 @@ fn parse_param_type(ty: &Type) -> syn::Result<ParamTypeSpec> {
         }
         "Vec" => {
             let inner = single_type_arg(segment, ty)?;
-            if let Type::Path(inner_path) = inner {
-                if let Some(inner_seg) = inner_path.path.segments.last() {
-                    if inner_seg.ident == "u8" && matches!(inner_seg.arguments, PathArguments::None)
-                    {
-                        return Ok(ParamTypeSpec::Bytes);
-                    }
-                }
+            if let Type::Path(inner_path) = inner
+                && let Some(inner_seg) = inner_path.path.segments.last()
+                && inner_seg.ident == "u8"
+                && matches!(inner_seg.arguments, PathArguments::None)
+            {
+                return Ok(ParamTypeSpec::Bytes);
             }
             Ok(ParamTypeSpec::Array(Box::new(parse_param_type(inner)?)))
         }

--- a/sdks/rust/src/dsl.rs
+++ b/sdks/rust/src/dsl.rs
@@ -1421,6 +1421,7 @@ pub enum Expr {
     },
 }
 
+#[allow(clippy::should_implement_trait)]
 impl Expr {
     /// Create a property reference expression
     pub fn prop(name: impl Into<String>) -> Self {
@@ -1809,6 +1810,7 @@ impl From<SourcePredicate> for Predicate {
     }
 }
 
+#[allow(clippy::should_implement_trait)]
 impl Predicate {
     /// Create an equality predicate.
     ///
@@ -2068,24 +2070,20 @@ impl From<ExprProjection> for Projection {
 }
 
 /// Sort order for ordering steps
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Order {
     /// Ascending order (smallest first)
+    #[default]
     Asc,
     /// Descending order (largest first)
     Desc,
 }
 
-impl Default for Order {
-    fn default() -> Self {
-        Order::Asc
-    }
-}
-
 /// Emit behavior for repeat steps
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EmitBehavior {
     /// Don't emit intermediate results.
+    #[default]
     None,
     /// Emit the current node stream before each repeat iteration.
     Before,
@@ -2093,12 +2091,6 @@ pub enum EmitBehavior {
     After,
     /// Emit both before and after each repeat iteration.
     All,
-}
-
-impl Default for EmitBehavior {
-    fn default() -> Self {
-        EmitBehavior::None
-    }
 }
 
 /// Aggregation function for reduce operations

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -307,7 +307,6 @@ impl<'hlx, 'a, R> QueryBuilder<'hlx, 'a, R> {
     ///
     /// Returns [`HelixError::SerializationError`] if `data` cannot be serialized
     /// to JSON.
-    #[must_use]
     pub fn body<T: Serialize + Sync>(mut self, data: &T) -> Result<Self, HelixError> {
         self.body = Some(sonic_rs::to_vec(data)?);
         Ok(self)


### PR DESCRIPTION
## Description
Adds a dedicated `helix-protocol` workspace crate that defines the first versioned HelixDB gRPC contract and generates Rust bindings with Tonic/Prost.

This establishes the native gRPC surface requested in #780 without coupling the protocol contract to CLI or SDK internals. The server implementation can now implement `helix.v1.Helix`, and SDKs can generate clients from the same checked-in protobuf source.

Included API surface:

- `Query` for unary dynamic/stored query execution.
- `QueryStream` for large result sets and long-running traversals.
- `Insert` for mutation-oriented document/record ingestion.
- `Search` for streamed vector search results.
- `Health` for cheap readiness checks.

The proto uses `bytes` for JSON payloads to preserve parity with the existing `/v1/query` HTTP contract while giving gRPC users a stable typed transport.

## Related Issues

Addresses #780

## Checklist when merging to main

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [x] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes

Rust verification was run locally with `cargo fmt --all`, `cargo test --workspace`, and `cargo clippy --workspace -- -D warnings`.

The repo does not contain a literal `helixdb/Cargo.toml`; the version bump was applied to the `helix-db` crate in `sdks/rust/Cargo.toml`.

The crate uses `protoc-bin-vendored` in `build.rs`, so contributors and CI do not need a system `protoc` installation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `helix-protocol`, a new workspace crate that defines the versioned `helix.v1` gRPC contract using Tonic/Prost, and extends the Rust SDK's `#[register]` macro with additional parameter types and comprehensive documentation.

- **New `helix-protocol` crate**: Adds `helix/v1/helix.proto` with five RPCs (`Query`, `QueryStream`, `Insert`, `Search`, `Health`), a `build.rs` that vendors `protoc` via `protoc-bin-vendored`, and a `transport` feature flag that gates `tonic/transport` for client/server flexibility.
- **Rust SDK macro improvements**: `helix-dsl-macros` gains `ParamObject`, `ParamValue`, `BTreeMap`/`HashMap` map types, and improved recursive dynamic-value coercion with cleaner error paths.
- **Documentation pass**: `sdks/rust/src/lib.rs` and `sdks/rust/src/dsl.rs` receive extensive doc-comment coverage including runnable examples and a new `client_tests` integration module.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-protocol/proto/helix/v1/helix.proto | New v1 proto contract; well-structured with reserved fields and cross-SDK options. Minor design concerns around SearchResult.sequence redundancy and non-optional id in MutationResponse. |
| helix-protocol/build.rs | Uses std::env::set_var to inject protoc path; correct for protoc-bin-vendored with tonic-build 0.12, though the cleaner .protoc_path() builder method is available. |
| helix-protocol/src/lib.rs | Clean protocol crate entry point; re-exports generated types under v1 module with DEFAULT_GRPC_PORT constant and three well-scoped tests for the generated message types. |
| helix-protocol/Cargo.toml | Well-configured crate manifest; transport feature correctly gates tonic/transport, prost and tonic versions aligned at 0.13/0.12 respectively. |
| sdks/rust/helix-dsl-macros/src/lib.rs | Comprehensive proc-macro for #[register]; new ParamObject/ParamValue type specs added with correct recursive dynamic-value coercion logic and good test coverage. |
| sdks/rust/src/lib.rs | Extensive documentation additions and client_tests module added; logic unchanged, all existing API surfaces preserved. |
| Cargo.toml | helix-protocol correctly added to workspace members list; no other changes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SDK as SDK / Client
    participant Tonic as helix-protocol<br/>(helix.v1.Helix)
    participant DB as HelixDB Server

    SDK->>Tonic: HelixClient::connect("http://localhost:6970")
    note over Tonic: gRPC over HTTP/2

    SDK->>DB: Query(QueryRequest)
    DB-->>SDK: "QueryResponse { json: bytes }"

    SDK->>DB: QueryStream(QueryRequest)
    loop stream
        DB-->>SDK: "QueryChunk { sequence, json }"
    end
    DB-->>SDK: END_STREAM

    SDK->>DB: Insert(InsertRequest)
    DB-->>SDK: "MutationResponse { id?, affected, json? }"

    SDK->>DB: Search(SearchRequest)
    loop stream (ranked)
        DB-->>SDK: "SearchResult { id, score, json, sequence }"
    end
    DB-->>SDK: END_STREAM

    SDK->>DB: "Health(HealthRequest {})"
    DB-->>SDK: "HealthResponse { status, version, message }"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Address gRPC review feedback"](https://github.com/helixdb/helix-db/commit/00a852ebc4589a042d9e0e91e71bd16d26cce87b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37399804)</sub>

<!-- /greptile_comment -->