### PR TITLE
feat(cli): add query dry-run mode

### DIFF
--- a/helix-cli/README.md
+++ b/helix-cli/README.md
@@ -10,7 +10,7 @@ Command-line interface for managing v2 Helix projects, local development instanc
 - `run`: run a local v2 instance in the background by default, attached with `--foreground`, or with persistent local storage using `--disk`.
 - `stop` / `restart` / `status`: manage local v2 instances and inspect Enterprise Cloud config.
 - `logs`: view local container logs or query Enterprise Cloud historical logs.
-- `query`: send a dynamic query request JSON file to `POST /v1/query`.
+- `query`: send a dynamic query request JSON file to `POST /v1/query`, or inspect it first with `--dry-run`.
 - `push`: compile and deploy an Enterprise query project to an Enterprise Cloud cluster.
 - `auth`: login, logout, or create an Enterprise Cloud API key.
 - `workspace`: manage active Enterprise Cloud workspace selection.

--- a/helix-cli/src/commands/chef.rs
+++ b/helix-cli/src/commands/chef.rs
@@ -1271,6 +1271,7 @@ async fn seed_starter_data() -> Result<()> {
             None,
             None,
             false,
+            false,
         )
     })
     .await

--- a/helix-cli/src/commands/query.rs
+++ b/helix-cli/src/commands/query.rs
@@ -16,15 +16,23 @@ pub async fn run(
     host: Option<String>,
     port: Option<u16>,
     compact: bool,
+    dry_run: bool,
 ) -> Result<()> {
-    let project = ProjectContext::find_and_load(None)?;
-    // Load a project-root .env so Enterprise query auth can come from a file
-    // instead of requiring the caller to export it in their shell.
-    let _ = dotenvy::from_path(project.root.join(".env"));
     let instance = instance.unwrap_or_else(|| "dev".to_string());
     let request_json = parse_query_request(file, json, ts, ts_file)?;
 
     validate_dynamic_request(&request_json, warm)?;
+    if dry_run {
+        if crate::output::Verbosity::current().show_normal() {
+            println!("{}", format_query_request(&request_json, compact)?);
+        }
+        return Ok(());
+    }
+
+    let project = ProjectContext::find_and_load(None)?;
+    // Load a project-root .env so Enterprise query auth can come from a file
+    // instead of requiring the caller to export it in their shell.
+    let _ = dotenvy::from_path(project.root.join(".env"));
     let client = reqwest::Client::new();
     let (mut request, endpoint, is_local) = match project.config.get_instance(&instance)? {
         InstanceInfo::Local(config) => {
@@ -122,6 +130,14 @@ fn connect_error(instance: &str, endpoint: &str, is_local: bool, cause: &str) ->
     ))
     .with_context(cause.to_string())
     .with_hint(hint)
+}
+
+fn format_query_request(request: &Value, compact: bool) -> Result<String> {
+    if compact {
+        Ok(serde_json::to_string(request)?)
+    } else {
+        Ok(serde_json::to_string_pretty(request)?)
+    }
 }
 
 fn parse_query_request(
@@ -257,5 +273,27 @@ mod tests {
         .to_string();
 
         assert!(error.contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn format_query_request_pretty_prints_dry_run_json() {
+        let request: Value =
+            serde_json::from_str(r#"{"request_type":"read","query":{"queries":[]}}"#).unwrap();
+
+        let output = format_query_request(&request, false).unwrap();
+
+        assert!(output.contains('\n'));
+        assert!(output.contains("\"request_type\": \"read\""));
+        assert!(output.contains("\n  \"query\": {"));
+    }
+
+    #[test]
+    fn format_query_request_compacts_dry_run_json() {
+        let request: Value =
+            serde_json::from_str(r#"{"request_type":"read","query":{"queries":[]}}"#).unwrap();
+
+        let output = format_query_request(&request, true).unwrap();
+
+        assert_eq!(output, r#"{"query":{"queries":[]},"request_type":"read"}"#);
     }
 }

--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -159,6 +159,7 @@ enum Commands {
     #[command(disable_help_flag = true)]
     #[command(after_help = r#"Examples:
   helix query --file examples/request.json
+  helix query --file examples/request.json --dry-run
   helix query -e 'readBatch().varAs("c", g().nWithLabel("User").count()).returning(["c"])'
 
 Docs: https://docs.helix-db.com/cli/command-reference/query"#)]
@@ -206,6 +207,9 @@ Docs: https://docs.helix-db.com/cli/command-reference/query"#)]
         /// Print compact single-line JSON
         #[arg(long, help_heading = "Output")]
         compact: bool,
+        /// Print the dynamic query request JSON without sending it
+        #[arg(long, help_heading = "Output")]
+        dry_run: bool,
     },
 
     /// Deploy an Enterprise Cloud instance
@@ -693,9 +697,13 @@ async fn main() -> Result<()> {
             host,
             port,
             compact,
+            dry_run,
             ..
         }) => {
-            commands::query::run(instance, file, json, ts, ts_file, warm, host, port, compact).await
+            commands::query::run(
+                instance, file, json, ts, ts_file, warm, host, port, compact, dry_run,
+            )
+            .await
         }
         Some(Commands::Push { instance, dev }) => {
             commands::push::run(instance, dev, &metrics_sender).await
@@ -1242,6 +1250,28 @@ mod tests {
             Some(Commands::Query { file, json, .. }) => {
                 assert!(file.is_none());
                 assert_eq!(json.as_deref(), Some(inline_json));
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn query_accepts_dry_run() {
+        let cli = Cli::parse_from([
+            "helix",
+            "query",
+            "dev",
+            "--json",
+            r#"{"request_type":"read","query":{"queries":[]}}"#,
+            "--dry-run",
+        ]);
+
+        match cli.command {
+            Some(Commands::Query {
+                dry_run, compact, ..
+            }) => {
+                assert!(dry_run);
+                assert!(!compact);
             }
             _ => panic!("expected query command"),
         }


### PR DESCRIPTION
## Description

Adds a `--dry-run` option to `helix query` so users can inspect the generated dynamic query request JSON without sending it to a Helix instance.

This works with all existing query inputs (`--file`, `--json`, `-e/--ts`, and `--ts-file`) and respects `--compact` for single-line output. Dry-run mode validates the request shape, prints the request body, and exits before loading project config or making an HTTP request.

## Related Issues

N/A

## Checklist when merging to main

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [x] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml` (N/A - CLI behavior only)

## Additional Notes

Verification run locally:

- `cargo fmt --all`
- `cargo test -p helix-cli`
- `HELIX_NO_UPDATE_CHECK=1 cargo run -p helix-cli --quiet -- query dev --json '{"request_type":"read","query":{"queries":[]}}' --dry-run --compact`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `--dry-run` flag to `helix query` that validates the constructed request body and prints it (respecting `--compact`) without loading project configuration or making an HTTP request.

- **`query.rs`**: `dry_run: bool` is added to `run()`; the early-return branch fires after `validate_dynamic_request` but before `ProjectContext::find_and_load`, plus a `format_query_request` helper and two unit tests.
- **`main.rs`**: Adds the `dry_run` field to the `Query` enum variant, wires it into the call site, and adds a parser-level test.
- **`chef.rs` / `README.md`**: Mechanical signature update and doc update respectively.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-cli/src/commands/query.rs | Adds dry_run parameter; early exit after validation but before project load; new format_query_request helper; two well-scoped unit tests. |
| helix-cli/src/main.rs | Adds dry_run field to Query enum, example in after_help, passes flag through to query::run, adds parser-level test. |
| helix-cli/src/commands/chef.rs | Mechanical update: adds false for the new dry_run parameter to the existing query::run call inside seed_starter_data. |
| helix-cli/README.md | Single-line doc update noting --dry-run on the query command; accurate and consistent with the implementation. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[helix query ...args] --> B[parse_query_request\nfile / json / ts / ts_file]
    B --> C{parse OK?}
    C -- error --> Z1[return Err]
    C -- ok --> D[validate_dynamic_request\nrequest_type + warm check]
    D --> E{valid?}
    E -- error --> Z2[return Err]
    E -- ok --> F{--dry-run?}
    F -- yes --> G{verbosity\nshow_normal?}
    G -- yes --> H[format_query_request\npretty or compact]
    H --> I[println! request body]
    I --> J[return Ok]
    G -- no --> J
    F -- no --> K[ProjectContext::find_and_load\n+ dotenvy .env]
    K --> L[build reqwest request\nLocal or Enterprise]
    L --> M[POST /v1/query]
    M --> N[print response]
    N --> J
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): add query dry-run mode"](https://github.com/helixdb/helix-db/commit/b1f99e4b86f35f29de08cbe38c299c3dcaf583d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37603452)</sub>

<!-- /greptile_comment -->