### PR TITLE
fix: treat existing volume as success in ensure_volume

### DIFF
--- a/crates/cli/src/local_runtime.rs
+++ b/crates/cli/src/local_runtime.rs
@@ -476,6 +476,10 @@ impl LocalRuntime {
     }
 
     fn ensure_volume(&self, volume: &str) -> Result<()> {
+        if self.resource_exists(&["volume", "inspect", volume]) {
+            return Ok(());
+        }
+
         let output = self
             .runtime_command()
             .args(["volume", "create", volume])
@@ -484,7 +488,9 @@ impl LocalRuntime {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(eyre!("Failed to create volume {volume}:\n{stderr}"));
+            if !stderr.to_ascii_lowercase().contains("already exists") {
+                return Err(eyre!("Failed to create volume {volume}:\n{stderr}"));
+            }
         }
 
         Ok(())

--- a/crates/cli/tests/e2e_cli.rs
+++ b/crates/cli/tests/e2e_cli.rs
@@ -6,6 +6,8 @@ use std::fs;
 use toml::Value as TomlValue;
 
 use support::{free_port, CliFixture};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn stdout(assert: Assert) -> String {
     String::from_utf8(assert.get_output().stdout.clone()).expect("stdout should be utf8")
@@ -560,4 +562,92 @@ gateway_url = "https://staging.example.com"
         );
         assert!(error.contains("No local instance specified"), "{error}");
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disk_start_reuses_an_existing_volume_without_creating_it() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/healthz"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let fixture = CliFixture::new_with_fake_runtime();
+    let project = fixture.root().join("existing-volume-project");
+    fixture
+        .command()
+        .args(["init", "--path"])
+        .arg(&project)
+        .args(["local", "--port"])
+        .arg(server.address().port().to_string())
+        .args(["--disk", "--no-skills"])
+        .assert()
+        .success();
+
+    fixture
+        .command()
+        .current_dir(&project)
+        .args(["start", "dev"])
+        .env("HELIX_TEST_RUNTIME_VOLUME_MODE", "existing")
+        .assert()
+        .success();
+
+    // an existing volume is inspected and reused, never re-created.
+    let log = fixture.runtime_log();
+    assert!(log.contains("volume inspect"), "{log}");
+    assert!(!log.contains("volume create"), "{log}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disk_start_tolerates_the_volume_create_race_but_surfaces_real_errors() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/healthz"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    // raced: inspect misses, create loses to another process, start still succeeds.
+    let raced = CliFixture::new_with_fake_runtime();
+    let raced_project = raced.root().join("raced-volume-project");
+    raced
+        .command()
+        .args(["init", "--path"])
+        .arg(&raced_project)
+        .args(["local", "--port"])
+        .arg(server.address().port().to_string())
+        .args(["--disk", "--no-skills"])
+        .assert()
+        .success();
+    raced
+        .command()
+        .current_dir(&raced_project)
+        .args(["start", "dev"])
+        .env("HELIX_TEST_RUNTIME_VOLUME_MODE", "raced")
+        .assert()
+        .success();
+
+    // denied: an unrelated create failure must fail the start with the real error.
+    let denied = CliFixture::new_with_fake_runtime();
+    let denied_project = denied.root().join("denied-volume-project");
+    denied
+        .command()
+        .args(["init", "--path"])
+        .arg(&denied_project)
+        .args(["local", "--port"])
+        .arg(server.address().port().to_string())
+        .args(["--disk", "--no-skills"])
+        .assert()
+        .success();
+    let error = stderr(
+        denied
+            .command()
+            .current_dir(&denied_project)
+            .args(["start", "dev"])
+            .env("HELIX_TEST_RUNTIME_VOLUME_MODE", "denied")
+            .assert()
+            .failure(),
+    );
+    assert!(error.contains("permission denied"), "{error}");
 }

--- a/crates/cli/tests/support/mod.rs
+++ b/crates/cli/tests/support/mod.rs
@@ -304,6 +304,23 @@ if "%1"=="network" (
   exit /b 1
 )
 if "%1"=="volume" (
+  if "%HELIX_TEST_RUNTIME_VOLUME_MODE%"=="existing" exit /b 0
+  if "%HELIX_TEST_RUNTIME_VOLUME_MODE%"=="raced" (
+    if "%2"=="create" (
+      echo volume already exists 1>&2
+      exit /b 1
+    )
+    echo not found 1>&2
+    exit /b 1
+  )
+  if "%HELIX_TEST_RUNTIME_VOLUME_MODE%"=="denied" (
+    if "%2"=="create" (
+      echo permission denied 1>&2
+      exit /b 1
+    )
+    echo not found 1>&2
+    exit /b 1
+  )
   if "%2"=="create" exit /b 0
   if "%HELIX_TEST_RUNTIME_RESOURCES_EXIST%"=="1" exit /b 0
   echo not found 1>&2
@@ -345,12 +362,46 @@ case "$1" in
     echo "No such container" >&2
     exit 1
     ;;
-  network|volume)
+  network)
     if [ "$2" = "create" ] || [ "$HELIX_TEST_RUNTIME_RESOURCES_EXIST" = "1" ]; then
       exit 0
     fi
     echo "not found" >&2
     exit 1
