### PR TITLE
docs: refresh CLI and contributor guidance

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,7 +48,7 @@ We welcome contributions from the community! This guide will help you get starte
 ## Prerequisites and Development Setup
 
 ### Required Tools
-- **Rust**: 1.75.0 or later (install via [rustup](https://rustup.rs/))
+- **Rust**: 1.97.1 (installed automatically from `rust-toolchain.toml` by [rustup](https://rustup.rs/))
 - **Cargo**: Comes with Rust
 - **Git**: For version control
 
@@ -76,8 +76,10 @@ We welcome contributions from the community! This guide will help you get starte
 
 ### Building Specific Components
 
-The Cargo workspace members are `helix-cli`, `metrics`, and `sdks/rust`:
+The Cargo workspace contains the server, database engine, planner, AST, graph algorithms, CLI, metrics, Rust SDK, UniFFI bindings, and database testkit. Common package targets include:
 - **CLI**: `cargo build -p helix-cli`
+- **Server**: `cargo build -p server`
+- **Database engine**: `cargo build -p db`
 - **Metrics**: `cargo build -p helix-metrics`
 - **Rust DSL SDK**: `cargo build -p helix-db` (the SDK crate in `sdks/rust`; docs at [docs.rs/helix-db](https://docs.rs/helix-db))
 
@@ -86,7 +88,7 @@ The TypeScript SDK (`sdks/typescript`) and Go SDK (`sdks/go`) build with their o
 ### Running HelixDB Locally
 1. Install the CLI (development version):
    ```bash
-   cargo install --path helix-cli
+   cargo install --path crates/cli
    ```
 
 2. Initialize a test project:
@@ -111,36 +113,36 @@ This repository contains the HelixDB engine, CLI, client SDKs, and metrics. For 
 
 ### Core Components
 
-#### `/helix-cli/` - Command-Line Interface
+#### `/crates/cli/` - Command-Line Interface
 User-facing CLI for managing HelixDB instances and deployments.
 
 **Directory Structure:**
 ```
-helix-cli/
+crates/cli/
 ├── src/
 │   ├── commands/           # CLI command implementations (one module per subcommand)
-│   │   ├── logs/          # Local + Enterprise Cloud log viewing
-│   │   ├── add.rs         # Add a local or Enterprise Cloud instance
-│   │   ├── auth.rs        # Enterprise Cloud auth (login/logout/create-key)
+│   │   ├── logs/          # Local + Helix Cloud log viewing
+│   │   ├── add.rs         # Add a local or Helix Cloud instance
+│   │   ├── auth.rs        # Helix Cloud auth (login/logout/create-key)
 │   │   ├── chef.rs        # Bootstrap a first Helix app for a coding agent
 │   │   ├── config.rs      # workspace/project/cluster config (hidden parent)
-│   │   ├── dashboard.rs   # Launch the Helix Dashboard
 │   │   ├── delete.rs      # Delete an instance and its local state
-│   │   ├── enterprise_deploy.rs # Enterprise Cloud deploy helpers
+│   │   ├── enterprise_deploy.rs # Helix Cloud deploy helpers
 │   │   ├── feedback.rs    # Send feedback to the Helix team
-│   │   ├── init.rs        # Initialize a v2 project
+│   │   ├── init.rs        # Initialize a project
 │   │   ├── metrics.rs     # Metrics configuration
 │   │   ├── prune.rs       # Prune local containers/workspaces
-│   │   ├── push.rs        # Deploy an Enterprise Cloud instance
+│   │   ├── push.rs        # Deploy a Helix Cloud instance
 │   │   ├── query.rs       # Send a query to POST /v2/query
 │   │   ├── restart.rs     # Restart a background local instance
+│   │   ├── skills.rs      # Install and manage Helix agent skills
 │   │   ├── start.rs       # Start a local instance (alias: run)
 │   │   ├── status.rs      # Instance status
 │   │   ├── stop.rs        # Stop a background local instance
-│   │   ├── sync.rs        # Sync Enterprise Cloud metadata into helix.toml
+│   │   ├── sync.rs        # Sync Helix Cloud metadata into helix.toml
 │   │   └── update.rs      # Self-update the CLI
 │   ├── config.rs          # helix.toml + ~/.helix config management
-│   ├── enterprise_cloud.rs # Enterprise Cloud REST types and fetchers
+│   ├── enterprise_cloud.rs # Helix Cloud REST types and fetchers
 │   ├── errors.rs          # Error handling
 │   ├── lib.rs             # Library interface + subcommand enums
 │   ├── local_runtime.rs   # Docker/Podman container lifecycle
@@ -158,41 +160,41 @@ helix-cli/
 ```
 
 **Available Commands:**
-- `helix init` - Initialize a v2 Helix project
+- `helix init` - Initialize a Helix project
 - `helix chef` (alias `cook`) - Bootstrap a first Helix app for a coding agent
-- `helix add` - Add a local or Enterprise Cloud instance to a project
+- `helix add` - Add a local or Helix Cloud instance to a project
 - `helix start` (alias `run`) - Start a local instance in the background
 - `helix stop` - Stop a background local instance
 - `helix restart` - Restart a background local instance
-- `helix status` - Show local and Enterprise Cloud instance status
-- `helix logs` - View logs for a local or Enterprise Cloud instance
+- `helix status` - Show local and Helix Cloud instance status
+- `helix logs` - View logs for a local or Helix Cloud instance
 - `helix query` - Send a query to `POST /v2/query`
-- `helix push` - Deploy an Enterprise Cloud instance
-- `helix auth` - Enterprise Cloud authentication (login/logout/create-key)
-- `helix workspace` - Manage the active Enterprise Cloud workspace
-- `helix project` - Manage the linked Enterprise Cloud project
-- `helix cluster` - List and inspect Enterprise Cloud clusters
-- `helix sync` - Sync Enterprise Cloud metadata into `helix.toml`
+- `helix push` - Deploy a Helix Cloud instance
+- `helix auth` - Helix Cloud authentication (login/logout/create-key)
+- `helix workspace` - Manage the active Helix Cloud workspace
+- `helix project` - Manage the linked Helix Cloud project
+- `helix cluster` - List and inspect Helix Cloud clusters
+- `helix sync` - Sync Helix Cloud metadata into `helix.toml`
 - `helix prune` - Prune local containers/workspaces
 - `helix delete` - Delete an instance from `helix.toml` and local state
+- `helix skills` - Install, update, and list Helix agent skills
 - `helix metrics` - Configure metrics collection (full/basic/off/status)
-- `helix dashboard` - Launch the Helix Dashboard (start/stop/status)
 - `helix update` - Update the CLI to the latest version
 - `helix feedback` - Send feedback to the Helix team
 
 **Deployment Targets:**
 - Local Docker/Podman containers (`helix start`) — image `ghcr.io/helixdb/helixdb:v0.0.3`
-- Helix Cloud (managed Enterprise hosting) via `helix push`
+- Helix Cloud via `helix push`
 
 **Build & Deploy Flow:**
 
 The v3 CLI is a runtime orchestrator — there is no `helix compile`/`helix check` step and no `.hx` query files.
 
 1. Scaffold a project with `helix init` (writes `helix.toml` and a `.helix/` workspace).
-2. Start a local instance with `helix start` — a Docker/Podman container running `ghcr.io/helixdb/helixdb:v0.0.3` (in-memory by default, on-disk with `--disk`).
+2. Start a local instance with `helix start` — a Docker/Podman container running `ghcr.io/helixdb/helixdb:v0.0.3` (in-memory by default, on-disk with `--disk`). The CLI waits for `GET /healthz` before returning.
 3. Author queries with the Rust, TypeScript, Go, or Python DSL; they serialize to query JSON.
 4. Send queries to a running instance via `POST /v2/query` (`helix query`); validation happens server-side.
-5. For production, deploy an Enterprise Cloud instance with `helix push`, managing auth/metadata via `helix auth`, `helix sync`, and the `workspace`/`project`/`cluster` commands.
+5. For production, deploy a Helix Cloud instance with `helix push`, managing auth/metadata via `helix auth`, `helix sync`, and the `workspace`/`project`/`cluster` commands.
 
 ### Supporting Components
 
@@ -204,7 +206,7 @@ Client libraries that build HelixDB queries and send them to a running instance.
 - `python/` - Python client and DSL (`helix-db`, imported as `helixdb`)
 - `tests/` - Cross-SDK parity tests and metadata registration tests
 
-#### `/metrics/` - Metrics
+#### `/crates/metrics/` - Metrics
 The `helix-metrics` crate used by the CLI for telemetry collection.
 
 #### `/assets/` - Brand Assets
@@ -236,13 +238,13 @@ QUERY addUser(name: String, age: I64) =>
 1. **Definition**: Author queries with a Rust, TypeScript, Go, or Python DSL
 2. **Serialization**: The DSL produces a query JSON AST (`POST /v2/query` body)
 3. **Execution**: Send to a running instance with `helix query`; the gateway validates and runs it server-side
-4. **Storage**: LMDB handles persistence with ACID guarantees
+4. **Storage**: The database engine uses memory, local disk, or S3-compatible object storage according to the selected run mode.
 
 ## Development Guidelines
 
 ### Code Style
 - Prefer functional patterns (pattern matching, iterators, closures)
-- Document code inline - no separate docs needed
+- Add doc comments for public contracts and update user-facing docs when behavior changes
 - Minimize dependencies
 - Use asserts liberally in production code
 
@@ -262,7 +264,7 @@ Tests live alongside the code in each crate and SDK:
 #### Test Structure
 
 **CLI Tests** (`helix-cli`)
-- Inline `#[cfg(test)]` modules throughout `helix-cli/src/`
+- Inline `#[cfg(test)]` modules throughout `crates/cli/src/`
 - clap argument-parsing tests in `src/main.rs` (every command/flag combo)
 - Config (de)serialization and backward-compat defaults in `src/config.rs`
 - `chef` prompt rendering, agent-priority, and stream-json parsing in `src/commands/chef.rs`
@@ -298,9 +300,9 @@ Format and lint before opening a PR: `cargo fmt` and `./clippy_check.sh`.
 - Ensure tests pass locally before opening PR
 
 ### Performance
-- Currently 1000x faster than Neo4j for graph operations
-- On par with Qdrant for vector search
-- LMDB provides memory-mapped performance
+- Benchmark performance-sensitive changes against a representative workload.
+- Include the dataset, hardware, command, and before/after results in the pull request.
+- Avoid unsupported comparative performance claims in code or documentation.
 
 ## Communication Channels
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@
 
 <hr>
 
-Cloud-launch correctness, coverage, cadence, and runtime contracts are
-documented in [the cloud-launch test guide](docs/CLOUD_LAUNCH_TESTING.md).
-
 HelixDB is a database that makes it easy to build all the components needed for AI applications in a single platform.
 
 You don't need a separate application DB, relational DB, vector DB, graph DB, or application layers to manage the multiple storage locations. HelixDB gives your agents federated access to company data, for memory, company brains, and applications.
@@ -65,7 +62,7 @@ If you'd rather wire things up yourself:
    mkdir my-helix-app && cd my-helix-app
    helix init
   ```
-2. **Start a local instance.** Runs a background container on port `6969` and waits until it accepts queries.
+2. **Start a local instance.** Runs `ghcr.io/helixdb/helixdb:v0.0.3` in a background container on port `6969` and waits for `GET /healthz` to report ready.
   ```bash
    helix start dev
   ```
@@ -253,6 +250,7 @@ helix auth login                                  # authenticate
 helix workspace switch <workspace>                # select workspace + project
 helix project switch <project>
 helix init cloud --cluster-id <cluster-id>        # or: helix add cloud --name production --cluster-id <id>
+helix push production                             # deploy the query project
 helix sync production                             # pull gateway URL + auth contract into helix.toml
 helix query production --file examples/request.json
 ```

--- a/crates/cli/CLAUDE.md
+++ b/crates/cli/CLAUDE.md
@@ -146,4 +146,4 @@ Snapshot safety excludes `.git`, `.helix`, `node_modules`, `.next`, `target`, bu
 
 Chef tests cover: prompt rendering (intent substitution, CRM fallback, Next.js stack keywords, summary sections, browser-open commands, dev-server persistence), agent-priority order, `build_agent_argv` per (agent, permission) combo, install-arg construction, tool-use formatting, and stream-json event parsing. The actual agent spawn / browser open are not unit-tested (require external processes) — verify those manually with `cargo run -p helix-cli -- chef`.
 
-Doc-tests in `output.rs` are `ignore`d (illustrative only). The `helix-cli/CHEF_COMMAND_PLAN.md` file is the original design doc and is now largely superseded by the implementation described above.
+Doc-tests in `output.rs` run as part of `cargo test -p helix-cli --doc`.

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -1,24 +1,25 @@
 # Helix CLI
 
-Command-line interface for managing v2 Helix projects, local development instances, and Enterprise Cloud deployments.
+Command-line interface for managing Helix projects, local development instances, and Helix Cloud deployments. The v3 CLI is a runtime orchestrator: queries are validated by a running instance, with no local compile/check step.
 
 ## Commands
 
-- `init`: initialize a v2 project with `helix.toml` and a query example.
+- `init`: initialize a project with `helix.toml` and a query example.
 - `chef`: bootstrap a first Helix app with skills, docs MCP, local runtime, starter queries, seed data, and a launched coding agent.
-- `add`: add a local v2 or Enterprise Cloud instance to an existing project.
-- `run`: run a local v2 instance in the background by default, attached with `--foreground`, with persistent local storage using `--disk`, or against a user-managed S3/S3-compatible prefix using `--storage-uri`.
-- `stop` / `restart` / `status`: manage local v2 instances and inspect Enterprise Cloud config.
-- `logs`: view local container logs or query Enterprise Cloud historical logs.
+- `add`: add a local or Helix Cloud instance to an existing project.
+- `start` (alias `run`): run `ghcr.io/helixdb/helixdb:v0.0.3` in the background by default, attached with `--foreground`, with persistent local storage using `--disk`, or against a user-managed S3/S3-compatible prefix using `--storage-uri`.
+- `stop` / `restart` / `status`: manage local instances and inspect Helix Cloud config.
+- `logs`: view local container logs or query Helix Cloud historical logs.
 - `query`: send a query request JSON file to `POST /v2/query`.
-- `push`: compile and deploy an Enterprise query project to an Enterprise Cloud cluster.
-- `auth`: login, logout, or create an Enterprise Cloud API key.
-- `workspace`: manage active Enterprise Cloud workspace selection.
-- `project`: manage linked Enterprise Cloud project selection.
-- `cluster`: list and inspect Enterprise Cloud clusters.
-- `sync`: reconcile Enterprise query project source and sync Enterprise Cloud metadata into `helix.toml`.
+- `push`: deploy a query project to a Helix Cloud cluster.
+- `auth`: login, logout, or create a Helix Cloud API key.
+- `workspace`: manage active Helix Cloud workspace selection.
+- `project`: manage linked Helix Cloud project selection.
+- `cluster`: list and inspect Helix Cloud clusters.
+- `sync`: reconcile query project source and sync Helix Cloud metadata into `helix.toml`.
 - `prune`: clean Helix-owned local containers, disk-mode volumes, and workspaces.
 - `delete`: remove an instance from `helix.toml` and clean local runtime state.
+- `skills`: install, update, and list Helix agent skills.
 - `metrics`: manage telemetry level.
 - `update`: update the CLI.
 - `feedback`: send feedback to the Helix team.

--- a/docs/cli/command-reference.mdx
+++ b/docs/cli/command-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CLI Command Reference"
-description: "Complete reference for all Helix CLI v2 commands and options"
+description: "Complete reference for all Helix CLI v3 commands and options"
 pageType: "Reference"
 ---
 
@@ -8,7 +8,7 @@ pageType: "Reference"
 
 > For the complete documentation index optimized for AI agents, see [llms.txt](/llms.txt).
 
-This page lists every command in Helix CLI v2. Click any command for full flag and example details.
+This page lists every command in Helix CLI v3. Click any command for full flag and example details.
 
 ## Global Options
 
@@ -25,7 +25,7 @@ helix -v, --verbose     Show detailed output with timing information
 
 | Command | Subcommands | Flags | Scope | Description |
 |:--------|:------------|:------|:------|:------------|
-| [`helix init`](/cli/command-reference/init) | `local`, `enterprise` | `-p`/`--path` | Local, Helix Cloud | Initialize a v2 Helix project |
+| [`helix init`](/cli/command-reference/init) | `local`, `enterprise` | `-p`/`--path` | Local, Helix Cloud | Initialize a Helix project |
 | [`helix chef`](/cli/command-reference/chef) | | | Local | Bootstrap a first Helix app with skills, docs MCP, starter queries, seed data, and a launched coding agent |
 | [`helix add`](/cli/command-reference/add) | `local`, `enterprise` | | Local, Helix Cloud | Add an instance to an existing project |
 | [`helix start`](/cli/command-reference/start) | | `--foreground`, `--port`, `--disk`, `--persist` | Local | Start a local instance (background by default) |

--- a/docs/cli/command-reference/add.mdx
+++ b/docs/cli/command-reference/add.mdx
@@ -22,7 +22,7 @@ If you omit the subcommand in a TTY, the CLI prompts you to choose between `loca
 
 | Sub-command | Description |
 |-------------|-------------|
-| `local` | Add a local v2 development instance. |
+| `local` | Add a local development instance. |
 | `enterprise` | Add a Helix Cloud instance linked to a cluster. |
 
 ## Top-level flags

--- a/docs/cli/command-reference/init.mdx
+++ b/docs/cli/command-reference/init.mdx
@@ -8,7 +8,7 @@ pageType: "Reference"
 
 > For the complete documentation index optimized for AI agents, see [llms.txt](/llms.txt).
 
-Initialize a v2 Helix project. Creates `helix.toml`, a `.helix/` workspace directory, a `.gitignore` entry, and — for local projects — an `AGENTS.md` for coding agents and an `examples/request.json` scaffold.
+Initialize a Helix project. Creates `helix.toml`, a `.helix/` workspace directory, a `.gitignore` entry, and — for local projects — an `AGENTS.md` for coding agents and an `examples/request.json` scaffold.
 
 ## Usage
 
@@ -22,7 +22,7 @@ If you omit the subcommand in a TTY, the CLI prompts you to choose between `loca
 
 | Sub-command | Description |
 |-------------|-------------|
-| `local` | Initialize a local v2 development project. |
+| `local` | Initialize a local development project. |
 | `enterprise` | Initialize a Helix Cloud project linked to a cluster. |
 
 ## Top-level flags

--- a/docs/cli/command-reference/start.mdx
+++ b/docs/cli/command-reference/start.mdx
@@ -8,7 +8,7 @@ pageType: "Reference"
 
 > For the complete documentation index optimized for AI agents, see [llms.txt](/llms.txt).
 
-Start a local v2 instance. By default the container starts in the background and the CLI waits until the local gateway accepts `POST /v2/query` requests before returning.
+Start a local instance. By default the container starts in the background and the CLI waits for `GET /healthz` to report ready before returning.
 
 <Note>
 `helix run` is a backwards-compatible alias for `helix start`.
@@ -41,7 +41,7 @@ helix start [INSTANCE] [OPTIONS]
 - Names the container `helix-<project>-<instance>` and publishes the configured port to container port `8080`.
 - Uses Docker or Podman based on `[project] container_runtime` in `helix.toml`.
 - Default storage is in-memory. Passing `--disk` starts a MinIO sidecar, creates the `helix-db` bucket, and runs `helixdb` with S3-compatible storage environment variables.
-- Background mode (`-d`, `--restart unless-stopped`) waits up to ~30 seconds for `POST /v2/query` readiness and prints the URL and container name when ready.
+- Background mode (`-d`, `--restart unless-stopped`) waits up to ~30 seconds for `GET /healthz` readiness and prints the URL and container name when ready.
 - Foreground mode (`--rm`) streams the container's stdout/stderr until Ctrl-C, then removes the container.
 
 <Warning>

--- a/docs/cli/getting-started.mdx
+++ b/docs/cli/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Getting started with HelixDB CLI"
-description: "Install the Helix CLI v2, bootstrap a first app, run a local instance, and send your first dynamic query"
+description: "Install the Helix CLI v3, bootstrap a first app, run a local instance, and send your first dynamic query"
 icon: "rocket"
 pageType: "Tutorial"
 ---
@@ -67,7 +67,7 @@ In a TTY, `helix init` prompts you to pick `local` or `enterprise`. Pass the sub
 helix start dev
 ```
 
-`helix start` pulls `ghcr.io/helixdb/helixdb:v0.0.3`, starts a background container named `helix-<project>-dev`, publishes port `6969`, and waits until the local server accepts `POST /v2/query` before returning.
+`helix start` pulls `ghcr.io/helixdb/helixdb:v0.0.3`, starts a background container named `helix-<project>-dev`, publishes port `6969`, and waits for `GET /healthz` to report ready before returning.
 
 To stream logs in the foreground instead, use `helix start dev --foreground` and stop the container with Ctrl-C.
 

--- a/docs/cli/troubleshooting.mdx
+++ b/docs/cli/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Troubleshooting"
-description: "Solutions to common issues and error messages in Helix CLI v2"
+description: "Solutions to common issues and error messages in Helix CLI v3"
 sidebarTitle: "Troubleshooting"
 icon: "wrench"
 mode: "wide"
@@ -11,7 +11,7 @@ pageType: "Troubleshooting"
 
 > For the complete documentation index optimized for AI agents, see [llms.txt](/llms.txt).
 
-This guide helps you resolve common issues with the Helix CLI v2.
+This guide helps you resolve common issues with the Helix CLI v3.
 
 ## Installation issues
 
@@ -51,7 +51,7 @@ export HELIX_NO_UPDATE_CHECK=1   # also accepts HELIX_DISABLE_UPDATE_CHECK
 
 ### `helix compile` / `helix check`
 
-These commands do **not** exist in HelixDB v2. There is no client-side compile or validation step — queries are validated **server-side** when you send them to a running instance. Author a JSON dynamic query and run it:
+These commands do **not** exist in Helix CLI v3. There is no client-side compile or validation step — queries are validated **server-side** when you send them to a running instance. Author a JSON dynamic query and run it:
 
 ```bash
 helix query dev --file examples/request.json
@@ -61,7 +61,7 @@ See [`helix query`](/cli/command-reference/query) for the request shape.
 
 ### `helix deploy`
 
-Use [`helix push <instance>`](/cli/command-reference/push) to deploy an Enterprise Cloud instance.
+Use [`helix push <instance>`](/cli/command-reference/push) to deploy a Helix Cloud instance.
 
 ### `--path` reported as an unexpected argument
 
@@ -159,7 +159,7 @@ local Helix did not become ready in time
 hint: check logs with 'helix logs' or verify port 6969 is reachable
 ```
 
-The `helixdb` container started but did not accept `POST /v2/query` within ~30 seconds. Tail the container with `helix logs <instance> --follow` to investigate.
+The `helixdb` container started but `GET /healthz` did not report ready within ~30 seconds. Tail the container with `helix logs <instance> --follow` to investigate.
 
 ## Authentication issues
 

--- a/docs/cli/workflows/local.mdx
+++ b/docs/cli/workflows/local.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Local Development"
-description: "Run a local v2 instance and iterate on dynamic JSON queries"
+description: "Run a local instance and iterate on dynamic JSON queries"
 icon: "computer"
 pageType: "Guide"
 ---
@@ -42,7 +42,7 @@ Use the manual flow below when you want to scaffold and run each step yourself.
     helix start dev
     ```
 
-    Starts a background container named `helix-my-helix-app-dev` on port `6969`. The CLI waits until the gateway accepts `POST /v2/query` before returning.
+    Starts a background container named `helix-my-helix-app-dev` on port `6969`. The CLI waits for `GET /healthz` to report ready before returning.
 
     For attached log streaming use `helix start dev --foreground` and stop with Ctrl-C.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4653,7 +4653,7 @@ In a TTY, `helix init` prompts you to pick `local` or `enterprise`. Pass the sub
 helix start dev
 ```
 
-`helix start` pulls `ghcr.io/helixdb/helixdb:v0.0.3`, starts a background container named `helix-<project>-dev`, publishes port `6969`, and waits until the local server accepts `POST /v2/query` before returning.
+`helix start` pulls `ghcr.io/helixdb/helixdb:v0.0.3`, starts a background container named `helix-<project>-dev`, publishes port `6969`, and waits for `GET /healthz` to report ready before returning.
 
 To stream logs in the foreground instead, use `helix start dev --foreground` and stop the container with Ctrl-C.
 
@@ -4785,7 +4785,7 @@ Use the manual flow below when you want to scaffold and run each step yourself.
     helix start dev
     ```
 
-    Starts a background container named `helix-my-helix-app-dev` on port `6969`. The CLI waits until the gateway accepts `POST /v2/query` before returning.
+    Starts a background container named `helix-my-helix-app-dev` on port `6969`. The CLI waits for `GET /healthz` to report ready before returning.
 
     For attached log streaming use `helix start dev --foreground` and stop with Ctrl-C.
 
@@ -5144,7 +5144,7 @@ Page type: Troubleshooting
 
 <div className="flex flex-wrap gap-2"><Badge color="orange" size="sm">Troubleshooting</Badge></div>
 
-This guide helps you resolve common issues with the Helix CLI v2.
+This guide helps you resolve common issues with the Helix CLI v3.
 
 ## Installation issues
 
@@ -5184,7 +5184,7 @@ export HELIX_NO_UPDATE_CHECK=1   # also accepts HELIX_DISABLE_UPDATE_CHECK
 
 ### `helix compile` / `helix check`
 
-These commands do **not** exist in HelixDB v2. There is no client-side compile or validation step — queries are validated **server-side** when you send them to a running instance. Author a JSON dynamic query and run it:
+These commands do **not** exist in Helix CLI v3. There is no client-side compile or validation step — queries are validated **server-side** when you send them to a running instance. Author a JSON dynamic query and run it:
 
 ```bash
 helix query dev --file examples/request.json
@@ -5194,7 +5194,7 @@ See [`helix query`](/cli/command-reference/query) for the request shape.
 
 ### `helix deploy`
 
-Use [`helix push <instance>`](/cli/command-reference/push) to deploy an Enterprise Cloud instance.
+Use [`helix push <instance>`](/cli/command-reference/push) to deploy a Helix Cloud instance.
 
 ### `--path` reported as an unexpected argument
 
@@ -5292,7 +5292,7 @@ local Helix did not become ready in time
 hint: check logs with 'helix logs' or verify port 6969 is reachable
 ```
 
-The `helixdb` container started but did not accept `POST /v2/query` within ~30 seconds. Tail the container with `helix logs <instance> --follow` to investigate.
+The `helixdb` container started but `GET /healthz` did not report ready within ~30 seconds. Tail the container with `helix logs <instance> --follow` to investigate.
 
 ## Authentication issues
 
@@ -5409,7 +5409,7 @@ Page type: Reference
 
 <div className="flex flex-wrap gap-2"><Badge color="gray" size="sm">Reference</Badge></div>
 
-This page lists every command in Helix CLI v2. Click any command for full flag and example details.
+This page lists every command in Helix CLI v3. Click any command for full flag and example details.
 
 ## Global Options
 
@@ -5426,7 +5426,7 @@ helix -v, --verbose     Show detailed output with timing information
 
 | Command | Subcommands | Flags | Scope | Description |
 |:--------|:------------|:------|:------|:------------|
-| [`helix init`](/cli/command-reference/init) | `local`, `enterprise` | `-p`/`--path` | Local, Helix Cloud | Initialize a v2 Helix project |
+| [`helix init`](/cli/command-reference/init) | `local`, `enterprise` | `-p`/`--path` | Local, Helix Cloud | Initialize a Helix project |
 | [`helix chef`](/cli/command-reference/chef) | | | Local | Bootstrap a first Helix app with skills, docs MCP, starter queries, seed data, and a launched coding agent |
 | [`helix add`](/cli/command-reference/add) | `local`, `enterprise` | | Local, Helix Cloud | Add an instance to an existing project |
 | [`helix start`](/cli/command-reference/start) | | `--foreground`, `--port`, `--disk`, `--persist` | Local | Start a local instance (background by default) |
@@ -5487,7 +5487,7 @@ If you omit the subcommand in a TTY, the CLI prompts you to choose between `loca
 
 | Sub-command | Description |
 |-------------|-------------|
-| `local` | Add a local v2 development instance. |
+| `local` | Add a local development instance. |
 | `enterprise` | Add a Helix Cloud instance linked to a cluster. |
 
 ## Top-level flags
@@ -5802,7 +5802,7 @@ Page type: Reference
 
 <div className="flex flex-wrap gap-2"><Badge color="gray" size="sm">Reference</Badge></div>
 
-Initialize a v2 Helix project. Creates `helix.toml`, a `.helix/` workspace directory, a `.gitignore` entry, and — for local projects — an `AGENTS.md` for coding agents and an `examples/request.json` scaffold.
+Initialize a Helix project. Creates `helix.toml`, a `.helix/` workspace directory, a `.gitignore` entry, and — for local projects — an `AGENTS.md` for coding agents and an `examples/request.json` scaffold.
 
 ## Usage
 
@@ -5816,7 +5816,7 @@ If you omit the subcommand in a TTY, the CLI prompts you to choose between `loca
 
 | Sub-command | Description |
 |-------------|-------------|
-| `local` | Initialize a local v2 development project. |
+| `local` | Initialize a local development project. |
 | `enterprise` | Initialize a Helix Cloud project linked to a cluster. |
 
 ## Top-level flags
@@ -6518,7 +6518,7 @@ Page type: Reference
 
 <div className="flex flex-wrap gap-2"><Badge color="gray" size="sm">Reference</Badge></div>
 
-Start a local v2 instance. By default the container starts in the background and the CLI waits until the local gateway accepts `POST /v2/query` requests before returning.
+Start a local instance. By default the container starts in the background and the CLI waits for `GET /healthz` to report ready before returning.
 
 `helix run` is a backwards-compatible alias for `helix start`.
 
@@ -6549,7 +6549,7 @@ helix start [INSTANCE] [OPTIONS]
 - Names the container `helix-<project>-<instance>` and publishes the configured port to container port `8080`.
 - Uses Docker or Podman based on `[project] container_runtime` in `helix.toml`.
 - Default storage is in-memory. Passing `--disk` starts a MinIO sidecar, creates the `helix-db` bucket, and runs `helixdb` with S3-compatible storage environment variables.
-- Background mode (`-d`, `--restart unless-stopped`) waits up to ~30 seconds for `POST /v2/query` readiness and prints the URL and container name when ready.
+- Background mode (`-d`, `--restart unless-stopped`) waits up to ~30 seconds for `GET /healthz` readiness and prints the URL and container name when ready.
 - Foreground mode (`--rm`) streams the container's stdout/stderr until Ctrl-C, then removes the container.
 
 The default `helixdb` storage mode is in-memory. Stopping or restarting an in-memory instance wipes all local data.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -57,14 +57,14 @@ Full walkthrough: https://docs.helix-db.com/cli/getting-started
 - [Troubleshoot HelixDB](https://docs.helix-db.com/database/helix-cloud/operate/troubleshooting): Diagnose query, index, vector, embedded, and local runtime failures — Page type: Troubleshooting
 
 ## Using the helix CLI
-- [Getting started with HelixDB CLI](https://docs.helix-db.com/cli/getting-started): Install the Helix CLI v2, bootstrap a first app, run a local instance, and send your first dynamic query — Page type: Tutorial
-- [Local Development](https://docs.helix-db.com/cli/workflows/local): Run a local v2 instance and iterate on dynamic JSON queries — Page type: Guide
+- [Getting started with HelixDB CLI](https://docs.helix-db.com/cli/getting-started): Install the Helix CLI v3, bootstrap a first app, run a local instance, and send your first dynamic query — Page type: Tutorial
+- [Local Development](https://docs.helix-db.com/cli/workflows/local): Run a local instance and iterate on dynamic JSON queries — Page type: Guide
 - [Helix Cloud](https://docs.helix-db.com/cli/workflows/helix_cloud): Authenticate, link a project, and query a Helix Cloud cluster from the CLI — Page type: Guide
 - [Configuration Guide](https://docs.helix-db.com/cli/configuration): Reference for helix.toml, ~/.helix/config, and credentials — Page type: Reference
-- [Troubleshooting](https://docs.helix-db.com/cli/troubleshooting): Solutions to common issues and error messages in Helix CLI v2 — Page type: Troubleshooting
+- [Troubleshooting](https://docs.helix-db.com/cli/troubleshooting): Solutions to common issues and error messages in Helix CLI v3 — Page type: Troubleshooting
 
 ## CLI Command Reference
-- [CLI Command Reference](https://docs.helix-db.com/cli/command-reference): Complete reference for all Helix CLI v2 commands and options — Page type: Reference
+- [CLI Command Reference](https://docs.helix-db.com/cli/command-reference): Complete reference for all Helix CLI v3 commands and options — Page type: Reference
 - [helix add](https://docs.helix-db.com/cli/command-reference/add) — Page type: Reference
 - [helix auth](https://docs.helix-db.com/cli/command-reference/auth) — Page type: Reference
 - [helix chef](https://docs.helix-db.com/cli/command-reference/chef) — Page type: Reference


### PR DESCRIPTION
## Summary

- align the root README and contributor guide with the current repository layout, Rust toolchain, CLI command surface, storage architecture, and local image
- update CLI docs from stale v2 terminology to the current v3 model
- document `/healthz` as the local startup readiness contract while retaining `/v2/query` as the query endpoint
- regenerate `docs/llms.txt` and `docs/llms-full.txt`

## Notable cleanup

- remove a broken root README link
- fix the CLI install path and source-tree paths
- remove a nonexistent `helix dashboard` command
- remove obsolete LMDB and unsupported comparative performance claims
- add the missing `helix skills` command

## Validation

- `cargo test -p helix-cli --doc`
- `cargo fmt --all -- --check`
- `npm run check` in `docs/`
- repository-wide stale image/runtime terminology scan
- verified root external documentation/install links return HTTP 200

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR refreshes contributor and CLI guidance for the current repository layout and v3 command model.
- Updates toolchain, package-path, storage, image, and command guidance.
- Documents `GET /healthz` as the local readiness contract while retaining `POST /v2/query` for queries.
- Adds the skills command, removes obsolete terminology and commands, and regenerates the LLM documentation artifacts.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CONTRIBUTORS.md | Refreshes repository layout, Rust toolchain, package targets, CLI commands, storage architecture, and contributor guidance without introducing an actionable changed-line defect. |
| README.md | Updates local startup and cloud workflow documentation to match the current image, readiness endpoint, and deployment sequence. |
| crates/cli/README.md | Recasts the CLI as a v3 runtime orchestrator and aligns its command inventory with the implementation. |
| docs/cli/command-reference.mdx | Updates the command index to v3 terminology and adds the implemented skills command. |
| docs/cli/command-reference/start.mdx | Correctly replaces query-endpoint probing language with the implemented `/healthz` readiness behavior. |
| docs/cli/getting-started.mdx | Aligns the tutorial with current v3 terminology and local startup readiness behavior. |
| docs/cli/troubleshooting.mdx | Updates troubleshooting language for v3, Helix Cloud naming, and `/healthz` startup checks. |
| docs/llms-full.txt | Regenerated full documentation output consistently reflects the changed MDX sources. |
| docs/llms.txt | Regenerated documentation index consistently reflects the updated v3 page metadata. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: refresh CLI and contributor guidan..."](https://github.com/helixdb/helix-db/commit/d41006adb2dbcb49b32a53eb1333e60bea0f072d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51458270)</sub>

<!-- /greptile_comment -->