### PR TITLE
Use commutative merges for bitmap index inserts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4835,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
 dependencies = [
  "chrono",
  "log",
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,7 +3683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -3704,7 +3704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4790,7 +4790,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=aa8a76c6e933d811fd811c296e86b067665e97f5#aa8a76c6e933d811fd811c296e86b067665e97f5"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4835,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=aa8a76c6e933d811fd811c296e86b067665e97f5#aa8a76c6e933d811fd811c296e86b067665e97f5"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
 dependencies = [
  "chrono",
  "log",
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=aa8a76c6e933d811fd811c296e86b067665e97f5#aa8a76c6e933d811fd811c296e86b067665e97f5"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4835,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
 dependencies = [
  "chrono",
  "log",
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4835,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
 dependencies = [
  "chrono",
  "log",
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db-testkit/fuzz/Cargo.lock
+++ b/crates/db-testkit/fuzz/Cargo.lock
@@ -3140,7 +3140,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3185,7 +3185,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
 dependencies = [
  "chrono",
  "log",
@@ -3200,7 +3200,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db-testkit/fuzz/Cargo.lock
+++ b/crates/db-testkit/fuzz/Cargo.lock
@@ -3140,7 +3140,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=aa8a76c6e933d811fd811c296e86b067665e97f5#aa8a76c6e933d811fd811c296e86b067665e97f5"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3185,7 +3185,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=aa8a76c6e933d811fd811c296e86b067665e97f5#aa8a76c6e933d811fd811c296e86b067665e97f5"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
 dependencies = [
  "chrono",
  "log",
@@ -3200,7 +3200,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=aa8a76c6e933d811fd811c296e86b067665e97f5#aa8a76c6e933d811fd811c296e86b067665e97f5"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db-testkit/fuzz/Cargo.lock
+++ b/crates/db-testkit/fuzz/Cargo.lock
@@ -3140,7 +3140,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3185,7 +3185,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
 dependencies = [
  "chrono",
  "log",
@@ -3200,7 +3200,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db-testkit/fuzz/Cargo.lock
+++ b/crates/db-testkit/fuzz/Cargo.lock
@@ -3140,7 +3140,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3185,7 +3185,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
 dependencies = [
  "chrono",
  "log",
@@ -3200,7 +3200,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "41ae2a0f0d22719750da67a4cea0cda6b6da7f9e" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "624b53f6e2bb0fba904373636e8f668bdce7ee09" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-metrics = { path = "../metrics" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "aa8a76c6e933d811fd811c296e86b067665e97f5" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "c6cfdb095b32d3e946bc06fb9604dbd4629911b1" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-metrics = { path = "../metrics" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "c6cfdb095b32d3e946bc06fb9604dbd4629911b1" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "41ae2a0f0d22719750da67a4cea0cda6b6da7f9e" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-metrics = { path = "../metrics" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "624b53f6e2bb0fba904373636e8f668bdce7ee09" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-metrics = { path = "../metrics" }

--- a/crates/db/fuzz/Cargo.lock
+++ b/crates/db/fuzz/Cargo.lock
@@ -3120,7 +3120,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3165,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
 dependencies = [
  "chrono",
  "log",
@@ -3180,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db/fuzz/Cargo.lock
+++ b/crates/db/fuzz/Cargo.lock
@@ -3120,7 +3120,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3165,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
 dependencies = [
  "chrono",
  "log",
@@ -3180,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db/fuzz/Cargo.lock
+++ b/crates/db/fuzz/Cargo.lock
@@ -3120,7 +3120,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3165,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
 dependencies = [
  "chrono",
  "log",
@@ -3180,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db/fuzz/Cargo.lock
+++ b/crates/db/fuzz/Cargo.lock
@@ -3120,7 +3120,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=aa8a76c6e933d811fd811c296e86b067665e97f5#aa8a76c6e933d811fd811c296e86b067665e97f5"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3165,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=aa8a76c6e933d811fd811c296e86b067665e97f5#aa8a76c6e933d811fd811c296e86b067665e97f5"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
 dependencies = [
  "chrono",
  "log",
@@ -3180,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=aa8a76c6e933d811fd811c296e86b067665e97f5#aa8a76c6e933d811fd811c296e86b067665e97f5"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -2556,7 +2556,8 @@ async fn stage_bitmap_changes(
     for (key, changes) in changes {
         if changes.values().all(|present| *present) {
             let additions = roaring::RoaringTreemap::from_iter(changes.keys().copied());
-            transaction.merge(key, SecondaryEqualityBitmapValue::new(additions).encode())?;
+            transaction
+                .merge_commutative(key, SecondaryEqualityBitmapValue::new(additions).encode())?;
             continue;
         }
 
@@ -4882,6 +4883,76 @@ mod tests {
         );
 
         db.close().await.expect("mixed bitmap database closes");
+    }
+
+    #[tokio::test]
+    async fn pure_bitmap_additions_commit_without_conflicts() {
+        let db = test_db("secondary-commutative-bitmap-additions").await;
+        let handle = active_read_handle(
+            &db,
+            SecondaryIndexDefinition::node_equality("User", "status")
+                .expect("node equality definition validates"),
+        )
+        .await;
+        let definition = handle
+            .secondary_definition()
+            .expect("secondary handle retains its definition");
+        let key = secondary_entry_key(
+            handle.scope(),
+            handle.index_id(),
+            handle.generation(),
+            definition,
+            CanonicalSecondaryValue::equality_string("shared"),
+            IndexEntityId::initial(),
+        )
+        .expect("bitmap key validates");
+        db.put(
+            &key,
+            SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1])).encode(),
+        )
+        .await
+        .expect("initial bitmap persists");
+
+        let left = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .expect("left bitmap transaction begins");
+        let right = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .expect("right bitmap transaction begins");
+        stage_bitmap_changes(
+            &left,
+            &BTreeMap::from([(key.clone(), BTreeMap::from([(2, true)]))]),
+        )
+        .await
+        .expect("left addition stages");
+        stage_bitmap_changes(
+            &right,
+            &BTreeMap::from([(key.clone(), BTreeMap::from([(3, true)]))]),
+        )
+        .await
+        .expect("right addition stages");
+
+        left.commit().await.expect("left addition commits");
+        right.commit().await.expect("right addition commits");
+        assert_eq!(
+            SecondaryEqualityBitmapValue::decode(
+                &db.get(&key)
+                    .await
+                    .expect("merged bitmap is readable")
+                    .expect("merged bitmap remains present"),
+            )
+            .expect("merged bitmap decodes")
+            .ids()
+            .iter()
+            .collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+
+        db.close()
+            .await
+            .expect("commutative bitmap database closes");
     }
 
     #[tokio::test]

--- a/crates/db/src/merge_operator.rs
+++ b/crates/db/src/merge_operator.rs
@@ -909,6 +909,35 @@ mod tests {
     }
 
     #[test]
+    fn bitmap_add_operands_commute_for_every_existing_bitmap() {
+        let key = Key::Data {
+            scope: DataScope::LegacyUnscoped,
+            kind: DataKeyKind::EdgePairIndex(EdgePairIndexKey::new(1, 3)),
+        }
+        .to_bytes();
+        let mut existing = RoaringTreemap::new();
+        existing.insert(41);
+        let existing = BitmapMergeOperator::encode(&existing).expect("existing bitmap encodes");
+        let operator = HelixMergeOperator::new();
+
+        let left_then_right = operator
+            .merge(&key, Some(existing.clone()), encode_bitmap_add(42))
+            .and_then(|value| operator.merge(&key, Some(value), encode_bitmap_add(43)))
+            .expect("left-then-right bitmap operands merge");
+        let right_then_left = operator
+            .merge(&key, Some(existing), encode_bitmap_add(43))
+            .and_then(|value| operator.merge(&key, Some(value), encode_bitmap_add(42)))
+            .expect("right-then-left bitmap operands merge");
+
+        let left_then_right = RoaringTreemap::deserialize_from(Cursor::new(left_then_right))
+            .expect("left-then-right bitmap decodes");
+        let right_then_left = RoaringTreemap::deserialize_from(Cursor::new(right_then_left))
+            .expect("right-then-left bitmap decodes");
+        assert_eq!(left_then_right, right_then_left);
+        assert_eq!(left_then_right.iter().collect::<Vec<_>>(), vec![41, 42, 43],);
+    }
+
+    #[test]
     fn layer0_merge_preserves_simhash_across_neighbor_delta() {
         let mut key = vec![VECTOR_HOT_KEYSPACE_PREFIX];
         key.extend_from_slice(&9_u64.to_be_bytes());

--- a/crates/db/src/search/mod.rs
+++ b/crates/db/src/search/mod.rs
@@ -638,7 +638,7 @@ pub async fn add_to_equality_index_scoped(
     }
     .to_bytes();
 
-    txn.merge(&key, crate::merge_operator::encode_bitmap_add(node_id))?;
+    txn.merge_commutative(&key, crate::merge_operator::encode_bitmap_add(node_id))?;
     Ok(())
 }
 
@@ -1599,7 +1599,7 @@ pub async fn add_to_edge_label_index_scoped(
             )),
         }
         .to_bytes();
-    txn.merge(&out_key, crate::merge_operator::encode_bitmap_add(to))?;
+    txn.merge_commutative(&out_key, crate::merge_operator::encode_bitmap_add(to))?;
 
     // Update incoming index: to + label -> from
     let in_key =
@@ -1610,7 +1610,7 @@ pub async fn add_to_edge_label_index_scoped(
             )),
         }
         .to_bytes();
-    txn.merge(&in_key, crate::merge_operator::encode_bitmap_add(from))?;
+    txn.merge_commutative(&in_key, crate::merge_operator::encode_bitmap_add(from))?;
 
     Ok(())
 }
@@ -1783,7 +1783,7 @@ pub async fn add_to_edge_equality_index_scoped(
         ))),
     }
     .to_bytes();
-    txn.merge(&out_key, crate::merge_operator::encode_bitmap_add(edge_id))?;
+    txn.merge_commutative(&out_key, crate::merge_operator::encode_bitmap_add(edge_id))?;
 
     let in_key = Key::Data {
         scope: tenant_scope,
@@ -1795,7 +1795,7 @@ pub async fn add_to_edge_equality_index_scoped(
         ))),
     }
     .to_bytes();
-    txn.merge(&in_key, crate::merge_operator::encode_bitmap_add(edge_id))?;
+    txn.merge_commutative(&in_key, crate::merge_operator::encode_bitmap_add(edge_id))?;
 
     let global_key = Key::Data {
         scope: tenant_scope,
@@ -1807,7 +1807,7 @@ pub async fn add_to_edge_equality_index_scoped(
         )),
     }
     .to_bytes();
-    txn.merge(
+    txn.merge_commutative(
         &global_key,
         crate::merge_operator::encode_bitmap_add(edge_id),
     )?;
@@ -2020,7 +2020,7 @@ pub async fn add_to_global_edge_label_index_scoped(
         ))),
     }
     .to_bytes();
