### PR TITLE
Cli cross os local tests and windows fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,7 +783,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helix-cli"
-version = "3.0.6"
+version = "3.0.8"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-cli"
-version = "3.0.6"
+version = "3.0.8"
 edition = "2024"
 
 [dependencies]

--- a/helix-cli/src/local_runtime.rs
+++ b/helix-cli/src/local_runtime.rs
@@ -4,6 +4,7 @@ use crate::output::Step;
 use crate::project::ProjectContext;
 use crate::utils::command_exists;
 use eyre::{Result, eyre};
+use std::ffi::OsString;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::process::{Command, Output, Stdio};
@@ -24,6 +25,7 @@ const MINIO_SECRET_KEY: &str = "minioadmin";
 const LOCAL_S3_BUCKET: &str = "helix-db";
 const LOCAL_S3_REGION: &str = "us-east-1";
 const LOCAL_DB_PATH: &str = "db/";
+const TEST_CONTAINER_RUNTIME_BIN_ENV: &str = "HELIX_TEST_CONTAINER_RUNTIME_BIN";
 
 #[derive(Debug, Clone)]
 pub struct LocalRuntime {
@@ -55,7 +57,7 @@ impl LocalRuntime {
     }
 
     pub fn check_available(runtime: ContainerRuntime) -> Result<()> {
-        let output = match Command::new(runtime.binary()).arg("info").output() {
+        let output = match runtime_command(runtime).arg("info").output() {
             Ok(output) => output,
             // The binary itself couldn't be spawned — the runtime isn't installed,
             // so there's nothing for us to auto-start.
@@ -90,7 +92,7 @@ impl LocalRuntime {
     /// Returns `true` if the runtime daemon answers an `info` probe. This is a
     /// quick, non-blocking check — it never tries to auto-start the daemon.
     pub(crate) fn is_running(runtime: ContainerRuntime) -> bool {
-        Command::new(runtime.binary())
+        runtime_command(runtime)
             .arg("info")
             .output()
             .map(|o| o.status.success())
@@ -170,7 +172,8 @@ impl LocalRuntime {
 
     fn pull_image_ref(&self, image: &str) -> Result<()> {
         Step::verbose_substep(&format!("Pulling {image}"));
-        let output = Command::new(self.runtime.binary())
+        let output = self
+            .runtime_command()
             .args(["pull", image])
             .output()
             .map_err(|e| eyre!("Failed to pull {image}: {e}"))?;
@@ -188,7 +191,7 @@ impl LocalRuntime {
     }
 
     fn image_exists(&self, image: &str) -> bool {
-        Command::new(self.runtime.binary())
+        self.runtime_command()
             .args(["image", "inspect", image])
             .output()
             .map(|output| output.status.success())
@@ -210,7 +213,8 @@ impl LocalRuntime {
         };
 
         let args = helix_run_args(&name, &image, config.port, true, disk_resources.as_ref());
-        let output = Command::new(self.runtime.binary())
+        let output = self
+            .runtime_command()
             .args(&args)
             .output()
             .map_err(|e| eyre!("Failed to start {name}: {e}"))?;
@@ -243,7 +247,8 @@ impl LocalRuntime {
         };
         let args = helix_run_args(&name, &image, config.port, false, disk_resources.as_ref());
 
-        let mut child = TokioCommand::new(self.runtime.binary())
+        let mut child = self
+            .runtime_tokio_command()
             .args(&args)
             .stdin(Stdio::inherit())
             .stdout(Stdio::inherit())
@@ -297,7 +302,8 @@ impl LocalRuntime {
         }
 
         let name = self.container_name(instance_name);
-        let output = Command::new(self.runtime.binary())
+        let output = self
+            .runtime_command()
             .args(["restart", &name])
             .output()
             .map_err(|e| eyre!("Failed to restart {name}: {e}"))?;
@@ -312,7 +318,7 @@ impl LocalRuntime {
 
     pub fn logs(&self, instance_name: &str, follow: bool) -> Result<()> {
         let name = self.container_name(instance_name);
-        let mut command = Command::new(self.runtime.binary());
+        let mut command = self.runtime_command();
         command.arg("logs");
         if follow {
             command.arg("-f");
@@ -336,7 +342,8 @@ impl LocalRuntime {
 
     pub fn status(&self, instance_name: &str) -> Result<Option<LocalStatus>> {
         let name = self.container_name(instance_name);
-        let output = Command::new(self.runtime.binary())
+        let output = self
+            .runtime_command()
             .args([
                 "ps",
                 "-a",
@@ -378,16 +385,13 @@ impl LocalRuntime {
     }
 
     pub fn run_command(&self, args: &[&str]) -> Result<Output> {
-        Command::new(self.runtime.binary())
-            .args(args)
-            .output()
-            .map_err(|e| {
-                eyre!(
-                    "Failed to run {} {}: {e}",
-                    self.runtime.binary(),
-                    args.join(" ")
-                )
-            })
+        self.runtime_command().args(args).output().map_err(|e| {
+            eyre!(
+                "Failed to run {} {}: {e}",
+                self.runtime.binary(),
+                args.join(" ")
+            )
+        })
     }
 
     fn disk_resources(&self, instance_name: &str) -> DiskRuntimeResources {
@@ -408,7 +412,8 @@ impl LocalRuntime {
         let _ = self.remove_container(&resources.minio_container);
 
         let args = minio_run_args(&resources);
-        let output = Command::new(self.runtime.binary())
+        let output = self
+            .runtime_command()
             .args(&args)
             .output()
             .map_err(|e| eyre!("Failed to start {}: {e}", resources.minio_container))?;
@@ -430,7 +435,8 @@ impl LocalRuntime {
             return Ok(());
         }
 
-        let output = Command::new(self.runtime.binary())
+        let output = self
+            .runtime_command()
             .args(["network", "create", network])
             .output()
             .map_err(|e| eyre!("Failed to create network {network}: {e}"))?;
@@ -446,7 +452,8 @@ impl LocalRuntime {
     }
 
     fn ensure_volume(&self, volume: &str) -> Result<()> {
-        let output = Command::new(self.runtime.binary())
+        let output = self
+            .runtime_command()
             .args(["volume", "create", volume])
             .output()
             .map_err(|e| eyre!("Failed to create volume {volume}: {e}"))?;
@@ -465,7 +472,8 @@ impl LocalRuntime {
         let mut last_stderr = String::new();
 
         while Instant::now() < deadline {
-            let output = Command::new(self.runtime.binary())
+            let output = self
+                .runtime_command()
                 .args(&args)
                 .output()
                 .map_err(|e| eyre!("Failed to initialize local MinIO bucket: {e}"))?;
@@ -497,7 +505,8 @@ impl LocalRuntime {
     }
 
     fn remove_network(&self, network: &str) -> Result<bool> {
-        let output = Command::new(self.runtime.binary())
+        let output = self
+            .runtime_command()
             .args(["network", "rm", network])
             .output()
             .map_err(|e| eyre!("Failed to remove network {network}: {e}"))?;
@@ -514,7 +523,8 @@ impl LocalRuntime {
     }
 
     fn remove_volume(&self, volume: &str) -> Result<bool> {
-        let output = Command::new(self.runtime.binary())
+        let output = self
+            .runtime_command()
             .args(["volume", "rm", volume])
             .output()
             .map_err(|e| eyre!("Failed to remove volume {volume}: {e}"))?;
@@ -531,7 +541,7 @@ impl LocalRuntime {
     }
 
     fn resource_exists(&self, args: &[&str]) -> bool {
-        Command::new(self.runtime.binary())
+        self.runtime_command()
             .args(args)
             .output()
             .map(|output| output.status.success())
@@ -539,7 +549,8 @@ impl LocalRuntime {
     }
 
     fn remove_container(&self, name: &str) -> Result<bool> {
-        let output = Command::new(self.runtime.binary())
+        let output = self
+            .runtime_command()
             .args(["rm", "-f", name])
             .output()
             .map_err(|e| eyre!("Failed to remove {name}: {e}"))?;
@@ -598,6 +609,52 @@ impl LocalRuntime {
 
         response.starts_with("HTTP/1.1 2") || response.starts_with("HTTP/1.0 2")
     }
+
+    fn runtime_command(&self) -> Command {
+        runtime_command(self.runtime)
+    }
+
+    fn runtime_tokio_command(&self) -> TokioCommand {
+        runtime_tokio_command(self.runtime)
+    }
+}
+
+fn runtime_command(runtime: ContainerRuntime) -> Command {
+    match std::env::var_os(TEST_CONTAINER_RUNTIME_BIN_ENV) {
+        Some(bin) => command_from_test_runtime_bin(bin),
+        None => Command::new(runtime.binary()),
+    }
+}
+
+fn runtime_tokio_command(runtime: ContainerRuntime) -> TokioCommand {
+    match std::env::var_os(TEST_CONTAINER_RUNTIME_BIN_ENV) {
+        Some(bin) => tokio_command_from_test_runtime_bin(bin),
+        None => TokioCommand::new(runtime.binary()),
+    }
+}
+
+#[cfg(windows)]
+fn command_from_test_runtime_bin(bin: OsString) -> Command {
+    let mut command = Command::new("cmd");
+    command.arg("/C").arg("call").arg(bin);
+    command
+}
+
+#[cfg(not(windows))]
+fn command_from_test_runtime_bin(bin: OsString) -> Command {
+    Command::new(bin)
+}
+
+#[cfg(windows)]
+fn tokio_command_from_test_runtime_bin(bin: OsString) -> TokioCommand {
+    let mut command = TokioCommand::new("cmd");
+    command.arg("/C").arg("call").arg(bin);
+    command
+}
+
+#[cfg(not(windows))]
+fn tokio_command_from_test_runtime_bin(bin: OsString) -> TokioCommand {
+    TokioCommand::new(bin)
 }
 
 /// Build the error for a container runtime whose binary is missing from PATH.

--- a/helix-cli/src/utils.rs
+++ b/helix-cli/src/utils.rs
@@ -173,9 +173,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn command_exists_in_path_finds_unix_executable() {
+    fn command_exists_in_path_finds_platform_executable() {
         let dir = tempfile::tempdir().unwrap();
-        let command = dir.path().join("node");
+        let command = dir
+            .path()
+            .join(if cfg!(windows) { "node.CMD" } else { "node" });
         std::fs::write(&command, "").unwrap();
 
         #[cfg(unix)]
@@ -189,7 +191,7 @@ mod tests {
         assert!(command_exists_in_path(
             "node",
             Some(dir.path().as_os_str().to_os_string()),
-            None,
+            Some(OsString::from(".CMD")),
         ));
     }
 

--- a/helix-cli/src/utils.rs
+++ b/helix-cli/src/utils.rs
@@ -1,14 +1,78 @@
 use crate::errors::CliError;
 use color_eyre::owo_colors::OwoColorize;
 use eyre::Result;
+use std::ffi::OsString;
 use std::io::IsTerminal;
+use std::path::Path;
 
 pub fn command_exists(command: &str) -> bool {
-    std::process::Command::new("which")
-        .arg(command)
-        .output()
-        .map(|output| output.status.success())
-        .unwrap_or(false)
+    command_exists_in_path(
+        command,
+        std::env::var_os("PATH"),
+        std::env::var_os("PATHEXT"),
+    )
+}
+
+fn command_exists_in_path(
+    command: &str,
+    path: Option<OsString>,
+    path_ext: Option<OsString>,
+) -> bool {
+    let command_path = Path::new(command);
+    if command_path.components().count() > 1 {
+        return is_executable(command_path);
+    }
+
+    let Some(path) = path else {
+        return false;
+    };
+
+    let extensions = command_extensions(command, path_ext);
+    std::env::split_paths(&path).any(|dir| {
+        extensions
+            .iter()
+            .any(|extension| is_executable(&dir.join(format!("{command}{extension}"))))
+    })
+}
+
+fn command_extensions(command: &str, path_ext: Option<OsString>) -> Vec<String> {
+    if cfg!(windows) && Path::new(command).extension().is_none() {
+        let path_ext = path_ext
+            .and_then(|value| value.into_string().ok())
+            .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".to_string());
+        let mut extensions = vec![String::new()];
+        extensions.extend(
+            path_ext
+                .split(';')
+                .filter(|extension| !extension.is_empty())
+                .map(|extension| {
+                    if extension.starts_with('.') {
+                        extension.to_string()
+                    } else {
+                        format!(".{extension}")
+                    }
+                }),
+        );
+        extensions
+    } else {
+        vec![String::new()]
+    }
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    path.is_file()
+        && path
+            .metadata()
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
 }
 
 pub fn print_newline() {
@@ -102,4 +166,41 @@ pub fn add_env_var_to_file(path: &std::path::Path, key: &str, value: &str) -> Re
 
     std::fs::write(path, content)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_exists_in_path_finds_unix_executable() {
+        let dir = tempfile::tempdir().unwrap();
+        let command = dir.path().join("node");
+        std::fs::write(&command, "").unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&command).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&command, permissions).unwrap();
+        }
+
+        assert!(command_exists_in_path(
+            "node",
+            Some(dir.path().as_os_str().to_os_string()),
+            None,
+        ));
+    }
+
+    #[test]
+    fn command_extensions_include_windows_path_ext() {
+        let extensions = command_extensions("node", Some(OsString::from(".EXE;.CMD")));
+
+        if cfg!(windows) {
+            assert_eq!(extensions, vec!["", ".EXE", ".CMD"]);
+        } else {
+            assert_eq!(extensions, vec![""]);
+        }
+    }
 }

--- a/helix-cli/tests/e2e_cli.rs
+++ b/helix-cli/tests/e2e_cli.rs
@@ -128,7 +128,7 @@ fn init_and_add_generate_expected_project_files() {
 
 #[test]
 fn local_runtime_commands_have_cross_platform_no_daemon_smoke_coverage() {
-    let fixture = CliFixture::new();
+    let fixture = CliFixture::new_with_fake_runtime();
     let project = fixture.root().join("local-command-project");
 
     fixture

--- a/helix-cli/tests/e2e_cli.rs
+++ b/helix-cli/tests/e2e_cli.rs
@@ -127,6 +127,110 @@ fn init_and_add_generate_expected_project_files() {
 }
 
 #[test]
+fn local_runtime_commands_have_cross_platform_no_daemon_smoke_coverage() {
+    let fixture = CliFixture::new();
+    let project = fixture.root().join("local-command-project");
+
+    fixture
+        .command()
+        .args(["init", "--path"])
+        .arg(&project)
+        .args(["local", "--no-skills"])
+        .assert()
+        .success();
+
+    let status = stdout(
+        fixture
+            .command()
+            .current_dir(&project)
+            .args(["status", "dev"])
+            .assert()
+            .success(),
+    );
+    assert!(status.contains("dev (local)"));
+    assert!(status.contains("not created"));
+
+    let logs = stdout(
+        fixture
+            .command()
+            .current_dir(&project)
+            .args(["logs", "dev"])
+            .assert()
+            .success(),
+    );
+    assert!(logs.contains("fake logs"));
+
+    let stop = stdout(
+        fixture
+            .command()
+            .current_dir(&project)
+            .args(["stop", "dev"])
+            .assert()
+            .success(),
+    );
+    assert!(stop.contains("was not running"));
+
+    let prune = stdout(
+        fixture
+            .command()
+            .current_dir(&project)
+            .args(["prune", "dev"])
+            .assert()
+            .success(),
+    );
+    assert!(prune.contains("No local runtime resources found"));
+
+    let mut config_text = fs::read_to_string(project.join("helix.toml")).unwrap();
+    config_text.push_str(
+        r#"
+
+[enterprise.production]
+cluster_id = "cluster-test"
+gateway_url = "http://127.0.0.1:9999"
+"#,
+    );
+    fs::write(project.join("helix.toml"), config_text).unwrap();
+
+    let start_cloud = stderr(
+        fixture
+            .command()
+            .current_dir(&project)
+            .args(["start", "production"])
+            .assert()
+            .failure(),
+    );
+    assert!(start_cloud.contains("'production' is not a local v2 instance"));
+
+    let restart_cloud = stderr(
+        fixture
+            .command()
+            .current_dir(&project)
+            .args(["restart", "production"])
+            .assert()
+            .failure(),
+    );
+    assert!(restart_cloud.contains("'production' is not a local v2 instance"));
+
+    fixture
+        .command()
+        .current_dir(&project)
+        .args(["delete", "dev", "--yes"])
+        .assert()
+        .success();
+
+    let config_text = fs::read_to_string(project.join("helix.toml")).unwrap();
+    let config: TomlValue = toml::from_str(&config_text).unwrap();
+    assert!(
+        config
+            .get("local")
+            .and_then(TomlValue::as_table)
+            .map(|local| local.is_empty())
+            .unwrap_or(true)
+    );
+    assert!(config["enterprise"]["production"].is_table());
+}
+
+#[test]
 fn project_and_metrics_commands_use_isolated_state() {
     let fixture = CliFixture::new();
     let project = fixture.root().join("state-project");

--- a/helix-cli/tests/support/mod.rs
+++ b/helix-cli/tests/support/mod.rs
@@ -10,6 +10,7 @@ pub struct CliFixture {
     home: PathBuf,
     helix_home: PathBuf,
     cache: PathBuf,
+    bin: PathBuf,
 }
 
 impl CliFixture {
@@ -22,9 +23,11 @@ impl CliFixture {
         let home = root_path.join("home");
         let helix_home = root_path.join("helix-home");
         let cache = root_path.join("helix-cache");
+        let bin = root_path.join("bin");
         fs::create_dir_all(&home).expect("create isolated home");
         fs::create_dir_all(&helix_home).expect("create isolated helix home");
         fs::create_dir_all(&cache).expect("create isolated cache");
+        install_fake_docker(&bin);
 
         let tempdir = if std::env::var_os("HELIX_E2E_KEEP_TMP").is_some() {
             std::mem::forget(root);
@@ -39,6 +42,7 @@ impl CliFixture {
             home,
             helix_home,
             cache,
+            bin,
         }
     }
 
@@ -48,6 +52,7 @@ impl CliFixture {
 
     pub fn command(&self) -> Command {
         let mut command = Command::cargo_bin("helix").expect("helix binary should be built");
+        let path = prepend_path(&self.bin);
         command
             .env("HELIX_NO_UPDATE_CHECK", "1")
             .env("HELIX_DISABLE_UPDATE_CHECK", "1")
@@ -56,8 +61,76 @@ impl CliFixture {
             .env("HELIX_CACHE_DIR", &self.cache)
             .env("HOME", &self.home)
             .env("USERPROFILE", &self.home)
+            .env("PATH", path)
+            .env("PATHEXT", ".COM;.EXE;.BAT;.CMD")
             .env("CLICOLOR", "0");
         command
+    }
+}
+
+fn prepend_path(bin: &Path) -> std::ffi::OsString {
+    let mut paths = vec![bin.to_path_buf()];
+    if let Some(path) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&path));
+    }
+    std::env::join_paths(paths).expect("join PATH")
+}
+
+fn install_fake_docker(bin: &Path) {
+    fs::create_dir_all(bin).expect("create fake docker bin");
+
+    #[cfg(windows)]
+    {
+        let script = bin.join("docker.cmd");
+        fs::write(
+            &script,
+            r#"@echo off
+if "%1"=="info" exit /b 0
+if "%1"=="ps" exit /b 0
+if "%1"=="logs" (
+  echo fake logs
+  exit /b 0
+)
+if "%1"=="rm" (
+  echo No such container 1>&2
+  exit /b 1
+)
+if "%1"=="network" (
+  echo not found 1>&2
+  exit /b 1
+)
+if "%1"=="volume" (
+  echo not found 1>&2
+  exit /b 1
+)
+exit /b 0
+"#,
+        )
+        .expect("write fake docker cmd");
+    }
+
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script = bin.join("docker");
+        fs::write(
+            &script,
+            r#"#!/bin/sh
+case "$1" in
+  info) exit 0 ;;
+  ps) exit 0 ;;
+  logs) echo "fake logs"; exit 0 ;;
+  rm) echo "No such container" >&2; exit 1 ;;
+  network|volume) echo "not found" >&2; exit 1 ;;
+  *) exit 0 ;;
+esac
+"#,
+        )
+        .expect("write fake docker script");
+        let mut permissions = fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).unwrap();
     }
 }
 

--- a/helix-cli/tests/support/mod.rs
+++ b/helix-cli/tests/support/mod.rs
@@ -10,11 +10,20 @@ pub struct CliFixture {
     home: PathBuf,
     helix_home: PathBuf,
     cache: PathBuf,
-    bin: PathBuf,
+    test_runtime_bin: Option<PathBuf>,
 }
 
 impl CliFixture {
     pub fn new() -> Self {
+        Self::new_inner(false)
+    }
+
+    #[allow(dead_code)]
+    pub fn new_with_fake_runtime() -> Self {
+        Self::new_inner(true)
+    }
+
+    fn new_inner(fake_runtime: bool) -> Self {
         let root = Builder::new()
             .prefix("helix-cli-e2e-")
             .tempdir()
@@ -23,11 +32,10 @@ impl CliFixture {
         let home = root_path.join("home");
         let helix_home = root_path.join("helix-home");
         let cache = root_path.join("helix-cache");
-        let bin = root_path.join("bin");
         fs::create_dir_all(&home).expect("create isolated home");
         fs::create_dir_all(&helix_home).expect("create isolated helix home");
         fs::create_dir_all(&cache).expect("create isolated cache");
-        install_fake_docker(&bin);
+        let test_runtime_bin = fake_runtime.then(|| install_fake_docker(&root_path.join("bin")));
 
         let tempdir = if std::env::var_os("HELIX_E2E_KEEP_TMP").is_some() {
             std::mem::forget(root);
@@ -42,7 +50,7 @@ impl CliFixture {
             home,
             helix_home,
             cache,
-            bin,
+            test_runtime_bin,
         }
     }
 
@@ -52,7 +60,6 @@ impl CliFixture {
 
     pub fn command(&self) -> Command {
         let mut command = Command::cargo_bin("helix").expect("helix binary should be built");
-        let path = prepend_path(&self.bin);
         command
             .env("HELIX_NO_UPDATE_CHECK", "1")
             .env("HELIX_DISABLE_UPDATE_CHECK", "1")
@@ -61,22 +68,16 @@ impl CliFixture {
             .env("HELIX_CACHE_DIR", &self.cache)
             .env("HOME", &self.home)
             .env("USERPROFILE", &self.home)
-            .env("PATH", path)
             .env("PATHEXT", ".COM;.EXE;.BAT;.CMD")
             .env("CLICOLOR", "0");
+        if let Some(test_runtime_bin) = &self.test_runtime_bin {
+            command.env("HELIX_TEST_CONTAINER_RUNTIME_BIN", test_runtime_bin);
+        }
         command
     }
 }
 
-fn prepend_path(bin: &Path) -> std::ffi::OsString {
-    let mut paths = vec![bin.to_path_buf()];
-    if let Some(path) = std::env::var_os("PATH") {
-        paths.extend(std::env::split_paths(&path));
-    }
-    std::env::join_paths(paths).expect("join PATH")
-}
-
-fn install_fake_docker(bin: &Path) {
+fn install_fake_docker(bin: &Path) -> PathBuf {
     fs::create_dir_all(bin).expect("create fake docker bin");
 
     #[cfg(windows)]
@@ -107,6 +108,7 @@ exit /b 0
 "#,
         )
         .expect("write fake docker cmd");
+        script
     }
 
     #[cfg(not(windows))]
@@ -131,6 +133,7 @@ esac
         let mut permissions = fs::metadata(&script).unwrap().permissions();
         permissions.set_mode(0o755);
         fs::set_permissions(&script, permissions).unwrap();
+        script
     }
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the Unix-only `which`-based `command_exists` implementation with a portable PATH/PATHEXT walker, and adds a fake-docker test fixture so local runtime CLI commands (`status`, `logs`, `stop`, `prune`, `delete`) can be smoke-tested on any OS without a running Docker daemon.

- **`utils.rs`**: New `command_exists_in_path` + `is_executable` pair handles Windows PATHEXT extension probing and Unix permission-bit checking, with inline unit tests for both paths.
- **`tests/support/mod.rs`**: `CliFixture` now writes a platform-appropriate fake `docker` script into an isolated `bin/` directory and prepends it to the subprocess PATH, replacing any real Docker in the test environment.
- **`tests/e2e_cli.rs`**: New `local_runtime_commands_have_cross_platform_no_daemon_smoke_coverage` test exercises the full lifecycle of a local dev environment including an expected-failure path for cloud-only instances.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-cli/src/utils.rs | Replaces Unix-only `which`-based command detection with a cross-platform implementation using PATH/PATHEXT; minor double-syscall in the Unix `is_executable` path. |
| helix-cli/tests/support/mod.rs | Adds fake-docker installation and PATH prepending to the CliFixture, enabling local runtime tests without a real Docker daemon on both Unix and Windows. |
| helix-cli/tests/e2e_cli.rs | Adds a no-daemon smoke test covering status/logs/stop/prune/start/restart/delete across platforms using the new fake docker; assertions look correct for the expected CLI output. |
| helix-cli/Cargo.toml | Bumps version from 3.0.6 to 3.0.8; no other changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as e2e_cli.rs
    participant Fixture as CliFixture
    participant Helix as helix binary
    participant Utils as utils::command_exists
    participant FakeDocker as fake docker script

    Test->>Fixture: CliFixture::new()
    Fixture->>FakeDocker: install_fake_docker(bin/)
    Fixture-->>Test: fixture with PATH prepended

    Test->>Helix: "helix status dev"
    Helix->>Utils: command_exists("docker")
    Utils->>Utils: split PATH, probe PATHEXT extensions
    Utils->>FakeDocker: is_executable bin/docker
    Utils-->>Helix: true
    Helix->>FakeDocker: "docker ps"
    FakeDocker-->>Helix: exit 0, no output
    Helix-->>Test: "not created"

    Test->>Helix: "helix logs dev"
    Helix->>FakeDocker: "docker logs container"
    FakeDocker-->>Helix: "fake logs" exit 0
    Helix-->>Test: stdout contains "fake logs"

    Test->>Helix: "helix start production"
    Helix-->>Test: stderr not-a-local-instance error, exit 1
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as e2e_cli.rs
    participant Fixture as CliFixture
    participant Helix as helix binary
    participant Utils as utils::command_exists
    participant FakeDocker as fake docker script

    Test->>Fixture: CliFixture::new()
    Fixture->>FakeDocker: install_fake_docker(bin/)
    Fixture-->>Test: fixture with PATH prepended

    Test->>Helix: "helix status dev"
    Helix->>Utils: command_exists("docker")
    Utils->>Utils: split PATH, probe PATHEXT extensions
    Utils->>FakeDocker: is_executable bin/docker
    Utils-->>Helix: true
    Helix->>FakeDocker: "docker ps"
    FakeDocker-->>Helix: exit 0, no output
    Helix-->>Test: "not created"

    Test->>Helix: "helix logs dev"
    Helix->>FakeDocker: "docker logs container"
    FakeDocker-->>Helix: "fake logs" exit 0
    Helix-->>Test: stdout contains "fake logs"

    Test->>Helix: "helix start production"
    Helix-->>Test: stderr not-a-local-instance error, exit 1
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Expand cross-platform CLI command covera..."](https://github.com/helixdb/helix-db/commit/107b4b21b8dc0f841e1de69be749d74d1a78ed06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41952238)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->