### PR TITLE
Update helix-cli version to 3.0.6 in Cargo.toml and Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,7 +783,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helix-cli"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-cli"
-version = "3.0.5"
+version = "3.0.6"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `helix-cli` crate version from `3.0.5` to `3.0.6` in both `helix-cli/Cargo.toml` and the workspace `Cargo.lock`.

- The version change is applied consistently across both files, with no other modifications.
- No dependency additions, removals, or code changes are included in this diff.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-cli/Cargo.toml | Version bumped from 3.0.5 to 3.0.6; no other changes. |
| Cargo.lock | Lock file updated to reflect the new helix-cli version 3.0.6; consistent with Cargo.toml change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["helix-cli/Cargo.toml\nversion: 3.0.5 → 3.0.6"] --> B["Cargo.lock\nhelix-cli entry updated\n3.0.5 → 3.0.6"]
    B --> C["Workspace lock file\nconsistent with Cargo.toml"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["helix-cli/Cargo.toml\nversion: 3.0.5 → 3.0.6"] --> B["Cargo.lock\nhelix-cli entry updated\n3.0.5 → 3.0.6"]
    B --> C["Workspace lock file\nconsistent with Cargo.toml"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Update helix-cli version to 3.0.6 in Car..."](https://github.com/helixdb/helix-db/commit/b30cbe0a74553ef57593cf2073eb36da630d5d25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38086264)</sub>

<!-- /greptile_comment -->