-    txn.merge(&key, crate::merge_operator::encode_bitmap_add(edge_id))?;
+    txn.merge_commutative(&key, crate::merge_operator::encode_bitmap_add(edge_id))?;
     Ok(())
 }
 
@@ -2163,7 +2163,7 @@ pub async fn add_to_edge_pair_index_scoped(
         kind: DataKeyKind::EdgePairIndex(crate::encoding::keys::EdgePairIndexKey::new(from, to)),
     }
     .to_bytes();
-    txn.merge(&key, crate::merge_operator::encode_bitmap_add(edge_id))?;
+    txn.merge_commutative(&key, crate::merge_operator::encode_bitmap_add(edge_id))?;
     Ok(())
 }
 
@@ -3723,6 +3723,232 @@ mod tests {
             .expect_err("malformed bitmap should fail")
             .to_string()
             .contains("Failed to decode RoaringTreemap"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_bitmap_inserts_cover_every_family_and_tenant_scope() {
+        const INSERTS_PER_TENANT: u64 = 16;
+
+        let db = crate::HelixDB::open(crate::HelixDbSource::InMemory {
+            database: "search-concurrent-bitmap-families".to_string(),
+        })
+        .await
+        .expect("db opens");
+        let tenant_a =
+            crate::encoding::keys::tenant::TenantId::from_ulid_str("0000000000000000000000000A")
+                .expect("valid tenant");
+        let tenant_b =
+            crate::encoding::keys::tenant::TenantId::from_ulid_str("0000000000000000000000000B")
+                .expect("valid tenant");
+        let normal_property = scoped_secondary_index_property("User", "status");
+
+        for (scope, node_start, edge_start) in [
+            (DataScope::Tenant(tenant_a), 1_000_u64, 10_000_u64),
+            (DataScope::Tenant(tenant_b), 2_000_u64, 20_000_u64),
+        ] {
+            let mut transactions = Vec::new();
+            for offset in 0..INSERTS_PER_TENANT {
+                let node_id = node_start + offset;
+                let edge_id = edge_start + offset;
+                let txn = db
+                    .inner_db()
+                    .begin(IsolationLevel::SerializableSnapshot)
+                    .await
+                    .expect("transaction starts");
+
+                add_to_equality_index_scoped(&txn, "$label", "User", node_id, scope)
+                    .await
+                    .expect("node label insert succeeds");
+                add_to_equality_index_scoped(&txn, &normal_property, "active", node_id, scope)
+                    .await
+                    .expect("node equality insert succeeds");
+                add_to_edge_label_index_scoped(&txn, 31, node_id + 30_000, "FOLLOWS", scope)
+                    .await
+                    .expect("outgoing edge-label insert succeeds");
+                add_to_edge_label_index_scoped(&txn, node_id + 40_000, 32, "FOLLOWS", scope)
+                    .await
+                    .expect("incoming edge-label insert succeeds");
+                add_to_edge_equality_index_scoped(&txn, 41, 42, edge_id, "status", "active", scope)
+                    .await
+                    .expect("edge equality insert succeeds");
+                add_to_global_edge_label_index_scoped(&txn, "FOLLOWS", edge_id, scope)
+                    .await
+                    .expect("global edge-label insert succeeds");
+                add_to_edge_pair_index_scoped(&txn, 51, 52, edge_id, scope)
+                    .await
+                    .expect("edge-pair insert succeeds");
+                transactions.push(txn);
+            }
+
+            for result in
+                futures::future::join_all(transactions.into_iter().map(|txn| txn.commit())).await
+            {
+                result.expect("commutative bitmap transaction commits");
+            }
+        }
+
+        let read = db
+            .inner_db()
+            .begin(IsolationLevel::Snapshot)
+            .await
+            .expect("read transaction starts");
+        for (scope, node_start, edge_start) in [
+            (DataScope::Tenant(tenant_a), 1_000_u64, 10_000_u64),
+            (DataScope::Tenant(tenant_b), 2_000_u64, 20_000_u64),
+        ] {
+            let expected_nodes = (node_start..node_start + INSERTS_PER_TENANT).collect::<Vec<_>>();
+            let expected_edges = (edge_start..edge_start + INSERTS_PER_TENANT).collect::<Vec<_>>();
+
+            assert_eq!(
+                lookup_equality_index_scoped(&read, "$label", "User", scope)
+                    .await
+                    .expect("node-label lookup succeeds"),
+                expected_nodes,
+            );
+            assert_eq!(
+                lookup_equality_index_scoped(&read, &normal_property, "active", scope)
+                    .await
+                    .expect("node-equality lookup succeeds"),
+                expected_nodes,
+            );
+            assert_eq!(
+                lookup_out_neighbors_by_label_scoped(&read, 31, "FOLLOWS", scope)
+                    .await
+                    .expect("outgoing edge-label lookup succeeds")
+                    .iter()
+                    .collect::<Vec<_>>(),
+                expected_nodes
+                    .iter()
+                    .map(|node_id| node_id + 30_000)
+                    .collect::<Vec<_>>(),
+            );
+            assert_eq!(
+                lookup_in_neighbors_by_label_scoped(&read, 32, "FOLLOWS", scope)
+                    .await
+                    .expect("incoming edge-label lookup succeeds")
+                    .iter()
+                    .collect::<Vec<_>>(),
+                expected_nodes
+                    .iter()
+                    .map(|node_id| node_id + 40_000)
+                    .collect::<Vec<_>>(),
+            );
+            assert_eq!(
+                lookup_edges_out_by_equality_scoped(&read, 41, "status", "active", scope,)
+                    .await
+                    .expect("outgoing edge-equality lookup succeeds")
+                    .iter()
+                    .collect::<Vec<_>>(),
+                expected_edges,
+            );
+            assert_eq!(
+                lookup_edges_in_by_equality_scoped(&read, 42, "status", "active", scope)
+                    .await
+                    .expect("incoming edge-equality lookup succeeds")
+                    .iter()
+                    .collect::<Vec<_>>(),
+                expected_edges,
+            );
+            assert_eq!(
+                lookup_global_edge_equality_index_scoped(&read, "status", "active", scope,)
+                    .await
+                    .expect("global edge-equality lookup succeeds")
+                    .iter()
+                    .collect::<Vec<_>>(),
+                expected_edges,
+            );
+            assert_eq!(
+                lookup_global_edge_label_index_scoped(&read, "FOLLOWS", scope)
+                    .await
+                    .expect("global edge-label lookup succeeds")
+                    .iter()
+                    .collect::<Vec<_>>(),
+                expected_edges,
+            );
+            assert_eq!(
+                lookup_edge_pair_index_scoped(&read, 51, 52, scope)
+                    .await
+                    .expect("edge-pair lookup succeeds")
+                    .iter()
+                    .collect::<Vec<_>>(),
+                expected_edges,
+            );
+        }
+        assert!(
+            lookup_equality_index(&read, "$label", "User")
+                .await
+                .expect("legacy node-label lookup succeeds")
+                .is_empty(),
+            "tenant writes must not leak into the legacy scope",
+        );
+    }
+
+    #[tokio::test]
+    async fn bitmap_insert_and_remove_races_conflict_in_both_commit_orders() {
+        let db = crate::HelixDB::open(crate::HelixDbSource::InMemory {
+            database: "search-bitmap-insert-remove-races".to_string(),
+        })
+        .await
+        .expect("db opens");
+
+        for (value, insert_commits_first) in [("insert-first", true), ("remove-first", false)] {
+            let seed = db
+                .inner_db()
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("seed transaction starts");
+            add_to_equality_index(&seed, "race", value, 1)
+                .await
+                .expect("seed insert succeeds");
+            seed.commit().await.expect("seed transaction commits");
+
+            let insert = db
+                .inner_db()
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("insert transaction starts");
+            let remove = db
+                .inner_db()
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("remove transaction starts");
+            add_to_equality_index(&insert, "race", value, 2)
+                .await
+                .expect("racing insert buffers");
+            remove_from_equality_index(&remove, "race", value, 1)
+                .await
+                .expect("racing removal buffers");
+
+            if insert_commits_first {
+                insert.commit().await.expect("insert commits first");
+                assert!(
+                    remove.commit().await.is_err(),
+                    "read-modify-write removal must conflict with a committed insert",
+                );
+            } else {
+                remove.commit().await.expect("removal commits first");
+                assert!(
+                    insert.commit().await.is_err(),
+                    "insert must conflict with a committed read-modify-write removal",
+                );
+            }
+        }
+
+        let read = db
+            .inner_db()
+            .begin(IsolationLevel::Snapshot)
+            .await
+            .expect("read transaction starts");
+        assert_eq!(
+            lookup_equality_index(&read, "race", "insert-first")
+                .await
+                .expect("insert-first lookup succeeds"),
+            vec![1, 2],
+        );
+        assert!(lookup_equality_index(&read, "race", "remove-first")
+            .await
+            .expect("remove-first lookup succeeds")
+            .is_empty(),);
     }
 
     #[tokio::test]

--- a/tools/hyperscale-migration-parity/Cargo.lock
+++ b/tools/hyperscale-migration-parity/Cargo.lock
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
 dependencies = [
  "chrono",
  "log",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
 dependencies = [
  "async-trait",
  "bytes",

--- a/tools/hyperscale-migration-parity/Cargo.lock
+++ b/tools/hyperscale-migration-parity/Cargo.lock
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
 dependencies = [
  "chrono",
  "log",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ae2a0f0d22719750da67a4cea0cda6b6da7f9e#41ae2a0f0d22719750da67a4cea0cda6b6da7f9e"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
 dependencies = [
  "async-trait",
  "bytes",

--- a/tools/hyperscale-migration-parity/Cargo.lock
+++ b/tools/hyperscale-migration-parity/Cargo.lock
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=aa8a76c6e933d811fd811c296e86b067665e97f5#aa8a76c6e933d811fd811c296e86b067665e97f5"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=aa8a76c6e933d811fd811c296e86b067665e97f5#aa8a76c6e933d811fd811c296e86b067665e97f5"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
 dependencies = [
  "chrono",
  "log",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=aa8a76c6e933d811fd811c296e86b067665e97f5#aa8a76c6e933d811fd811c296e86b067665e97f5"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=c6cfdb095b32d3e946bc06fb9604dbd4629911b1#c6cfdb095b32d3e946bc06fb9604dbd4629911b1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/tools/hyperscale-migration-parity/Cargo.lock
+++ b/tools/hyperscale-migration-parity/Cargo.lock
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "slatedb"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
 dependencies = [
  "chrono",
  "log",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=624b53f6e2bb0fba904373636e8f668bdce7ee09#624b53f6e2bb0fba904373636e8f668bdce7ee09"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
 dependencies = [
  "async-trait",
  "bytes",

--- a/tools/hyperscale-migration-parity/Cargo.toml
+++ b/tools/hyperscale-migration-parity/Cargo.toml
@@ -16,8 +16,8 @@ futures = "0.3"
 baseline-helix-dsl = { package = "helix-db", version = "=2.0.5" }
 helix = { path = "../../../helix-hyperscale-migration-parity-source/enterprise/helix" }
 hyperscale-slatedb = { package = "slatedb", path = "../../../helix-hyperscale-migration-parity-source/enterprise/slatedb/slatedb" }
-target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "624b53f6e2bb0fba904373636e8f668bdce7ee09" }
-target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "624b53f6e2bb0fba904373636e8f668bdce7ee09" }
+target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e" }
+target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e" }
 object_store = { version = "0.12", features = ["aws"] }
 object_store_014 = { package = "object_store", version = "0.14", features = ["aws"] }
 roaring = { version = "0.11", features = ["serde"] }

--- a/tools/hyperscale-migration-parity/Cargo.toml
+++ b/tools/hyperscale-migration-parity/Cargo.toml
@@ -16,8 +16,8 @@ futures = "0.3"
 baseline-helix-dsl = { package = "helix-db", version = "=2.0.5" }
 helix = { path = "../../../helix-hyperscale-migration-parity-source/enterprise/helix" }
 hyperscale-slatedb = { package = "slatedb", path = "../../../helix-hyperscale-migration-parity-source/enterprise/slatedb/slatedb" }
-target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "aa8a76c6e933d811fd811c296e86b067665e97f5" }
-target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "aa8a76c6e933d811fd811c296e86b067665e97f5" }
+target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "c6cfdb095b32d3e946bc06fb9604dbd4629911b1" }
+target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "c6cfdb095b32d3e946bc06fb9604dbd4629911b1" }
 object_store = { version = "0.12", features = ["aws"] }
 object_store_014 = { package = "object_store", version = "0.14", features = ["aws"] }
 roaring = { version = "0.11", features = ["serde"] }

--- a/tools/hyperscale-migration-parity/Cargo.toml
+++ b/tools/hyperscale-migration-parity/Cargo.toml
@@ -16,8 +16,8 @@ futures = "0.3"
 baseline-helix-dsl = { package = "helix-db", version = "=2.0.5" }
 helix = { path = "../../../helix-hyperscale-migration-parity-source/enterprise/helix" }
 hyperscale-slatedb = { package = "slatedb", path = "../../../helix-hyperscale-migration-parity-source/enterprise/slatedb/slatedb" }
-target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "41ae2a0f0d22719750da67a4cea0cda6b6da7f9e" }
-target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "41ae2a0f0d22719750da67a4cea0cda6b6da7f9e" }
+target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "624b53f6e2bb0fba904373636e8f668bdce7ee09" }
+target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "624b53f6e2bb0fba904373636e8f668bdce7ee09" }
 object_store = { version = "0.12", features = ["aws"] }
 object_store_014 = { package = "object_store", version = "0.14", features = ["aws"] }
 roaring = { version = "0.11", features = ["serde"] }

