### PR TITLE
docs: add July HelixDB release notes

### DIFF
--- a/docs/database/helix-db/start-here/release-notes.mdx
+++ b/docs/database/helix-db/start-here/release-notes.mdx
@@ -13,19 +13,14 @@ pageType: "Reference"
 <Update
   label="July 2026"
   rss={{
-    title: "HelixDB V3",
-    description: "A new transactional engine, unified query model, and consistent Cloud, local-server, and embedded execution paths"
+    title: "HelixDB is now open source",
+    description: "Open-source HelixDB, a new query planner, embedded execution, and vector prefiltering"
   }}
 >
-HelixDB V3 is a full-stack implementation of one graph database with native vector and
-full-text search, shared query semantics, and multiple deployment modes.
-
-- **[Unified query model](/database/helix-db/query-guides/advanced)** — Rust, TypeScript, Go, and Python build the same typed operation-tree request. Networked clients send it to `POST /v2/query`; embedded clients execute it in process.
-- **[New transactional engine](/database/helix-cloud/operate/guarantees)** — the SlateDB-based engine uses serializable snapshot isolation, MVCC conflict detection, atomic write batches, and memory, disk, or S3-compatible object storage.
-- **Integrated indexes** — graph traversals, equality and range filters, vector search, and BM25 full-text search participate in the same request and transactional state.
-- **[Cloud, local, and embedded modes](/database/helix-db/start-here/run-modes)** — applications can keep the same query model while moving between managed Helix Cloud, the standalone Docker server, and in-process execution.
-- **[CLI v3](/cli/getting-started)** — the CLI is now a runtime orchestrator for project setup, local containers, queries, and Cloud deployment. The old `compile`, `check`, and `.hx` workflow is no longer part of the current CLI.
-- **Reliability foundation** — cross-SDK parity suites, deterministic lifecycle and transaction models, fuzz targets, production-scale index coverage, Docker packaging checks, and Cloud launch gates now exercise the implementation end to end.
+- **Open-source database** — the engine moved out of `helix-hyperscale` into the public, modular `helix-db` workspace.
+- **New query planner** — a dedicated logical and physical planning layer optimizes the typed operation-tree AST before execution.
+- **[Embedded database](/database/helix-db/start-here/local-development/embedded-database)** — run the same engine and queries in process with memory, disk, or object storage.
+- **[Vector prefiltering](/database/helix-db/query-guides/filtering#vector-prefiltering)** — traverse and filter an exact candidate set before vector ranking, so results cannot escape graph or permission boundaries.
 </Update>
 
 <Update

--- a/docs/database/helix-db/start-here/release-notes.mdx
+++ b/docs/database/helix-db/start-here/release-notes.mdx
@@ -11,6 +11,24 @@ pageType: "Reference"
 > For the complete documentation index optimized for AI agents, see [llms.txt](/llms.txt).
 
 <Update
+  label="July 2026"
+  rss={{
+    title: "HelixDB V3",
+    description: "A new transactional engine, unified query model, and consistent Cloud, local-server, and embedded execution paths"
+  }}
+>
+HelixDB V3 is a full-stack implementation of one graph database with native vector and
+full-text search, shared query semantics, and multiple deployment modes.
+
+- **[Unified query model](/database/helix-db/query-guides/advanced)** — Rust, TypeScript, Go, and Python build the same typed operation-tree request. Networked clients send it to `POST /v2/query`; embedded clients execute it in process.
+- **[New transactional engine](/database/helix-cloud/operate/guarantees)** — the SlateDB-based engine uses serializable snapshot isolation, MVCC conflict detection, atomic write batches, and memory, disk, or S3-compatible object storage.
+- **Integrated indexes** — graph traversals, equality and range filters, vector search, and BM25 full-text search participate in the same request and transactional state.
+- **[Cloud, local, and embedded modes](/database/helix-db/start-here/run-modes)** — applications can keep the same query model while moving between managed Helix Cloud, the standalone Docker server, and in-process execution.
+- **[CLI v3](/cli/getting-started)** — the CLI is now a runtime orchestrator for project setup, local containers, queries, and Cloud deployment. The old `compile`, `check`, and `.hx` workflow is no longer part of the current CLI.
+- **Reliability foundation** — cross-SDK parity suites, deterministic lifecycle and transaction models, fuzz targets, production-scale index coverage, Docker packaging checks, and Cloud launch gates now exercise the implementation end to end.
+</Update>
+
+<Update
   label="June 2026"
   rss={{
     title: "Row bindings, Python SDK, and CLI improvements",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1276,6 +1276,16 @@ Page type: Reference
 
 <div className="flex flex-wrap gap-2"><Badge color="gray" size="sm">Reference</Badge></div>
 
+HelixDB V3 is a full-stack implementation of one graph database with native vector and
+full-text search, shared query semantics, and multiple deployment modes.
+
+- **[Unified query model](/database/helix-db/query-guides/advanced)** — Rust, TypeScript, Go, and Python build the same typed operation-tree request. Networked clients send it to `POST /v2/query`; embedded clients execute it in process.
+- **[New transactional engine](/database/helix-cloud/operate/guarantees)** — the SlateDB-based engine uses serializable snapshot isolation, MVCC conflict detection, atomic write batches, and memory, disk, or S3-compatible object storage.
+- **Integrated indexes** — graph traversals, equality and range filters, vector search, and BM25 full-text search participate in the same request and transactional state.
+- **[Cloud, local, and embedded modes](/database/helix-db/start-here/run-modes)** — applications can keep the same query model while moving between managed Helix Cloud, the standalone Docker server, and in-process execution.
+- **[CLI v3](/cli/getting-started)** — the CLI is now a runtime orchestrator for project setup, local containers, queries, and Cloud deployment. The old `compile`, `check`, and `.hx` workflow is no longer part of the current CLI.
+- **Reliability foundation** — cross-SDK parity suites, deterministic lifecycle and transaction models, fuzz targets, production-scale index coverage, Docker packaging checks, and Cloud launch gates now exercise the implementation end to end.
+
 - **[Row bindings](/database/helix-db/query-guides/advanced)** — `bind` + `projectBindings` / `projectDistinctBindings` correlate values captured at different hops of a single traversal.
 - **Python SDK** — new zero-dependency synchronous SDK (`helix-db`, imported as `helixdb`).
 - **CLI 3.0.6** — `--path` flag on `helix add`.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1276,15 +1276,10 @@ Page type: Reference
 
 <div className="flex flex-wrap gap-2"><Badge color="gray" size="sm">Reference</Badge></div>
 
-HelixDB V3 is a full-stack implementation of one graph database with native vector and
-full-text search, shared query semantics, and multiple deployment modes.
-
-- **[Unified query model](/database/helix-db/query-guides/advanced)** — Rust, TypeScript, Go, and Python build the same typed operation-tree request. Networked clients send it to `POST /v2/query`; embedded clients execute it in process.
-- **[New transactional engine](/database/helix-cloud/operate/guarantees)** — the SlateDB-based engine uses serializable snapshot isolation, MVCC conflict detection, atomic write batches, and memory, disk, or S3-compatible object storage.
-- **Integrated indexes** — graph traversals, equality and range filters, vector search, and BM25 full-text search participate in the same request and transactional state.
-- **[Cloud, local, and embedded modes](/database/helix-db/start-here/run-modes)** — applications can keep the same query model while moving between managed Helix Cloud, the standalone Docker server, and in-process execution.
-- **[CLI v3](/cli/getting-started)** — the CLI is now a runtime orchestrator for project setup, local containers, queries, and Cloud deployment. The old `compile`, `check`, and `.hx` workflow is no longer part of the current CLI.
-- **Reliability foundation** — cross-SDK parity suites, deterministic lifecycle and transaction models, fuzz targets, production-scale index coverage, Docker packaging checks, and Cloud launch gates now exercise the implementation end to end.
+- **Open-source database** — the engine moved out of `helix-hyperscale` into the public, modular `helix-db` workspace.
+- **New query planner** — a dedicated logical and physical planning layer optimizes the typed operation-tree AST before execution.
+- **[Embedded database](/database/helix-db/start-here/local-development/embedded-database)** — run the same engine and queries in process with memory, disk, or object storage.
+- **[Vector prefiltering](/database/helix-db/query-guides/filtering#vector-prefiltering)** — traverse and filter an exact candidate set before vector ranking, so results cannot escape graph or permission boundaries.
 
 - **[Row bindings](/database/helix-db/query-guides/advanced)** — `bind` + `projectBindings` / `projectDistinctBindings` correlate values captured at different hops of a single traversal.
 - **Python SDK** — new zero-dependency synchronous SDK (`helix-db`, imported as `helixdb`).


### PR DESCRIPTION
## Summary

- add a July 2026 release-note entry for HelixDB V3
- summarize the shared operation-tree query model, new transactional engine, integrated indexes, deployment modes, CLI v3, and reliability work
- link the entry to the detailed query, guarantees, deployment, and CLI documentation
- regenerate `docs/llms-full.txt`

## Validation

- `npm run generate-llms` in `docs/`
- `npm run check` in `docs/`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the July 2026 HelixDB release notes and regenerates the consolidated AI-oriented documentation.
- Announces the public modular database workspace and new query planner.
- Documents embedded memory, disk, and object-storage execution.
- Highlights exact vector prefiltering and links to detailed guides.
- Synchronizes the new entry into `docs/llms-full.txt`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/database/helix-db/start-here/release-notes.mdx | Adds a July 2026 release entry with four supported capability descriptions and valid documentation references. |
| docs/llms-full.txt | Regenerates the consolidated documentation with the four new release-note bullets in the established output format. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add July HelixDB release notes"](https://github.com/helixdb/helix-db/commit/a5ad567498ac28d510d623d7ba79c2715f7693d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51464322)</sub>

<!-- /greptile_comment -->