+    ;;
+  volume)
+    case "${HELIX_TEST_RUNTIME_VOLUME_MODE:-fresh}" in
+      existing)
+        # inspect succeeds, so ensure_volume returns before ever creating
+        exit 0
+        ;;
+      raced)
+        # inspect misses, create loses the race to another process
+        if [ "$2" = "create" ]; then
+          echo "volume already exists" >&2
+          exit 1
+        fi
+        echo "not found" >&2
+        exit 1
+        ;;
+      denied)
+        # inspect misses, create fails for an unrelated reason
+        if [ "$2" = "create" ]; then
+          echo "permission denied" >&2
+          exit 1
+        fi
+        echo "not found" >&2
+        exit 1
+        ;;
+      *)
+        # fresh: inspect misses, create succeeds
+        if [ "$2" = "create" ] || [ "$HELIX_TEST_RUNTIME_RESOURCES_EXIST" = "1" ]; then
+          exit 0
+        fi
+        echo "not found" >&2
+        exit 1
+        ;;
+    esac
     ;;
   *) exit 0 ;;
 esac


### PR DESCRIPTION
podman errors when the volume already exists, docker does not. on a persistent
(--disk) instance the volume always exists after the first start, so helix start
fails every time on podman and the instance can never be restarted with its data.

repro:
1. container_runtime = "podman" in helix.toml
2. helix start dev --disk --persist
3. helix stop dev
4. helix start dev   -> Failed to create volume ... already exists

ensure_network already tolerates "already exists". this makes ensure_volume do
the same.
- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

did not bump version numbers, happy to if you want that in this pr. tested on
podman 4.9.3 in wsl2 arm64: with this change a --disk instance restarts cleanly
and keeps its data.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Podman-specific restart failure for `--disk` instances by making `ensure_volume` tolerate an "already exists" error from the container runtime — the same defensive pattern that `ensure_network` already uses.

- `ensure_volume` now checks the stderr of a failed `volume create` call and skips the error when it contains `"already exists"`, matching the behaviour of `ensure_network`.
- The root cause is that Podman exits non-zero when creating an already-existing volume, while Docker exits zero; on every restart of a persistent instance the volume is already present, so Podman was failing every time.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helix-cli/src/local_runtime.rs | Adds "already exists" stderr tolerance to ensure_volume, mirroring the existing pattern in ensure_network; one minor inconsistency: ensure_network has an upfront resource_exists pre-check that ensure_volume still lacks |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as helix start
    participant LR as LocalRuntime
    participant RT as Container Runtime (podman/docker)

    CLI->>LR: start_disk_dependencies()
    LR->>LR: ensure_network(network)
    LR->>RT: "network inspect {name}"
    alt network exists
        RT-->>LR: success early return
    else network missing
        RT-->>LR: not found
        LR->>RT: "network create {name}"
        RT-->>LR: ok or already exists Ok(())
    end

    LR->>LR: ensure_volume(volume)
    LR->>RT: "volume create {name}"
    alt docker volume new
        RT-->>LR: ok Ok(())
    else podman volume already exists
        RT-->>LR: error already exists
        Note over LR: stderr contains already exists treat as Ok(()) THIS PR
    else other error
        RT-->>LR: error other reason
        LR-->>CLI: Err
    end

    LR->>RT: run minio container
    LR-->>CLI: Ok(DiskRuntimeResources)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as helix start
    participant LR as LocalRuntime
    participant RT as Container Runtime (podman/docker)

    CLI->>LR: start_disk_dependencies()
    LR->>LR: ensure_network(network)
    LR->>RT: "network inspect {name}"
    alt network exists
        RT-->>LR: success early return
    else network missing
        RT-->>LR: not found
        LR->>RT: "network create {name}"
        RT-->>LR: ok or already exists Ok(())
    end

    LR->>LR: ensure_volume(volume)
    LR->>RT: "volume create {name}"
    alt docker volume new
        RT-->>LR: ok Ok(())
    else podman volume already exists
        RT-->>LR: error already exists
        Note over LR: stderr contains already exists treat as Ok(()) THIS PR
    else other error
        RT-->>LR: error other reason
        LR-->>CLI: Err
    end

    LR->>RT: run minio container
    LR-->>CLI: Ok(DiskRuntimeResources)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: treat existing volume as success in..."](https://github.com/helixdb/helix-db/commit/22b1fc02d783c484b33018a5f27f09f835d3b12a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44033487)</sub>

<!-- /greptile_comment -->