--- a/tools/hyperscale-migration-parity/Cargo.toml
+++ b/tools/hyperscale-migration-parity/Cargo.toml
@@ -16,8 +16,8 @@ futures = "0.3"
 baseline-helix-dsl = { package = "helix-db", version = "=2.0.5" }
 helix = { path = "../../../helix-hyperscale-migration-parity-source/enterprise/helix" }
 hyperscale-slatedb = { package = "slatedb", path = "../../../helix-hyperscale-migration-parity-source/enterprise/slatedb/slatedb" }
-target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "c6cfdb095b32d3e946bc06fb9604dbd4629911b1" }
-target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "c6cfdb095b32d3e946bc06fb9604dbd4629911b1" }
+target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "41ae2a0f0d22719750da67a4cea0cda6b6da7f9e" }
+target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "41ae2a0f0d22719750da67a4cea0cda6b6da7f9e" }
 object_store = { version = "0.12", features = ["aws"] }
 object_store_014 = { package = "object_store", version = "0.14", features = ["aws"] }
 roaring = { version = "0.11", features = ["serde"] }


### PR DESCRIPTION
## Summary

- Use SlateDB `merge_commutative` for add-only Roaring bitmap updates.
- Apply it to existing bitmap-backed node and edge indexes and to lifecycle-managed V4 nonunique equality indexes.
- Keep every removal-bearing update on the exclusive read-modify-write path.
- Pin SlateDB to merged commit `dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e` from HelixDB/slatedb#6.

