### PR TITLE
Update SDK versions to 2.0.6 and enhance row binding functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "helix-db"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "chrono",
  "helix-dsl-macros",

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -113,6 +113,55 @@ Always pass explicit names to `Returning(...)` for values you want back. A
 zero-arg `Returning()` is supported for intentional empty responses and
 serializes as `"returns":[]`.
 
+## Row Bindings
+
+Use `Bind(...)` when a multi-hop traversal needs to keep earlier elements
+correlated with later results. Row bindings are row-local: each path keeps its
+own named bindings, and `ProjectDistinctBindings(...)` can emit one output row
+per projected tuple.
+
+```go
+func ServiceWorkloads(tenantID string) helix.Request {
+	q := helix.ReadQuery("service_workloads")
+	tenant := q.ParamString("tenant_id", tenantID)
+
+	return q.
+		VarAs("dependencies",
+			helix.G().
+				NWithLabel("Service").
+				Where(helix.PredEq("tenantId", tenant)).
+				Bind("service").
+				Out("ROUTES_TO").
+				Where(helix.PredEq("tenantId", tenant)).
+				Bind("pod").
+				In("MANAGES").
+				Where(helix.PredEq("tenantId", tenant)).
+				Bind("owner").
+				Union(
+					helix.Sub().
+						Where(helix.PredEq("type", "ReplicaSet")).
+						In("CREATES").
+						Where(helix.PredEq("type", "Deployment")).
+						Where(helix.PredEq("tenantId", tenant)).
+						Bind("workload"),
+					helix.Sub().
+						Where(helix.PredIsIn("type", []string{"Deployment", "StatefulSet", "DaemonSet"})).
+						Bind("workload"),
+				).
+				ProjectDistinctBindings(
+					helix.ProjectNamedBinding("service", "$id", "service_id"),
+					helix.ProjectNamedBinding("workload", "$id", "workload_id"),
+				),
+		).
+		Returning("dependencies")
+}
+```
+
+Binding projections can read virtual fields such as `$id`, `$label`, `$from`,
+`$to`, `$distance`, and `$score` from either the current element or a named
+binding. Use `ProjectBindingCoalesce(...)` when optional branches may or may not
+create a binding.
+
 ## Conflicts And Retries
 
 `Client.Exec` does not retry HTTP 409 conflicts automatically. Callers should

--- a/sdks/go/cmd/generate-parity-fixtures/main.go
+++ b/sdks/go/cmd/generate-parity-fixtures/main.go
@@ -67,8 +67,8 @@ func run() error {
 	if runtimeCount != 224 {
 		return fmt.Errorf("generated %d runtime fixtures, expected 224", runtimeCount)
 	}
-	if jsonOnlyCount != 10 {
-		return fmt.Errorf("generated %d json-only fixtures, expected 10", jsonOnlyCount)
+	if jsonOnlyCount != 12 {
+		return fmt.Errorf("generated %d json-only fixtures, expected 12", jsonOnlyCount)
 	}
 
 	return nil
@@ -487,7 +487,29 @@ func jsonOnlyFixtures() []fixture {
 			)).Returning("endpoints"),
 		),
 		jsonOnly(
-			"909-range-index-direction",
+			"909-row-binding-basic-projection",
+			read().VarAs("bindings", helix.G().NWithLabel("ParityService").Bind("service").ProjectBindings(
+				helix.ProjectNamedBinding("service", "$id", "service_id"),
+				helix.ProjectCurrentBinding("metadata.name", "current_name"),
+				helix.ProjectNamedBinding("missing_binding", "externalId", "missing_external_id"),
+			)).Returning("bindings"),
+		),
+		jsonOnly(
+			"910-row-binding-branch-distinct-projection",
+			read().VarAs("workloads", helix.G().NWithLabel("ParityService").Bind("service").Out("ROUTES_TO").Bind("pod").Optional(helix.Sub().In("CREATES").Bind("deployment")).Union(
+				helix.Sub().In("MANAGES").Bind("owner"),
+				helix.Sub().Out("ROUTES_TO").Bind("workload"),
+			).ProjectDistinctBindings(
+				helix.ProjectNamedBinding("service", "$id", "service_id"),
+				helix.ProjectBindingCoalesce([]helix.BindingValueRef{
+					helix.NamedBindingValue("deployment", "$id"),
+					helix.NamedBindingValue("owner", "$id"),
+					helix.NamedBindingValue("workload", "$id"),
+				}, "workload_id"),
+			)).Returning("workloads"),
+		),
+		jsonOnly(
+			"911-range-index-direction",
 			write().
 				VarAs("node_desc", helix.G().CreateIndexIfNotExists(helix.NodeRangeDescIndex("ParityUser", "age"))).
 				VarAs("edge_desc", helix.G().CreateIndexIfNotExists(helix.EdgeRangeDescIndex("FOLLOWS", "weight"))).

--- a/sdks/go/dsl.go
+++ b/sdks/go/dsl.go
@@ -614,6 +614,64 @@ func (p Projection) MarshalJSON() ([]byte, error) {
 	}{p.Source, p.Alias})
 }
 
