### PR TITLE
cli fixes

### DIFF
--- a/helix-cli/README.md
+++ b/helix-cli/README.md
@@ -15,7 +15,7 @@ Command-line interface for managing v2 Helix projects, local development instanc
 - `auth`: login, logout, or create an Enterprise Cloud API key.
 - `workspace`: manage active Enterprise Cloud workspace selection.
 - `project`: manage linked Enterprise Cloud project selection.
-- `cluster`: list and inspect Enterprise Cloud clusters.
+- `cluster`: list standard and Enterprise Cloud clusters.
 - `sync`: reconcile Enterprise query project source and sync Enterprise Cloud metadata into `helix.toml`.
 - `prune`: clean Helix-owned local containers, disk-mode volumes, and workspaces.
 - `delete`: remove an instance from `helix.toml` and clean local runtime state.

--- a/helix-cli/src/commands/config.rs
+++ b/helix-cli/src/commands/config.rs
@@ -1,7 +1,7 @@
 use crate::commands::auth::require_auth;
 use crate::config::WorkspaceConfig;
 use crate::enterprise_cloud::{
-    CliClusterIndex, CliClusterIndexes, CliEnterpriseCluster, cloud_base_url,
+    CliClusterIndexes, CliEnterpriseCluster, CliIndexSnapshot, cloud_base_url,
     fetch_indexes_for_cluster, fetch_projects, fetch_workspaces, find_project_by_id,
     find_project_by_name, find_workspace_by_id, find_workspace_by_slug, list_clusters_for_context,
     resolve_enterprise_cluster,
@@ -333,7 +333,7 @@ async fn list_indexes_for_cluster(
     let cluster_id = resolve_cluster_id_for_indexes(cluster_id)?;
     let credentials = require_auth().await?;
     let client = reqwest::Client::new();
-    let indexes = fetch_indexes_for_cluster(
+    let (indexes, raw) = fetch_indexes_for_cluster(
         &client,
         &cloud_base_url(),
         &credentials.helix_admin_key,
@@ -342,10 +342,11 @@ async fn list_indexes_for_cluster(
     .await?;
 
     if format == ConfigOutputFormat::Json {
-        return print_json(&indexes);
+        // Print the raw API body so JSON output always mirrors the API exactly.
+        return print_json(&raw);
     }
 
-    print_cluster_indexes(&cluster_id, &indexes);
+    print_cluster_indexes(&cluster_id, &indexes, &raw);
     Ok(())
 }
 
@@ -396,34 +397,117 @@ fn resolve_cluster_id_for_indexes(cluster_id: Option<String>) -> Result<String> 
         .ok_or_else(|| eyre!("Enterprise instance '{instance_name}' was not found"))
 }
 
-fn print_cluster_indexes(cluster_id: &str, indexes: &CliClusterIndexes) {
-    println!("{}", "Cluster indexes".bold());
-    println!("  Cluster: {cluster_id}");
-    print_index_group("Vector indexes", &indexes.vector_indexes);
-    print_index_group("Equality indexes", &indexes.equality_indexes);
-    print_index_group("Range indexes", &indexes.range_indexes);
-}
-
-fn print_index_group(title: &str, indexes: &[CliClusterIndex]) {
-    println!("  {title}:");
-    if indexes.is_empty() {
-        println!("    (none)");
+fn print_cluster_indexes(cluster_id: &str, indexes: &CliClusterIndexes, raw: &serde_json::Value) {
+    // If we couldn't recognize any backend in the response, fall back to the raw
+    // JSON so the user always sees what the API actually returned.
+    let Some(canonical) = indexes.canonical_backend() else {
+        println!("{}", "Cluster indexes".bold());
+        println!("  Cluster: {cluster_id}");
+        println!(
+            "  {}",
+            "Unrecognized response shape; raw API response:".yellow()
+        );
+        if let Ok(pretty) = serde_json::to_string_pretty(raw) {
+            println!("{pretty}");
+        }
         return;
-    }
+    };
 
-    for index in indexes {
-        let name = if index.index_name.trim().is_empty() {
-            "<unnamed>"
-        } else {
-            index.index_name.as_str()
-        };
-        match index.index_type.as_deref() {
-            Some(index_type) if !index_type.trim().is_empty() => {
-                println!("    {name} ({index_type})");
-            }
-            _ => println!("    {name}"),
+    let mode = indexes.mode.as_deref().unwrap_or("unknown");
+    let backend_count = indexes.readable_backends.len().max(indexes.backends.len());
+    let writer = if canonical.pod.is_empty() {
+        "unknown"
+    } else {
+        canonical.pod.as_str()
+    };
+
+    println!(
+        "{} (mode: {mode}, {backend_count} backend(s), writer {writer})",
+        "Cluster indexes".bold()
+    );
+    println!("  Cluster: {cluster_id}");
+
+    let snap = &canonical.snapshot;
+    print_snapshot_counts("Node", snap, true);
+    print_snapshot_counts("Edge", snap, false);
+    println!(
+        "  {}",
+        "Run with --format json for the full per-index listing.".dimmed()
+    );
+
+    // Surface any errors reported by the cluster.
+    if !indexes.errors.is_empty() {
+        println!("  {}", "Errors:".red());
+        for err in &indexes.errors {
+            println!("    {err}");
         }
     }
+
+    // Warn if any readable backend diverges from the writer's index counts
+    // (a replication-lag signal). Counts are sufficient; no full diff.
+    let writer_sig = snapshot_signature(snap);
+    let diverging: Vec<&str> = indexes
+        .backends
+        .iter()
+        .filter(|b| b.pod != canonical.pod && snapshot_signature(&b.snapshot) != writer_sig)
+        .map(|b| b.pod.as_str())
+        .collect();
+    if !diverging.is_empty() {
+        println!(
+            "  {} backend(s) diverge from the writer (replication lag?): {}",
+            "Warning:".yellow(),
+            diverging.join(", ")
+        );
+    }
+}
+
+/// Prints a one-line per-category count summary for the node or edge half of a
+/// snapshot.
+fn print_snapshot_counts(label: &str, snap: &CliIndexSnapshot, node: bool) {
+    let (label_index, equality, range, range_desc, text, vector) = if node {
+        (
+            snap.node_label_index,
+            snap.node_equality_indexes.len(),
+            snap.node_range_indexes.len(),
+            snap.node_range_desc_indexes.len(),
+            snap.node_text_indexes.len(),
+            snap.node_vector_indexes.len(),
+        )
+    } else {
+        (
+            snap.edge_label_index,
+            snap.edge_equality_indexes.len(),
+            snap.edge_range_indexes.len(),
+            snap.edge_range_desc_indexes.len(),
+            snap.edge_text_indexes.len(),
+            snap.edge_vector_indexes.len(),
+        )
+    };
+    let label_index = if label_index { "enabled" } else { "disabled" };
+    println!(
+        "  {label}:  label index {label_index} | equality {equality} | text {text} | vector {vector} | range {range} | range_desc {range_desc}"
+    );
+}
+
+/// A cheap comparable signature of a snapshot's per-category counts, used to
+/// detect backend divergence without a full diff. Counts (not contents) are
+/// compared deliberately: backends return the same indexes in differing orders,
+/// so a content/Vec comparison would report spurious divergence.
+fn snapshot_signature(snap: &CliIndexSnapshot) -> Vec<usize> {
+    vec![
+        snap.node_label_index as usize,
+        snap.edge_label_index as usize,
+        snap.node_equality_indexes.len(),
+        snap.node_range_indexes.len(),
+        snap.node_range_desc_indexes.len(),
+        snap.node_text_indexes.len(),
+        snap.node_vector_indexes.len(),
+        snap.edge_equality_indexes.len(),
+        snap.edge_range_indexes.len(),
+        snap.edge_range_desc_indexes.len(),
+        snap.edge_text_indexes.len(),
+        snap.edge_vector_indexes.len(),
+    ]
 }
 
 fn print_enterprise_clusters(clusters: &[CliEnterpriseCluster]) {

--- a/helix-cli/src/commands/config.rs
+++ b/helix-cli/src/commands/config.rs
@@ -1,10 +1,10 @@
 use crate::commands::auth::require_auth;
 use crate::config::WorkspaceConfig;
 use crate::enterprise_cloud::{
-    CliClusterIndexes, CliEnterpriseCluster, CliIndexSnapshot, cloud_base_url,
-    fetch_indexes_for_cluster, fetch_projects, fetch_workspaces, find_project_by_id,
-    find_project_by_name, find_workspace_by_id, find_workspace_by_slug, list_clusters_for_context,
-    resolve_enterprise_cluster,
+    CliClusterIndexes, CliClusterList, CliEnterpriseCluster, CliIndexSnapshot, CliStandardCluster,
+    cloud_base_url, fetch_indexes_for_cluster, fetch_projects, fetch_workspaces,
+    find_project_by_id, find_project_by_name, find_workspace_by_id, find_workspace_by_slug,
+    list_clusters_for_context, resolve_enterprise_cluster,
 };
 use crate::project::ProjectContext;
 use crate::prompts;
@@ -322,7 +322,7 @@ async fn cluster_list(
     if format == ConfigOutputFormat::Json {
         return print_json(&clusters);
     }
-    print_enterprise_clusters(&clusters);
+    print_cloud_clusters(&clusters);
     Ok(())
 }
 
@@ -510,10 +510,48 @@ fn snapshot_signature(snap: &CliIndexSnapshot) -> Vec<usize> {
     ]
 }
 
-fn print_enterprise_clusters(clusters: &[CliEnterpriseCluster]) {
-    println!("{}", "Enterprise clusters".bold());
+fn print_cloud_clusters(clusters: &CliClusterList) {
+    print_standard_clusters(&clusters.standard);
+    println!();
+    print_enterprise_clusters(&clusters.enterprise);
+}
+
+fn print_standard_clusters(clusters: &[CliStandardCluster]) {
+    println!("{}", "Standard clusters".bold());
+    if clusters.is_empty() {
+        println!("  (none)");
+        return;
+    }
     for cluster in clusters {
         println!("  {} ({})", cluster.name, cluster.cluster_id);
+        if let Some(project_name) = &cluster.project_name {
+            println!("    project: {project_name}");
+        }
+        if let Some(build_mode) = &cluster.build_mode {
+            println!("    build mode: {build_mode}");
+        }
+        match (cluster.max_memory_gb, cluster.max_vcpus) {
+            (Some(memory_gb), Some(vcpus)) => {
+                println!("    resources: {memory_gb} GB, {vcpus} vCPU");
+            }
+            (Some(memory_gb), None) => println!("    memory: {memory_gb} GB"),
+            (None, Some(vcpus)) => println!("    vCPU: {vcpus}"),
+            (None, None) => {}
+        }
+    }
+}
+
+fn print_enterprise_clusters(clusters: &[CliEnterpriseCluster]) {
+    println!("{}", "Enterprise clusters".bold());
+    if clusters.is_empty() {
+        println!("  (none)");
+        return;
+    }
+    for cluster in clusters {
+        println!("  {} ({})", cluster.name, cluster.cluster_id);
+        if let Some(project_name) = &cluster.project_name {
+            println!("    project: {project_name}");
+        }
         if let Some(gateway_url) = &cluster.gateway_url {
             println!("    gateway: {gateway_url}");
         }
@@ -541,7 +579,8 @@ async fn cluster_select() -> Result<()> {
         project_id.as_deref(),
         workspace_id.as_deref(),
     )
-    .await?;
+    .await?
+    .enterprise;
 
     let items: Vec<(String, String, String)> = clusters
         .iter()
@@ -635,7 +674,8 @@ pub async fn resolve_enterprise_target(
                 project_ctx.as_deref(),
                 workspace_id.as_deref(),
             )
-            .await?;
+            .await?
+            .enterprise;
             let items: Vec<(String, String, String)> = clusters
                 .iter()
                 .map(|cluster| {

--- a/helix-cli/src/enterprise_cloud.rs
+++ b/helix-cli/src/enterprise_cloud.rs
@@ -54,13 +54,80 @@ pub struct CliProjectClusters {
     pub project_id: String,
     pub project_name: String,
     #[serde(default)]
+    pub standard: Vec<CliStandardCluster>,
+    #[serde(default)]
     pub enterprise: Vec<CliEnterpriseCluster>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CliWorkspaceClusters {
     #[serde(default)]
+    pub standard: Vec<CliStandardCluster>,
+    #[serde(default)]
     pub enterprise: Vec<CliEnterpriseCluster>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CliClusterList {
+    #[serde(default)]
+    pub standard: Vec<CliStandardCluster>,
+    #[serde(default)]
+    pub enterprise: Vec<CliEnterpriseCluster>,
+}
+
+impl From<CliProjectClusters> for CliClusterList {
+    fn from(clusters: CliProjectClusters) -> Self {
+        let CliProjectClusters {
+            project_id,
+            project_name,
+            mut standard,
+            mut enterprise,
+        } = clusters;
+
+        for cluster in &mut standard {
+            cluster.project_id.get_or_insert_with(|| project_id.clone());
+            cluster
+                .project_name
+                .get_or_insert_with(|| project_name.clone());
+        }
+        for cluster in &mut enterprise {
+            cluster.project_id.get_or_insert_with(|| project_id.clone());
+            cluster
+                .project_name
+                .get_or_insert_with(|| project_name.clone());
+        }
+
+        Self {
+            standard,
+            enterprise,
+        }
+    }
+}
+
+impl From<CliWorkspaceClusters> for CliClusterList {
+    fn from(clusters: CliWorkspaceClusters) -> Self {
+        Self {
+            standard: clusters.standard,
+            enterprise: clusters.enterprise,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliStandardCluster {
+    pub cluster_id: String,
+    #[serde(alias = "cluster_name")]
+    pub name: String,
+    #[serde(default)]
+    pub project_id: Option<String>,
+    #[serde(default)]
+    pub project_name: Option<String>,
+    #[serde(default)]
+    pub build_mode: Option<String>,
+    #[serde(default)]
+    pub max_memory_gb: Option<u32>,
+    #[serde(default)]
+    pub max_vcpus: Option<f32>,
 }
 
 /// A per-backend index snapshot. Each index entry is a `[label, property]`
@@ -404,25 +471,25 @@ pub fn find_enterprise_cluster_by_id<'a>(
     clusters.iter().find(|cluster| cluster.cluster_id == id)
 }
 
-/// List the Enterprise clusters available for a project (preferred) or workspace.
+/// List the Cloud clusters available for a project (preferred) or workspace.
 pub async fn list_clusters_for_context(
     client: &Client,
     base_url: &str,
     api_key: &str,
     project_id: Option<&str>,
     workspace_id: Option<&str>,
-) -> Result<Vec<CliEnterpriseCluster>> {
+) -> Result<CliClusterList> {
     if let Some(project_id) = project_id {
         Ok(
             fetch_project_clusters(client, base_url, api_key, project_id)
                 .await?
-                .enterprise,
+                .into(),
         )
     } else if let Some(workspace_id) = workspace_id {
         Ok(
             fetch_workspace_clusters(client, base_url, api_key, workspace_id)
                 .await?
-                .enterprise,
+                .into(),
         )
     } else {
         Err(eyre!(
@@ -480,6 +547,75 @@ pub async fn resolve_enterprise_cluster(
         workspace_id,
         cluster,
     })
+}
+
+#[cfg(test)]
+mod cluster_list_tests {
+    use super::*;
+
+    #[test]
+    fn project_clusters_preserve_standard_and_enterprise() {
+        let response: CliProjectClusters = serde_json::from_value(serde_json::json!({
+            "project_id": "project-1",
+            "project_name": "demo",
+            "standard": [{
+                "cluster_id": "standard-1",
+                "cluster_name": "standard-a",
+                "build_mode": "prod",
+                "max_memory_gb": 4,
+                "max_vcpus": 2.0
+            }],
+            "enterprise": [{
+                "cluster_id": "enterprise-1",
+                "cluster_name": "enterprise-a",
+                "availability_mode": "ha",
+                "gateway_node_type": "GW-40",
+                "db_node_type": "HLX-160",
+                "min_gateway_count": 3,
+                "max_gateway_count": 3,
+                "min_hyperscale_count": 3,
+                "max_hyperscale_count": 3
+            }]
+        }))
+        .unwrap();
+
+        let list = CliClusterList::from(response);
+
+        assert_eq!(list.standard.len(), 1);
+        assert_eq!(list.enterprise.len(), 1);
+        assert_eq!(list.standard[0].name, "standard-a");
+        assert_eq!(list.standard[0].project_id.as_deref(), Some("project-1"));
+        assert_eq!(list.standard[0].project_name.as_deref(), Some("demo"));
+        assert_eq!(list.standard[0].build_mode.as_deref(), Some("prod"));
+        assert_eq!(list.standard[0].max_memory_gb, Some(4));
+        assert_eq!(list.standard[0].max_vcpus, Some(2.0));
+        assert_eq!(list.enterprise[0].project_id.as_deref(), Some("project-1"));
+        assert_eq!(list.enterprise[0].project_name.as_deref(), Some("demo"));
+    }
+
+    #[test]
+    fn workspace_clusters_preserve_project_scoped_standard_metadata() {
+        let response: CliWorkspaceClusters = serde_json::from_value(serde_json::json!({
+            "standard": [{
+                "cluster_id": "standard-1",
+                "cluster_name": "standard-a",
+                "project_id": "project-1",
+                "project_name": "demo",
+                "build_mode": "dev",
+                "max_memory_gb": 1,
+                "max_vcpus": 1.0
+            }],
+            "enterprise": []
+        }))
+        .unwrap();
+
+        let list = CliClusterList::from(response);
+
+        assert_eq!(list.standard.len(), 1);
+        assert!(list.enterprise.is_empty());
+        assert_eq!(list.standard[0].cluster_id, "standard-1");
+        assert_eq!(list.standard[0].project_name.as_deref(), Some("demo"));
+    }
 }
 
 #[cfg(test)]

--- a/helix-cli/src/enterprise_cloud.rs
+++ b/helix-cli/src/enterprise_cloud.rs
@@ -63,24 +63,82 @@ pub struct CliWorkspaceClusters {
     pub enterprise: Vec<CliEnterpriseCluster>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CliClusterIndex {
-    #[serde(default, rename = "name", alias = "index_name")]
-    pub index_name: String,
-    #[serde(default, rename = "type", alias = "index_type")]
-    pub index_type: Option<String>,
+/// A per-backend index snapshot. Each index entry is a `[label, property]`
+/// tuple. Unknown sibling keys are captured in `extra` so future schema
+/// additions are not silently dropped.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CliIndexSnapshot {
+    #[serde(default)]
+    pub node_label_index: bool,
+    #[serde(default)]
+    pub edge_label_index: bool,
+    #[serde(default)]
+    pub node_equality_indexes: Vec<(String, String)>,
+    #[serde(default)]
+    pub node_range_indexes: Vec<(String, String)>,
+    #[serde(default)]
+    pub node_range_desc_indexes: Vec<(String, String)>,
+    #[serde(default)]
+    pub node_text_indexes: Vec<(String, String)>,
+    #[serde(default)]
+    pub node_vector_indexes: Vec<(String, String)>,
+    #[serde(default)]
+    pub edge_equality_indexes: Vec<(String, String)>,
+    #[serde(default)]
+    pub edge_range_indexes: Vec<(String, String)>,
+    #[serde(default)]
+    pub edge_range_desc_indexes: Vec<(String, String)>,
+    #[serde(default)]
+    pub edge_text_indexes: Vec<(String, String)>,
+    #[serde(default)]
+    pub edge_vector_indexes: Vec<(String, String)>,
     #[serde(flatten)]
     pub extra: BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliClusterBackend {
+    #[serde(default)]
+    pub pod: String,
+    #[serde(default)]
+    pub snapshot: CliIndexSnapshot,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CliClusterIndexes {
     #[serde(default)]
-    pub vector_indexes: Vec<CliClusterIndex>,
+    pub mode: Option<String>,
     #[serde(default)]
-    pub equality_indexes: Vec<CliClusterIndex>,
+    pub backends: Vec<CliClusterBackend>,
     #[serde(default)]
-    pub range_indexes: Vec<CliClusterIndex>,
+    pub readable_backends: Vec<String>,
+    /// Authoritative backend; only its `pod` field is needed for display.
+    #[serde(default)]
+    pub writer_backend: Option<serde_json::Value>,
+    #[serde(default)]
+    pub errors: Vec<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+impl CliClusterIndexes {
+    /// The pod id of the writer backend, if present in the response.
+    pub fn writer_pod(&self) -> Option<&str> {
+        self.writer_backend
+            .as_ref()?
+            .get("pod")
+            .and_then(|v| v.as_str())
+    }
+
+    /// The writer backend's snapshot, falling back to the first backend.
+    pub fn canonical_backend(&self) -> Option<&CliClusterBackend> {
+        if let Some(pod) = self.writer_pod()
+            && let Some(b) = self.backends.iter().find(|b| b.pod == pod)
+        {
+            return Some(b);
+        }
+        self.backends.first()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -279,19 +337,25 @@ pub async fn fetch_workspace_clusters(
     .await
 }
 
+/// Fetches the cluster index snapshot. Returns the typed view alongside the raw
+/// JSON body so callers can render the typed summary while still emitting the
+/// exact API response for `--format json` (and as a fallback when the shape is
+/// unrecognized).
 pub async fn fetch_indexes_for_cluster(
     client: &Client,
     base_url: &str,
     api_key: &str,
     cluster_id: &str,
-) -> Result<CliClusterIndexes> {
-    get_json(
+) -> Result<(CliClusterIndexes, serde_json::Value)> {
+    let raw: serde_json::Value = get_json(
         client,
         format!("{base_url}/api/cli/enterprise-clusters/{cluster_id}/indexes"),
         api_key,
         "fetch cluster indexes",
     )
-    .await
+    .await?;
+    let typed: CliClusterIndexes = serde_json::from_value(raw.clone())?;
+    Ok((typed, raw))
 }
 
 pub async fn fetch_enterprise_cluster_project(
@@ -416,4 +480,112 @@ pub async fn resolve_enterprise_cluster(
         workspace_id,
         cluster,
     })
+}
+
+#[cfg(test)]
+mod index_tests {
+    use super::*;
+
+    // A trimmed but structurally-faithful sample of the real
+    // `/api/cli/enterprise-clusters/{id}/indexes` response (pod_pool, 2 replicas).
+    const REAL_RESPONSE: &str = r#"{
+        "phase": { "phase": "stable", "writer": { "pod": "pod-a", "term": 15 } },
+        "mode": "pod_pool",
+        "errors": [],
+        "readable_backends": ["pod-a", "pod-b"],
+        "writer_backend": { "pod": "pod-a", "healthy": true, "accepting_writes": true },
+        "backends": [
+            { "pod": "pod-a", "snapshot": {
+                "node_label_index": true,
+                "edge_label_index": true,
+                "node_equality_indexes": [["User","externalId"], ["Project","firmId"]],
+                "node_text_indexes": [["User","firstName"]],
+                "node_vector_indexes": [["DocumentChunk","embedding"]],
+                "node_range_indexes": [],
+                "node_range_desc_indexes": [],
+                "edge_equality_indexes": [["ForClient","firmId"]],
+                "edge_text_indexes": [],
+                "edge_vector_indexes": [],
+                "edge_range_indexes": [],
+                "edge_range_desc_indexes": []
+            }},
+            { "pod": "pod-b", "snapshot": {
+                "node_label_index": true,
+                "edge_label_index": true,
+                "node_equality_indexes": [["User","externalId"], ["Project","firmId"]],
+                "node_text_indexes": [["User","firstName"]],
+                "node_vector_indexes": [["DocumentChunk","embedding"]],
+                "node_range_indexes": [],
+                "node_range_desc_indexes": [],
+                "edge_equality_indexes": [["ForClient","firmId"]],
+                "edge_text_indexes": [],
+                "edge_vector_indexes": [],
+                "edge_range_indexes": [],
+                "edge_range_desc_indexes": []
+            }}
+        ]
+    }"#;
+
+    #[test]
+    fn deserializes_real_multi_backend_response() {
+        let parsed: CliClusterIndexes = serde_json::from_str(REAL_RESPONSE).unwrap();
+
+        assert_eq!(parsed.mode.as_deref(), Some("pod_pool"));
+        assert_eq!(parsed.readable_backends.len(), 2);
+        assert_eq!(parsed.writer_pod(), Some("pod-a"));
+
+        let canonical = parsed.canonical_backend().expect("writer backend resolved");
+        assert_eq!(canonical.pod, "pod-a");
+
+        let snap = &canonical.snapshot;
+        assert!(snap.node_label_index);
+        assert!(snap.edge_label_index);
+        assert_eq!(
+            snap.node_equality_indexes,
+            vec![
+                ("User".to_string(), "externalId".to_string()),
+                ("Project".to_string(), "firmId".to_string())
+            ]
+        );
+        assert_eq!(
+            snap.node_vector_indexes,
+            vec![("DocumentChunk".to_string(), "embedding".to_string())]
+        );
+        assert_eq!(
+            snap.node_text_indexes,
+            vec![("User".to_string(), "firstName".to_string())]
+        );
+        assert_eq!(
+            snap.edge_equality_indexes,
+            vec![("ForClient".to_string(), "firmId".to_string())]
+        );
+        assert!(snap.node_range_indexes.is_empty());
+    }
+
+    #[test]
+    fn canonical_falls_back_to_first_backend_without_writer() {
+        // No writer_backend field -> fall back to the first backend.
+        let body = r#"{
+            "mode": "pod_pool",
+            "backends": [ { "pod": "only-pod", "snapshot": { "node_label_index": true } } ]
+        }"#;
+        let parsed: CliClusterIndexes = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.writer_pod(), None);
+        assert_eq!(
+            parsed.canonical_backend().map(|b| b.pod.as_str()),
+            Some("only-pod")
+        );
+    }
+
+    #[test]
+    fn unrecognized_shape_yields_no_backend() {
+        // The old/wrong shape (or any body without `backends`) must not pretend
+        // success: there is no canonical backend, so the caller prints raw JSON.
+        let old_shape = r#"{ "vector_indexes": [], "equality_indexes": [], "range_indexes": [] }"#;
+        let parsed: CliClusterIndexes = serde_json::from_str(old_shape).unwrap();
+        assert!(parsed.backends.is_empty());
+        assert!(parsed.canonical_backend().is_none());
+        // The unknown keys are captured in `extra`, not silently dropped.
+        assert!(parsed.extra.contains_key("vector_indexes"));
+    }
 }

--- a/helix-cli/src/lib.rs
+++ b/helix-cli/src/lib.rs
@@ -176,7 +176,7 @@ pub enum ConfigAction {
         #[command(subcommand)]
         action: ProjectConfigAction,
     },
-    /// List Enterprise clusters
+    /// List Cloud clusters
     Cluster {
         #[command(subcommand)]
         action: ClusterConfigAction,
@@ -227,7 +227,7 @@ pub enum ProjectConfigAction {
 
 #[derive(Subcommand)]
 pub enum ClusterConfigAction {
-    /// List Enterprise clusters
+    /// List Cloud clusters
     List {
         #[arg(long)]
         workspace_id: Option<String>,

--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -242,7 +242,7 @@ Docs: https://docs.helix-db.com/cli/command-reference/query"#)]
         action: Option<ProjectConfigAction>,
     },
 
-    /// List and inspect Enterprise Cloud clusters
+    /// List and inspect Cloud clusters
     Cluster {
         #[command(subcommand)]
         action: Option<ClusterConfigAction>,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the Helix CLI's cluster commands to surface both **standard** and **enterprise** Cloud clusters side-by-side, and overhauls the cluster-index display to use the new multi-backend, pod-pool API schema (with replication-lag divergence detection and a raw-JSON fallback for unrecognized shapes).

- **New types** (`CliStandardCluster`, `CliClusterList`, `CliIndexSnapshot`, `CliClusterBackend`) replace the old flat `CliClusterIndex` model; `From` impls cleanly propagate project metadata when converting API responses, and the changes are backed by inline unit tests.
- **`fetch_indexes_for_cluster`** now returns a `(typed, raw)` pair so `--format json` always mirrors the exact API body while the human-readable path renders a writer-centric summary with replication-lag warnings.
- **`cluster_select` / `resolve_enterprise_target`** preserve their existing behavior by immediately narrowing the new `CliClusterList` to `.enterprise`, so the interactive init/add flows are unaffected by the schema change.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-cli/src/enterprise_cloud.rs | Major restructuring: added CliStandardCluster, CliClusterList, CliIndexSnapshot, CliClusterBackend, and new CliClusterIndexes schema; fetch_indexes_for_cluster now returns a raw+typed pair; well-covered by inline tests. |
| helix-cli/src/commands/config.rs | Updated cluster printing to show both standard and enterprise clusters; added backend-aware index summary with replication-lag divergence warning; one minor display ambiguity in backend_count calculation. |
| helix-cli/src/lib.rs | Minor doc comment updates changing Enterprise clusters to Cloud clusters. |
| helix-cli/src/main.rs | Minor doc comment update changing Enterprise Cloud clusters to Cloud clusters. |
| helix-cli/README.md | One-line wording update for the cluster command description to reflect standard + enterprise support. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[helix cluster list / indexes] --> B{command}
    B -->|list| C[list_clusters_for_context]
    B -->|indexes| D[fetch_indexes_for_cluster]

    C --> E{project_id?}
    E -->|yes| F[fetch_project_clusters → CliProjectClusters]
    E -->|no| G[fetch_workspace_clusters → CliWorkspaceClusters]
    F --> H[From impl → CliClusterList\npropagate project_id/name]
    G --> I[From impl → CliClusterList]
    H --> J{format?}
    I --> J
    J -->|json| K[print_json standard+enterprise]
    J -->|text| L[print_cloud_clusters\nprint_standard_clusters\nprint_enterprise_clusters]

    D --> M[get_json → raw serde_json::Value]
    M --> N[serde_json::from_value → CliClusterIndexes]
    N --> O{format?}
    O -->|json| P[print_json raw]
    O -->|text| Q{canonical_backend?}
    Q -->|none| R[print raw JSON fallback]
    Q -->|some| S[print writer summary\ndivergence check\nerror list]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[helix cluster list / indexes] --> B{command}
    B -->|list| C[list_clusters_for_context]
    B -->|indexes| D[fetch_indexes_for_cluster]

    C --> E{project_id?}
    E -->|yes| F[fetch_project_clusters → CliProjectClusters]
    E -->|no| G[fetch_workspace_clusters → CliWorkspaceClusters]
    F --> H[From impl → CliClusterList\npropagate project_id/name]
    G --> I[From impl → CliClusterList]
    H --> J{format?}
    I --> J
    J -->|json| K[print_json standard+enterprise]
    J -->|text| L[print_cloud_clusters\nprint_standard_clusters\nprint_enterprise_clusters]

    D --> M[get_json → raw serde_json::Value]
    M --> N[serde_json::from_value → CliClusterIndexes]
    N --> O{format?}
    O -->|json| P[print_json raw]
    O -->|text| Q{canonical_backend?}
    Q -->|none| R[print raw JSON fallback]
    Q -->|some| S[print writer summary\ndivergence check\nerror list]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Enhance cluster management in CLI by int..."](https://github.com/helixdb/helix-db/commit/0b34912d49f2f58dff05bd687a47c4097089d7d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41378726)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->