## Why

Concurrent inserts commonly add different entity IDs to the same bitmap key. Bitmap union is commutative, but ordinary transactional merges classify these writes as exclusive, causing avoidable conflicts and retries.

## Implementation

- Node label and equality additions use commutative merges.
- Edge label-neighbor, equality, global-label, global-equality, and edge-pair additions use commutative merges.
- Pure V4 secondary-equality additions are grouped per bitmap key and use one commutative merge operand.
- V4 updates containing a removal still read the current bitmap and exclusively replace or delete it.
- Tests prove add operands commute, concurrent add/add transactions retain every ID, tenant scopes remain isolated, and insert/remove races still conflict in either commit order.

## Storage compatibility

This changes transaction conflict classification only. Bitmap operands, stored bitmap values, and index key formats are unchanged. No migration is required.

## Validation

- `cargo test -p db bitmap --lib --locked`
- `cargo test --workspace --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `git diff --check origin/main...HEAD`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR classifies add-only bitmap index updates as commutative SlateDB merges while retaining exclusive read-modify-write behavior for updates containing removals.
- Applies commutative bitmap additions across legacy node and edge index families.
- Applies grouped commutative additions to lifecycle-managed V4 secondary equality indexes.
- Pins SlateDB to the revision providing the new transaction API and adds concurrency, tenant-isolation, commutativity, and insert/remove conflict tests.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/db/src/search/mod.rs | Converts add-only node and edge bitmap index writes to commutative merges and adds broad concurrency, scope-isolation, and removal-conflict coverage. |
| crates/db/src/index_lifecycle/secondary.rs | Uses commutative merges only for grouped pure additions while preserving exclusive replacement or deletion for removal-bearing V4 updates. |
| crates/db/src/merge_operator.rs | Adds a direct test showing bitmap-add operands produce the same union regardless of application order. |
| crates/db/Cargo.toml | Pins SlateDB to the revision that exposes commutative transactional merges. |
| tools/hyperscale-migration-parity/Cargo.toml | Keeps the migration-parity target SlateDB dependencies aligned with the database crate's new revision. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    U[Bitmap index update] --> R{Contains a removal?}
    R -- No --> G[Group additions by bitmap key]
    G --> C[merge_commutative bitmap-union operand]
    R -- Yes --> X[Read current bitmap exclusively]
    X --> A[Apply additions and removals]
    A --> E{Bitmap empty?}
    E -- Yes --> D[Delete key]
    E -- No --> P[Replace bitmap with put]
    C --> T[Commit transaction]
    D --> T
    P --> T
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(db): pin merged commutative SlateD..."](https://github.com/helixdb/helix-db/commit/af8a46cc8b81a36a4a4bc56b9bfdf40f1eae7779) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52260656)</sub>

<!-- /greptile_comment -->