+type BindingTarget struct {
+	current bool
+	name    string
+}
+
+func CurrentBinding() BindingTarget { return BindingTarget{current: true} }
+func Binding(name string) BindingTarget {
+	return BindingTarget{name: name}
+}
+
+func (t BindingTarget) MarshalJSON() ([]byte, error) {
+	if t.current {
+		return json.Marshal("Current")
+	}
+	return json.Marshal(map[string]string{"Binding": t.name})
+}
+
+type BindingValueRef struct {
+	Target BindingTarget `json:"target"`
+	Source string        `json:"source"`
+}
+
+func BindingValue(target BindingTarget, source string) BindingValueRef {
+	return BindingValueRef{Target: target, Source: source}
+}
+func CurrentBindingValue(source string) BindingValueRef {
+	return BindingValue(CurrentBinding(), source)
+}
+func NamedBindingValue(name, source string) BindingValueRef {
+	return BindingValue(Binding(name), source)
+}
+
+type BindingProjection struct {
+	Kind   string            `json:"kind"`
+	Target *BindingTarget    `json:"target,omitempty"`
+	Source string            `json:"source,omitempty"`
+	Alias  string            `json:"alias"`
+	Refs   []BindingValueRef `json:"refs,omitempty"`
+}
+
+func ProjectBinding(target BindingTarget, source, alias string) BindingProjection {
+	return BindingProjection{Kind: "Property", Target: &target, Source: source, Alias: alias}
+}
+func ProjectCurrentBinding(source, alias string) BindingProjection {
+	return ProjectBinding(CurrentBinding(), source, alias)
+}
+func ProjectNamedBinding(name, source, alias string) BindingProjection {
+	return ProjectBinding(Binding(name), source, alias)
+}
+func ProjectBindingCoalesce(refs []BindingValueRef, alias string) BindingProjection {
+	return BindingProjection{Kind: "Coalesce", Refs: refs, Alias: alias}
+}
+
+type projectBindingsStep struct {
+	Projections []BindingProjection `json:"projections"`
+	Distinct    bool                `json:"distinct"`
+}
+
 type Order string
 
 const (
@@ -960,10 +1018,16 @@ func (t *Traversal) As(name string) *Traversal     { return t.add(step("As", nam
 func (t *Traversal) Store(name string) *Traversal  { return t.add(step("Store", name)) }
 func (t *Traversal) Select(name string) *Traversal { return t.add(step("Select", name)) }
 func (t *Traversal) Inject(name string) *Traversal { return t.add(step("Inject", name)) }
-func (t *Traversal) Count() *Traversal             { return t.addTerminal(unitStep("Count")) }
-func (t *Traversal) Exists() *Traversal            { return t.addTerminal(unitStep("Exists")) }
-func (t *Traversal) ID() *Traversal                { return t.addTerminal(unitStep("Id")) }
-func (t *Traversal) Label() *Traversal             { return t.addTerminal(unitStep("Label")) }
+func (t *Traversal) Bind(name string) *Traversal {
+	if name == "" {
+		return t.record(errors.New("helix: binding name must not be empty"))
+	}
+	return t.add(step("Bind", name))
+}
+func (t *Traversal) Count() *Traversal  { return t.addTerminal(unitStep("Count")) }
+func (t *Traversal) Exists() *Traversal { return t.addTerminal(unitStep("Exists")) }
+func (t *Traversal) ID() *Traversal     { return t.addTerminal(unitStep("Id")) }
+func (t *Traversal) Label() *Traversal  { return t.addTerminal(unitStep("Label")) }
 func (t *Traversal) Values(properties ...string) *Traversal {
 	return t.addTerminal(step("Values", properties))
 }
@@ -976,6 +1040,12 @@ func (t *Traversal) ValueMap(properties ...string) *Traversal {
 func (t *Traversal) ValueMapAll() *Traversal { return t.addTerminal(step("ValueMap", nil)) }
 func (t *Traversal) Project(projections ...Projection) *Traversal {
 	return t.addTerminal(step("Project", projections))
+}
+func (t *Traversal) ProjectBindings(projections ...BindingProjection) *Traversal {
+	return t.addTerminal(step("ProjectBindings", projectBindingsStep{Projections: projections, Distinct: false}))
+}
+func (t *Traversal) ProjectDistinctBindings(projections ...BindingProjection) *Traversal {
+	return t.addTerminal(step("ProjectBindings", projectBindingsStep{Projections: projections, Distinct: true}))
 }
 func (t *Traversal) EdgeProperties() *Traversal { return t.addTerminal(unitStep("EdgeProperties")) }
 func (t *Traversal) AddN(label string, props Props) *Traversal {
@@ -1136,6 +1206,12 @@ func (s SubTraversal) Limit(bound any) SubTraversal {
 	return s.add(step("Limit", *b.literal))
 }
 func (s SubTraversal) Count() SubTraversal { return s.add(unitStep("Count")) }
+func (s SubTraversal) Bind(name string) SubTraversal {
+	if name == "" {
+		return s
+	}
+	return s.add(step("Bind", name))
+}
 
 type BatchCondition struct {
 	kind  string

--- a/sdks/go/dsl_test.go
+++ b/sdks/go/dsl_test.go
@@ -62,6 +62,47 @@ func TestEdgeEndpointProjectionJSON(t *testing.T) {
 	}
 }
 
+func TestRowBindingProjectionJSON(t *testing.T) {
+	req := ReadQuery("service_workloads").
+		VarAs("workloads", G().NWithLabel("Service").Bind("service").Out("ROUTES_TO").Bind("pod").Optional(Sub().In("CREATES").Bind("deployment")).Union(
+			Sub().In("MANAGES").Bind("owner"),
+			Sub().Out("ROUTES_TO").Bind("workload"),
+		).ProjectDistinctBindings(
+			ProjectNamedBinding("service", "$id", "service_id"),
+			ProjectCurrentBinding("$id", "current_id"),
+			ProjectNamedBinding("missing_binding", "externalId", "missing_external_id"),
+			ProjectBindingCoalesce([]BindingValueRef{
+				NamedBindingValue("deployment", "$id"),
+				NamedBindingValue("owner", "$id"),
+				NamedBindingValue("workload", "$id"),
+			}, "workload_id"),
+		)).
+		Returning("workloads")
+	body, err := MarshalRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonText := string(body)
+	for _, want := range []string{
+		`"Bind":"service"`,
+		`"Bind":"deployment"`,
+		`"ProjectBindings":{"projections":[{"kind":"Property","target":{"Binding":"service"},"source":"$id","alias":"service_id"}`,
+		`{"kind":"Property","target":"Current","source":"$id","alias":"current_id"}`,
+		`{"kind":"Coalesce","alias":"workload_id","refs":[{"target":{"Binding":"deployment"},"source":"$id"},{"target":{"Binding":"owner"},"source":"$id"},{"target":{"Binding":"workload"},"source":"$id"}]}`,
+		`"distinct":true`,
+	} {
+		if !strings.Contains(jsonText, want) {
+			t.Fatalf("request JSON missing %s in %s", want, jsonText)
+		}
+	}
+}
+
+func TestBindRejectsEmptyName(t *testing.T) {
+	if err := G().NWithLabel("Service").Bind("").ProjectBindings(ProjectCurrentBinding("$id", "id")).Validate(); err == nil {
+		t.Fatal("expected empty binding name to fail validation")
+	}
+}
+
 func TestReadQueryRejectsWriteTraversal(t *testing.T) {
 	req := ReadQuery("bad").VarAs("created", G().AddN("User", Props{Prop("name", "Alice")})).Returning("created")
 	if err := req.Validate(); err == nil {

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-db"
-version = "2.0.5"
+version = "2.0.6"
 edition = "2021"
 rust-version = "1.75"
 description = "Library for working with HelixDB"

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -454,6 +454,52 @@ read_batch()
     .returning(["heavy_edges", "targets"]);
 ```
 
+## Row Bindings
+
+Use `.bind(...)` when a multi-hop traversal needs to keep earlier elements correlated with later results. Row bindings are row-local: each path keeps its own named bindings, and `.project_distinct_bindings(...)` can emit one output row per projected tuple.
+
+```rust
+read_batch()
+    .var_as(
+        "dependencies",
+        g()
+            .n_with_label("Service")
+            .where_(Predicate::eq("tenant_id", "acme"))
+            .bind("service")
+            .out(Some("ROUTES_TO"))
+            .where_(Predicate::eq("tenant_id", "acme"))
+            .bind("pod")
+            .in_(Some("MANAGES"))
+            .where_(Predicate::eq("tenant_id", "acme"))
+            .bind("owner")
+            .union(vec![
+                sub()
+                    .where_(Predicate::eq("type", "ReplicaSet"))
+                    .in_(Some("CREATES"))
+                    .where_(Predicate::eq("type", "Deployment"))
+                    .where_(Predicate::eq("tenant_id", "acme"))
+                    .bind("workload"),
+                sub()
+                    .where_(Predicate::is_in(
+                        "type",
+                        vec![
+                            "Deployment".to_string(),
+                            "StatefulSet".to_string(),
+                            "DaemonSet".to_string(),
+                        ],
+                    ))
+                    .bind("workload"),
+            ])
+            .project_distinct_bindings(vec![
+                BindingProjection::binding("service", "$id", "service_id"),
+                BindingProjection::binding("workload", "$id", "workload_id"),
+            ]),
+    )
+    .returning(["dependencies"]);
+```
+
+Binding projections can read virtual fields such as `$id`, `$label`, `$from`, `$to`, `$distance`, and `$score` from either `BindingTarget::Current` or a named binding. Use `BindingProjection::coalesce(...)` when optional branches may or may not create a binding.
+
 ## Branching and Repetition
 
 ```rust

--- a/sdks/rust/examples/generate_parity_fixtures.rs
+++ b/sdks/rust/examples/generate_parity_fixtures.rs
@@ -1373,7 +1373,58 @@ fn json_only_fixtures() -> Vec<Fixture> {
             ),
         ),
         json_only(
-            "909-range-index-direction",
+            "909-row-binding-basic-projection",
+            read_request(
+                read_batch()
+                    .var_as(
+                        "bindings",
+                        g().n_with_label("ParityService")
+                            .bind("service")
+                            .project_bindings(vec![
+                                BindingProjection::binding("service", "$id", "service_id"),
+                                BindingProjection::current("metadata.name", "current_name"),
+                                BindingProjection::binding(
+                                    "missing_binding",
+                                    "externalId",
+                                    "missing_external_id",
+                                ),
+                            ]),
+                    )
+                    .returning(["bindings"]),
+            ),
+        ),
+        json_only(
+            "910-row-binding-branch-distinct-projection",
+            read_request(
+                read_batch()
+                    .var_as(
+                        "workloads",
+                        g().n_with_label("ParityService")
+                            .bind("service")
+                            .out(Some("ROUTES_TO"))
+                            .bind("pod")
+                            .optional(sub().in_(Some("CREATES")).bind("deployment"))
+                            .union(vec![
+                                sub().in_(Some("MANAGES")).bind("owner"),
+                                sub().out(Some("ROUTES_TO")).bind("workload"),
+                            ])
+                            .project_distinct_bindings(vec![
+                                BindingProjection::binding("service", "$id", "service_id"),
+                                BindingProjection::coalesce(
+                                    vec![
+                                        BindingValueRef::binding("deployment", "$id"),
+                                        BindingValueRef::binding("owner", "$id"),
+                                        BindingValueRef::binding("workload", "$id"),
+                                    ],
+                                    "workload_id",
+                                ),
+                            ]),
+                    )
+                    .returning(["workloads"]),
+            ),
+        ),
+        json_only(
+            "911-range-index-direction",
             write_request(
                 write_batch()
                     .var_as(

--- a/sdks/rust/src/dsl.rs
+++ b/sdks/rust/src/dsl.rs
@@ -2077,6 +2077,121 @@ impl From<ExprProjection> for Projection {
     }
 }
 
+/// Target for a row-binding projection reference.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum BindingTarget {
+    /// The current traverser element.
+    Current,
+    /// A named row-local binding captured by `bind()`.
+    Binding(String),
+}
+
+impl BindingTarget {
+    /// Reference the current traverser element.
+    pub fn current() -> Self {
+        Self::Current
+    }
+
+    /// Reference a named row-local binding.
+    pub fn binding(name: impl Into<String>) -> Self {
+        Self::Binding(name.into())
+    }
+}
+
+/// A property reference used by binding projection expressions.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BindingValueRef {
+    /// Current element or named binding to read from.
+    pub target: BindingTarget,
+    /// Property or virtual field to read.
+    pub source: String,
+}
+
+impl BindingValueRef {
+    /// Create a binding projection value reference.
+    pub fn new(target: BindingTarget, source: impl Into<String>) -> Self {
+        Self {
+            target,
+            source: source.into(),
+        }
+    }
+
+    /// Reference a property on the current traverser element.
+    pub fn current(source: impl Into<String>) -> Self {
+        Self::new(BindingTarget::Current, source)
+    }
+
+    /// Reference a property on a named row binding.
+    pub fn binding(name: impl Into<String>, source: impl Into<String>) -> Self {
+        Self::new(BindingTarget::Binding(name.into()), source)
+    }
+}
+
+/// A terminal projection entry for row-local bindings.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum BindingProjection {
+    /// Project a property or virtual field from the current element or a binding.
+    Property {
+        /// Current element or named binding to read from.
+        target: BindingTarget,
+        /// Property or virtual field to read.
+        source: String,
+        /// Name to use in the output row.
+        alias: String,
+    },
+    /// Project the first present non-null property from a list of references.
+    Coalesce {
+        /// Candidate references in fallback order.
+        refs: Vec<BindingValueRef>,
+        /// Name to use in the output row.
+        alias: String,
+    },
+}
+
+impl BindingProjection {
+    /// Project a property or virtual field from the current element or a binding.
+    pub fn property(
+        target: BindingTarget,
+        source: impl Into<String>,
+        alias: impl Into<String>,
+    ) -> Self {
+        Self::Property {
+            target,
+            source: source.into(),
+            alias: alias.into(),
+        }
+    }
+
+    /// Project a property or virtual field from the current traverser element.
+    pub fn current(source: impl Into<String>, alias: impl Into<String>) -> Self {
+        Self::property(BindingTarget::Current, source, alias)
+    }
+
+    /// Project a property or virtual field from a named row binding.
+    pub fn binding(
+        name: impl Into<String>,
+        source: impl Into<String>,
+        alias: impl Into<String>,
+    ) -> Self {
+        Self::property(BindingTarget::Binding(name.into()), source, alias)
+    }
+
+    /// Project the first present non-null property from a list of references.
+    pub fn coalesce(refs: Vec<BindingValueRef>, alias: impl Into<String>) -> Self {
+        Self::Coalesce {
+            refs,
+            alias: alias.into(),
+        }
+    }
+}
+
+fn validate_binding_name(name: impl Into<String>) -> String {
+    let name = name.into();
+    assert!(!name.is_empty(), "binding name must not be empty");
+    name
+}
+
 /// Sort order for ordering steps
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Order {
@@ -2322,6 +2437,12 @@ impl SubTraversal {
     /// Replace current traversal with nodes from a variable
     pub fn select(mut self, name: impl Into<String>) -> Self {
         self.steps.push(Step::Select(name.into()));
+        self
+    }
+
+    /// Capture the current element as a row-local binding and enter row mode.
+    pub fn bind(mut self, name: impl Into<String>) -> Self {
+        self.steps.push(Step::Bind(validate_binding_name(name)));
         self
     }
 
@@ -2887,6 +3008,9 @@ pub enum Step {
     /// Builder form: `.select("x")`
     Select(String),
 
+    /// Capture the current element as a row-local binding and enter row mode.
+    Bind(String),
+
     // Terminal Steps - End the traversal
     /// Count results (returns single value)
     Count,
@@ -2915,6 +3039,14 @@ pub enum Step {
 
     /// Project properties and expressions with optional renaming.
     Project(Vec<Projection>),
+
+    /// Project row-local bindings and optionally deduplicate projected rows.
+    ProjectBindings {
+        /// Projection entries to evaluate for each traverser row.
+        projections: Vec<BindingProjection>,
+        /// Whether to deduplicate identical projected property rows.
+        distinct: bool,
+    },
 
     /// Return edge properties for the current edge stream.
     ///
@@ -3213,6 +3345,7 @@ impl<S: TraversalState, M: MutationMode> Traversal<S, M> {
                     | Step::Values(_)
                     | Step::ValueMap(_)
                     | Step::Project(_)
+                    | Step::ProjectBindings { .. }
                     | Step::EdgeProperties
                     | Step::CreateIndex { .. }
                     | Step::DropIndex { .. }
@@ -3768,6 +3901,11 @@ impl<M: MutationMode> Traversal<OnNodes, M> {
         self.push_step(Step::Select(name.into()))
     }
 
+    /// Capture the current node as a row-local binding and enter row mode.
+    pub fn bind(self, name: impl Into<String>) -> Self {
+        self.push_step(Step::Bind(validate_binding_name(name)))
+    }
+
     /// Union the current node stream with nodes stored in `var_name`.
     ///
     /// This keeps the current stream and adds any nodes stored in the named
@@ -3828,6 +3966,25 @@ impl<M: MutationMode> Traversal<OnNodes, M> {
         self.push_step(Step::Project(
             projections.into_iter().map(Into::into).collect(),
         ))
+    }
+
+    /// Project row-local bindings, preserving duplicate projected rows.
+    pub fn project_bindings(self, projections: Vec<BindingProjection>) -> Traversal<Terminal, M> {
+        self.push_step(Step::ProjectBindings {
+            projections,
+            distinct: false,
+        })
+    }
+
+    /// Project row-local bindings and deduplicate identical projected rows.
+    pub fn project_distinct_bindings(
+        self,
+        projections: Vec<BindingProjection>,
+    ) -> Traversal<Terminal, M> {
+        self.push_step(Step::ProjectBindings {
+            projections,
+            distinct: true,
+        })
     }
 
     // Ordering Steps: OnNodes -> OnNodes
@@ -4183,6 +4340,11 @@ impl<M: MutationMode> Traversal<OnEdges, M> {
         self.push_step(Step::Store(name.into()))
     }
 
+    /// Capture the current edge as a row-local binding and enter row mode.
+    pub fn bind(self, name: impl Into<String>) -> Self {
+        self.push_step(Step::Bind(validate_binding_name(name)))
+    }
+
     // Terminal Steps: OnEdges -> Terminal
 
     /// Count the number of edges
@@ -4213,6 +4375,25 @@ impl<M: MutationMode> Traversal<OnEdges, M> {
         self.push_step(Step::Project(
             projections.into_iter().map(Into::into).collect(),
         ))
+    }
+
+    /// Project row-local bindings, preserving duplicate projected rows.
+    pub fn project_bindings(self, projections: Vec<BindingProjection>) -> Traversal<Terminal, M> {
+        self.push_step(Step::ProjectBindings {
+            projections,
+            distinct: false,
+        })
+    }
+
+    /// Project row-local bindings and deduplicate identical projected rows.
+    pub fn project_distinct_bindings(
+        self,
+        projections: Vec<BindingProjection>,
+    ) -> Traversal<Terminal, M> {
+        self.push_step(Step::ProjectBindings {
+            projections,
+            distinct: true,
+        })
     }
 
     /// Get edge properties
@@ -4702,15 +4883,16 @@ pub fn write_batch() -> WriteBatch {
 pub mod prelude {
     pub use crate::{
         g, read_batch, register, sub, write_batch, AggregateFunction, BatchCondition, BatchEntry,
-        CompareOp, DateTime, DynamicQueryError, DynamicQueryRequest, DynamicQueryRequestType,
-        DynamicQueryValue, EdgeId, EdgeRef, EmitBehavior, Expr, ExprProjection, IndexSpec, NodeId,
-        NodeRef, Order, ParamObject, ParamValue, Predicate, Projection, PropertyInput,
-        PropertyProjection, PropertyValue, ReadBatch, RepeatConfig, SourcePredicate, StreamBound,
-        SubTraversal, Traversal, WriteBatch,
+        BindingProjection, BindingTarget, BindingValueRef, CompareOp, DateTime, DynamicQueryError,
+        DynamicQueryRequest, DynamicQueryRequestType, DynamicQueryValue, EdgeId, EdgeRef,
+        EmitBehavior, Expr, ExprProjection, IndexSpec, NodeId, NodeRef, Order, ParamObject,
+        ParamValue, Predicate, Projection, PropertyInput, PropertyProjection, PropertyValue,
+        ReadBatch, RepeatConfig, SourcePredicate, StreamBound, SubTraversal, Traversal, WriteBatch,
     };
     // query bundle generation
     pub use crate::{
         generate, generate_to_path, GenerateError, QueryBundle, QueryParamType, QueryParameter,
+        LEGACY_QUERY_BUNDLE_VERSION_V4, QUERY_BUNDLE_VERSION, SUPPORTED_QUERY_BUNDLE_VERSIONS,
     };
 }
 
@@ -4722,7 +4904,7 @@ pub type PropertyMap = HashMap<String, PropertyValue>;
 mod tests {
     use crate::query_generator::{
         deserialize_query_bundle, serialize_query_bundle, GenerateError, QueryBundle,
-        QueryParamType, QueryParameter, QUERY_BUNDLE_VERSION,
+        QueryParamType, QueryParameter, LEGACY_QUERY_BUNDLE_VERSION_V4, QUERY_BUNDLE_VERSION,
     };
 
     use super::*;
@@ -4761,6 +4943,63 @@ mod tests {
             Projection::property("$to.resource_id", "to_id")
         );
         assert_eq!(projections[2], Projection::property("$id", "edge_id"));
+    }
+
+    #[test]
+    fn row_binding_steps_serialize_expected_wire_shape() {
+        let traversal = g()
+            .n_with_label("Service")
+            .bind("service")
+            .out(Some("ROUTES_TO"))
+            .bind("pod")
+            .optional(sub().in_(Some("CREATES")).bind("deployment"))
+            .union(vec![
+                sub().in_(Some("MANAGES")).bind("owner"),
+                sub().out(Some("ROUTES_TO")).bind("workload"),
+            ])
+            .project_distinct_bindings(vec![
+                BindingProjection::binding("service", "$id", "service_id"),
+                BindingProjection::current("$id", "current_id"),
+                BindingProjection::coalesce(
+                    vec![
+                        BindingValueRef::binding("deployment", "$id"),
+                        BindingValueRef::binding("owner", "$id"),
+                        BindingValueRef::binding("missing", "$id"),
+                    ],
+                    "workload_id",
+                ),
+            ]);
+
+        assert!(traversal.has_terminal());
+        assert!(matches!(&traversal.steps[1], Step::Bind(name) if name == "service"));
+        assert!(matches!(
+            &traversal.steps[6],
+            Step::ProjectBindings { distinct: true, .. }
+        ));
+
+        let step_json =
+            sonic_rs::to_string(&Step::Bind("service".to_string())).expect("serialize bind step");
+        assert_eq!(step_json, r#"{"Bind":"service"}"#);
+
+        let projection_step = Step::ProjectBindings {
+            projections: vec![
+                BindingProjection::binding("service", "$id", "service_id"),
+                BindingProjection::coalesce(
+                    vec![
+                        BindingValueRef::binding("deployment", "$id"),
+                        BindingValueRef::binding("owner", "$id"),
+                    ],
+                    "workload_id",
+                ),
+            ],
+            distinct: true,
+        };
+        let projection_json =
+            sonic_rs::to_string(&projection_step).expect("serialize projection step");
+        assert_eq!(
+            projection_json,
+            r#"{"ProjectBindings":{"projections":[{"kind":"Property","target":{"Binding":"service"},"source":"$id","alias":"service_id"},{"kind":"Coalesce","refs":[{"target":{"Binding":"deployment"},"source":"$id"},{"target":{"Binding":"owner"},"source":"$id"}],"alias":"workload_id"}],"distinct":true}}"#
+        );
     }
 
     #[test]
@@ -4836,6 +5075,17 @@ mod tests {
                 expected: QUERY_BUNDLE_VERSION,
             }
         ));
+    }
+
+    #[test]
+    fn query_bundle_accepts_legacy_v4_version() {
+        let mut bundle = QueryBundle::default();
+        bundle.version = LEGACY_QUERY_BUNDLE_VERSION_V4;
+
+        let bytes = serialize_query_bundle(&bundle).expect("serialize query bundle");
+        let decoded = deserialize_query_bundle(&bytes).expect("legacy version should deserialize");
+
+        assert_eq!(decoded.version, LEGACY_QUERY_BUNDLE_VERSION_V4);
     }
 
     #[test]

--- a/sdks/rust/src/query_generator.rs
+++ b/sdks/rust/src/query_generator.rs
@@ -2,8 +2,15 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+/// Last query-bundle wire-format version before row-binding steps were added.
+pub const LEGACY_QUERY_BUNDLE_VERSION_V4: u32 = 4;
+
 /// Current wire-format version for generated query bundles.
-pub const QUERY_BUNDLE_VERSION: u32 = 4;
+pub const QUERY_BUNDLE_VERSION: u32 = 5;
+
+/// Query-bundle versions this SDK can deserialize.
+pub const SUPPORTED_QUERY_BUNDLE_VERSIONS: &[u32] =
+    &[LEGACY_QUERY_BUNDLE_VERSION_V4, QUERY_BUNDLE_VERSION];
 
 /// Declared shape of a registered query parameter.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -189,7 +196,7 @@ pub fn serialize_query_bundle(bundle: &QueryBundle) -> Result<Vec<u8>, GenerateE
 pub fn deserialize_query_bundle(bytes: &[u8]) -> Result<QueryBundle, GenerateError> {
     let bundle: QueryBundle = sonic_rs::from_slice(bytes)?;
 
-    if bundle.version != QUERY_BUNDLE_VERSION {
+    if !SUPPORTED_QUERY_BUNDLE_VERSIONS.contains(&bundle.version) {
         return Err(GenerateError::UnsupportedVersion {
             found: bundle.version,
             expected: QUERY_BUNDLE_VERSION,

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -139,6 +139,49 @@ g()
   .where(Predicate.eq("email", Expr.param("email")));
 ```
 
+## Row Bindings
+
+Use `bind(...)` when a multi-hop traversal needs to keep earlier elements correlated with later results. Row bindings are row-local: each path keeps its own named bindings, and `projectDistinctBindings(...)` can emit one output row per projected tuple.
+
+```ts
+import { BindingProjection, Predicate, g, readBatch, sub } from "@helix-db/helix-db";
+
+function serviceWorkloads(tenantId: string) {
+  return readBatch()
+    .varAs(
+      "dependencies",
+      g()
+        .nWithLabel("Service")
+        .where(Predicate.eq("tenantId", tenantId))
+        .bind("service")
+        .out("ROUTES_TO")
+        .where(Predicate.eq("tenantId", tenantId))
+        .bind("pod")
+        .in("MANAGES")
+        .where(Predicate.eq("tenantId", tenantId))
+        .bind("owner")
+        .union([
+          sub()
+            .where(Predicate.eq("type", "ReplicaSet"))
+            .in("CREATES")
+            .where(Predicate.eq("type", "Deployment"))
+            .where(Predicate.eq("tenantId", tenantId))
+            .bind("workload"),
+          sub()
+            .where(Predicate.isIn("type", ["Deployment", "StatefulSet", "DaemonSet"]))
+            .bind("workload"),
+        ])
+        .projectDistinctBindings([
+          BindingProjection.binding("service", "$id", "service_id"),
+          BindingProjection.binding("workload", "$id", "workload_id"),
+        ]),
+    )
+    .returning(["dependencies"]);
+}
+```
+
+Binding projections can read virtual fields such as `$id`, `$label`, `$from`, `$to`, `$distance`, and `$score` from either `BindingTarget.current()` or a named binding. Use `BindingProjection.coalesce(...)` when optional branches may or may not create a binding.
+
 ## Dynamic Requests
 
 For dynamic `/v1/query`, call your plain query function and serialize the returned batch as a request.
@@ -197,7 +240,7 @@ const json = serializeQueryBundle(bundle);
 await queries.generate("queries.json");
 ```
 
-Bundles use `QUERY_BUNDLE_VERSION = 4` and contain read routes, write routes, and per-route parameter metadata. `deserializeQueryBundle` validates the bundle version for TypeScript consumers.
+Bundles use `QUERY_BUNDLE_VERSION = 5` and contain read routes, write routes, and per-route parameter metadata. `deserializeQueryBundle` accepts the wire-compatible legacy version `4` plus version `5`, and rejects unknown future versions for TypeScript consumers.
 
 ## Number Handling
 

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helix-db/helix-db",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "TypeScript library for working with  HelixDB",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/scripts/parity/compare-json.ts
+++ b/sdks/typescript/scripts/parity/compare-json.ts
@@ -4,7 +4,7 @@ import { canonicalizeJson, parseJsonStructural, structuralJsonEqual } from "../.
 import { goGeneratedRoot, rustGeneratedRoot, typescriptGeneratedRoot } from "./paths.js";
 
 const EXPECTED_RUNTIME = 224;
-const EXPECTED_JSON_ONLY = 10;
+const EXPECTED_JSON_ONLY = 12;
 const EXPECTED_TOTAL = EXPECTED_RUNTIME + EXPECTED_JSON_ONLY;
 
 type Generated = {

--- a/sdks/typescript/scripts/parity/generate-fixtures.ts
+++ b/sdks/typescript/scripts/parity/generate-fixtures.ts
@@ -14,6 +14,7 @@ import {
   Order,
   Predicate,
   Projection,
+  BindingProjection,
   PropertyInput,
   PropertyValue,
   QueryParamType,
@@ -940,7 +941,53 @@ function jsonOnlyFixtures(): Fixture[] {
       ),
     ),
     jsonOnly(
-      "909-range-index-direction",
+      "909-row-binding-basic-projection",
+      DynamicQueryRequest.read(
+        readBatch()
+          .varAs(
+            "bindings",
+            g()
+              .nWithLabel("ParityService")
+              .bind("service")
+              .projectBindings([
+                BindingProjection.binding("service", "$id", "service_id"),
+                BindingProjection.current("metadata.name", "current_name"),
+                BindingProjection.binding("missing_binding", "externalId", "missing_external_id"),
+              ]),
+          )
+          .returning(["bindings"]),
+      ),
+    ),
+    jsonOnly(
+      "910-row-binding-branch-distinct-projection",
+      DynamicQueryRequest.read(
+        readBatch()
+          .varAs(
+            "workloads",
+            g()
+              .nWithLabel("ParityService")
+              .bind("service")
+              .out("ROUTES_TO")
+              .bind("pod")
+              .optional(sub().in("CREATES").bind("deployment"))
+              .union([sub().in("MANAGES").bind("owner"), sub().out("ROUTES_TO").bind("workload")])
+              .projectDistinctBindings([
+                BindingProjection.binding("service", "$id", "service_id"),
+                BindingProjection.coalesce(
+                  [
+                    BindingProjection.bindingRef("deployment", "$id"),
+                    BindingProjection.bindingRef("owner", "$id"),
+                    BindingProjection.bindingRef("workload", "$id"),
+                  ],
+                  "workload_id",
+                ),
+              ]),
+          )
+          .returning(["workloads"]),
+      ),
+    ),
+    jsonOnly(
+      "911-range-index-direction",
       DynamicQueryRequest.write(
         writeBatch()
           .varAs("node_desc", g().createIndexIfNotExists(IndexSpec.nodeRangeDesc("ParityUser", "age")))

--- a/sdks/typescript/src/dsl.ts
+++ b/sdks/typescript/src/dsl.ts
@@ -912,6 +912,55 @@ export class Projection implements Encodable {
   }
 }
 
+export type BindingTarget = "Current" | { Binding: string };
+
+export const BindingTarget = {
+  current(): BindingTarget {
+    return "Current";
+  },
+  binding(name: string): BindingTarget {
+    return { Binding: name };
+  },
+};
+
+export type BindingValueRef = {
+  target: BindingTarget;
+  source: string;
+};
+
+export type BindingProjection =
+  | { kind: "Property"; target: BindingTarget; source: string; alias: string }
+  | { kind: "Coalesce"; refs: BindingValueRef[]; alias: string };
+
+export const BindingProjection = {
+  property(target: BindingTarget, source: string, alias: string): BindingProjection {
+    return { kind: "Property", target, source, alias };
+  },
+  current(source: string, alias: string): BindingProjection {
+    return BindingProjection.property(BindingTarget.current(), source, alias);
+  },
+  binding(name: string, source: string, alias: string): BindingProjection {
+    return BindingProjection.property(BindingTarget.binding(name), source, alias);
+  },
+  valueRef(target: BindingTarget, source: string): BindingValueRef {
+    return { target, source };
+  },
+  currentRef(source: string): BindingValueRef {
+    return BindingProjection.valueRef(BindingTarget.current(), source);
+  },
+  bindingRef(name: string, source: string): BindingValueRef {
+    return BindingProjection.valueRef(BindingTarget.binding(name), source);
+  },
+  coalesce(refs: BindingValueRef[], alias: string): BindingProjection {
+    return { kind: "Coalesce", refs, alias };
+  },
+};
+
+function validateBindingName(name: string): string {
+  if (name.length === 0) throw new TypeError("binding name must not be empty");
+  return name;
+}
+
 export class RepeatConfig implements Encodable {
   readonly timesValue: number | null;
   readonly untilValue: Predicate | null;
@@ -1182,6 +1231,9 @@ export class Step implements Encodable {
   static select(name: string): Step {
     return Step.newtype("Select", name);
   }
+  static bind(name: string): Step {
+    return Step.newtype("Bind", validateBindingName(name));
+  }
   static count(): Step {
     return Step.unit("Count");
   }
@@ -1202,6 +1254,9 @@ export class Step implements Encodable {
   }
   static project(projections: ProjectionInput[]): Step {
     return Step.newtype("Project", projections.map(Projection.from));
+  }
+  static projectBindings(projections: BindingProjection[], distinct = false): Step {
+    return Step.struct("ProjectBindings", { projections, distinct });
   }
   static edgeProperties(): Step {
     return Step.unit("EdgeProperties");
@@ -1356,6 +1411,7 @@ export class Traversal<S extends TraversalState = "nodes", M extends MutationMod
         "Values",
         "ValueMap",
         "Project",
+        "ProjectBindings",
         "EdgeProperties",
         "CreateIndex",
         "DropIndex",
@@ -1607,6 +1663,9 @@ export class Traversal<S extends TraversalState = "nodes", M extends MutationMod
   select(name: string): Traversal<S, M> {
     return this.push(Step.select(name), this.state, this.mode) as Traversal<S, M>;
   }
+  bind(name: string): Traversal<S, M> {
+    return this.push(Step.bind(name), this.state, this.mode) as Traversal<S, M>;
+  }
   inject(name: string): Traversal<"nodes", M> {
     return this.push(Step.inject(name), "nodes", this.mode) as Traversal<"nodes", M>;
   }
@@ -1630,6 +1689,12 @@ export class Traversal<S extends TraversalState = "nodes", M extends MutationMod
   }
   project(projections: ProjectionInput[]): Traversal<"terminal", M> {
     return this.push(Step.project(projections), "terminal", this.mode) as Traversal<"terminal", M>;
+  }
+  projectBindings(projections: BindingProjection[]): Traversal<"terminal", M> {
+    return this.push(Step.projectBindings(projections, false), "terminal", this.mode) as Traversal<"terminal", M>;
+  }
+  projectDistinctBindings(projections: BindingProjection[]): Traversal<"terminal", M> {
+    return this.push(Step.projectBindings(projections, true), "terminal", this.mode) as Traversal<"terminal", M>;
   }
   edgeProperties(): Traversal<"terminal", M> {
     return this.push(Step.edgeProperties(), "terminal", this.mode) as Traversal<"terminal", M>;
@@ -1797,6 +1862,9 @@ export class SubTraversal implements Encodable {
   }
   select(name: string): SubTraversal {
     return this.push(Step.select(name));
+  }
+  bind(name: string): SubTraversal {
+    return this.push(Step.bind(name));
   }
   orderBy(property: string, order: Order): SubTraversal {
     return this.push(Step.orderBy(property, order));
@@ -2376,7 +2444,9 @@ function buildDynamicRequest<T extends ParamShape>(
   return applyDynamicQueryOptions(request, paramsOrOptions);
 }
 
-export const QUERY_BUNDLE_VERSION = 4;
+export const LEGACY_QUERY_BUNDLE_VERSION_V4 = 4;
+export const QUERY_BUNDLE_VERSION = 5;
+export const SUPPORTED_QUERY_BUNDLE_VERSIONS = [LEGACY_QUERY_BUNDLE_VERSION_V4, QUERY_BUNDLE_VERSION] as const;
 
 export interface QueryBundle extends Encodable {
   version: number;
@@ -2572,7 +2642,8 @@ export function serializeQueryBundle(bundle: QueryBundle): string {
 export function deserializeQueryBundle(json: string | Uint8Array): unknown {
   const text = typeof json === "string" ? json : new TextDecoder().decode(json);
   const parsed = JSON.parse(text) as { version?: number };
-  if (parsed.version !== QUERY_BUNDLE_VERSION) throw GenerateError.unsupportedVersion(parsed.version ?? -1, QUERY_BUNDLE_VERSION);
+  if (!SUPPORTED_QUERY_BUNDLE_VERSIONS.includes(parsed.version as (typeof SUPPORTED_QUERY_BUNDLE_VERSIONS)[number]))
+    throw GenerateError.unsupportedVersion(parsed.version ?? -1, QUERY_BUNDLE_VERSION);
   return parsed;
 }
 

--- a/sdks/typescript/test/basic.test.ts
+++ b/sdks/typescript/test/basic.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   BatchCondition,
+  BindingProjection,
   DateTime,
   DynamicQueryError,
   DynamicQueryValue,
@@ -20,6 +21,9 @@ import {
   SourcePredicate,
   Step,
   StreamBound,
+  LEGACY_QUERY_BUNDLE_VERSION_V4,
+  QUERY_BUNDLE_VERSION,
+  deserializeQueryBundle,
   defineParams,
   defineQueries,
   g,
@@ -161,6 +165,69 @@ assert.deepEqual(parsed(Projection.expr("age2", Expr.prop("age").add(Expr.val(1)
   alias: "age2",
   expr: { Add: [{ Property: "age" }, { Constant: { I64: 1 } }] },
 });
+assert.deepEqual(parsed(Step.bind("service")), { Bind: "service" });
+assert.deepEqual(
+  parsed(
+    Step.projectBindings(
+      [
+        BindingProjection.binding("service", "$id", "service_id"),
+        BindingProjection.coalesce(
+          [BindingProjection.bindingRef("deployment", "$id"), BindingProjection.bindingRef("owner", "$id")],
+          "workload_id",
+        ),
+      ],
+      true,
+    ),
+  ),
+  {
+    ProjectBindings: {
+      projections: [
+        { kind: "Property", target: { Binding: "service" }, source: "$id", alias: "service_id" },
+        {
+          kind: "Coalesce",
+          refs: [
+            { target: { Binding: "deployment" }, source: "$id" },
+            { target: { Binding: "owner" }, source: "$id" },
+          ],
+          alias: "workload_id",
+        },
+      ],
+      distinct: true,
+    },
+  },
+);
+
+const rowBindingTraversal = g()
+  .nWithLabel("Service")
+  .bind("service")
+  .optional(sub().in("CREATES").bind("deployment"))
+  .union([sub().in("MANAGES").bind("owner"), sub().out("ROUTES_TO").bind("workload")])
+  .projectDistinctBindings([
+    BindingProjection.binding("service", "$id", "service_id"),
+    BindingProjection.current("$id", "current_id"),
+    BindingProjection.binding("missing_binding", "externalId", "missing_external_id"),
+    BindingProjection.coalesce(
+      [
+        BindingProjection.bindingRef("deployment", "$id"),
+        BindingProjection.bindingRef("owner", "$id"),
+        BindingProjection.bindingRef("workload", "$id"),
+      ],
+      "workload_id",
+    ),
+  ]);
+assert.equal(rowBindingTraversal.hasTerminal(), true);
+assert.deepEqual(parsed(rowBindingTraversal).steps[1], { Bind: "service" });
+assert.equal(parsed(rowBindingTraversal).steps.at(-1).ProjectBindings.distinct, true);
+
+const legacyBundle = JSON.stringify({
+  version: LEGACY_QUERY_BUNDLE_VERSION_V4,
+  read_routes: {},
+  write_routes: {},
+  read_parameters: {},
+  write_parameters: {},
+});
+assert.equal((deserializeQueryBundle(legacyBundle) as { version: number }).version, LEGACY_QUERY_BUNDLE_VERSION_V4);
+assert.equal(QUERY_BUNDLE_VERSION, 5);
 
 const read = readBatch()
   .varAs("user", g().nWhere(SourcePredicate.eq("username", "alice")))
@@ -262,7 +329,7 @@ const queries = defineQueries({
 });
 
 const bundle = JSON.parse(serializeQueryBundle(queries.buildQueryBundle()));
-assert.equal(bundle.version, 4);
+assert.equal(bundle.version, QUERY_BUNDLE_VERSION);
 assert.deepEqual(bundle.read_parameters.registered_read, [
   { name: "tenant_id", ty: "String" },
   { name: "limit", ty: "I64" },

--- a/sdks/typescript/test/types.test-d.ts
+++ b/sdks/typescript/test/types.test-d.ts
@@ -1,4 +1,16 @@
-import { DateTime, defineParams, defineQueries, g, param, readBatch, registerRead, registerWrite, writeBatch } from "../src/index.js";
+import {
+  BindingProjection,
+  DateTime,
+  defineParams,
+  defineQueries,
+  g,
+  param,
+  readBatch,
+  registerRead,
+  registerWrite,
+  sub,
+  writeBatch,
+} from "../src/index.js";
 
 const readParams = defineParams({
   tenant: param.string(),
@@ -73,6 +85,22 @@ writeBatch()
     values: [{ id: 1, nested: { ok: true } }],
   });
 readBatch().varAs("count", g().nWithLabel("User").count()).toDynamicJson();
+readBatch()
+  .varAs(
+    "bindings",
+    g()
+      .nWithLabel("Service")
+      .bind("service")
+      .optional(sub().in("CREATES").bind("deployment"))
+      .projectDistinctBindings([
+        BindingProjection.binding("service", "$id", "service_id"),
+        BindingProjection.coalesce(
+          [BindingProjection.bindingRef("deployment", "$id"), BindingProjection.bindingRef("service", "$id")],
+          "workload_id",
+        ),
+      ]),
+  )
+  .toDynamicJson();
 
 // @ts-expect-error missing required parameters
 queries.call.find_users({ tenant: "acme" });


### PR DESCRIPTION
This commit updates the version of the `helix-db` SDKs for Go, Rust, and TypeScript to 2.0.6. It introduces new row binding features, allowing multi-hop traversals to maintain correlations between earlier and later elements. The `Bind` method has been added to facilitate this, along with `ProjectBindings` and `ProjectDistinctBindings` for handling projections. Additionally, the README files across SDKs have been updated to include examples of the new row binding capabilities, improving documentation and usability.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces row binding functionality across the Go, Rust, and TypeScript SDKs, bumping all three to version 2.0.6 and the query-bundle wire format from version 4 to 5. The new `bind`/`Bind` step captures the current traverser element under a row-local name, and `projectBindings`/`projectDistinctBindings` emit projected output rows from those named snapshots, enabling correlated multi-hop traversals.

- **New types added** (`BindingTarget`, `BindingValueRef`, `BindingProjection`) and corresponding builder methods are wired into `Traversal`, `SubTraversal`, and their `Step` serialisation in all three SDKs.
- **Query-bundle backward compatibility** is maintained via `LEGACY_QUERY_BUNDLE_VERSION_V4 = 4`; `deserializeQueryBundle` now accepts both v4 and v5 instead of rejecting v4 bundles.
- **Parity-fixture suite** is extended with two new JSON-only fixtures (909 and 910) covering basic projection and branch-distinct projection, with the previously-numbered 909 renumbered to 911.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdks/go/dsl.go | Adds Bind, ProjectBindings, and ProjectDistinctBindings steps to both Traversal and SubTraversal, plus supporting BindingTarget/BindingProjection types. SubTraversal.Bind("") silently no-ops rather than recording an error, inconsistent with Traversal.Bind which calls t.record(errors.New(...)). |
| sdks/go/dsl_test.go | Adds TestRowBindingProjectionJSON and TestBindRejectsEmptyName. The latter only tests Traversal.Bind(""), leaving the SubTraversal.Bind("") silent-no-op path untested. |
| sdks/rust/src/dsl.rs | Adds BindingTarget, BindingValueRef, BindingProjection types and bind()/project_bindings()/project_distinct_bindings() methods to both Traversal and SubTraversal. Validation is consistent across both (validate_binding_name panics on empty input). Prelude and test coverage are thorough. |
| sdks/rust/src/query_generator.rs | Bumps QUERY_BUNDLE_VERSION to 5, adds LEGACY_QUERY_BUNDLE_VERSION_V4 = 4, and broadens deserialize_query_bundle to accept both versions via SUPPORTED_QUERY_BUNDLE_VERSIONS. Backward-compatibility logic and test coverage look correct. |
| sdks/typescript/src/dsl.ts | Adds BindingTarget, BindingValueRef, BindingProjection namespace-objects plus bind()/projectBindings()/projectDistinctBindings() on Traversal and SubTraversal. validateBindingName throws eagerly, consistent across both traversal types. Version constants and deserializeQueryBundle version check are correct. |
| sdks/typescript/test/basic.test.ts | Adds wire-shape assertions for Step.bind and Step.projectBindings, a full row-binding traversal smoke test, and legacy-v4 bundle deserialization coverage. All assertions align with the expected JSON schema. |
| sdks/go/cmd/generate-parity-fixtures/main.go | Adds fixtures 909/910 for basic and branch-distinct row-binding projections, renumbers former 909 to 911, and updates the expected JSON-only count from 10 to 12. Changes are consistent across all three SDK fixture generators. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `sdks/go/dsl.go`, line 1227-1232 ([link](https://github.com/helixdb/helix-db/blob/203b3b97b7906df287fa173f8bd7b2e366a87019/sdks/go/dsl.go#L1227-L1232)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Silent no-op on empty binding name in SubTraversal**

   `SubTraversal.Bind("")` silently returns the unchanged traversal instead of surfacing any error, while `Traversal.Bind("")` correctly records an error via `t.record(...)`. If a caller writes `Sub().In("CREATES").Bind("")`, the binding step is simply dropped with no validation signal — any downstream `ProjectBindings` or `ProjectDistinctBindings` that references that name will silently receive a missing/null value instead of failing at client-side validation. `TestBindRejectsEmptyName` only covers the `Traversal` path, leaving `SubTraversal` unguarded.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Update SDK versions to 2.0.6 and enhance..."](https://github.com/helixdb/helix-db/commit/203b3b97b7906df287fa173f8bd7b2e366a87019) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39537147)</sub>

<!-- /greptile_comment -->