### PR TITLE
feat(python): add asynchronous client (HEL-802)

### DIFF
--- a/.github/workflows/sdk-query-parity.yml
+++ b/.github/workflows/sdk-query-parity.yml
@@ -53,6 +53,22 @@ jobs:
           components: clippy, rustfmt
       - run: npm ci
         working-directory: sdks/typescript
+      - run: python -m pip install -e './sdks/python[dev]'
+      - name: Check changed Python SDK sources
+        working-directory: sdks/python
+        run: |
+          files=(
+            src/helixdb/_client_common.py
+            src/helixdb/async_client.py
+            src/helixdb/client.py
+            src/helixdb/__init__.py
+            tests/test_client.py
+            tests/test_async_client.py
+            scripts/run_embedded_parity.py
+            scripts/run_server_parity.py
+          )
+          ruff format --check "${files[@]}"
+          ruff check "${files[@]}"
       - run: npm test
         working-directory: sdks/typescript
       - run: npm run parity:generate
@@ -168,6 +184,7 @@ jobs:
           cargo build --locked --manifest-path bindings/uniffi-bindgen/Cargo.toml --no-default-features --features node --bin helixdb-uniffi-bindgen-node
       - run: npm ci
         working-directory: sdks/typescript
+      - run: python -m pip install -e './sdks/python[dev]'
       - run: npm run parity:embedded
         working-directory: sdks/typescript
         env:
@@ -197,7 +214,8 @@ jobs:
         working-directory: sdks/typescript
       - run: npm run test:coverage
         working-directory: sdks/typescript
-      - run: python -m pip install coverage
+      - run: python -m pip install -e '.[dev]'
+        working-directory: sdks/python
       - run: python -m coverage run --branch --source=helixdb -m unittest discover -s tests
         working-directory: sdks/python
         env:

--- a/.github/workflows/sdk-query-parity.yml
+++ b/.github/workflows/sdk-query-parity.yml
@@ -80,6 +80,11 @@ jobs:
       - run: python -m unittest discover -s sdks/python/tests -v
         env:
           PYTHONPATH: sdks/python/src
+      - name: Run Python doctests
+        working-directory: sdks/python
+        run: >-
+          python -c 'import doctest, helixdb.async_client as module;
+          raise SystemExit(doctest.testmod(module).failed)'
       - run: go test ./...
         working-directory: sdks/go
       - run: cargo test --locked --manifest-path sdks/rust/Cargo.toml --lib

--- a/docs/database/helix-db/start-here/sdk-setup/python-project-setup.mdx
+++ b/docs/database/helix-db/start-here/sdk-setup/python-project-setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Python SDK"
-description: "Build HelixDB requests with an idiomatic synchronous Python client"
+description: "Build HelixDB requests with idiomatic synchronous and asynchronous Python clients"
 sidebarTitle: "Python"
 icon: "python"
 pageType: "Guide"
@@ -62,7 +62,34 @@ request = find_users().to_query_request(
 result = Client("http://localhost:6969").query(request)
 ```
 
-The query-only client has no native runtime dependency.
+The server clients have no native runtime dependency.
+
+### Async execution
+
+Reuse one async client to reuse its HTTP connection pool. HTTP requests have no
+timeout unless you explicitly configure one.
+
+```python
+import asyncio
+
+import httpx
+
+from helixdb import AsyncClient
+
+async def execute_queries():
+    limits = httpx.Limits(max_connections=20, max_keepalive_connections=10)
+    async with AsyncClient(timeout=10.0, limits=limits) as client:
+        return await asyncio.gather(
+            client.query(request),
+            client.execute(request, writer_only=True, timeout=2.0),
+        )
+
+results = asyncio.run(execute_queries())
+```
+
+Cancellation propagates as `asyncio.CancelledError`, closes the response stream,
+and leaves the client reusable. The client owns and closes an injected HTTPX
+async transport. `await client.close()` is idempotent.
 
 ## Embedded runtime
 
@@ -70,6 +97,29 @@ Install the SDK and embedded runtime with
 `python -m pip install helix-db helix-db-embedded`. See
 [Embedded database](/database/helix-db/start-here/local-development/embedded-database)
 for storage, cache, and handle configuration.
+
+```python
+import asyncio
+
+from helixdb import AsyncClient, Disk, InMemory
+
+async def query_embedded():
+    writer = await AsyncClient.embedded(InMemory("app"))
+    async with writer:
+        memory_result = await writer.query(request)
+
+    reader = await AsyncClient.embedded_reader(Disk("./data", "seeded-app"))
+    async with reader:
+        disk_checkpoint = await reader.query(request)
+
+    return memory_result, disk_checkpoint
+
+results = asyncio.run(query_embedded())
+```
+
+Async embedded queries await native UniFFI operations directly. Use
+`asyncio.timeout(...)` for cancellation boundaries. Async native graph loading is
+not part of this API; use the synchronous `Client.graph(...)` API.
 
 ## Verify
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1218,7 +1218,34 @@ request = find_users().to_query_request(
 result = Client("http://localhost:6969").query(request)
 ```
 
-The query-only client has no native runtime dependency.
+The server clients have no native runtime dependency.
+
+### Async execution
+
+Reuse one async client to reuse its HTTP connection pool. HTTP requests have no
+timeout unless you explicitly configure one.
+
+```python
+import asyncio
+
+import httpx
+
+from helixdb import AsyncClient
+
+async def execute_queries():
+    limits = httpx.Limits(max_connections=20, max_keepalive_connections=10)
+    async with AsyncClient(timeout=10.0, limits=limits) as client:
+        return await asyncio.gather(
+            client.query(request),
+            client.execute(request, writer_only=True, timeout=2.0),
+        )
+
+results = asyncio.run(execute_queries())
+```
+
+Cancellation propagates as `asyncio.CancelledError`, closes the response stream,
+and leaves the client reusable. The client owns and closes an injected HTTPX
+async transport. `await client.close()` is idempotent.
 
 ## Embedded runtime
 
@@ -1226,6 +1253,29 @@ Install the SDK and embedded runtime with
 `python -m pip install helix-db helix-db-embedded`. See
 [Embedded database](/database/helix-db/start-here/local-development/embedded-database)
 for storage, cache, and handle configuration.
+
+```python
+import asyncio
+
+from helixdb import AsyncClient, Disk, InMemory
+
+async def query_embedded():
+    writer = await AsyncClient.embedded(InMemory("app"))
+    async with writer:
+        memory_result = await writer.query(request)
+
+    reader = await AsyncClient.embedded_reader(Disk("./data", "seeded-app"))
+    async with reader:
+        disk_checkpoint = await reader.query(request)
+
+    return memory_result, disk_checkpoint
+
+results = asyncio.run(query_embedded())
+```
+
+Async embedded queries await native UniFFI operations directly. Use
+`asyncio.timeout(...)` for cancellation boundaries. Async native graph loading is
+not part of this API; use the synchronous `Client.graph(...)` API.
 
 ## Verify
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -23,7 +23,7 @@ Full walkthrough: https://docs.helix-db.com/cli/getting-started
 - [Rust SDK](https://docs.helix-db.com/database/helix-db/start-here/sdk-setup/rust-project-setup): Build typed HelixDB queries and execute them over HTTP or an embedded engine — Page type: Guide
 - [TypeScript SDK](https://docs.helix-db.com/database/helix-db/start-here/sdk-setup/typescript-project-setup): Build typed HelixDB requests for Node.js applications — Page type: Guide
 - [Go SDK](https://docs.helix-db.com/database/helix-db/start-here/sdk-setup/go-project-setup): Build and execute HelixDB requests with ordinary Go functions — Page type: Guide
-- [Python SDK](https://docs.helix-db.com/database/helix-db/start-here/sdk-setup/python-project-setup): Build HelixDB requests with an idiomatic synchronous Python client — Page type: Guide
+- [Python SDK](https://docs.helix-db.com/database/helix-db/start-here/sdk-setup/python-project-setup): Build HelixDB requests with idiomatic synchronous and asynchronous Python clients — Page type: Guide
 - [Roadmap](https://docs.helix-db.com/database/helix-db/start-here/roadmap): What we're building and what's coming next — Page type: Reference
 - [Release Notes](https://docs.helix-db.com/database/helix-db/start-here/release-notes): HelixDB Cloud Release Notes — Page type: Reference
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,8 +1,9 @@
 # HelixDB Python SDK
 
-The Python SDK pairs an idiomatic query-builder DSL with a dependency-free
-client for sending HelixDB queries to `POST /v2/query` or executing them against
-an embedded database.
+The Python SDK pairs an idiomatic query-builder DSL with synchronous and
+asynchronous clients for sending HelixDB queries to `POST /v2/query` or
+executing them against an embedded database. The async client uses HTTPX; the
+sync API remains unchanged.
 
 ```python
 from helixdb import Client, Predicate, g, read_batch
@@ -24,12 +25,47 @@ request = query.to_query_request()
 result = Client("http://localhost:6969").query(request)
 ```
 
+## Async Client
+
+Reuse one `AsyncClient` so its HTTPX connection pool can serve many requests.
+There is no timeout unless you configure one on the client or request.
+
+```python
+import asyncio
+
+import httpx
+
+from helixdb import AsyncClient
+
+async def main():
+    limits = httpx.Limits(max_connections=20, max_keepalive_connections=10)
+    async with AsyncClient(timeout=10.0, limits=limits) as client:
+        first, second = await asyncio.gather(
+            client.query(request),
+            client.execute(request, writer_only=True, timeout=2.0),
+        )
+        return first, second
+
+results = asyncio.run(main())
+```
+
+`AsyncClient`, `AsyncQueryBuilder`, and `AsyncQueryExecutionRequest` are also
+exported from the compatibility import path `helix_db`. Builder methods preserve
+the synchronous writer, warm, durability, authorization, and response contracts.
+
+HTTP cancellation propagates as `asyncio.CancelledError`; the response stream is
+closed and the client remains reusable. For embedded operations, use
+`asyncio.timeout(...)` when a cancellation boundary is required. HTTPX
+`AsyncBaseTransport` instances can be injected for custom networking or tests;
+the client owns and closes an injected transport. Calling `await client.close()`
+more than once is safe.
+
 Warm a read with `client.execute(request, warm_only=True)`. Helix Cloud fans the
 ordinary read out to every eligible backend, discards the results, and returns
-`204 No Content` with no query payload after at least one target succeeds. Pass
+an empty successful response after at least one target succeeds. Pass
 `writer_only=True` as well to warm only the authoritative writer. Warm writes
-return `400 Bad Request` before backend execution. A standalone local warm read
-can return its normal query payload instead.
+return an error before backend execution. A standalone local warm read can
+return its normal query payload instead.
 
 The DSL emits the same query JSON AST as the Rust, TypeScript, and Go
 SDKs. Python methods use `snake_case`; compatibility aliases such as
@@ -133,6 +169,26 @@ client = Client.embedded(
 `Client.embedded_reader(...)` opens an existing disk or object-storage database
 read-only. Stored routes and query bundles are not supported.
 
+The async client awaits native UniFFI operations directly and supports the same
+writer, reader, memory, disk, object-storage, and cache configurations.
+
+```python
+from helixdb import AsyncClient, Disk, InMemory
+
+async def embedded_query(request):
+    writer = await AsyncClient.embedded(InMemory("app"))
+    async with writer:
+        return await writer.query(request)
+
+async def read_checkpoint(request):
+    reader = await AsyncClient.embedded_reader(Disk("./data", "app"))
+    async with reader:
+        return await reader.query(request)
+```
+
+Concurrent `asyncio.gather(...)` calls are passed to the native runtime without
+a synchronous wrapper. Native graph loading remains available only on `Client`.
+
 ## Native graph algorithms
 
 ```python
@@ -152,10 +208,13 @@ scores = graph.betweenness_centrality(BetweennessOptions.graphify_default())
 
 The returned object retains the immutable Rust topology. Every accessor and
 algorithm runs locally without another Helix read. Native wheels are required
-for this graph API and embedded mode; query-only imports remain dependency free.
+for this graph API and embedded mode; server clients do not require the native
+runtime.
 
 Run the SDK tests from the repository root:
 
 ```sh
-PYTHONPATH=sdks/python/src python -m unittest discover sdks/python/tests
+python -m pip install -e './sdks/python[dev]'
+python -c 'import doctest, helixdb.async_client as module; raise SystemExit(doctest.testmod(module).failed)'
+python -m unittest discover -s sdks/python/tests
 ```

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
+dependencies = ["httpx>=0.28.1,<1"]
 
 [project.urls]
 Homepage = "https://github.com/HelixDB/helix-db"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -23,6 +23,9 @@ classifiers = [
 ]
 dependencies = ["httpx>=0.28.1,<1"]
 
+[project.optional-dependencies]
+dev = ["coverage>=7.10,<8", "ruff>=0.12,<1"]
+
 [project.urls]
 Homepage = "https://github.com/HelixDB/helix-db"
 Repository = "https://github.com/HelixDB/helix-db"
@@ -32,3 +35,15 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 helixdb = ["py.typed"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+"scripts/*.py" = ["E402"]
+"src/helix_db/__init__.py" = ["F401", "F403"]
+"src/helixdb/__init__.py" = ["F401", "F403"]

--- a/sdks/python/scripts/run_embedded_parity.py
+++ b/sdks/python/scripts/run_embedded_parity.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 from time import monotonic, sleep
 
 PYTHON_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PYTHON_ROOT / "src"))
 
+from parity_runtime_fixtures import (  # noqa: E402
+    base_runtime_fixtures,
+    node_permutation_fixtures,
+)
+
 from helixdb import (  # noqa: E402
+    AsyncClient,
     Client,
     Disk,
     EmbeddedCacheConfig,
@@ -22,8 +29,8 @@ from helixdb import (  # noqa: E402
     InMemory,
     LeidenOptions,
     MemoryCache,
-    NoPath,
     NodeRef,
+    NoPath,
     PropertyInput,
     PropertyValue,
     QueryRequest,
@@ -34,10 +41,6 @@ from helixdb import (  # noqa: E402
     g,
     read_batch,
     write_batch,
-)
-from parity_runtime_fixtures import (  # noqa: E402
-    base_runtime_fixtures,
-    node_permutation_fixtures,
 )
 
 TRANSACTION_CONFLICT_ATTEMPTS = 8
@@ -53,18 +56,14 @@ def main() -> None:
     for path in results.glob("*.json"):
         path.unlink()
 
-    database = os.environ.get(
-        "HELIX_EMBEDDED_PARITY_DATABASE", "python-sdk-embedded-parity"
-    )
+    database = os.environ.get("HELIX_EMBEDDED_PARITY_DATABASE", "python-sdk-embedded-parity")
     storage = os.environ.get("HELIX_EMBEDDED_PARITY_STORAGE", "memory")
     if storage == "memory":
         source = InMemory(database)
     elif storage == "disk":
         disk_root = os.environ.get("HELIX_EMBEDDED_PARITY_DISK_ROOT")
         if disk_root is None:
-            raise RuntimeError(
-                "HELIX_EMBEDDED_PARITY_DISK_ROOT is required for disk parity"
-            )
+            raise RuntimeError("HELIX_EMBEDDED_PARITY_DISK_ROOT is required for disk parity")
         source = Disk(disk_root, database)
     else:
         raise RuntimeError(f"unsupported embedded parity storage {storage}")
@@ -90,9 +89,7 @@ def main() -> None:
                         search_request = _required_fixture(fixtures, search_name)
                         actual = reader.query(search_request)
                         expected = json.loads(
-                            (results / f"{search_name}.json").read_text(
-                                encoding="utf-8"
-                            )
+                            (results / f"{search_name}.json").read_text(encoding="utf-8")
                         )
                         if actual != expected:
                             raise RuntimeError(
@@ -111,10 +108,7 @@ def main() -> None:
                         and error.details is not None
                         and TRANSACTION_CONFLICT_MESSAGE in error.details
                     )
-                    if (
-                        not is_transaction_conflict
-                        or attempt + 1 == TRANSACTION_CONFLICT_ATTEMPTS
-                    ):
+                    if not is_transaction_conflict or attempt + 1 == TRANSACTION_CONFLICT_ATTEMPTS:
                         raise
                     # Embedded storage reports retryable transaction conflicts in
                     # the error details; the losing transaction did not commit.
@@ -137,9 +131,7 @@ def main() -> None:
                         f"{search_name} returned the wrong post-DROP error: {error}"
                     ) from error
             else:
-                raise RuntimeError(
-                    f"{search_name} unexpectedly succeeded after index DROP"
-                )
+                raise RuntimeError(f"{search_name} unexpectedly succeeded after index DROP")
 
         graph = client.graph(
             GraphSelection(
@@ -165,9 +157,161 @@ def main() -> None:
         client.close()
 
 
-def _required_fixture(
-    fixtures: list[tuple[str, QueryRequest]], name: str
-) -> QueryRequest:
+async def async_main() -> None:
+    """Run the complete executable corpus through the asynchronous client."""
+
+    results_value = os.environ.get("HELIX_EMBEDDED_PARITY_RESULTS")
+    if results_value is None:
+        raise RuntimeError("HELIX_EMBEDDED_PARITY_RESULTS is required")
+    results = Path(results_value)
+    results.mkdir(parents=True, exist_ok=True)
+    for path in results.glob("*.json"):
+        path.unlink()
+
+    database = os.environ.get("HELIX_EMBEDDED_PARITY_DATABASE", "python-async-sdk-embedded-parity")
+    storage = os.environ.get("HELIX_EMBEDDED_PARITY_STORAGE", "memory")
+    if storage == "memory":
+        source = InMemory(database)
+    elif storage == "disk":
+        disk_root = os.environ.get("HELIX_EMBEDDED_PARITY_DISK_ROOT")
+        if disk_root is None:
+            raise RuntimeError("HELIX_EMBEDDED_PARITY_DISK_ROOT is required for disk parity")
+        source = Disk(disk_root, database)
+    else:
+        raise RuntimeError(f"unsupported embedded parity storage {storage}")
+
+    cache = EmbeddedCacheConfig(256 * 1024 * 1024, MemoryCache())
+    fixtures = sorted(
+        [*base_runtime_fixtures(), *node_permutation_fixtures()],
+        key=lambda fixture: fixture[0],
+    )
+    client = await AsyncClient.embedded(source, cache=cache)
+    try:
+        for name, request in fixtures:
+            if storage == "disk" and name == "900-write-active-text-items":
+                await client.close()
+                reader = await AsyncClient.embedded_reader(source, cache=cache)
+                try:
+                    for search_name in (
+                        "025-read-text-search-nodes",
+                        "027-read-text-search-edges",
+                    ):
+                        search_request = _required_fixture(fixtures, search_name)
+                        actual = await reader.query(search_request)
+                        expected = json.loads(
+                            (results / f"{search_name}.json").read_text(encoding="utf-8")
+                        )
+                        if actual != expected:
+                            raise RuntimeError(
+                                f"{search_name} changed after reopening an async disk reader"
+                            )
+                finally:
+                    await reader.close()
+                client = await AsyncClient.embedded(source, cache=cache)
+
+            response = await _query_with_conflict_retry_async(client, request)
+            await _await_index_operations_async(client, response)
+            (results / f"{name}.json").write_text(
+                json.dumps(_normalize_operation_ids(response), separators=(",", ":")),
+                encoding="utf-8",
+            )
+
+        for search_name in (
+            "025-read-text-search-nodes",
+            "027-read-text-search-edges",
+        ):
+            try:
+                await client.query(_required_fixture(fixtures, search_name))
+            except HelixError as error:
+                if "index_not_found" not in str(error):
+                    raise RuntimeError(
+                        f"{search_name} returned the wrong post-DROP error: {error}"
+                    ) from error
+            else:
+                raise RuntimeError(f"{search_name} unexpectedly succeeded after index DROP")
+
+        overlap_request = _required_fixture(fixtures, "002-read-count-all-users")
+        overlap_results = await asyncio.gather(*(client.query(overlap_request) for _ in range(8)))
+        if any(result != overlap_results[0] for result in overlap_results[1:]):
+            raise RuntimeError("overlapping async embedded reads returned different results")
+    finally:
+        await client.close()
+
+    concurrency_client = await AsyncClient.embedded(InMemory(f"{database}-concurrency"))
+    try:
+        writes = [
+            QueryRequest.write(
+                write_batch()
+                .var_as(
+                    "created",
+                    g().add_n(
+                        "AsyncParityConcurrent",
+                        {"sequence": sequence},
+                    ),
+                )
+                .returning(["created"])
+            )
+            for sequence in range(8)
+        ]
+        await asyncio.gather(
+            *(_query_with_conflict_retry_async(concurrency_client, request) for request in writes)
+        )
+        concurrent_read = QueryRequest.read(
+            read_batch()
+            .var_as(
+                "count",
+                g().n_with_label("AsyncParityConcurrent").count(),
+            )
+            .returning(["count"])
+        )
+        reads = await asyncio.gather(*(concurrency_client.query(concurrent_read) for _ in range(8)))
+        if any(result != reads[0] for result in reads[1:]):
+            raise RuntimeError("overlapping async embedded reads were inconsistent")
+    finally:
+        await concurrency_client.close()
+
+
+async def _query_with_conflict_retry_async(client: AsyncClient, request: QueryRequest) -> object:
+    for attempt in range(TRANSACTION_CONFLICT_ATTEMPTS):
+        try:
+            return await client.query(request)
+        except HelixError as error:
+            is_transaction_conflict = (
+                error.kind == "Embedded"
+                and error.details is not None
+                and TRANSACTION_CONFLICT_MESSAGE in error.details
+            )
+            if not is_transaction_conflict or attempt + 1 == TRANSACTION_CONFLICT_ATTEMPTS:
+                raise
+            await asyncio.sleep(0.01 * 2**attempt)
+    raise AssertionError("async transaction conflict retry loop exhausted")
+
+
+async def _await_index_operations_async(client: AsyncClient, response: object) -> None:
+    for operation_id in sorted(_collect_operation_ids(response)):
+        deadline = monotonic() + 60.0
+        while True:
+            status_response = await client.query(
+                QueryRequest.read(
+                    read_batch()
+                    .var_as("status", g().get_index_operation(operation_id))
+                    .returning(["status"])
+                )
+            )
+            status = status_response.get("status", {}).get("status")
+            if status == "succeeded":
+                break
+            if status not in {"queued", "running"}:
+                raise RuntimeError(
+                    f"operation {operation_id} reached unexpected status {status}: "
+                    f"{status_response}"
+                )
+            if monotonic() >= deadline:
+                raise TimeoutError(f"operation {operation_id} did not finish within 60s")
+            await asyncio.sleep(0.01)
+
+
+def _required_fixture(fixtures: list[tuple[str, QueryRequest]], name: str) -> QueryRequest:
     for fixture_name, request in fixtures:
         if fixture_name == name:
             return request
@@ -196,9 +340,7 @@ def _await_index_operations(client: Client, response: object) -> None:
                     f"{status_response}"
                 )
             if monotonic() >= deadline:
-                raise TimeoutError(
-                    f"operation {operation_id} did not finish within 60s"
-                )
+                raise TimeoutError(f"operation {operation_id} did not finish within 60s")
             sleep(0.01)
 
 
@@ -226,9 +368,7 @@ def _normalize_operation_ids(value: object) -> object:
         return [_normalize_operation_ids(entry) for entry in value]
     if not isinstance(value, dict):
         return value
-    normalized = {
-        key: _normalize_operation_ids(entry) for key, entry in value.items()
-    }
+    normalized = {key: _normalize_operation_ids(entry) for key, entry in value.items()}
     if normalized.get("kind") in {"accepted", "existing_operation"} and (
         "operation_id" in normalized
     ):
@@ -295,10 +435,7 @@ def _native_graph_acceptance(client: Client) -> None:
             variable,
             g().add_n(
                 label,
-                [
-                    (name, PropertyInput.value(value))
-                    for name, value in properties.items()
-                ],
+                [(name, PropertyInput.value(value)) for name, value in properties.items()],
             ),
         )
         returned.append(variable)
@@ -381,10 +518,7 @@ def _native_graph_acceptance(client: Client) -> None:
             .add_e(
                 label,
                 NodeRef.var(target),
-                [
-                    (name, PropertyInput.value(value))
-                    for name, value in properties.items()
-                ],
+                [(name, PropertyInput.value(value)) for name, value in properties.items()],
             ),
         )
         returned.append(variable)
@@ -447,10 +581,7 @@ def _native_graph_acceptance(client: Client) -> None:
     }
     assert typed.attributes == {"owner": "graphify", "version": 7}
     assert typed.copy().attributes == typed.attributes
-    assert (
-        typed.induced_subgraph((("typed", 1), b"\x00\xff")).attributes
-        == typed.attributes
-    )
+    assert typed.induced_subgraph((("typed", 1), b"\x00\xff")).attributes == typed.attributes
     assert typed.degree(("typed", 1)).node_id == ("typed", 1)
     assert {degree.node_id for degree in typed.degrees()} == {
         ("typed", 1),
@@ -467,9 +598,7 @@ def _native_graph_acceptance(client: Client) -> None:
     cycles = typed.simple_cycles(2)
     assert len(cycles.cycles) == 1
     assert set(cycles.cycles[0].node_ids) == {("typed", 1), b"\x00\xff"}
-    assert all(
-        isinstance(edge_id, GraphEdgeId) for edge_id in cycles.cycles[0].edge_ids
-    )
+    assert all(isinstance(edge_id, GraphEdgeId) for edge_id in cycles.cycles[0].edge_ids)
     assert {position.node_id for position in typed.spring_layout()} == {
         ("typed", 1),
         b"\x00\xff",
@@ -560,4 +689,7 @@ def _native_graph_acceptance(client: Client) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    if os.environ.get("HELIX_PYTHON_PARITY_MODE", "sync") == "async":
+        asyncio.run(async_main())
+    else:
+        main()

--- a/sdks/python/scripts/run_server_parity.py
+++ b/sdks/python/scripts/run_server_parity.py
@@ -1,0 +1,548 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from time import monotonic, sleep
+
+PYTHON_ROOT = Path(__file__).resolve().parents[1]
+WORKSPACE_ROOT = PYTHON_ROOT.parents[1]
+sys.path.insert(0, str(PYTHON_ROOT / "src"))
+
+from parity_runtime_fixtures import (  # noqa: E402
+    base_runtime_fixtures,
+    node_permutation_fixtures,
+)
+
+from helixdb import (  # noqa: E402
+    AsyncClient,
+    Client,
+    HelixError,
+    QueryRequest,
+    g,
+    read_batch,
+    write_batch,
+)
+
+EXPECTED_RUNTIME = 233
+TRANSACTION_CONFLICT_ATTEMPTS = 8
+
+
+@dataclass(frozen=True)
+class BinaryRuntime:
+    path: Path
+
+
+@dataclass(frozen=True)
+class ImageRuntime:
+    reference: str
+
+
+Runtime = BinaryRuntime | ImageRuntime
+
+
+class RuntimeController:
+    def __init__(self, runtime: Runtime, label: str, temporary_root: Path) -> None:
+        self.runtime = runtime
+        self.label = label
+        self.temporary_root = temporary_root
+        self.port = _unused_port()
+        self.grpc_port = _unused_port()
+        self.process: subprocess.Popen[bytes] | None = None
+        self.log_file = None
+        self.container = f"helixdb-python-parity-{label}-{uuid.uuid4().hex[:12]}"
+        self.volume = f"helixdb-python-parity-{label}-{uuid.uuid4().hex[:12]}"
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def prepare(self) -> None:
+        if isinstance(self.runtime, ImageRuntime):
+            _run(["docker", "image", "inspect", self.runtime.reference])
+            _run(["docker", "volume", "create", self.volume])
+
+    def start(self) -> None:
+        if isinstance(self.runtime, BinaryRuntime):
+            log_path = self.temporary_root / f"{self.label}.log"
+            self.log_file = log_path.open("ab")
+            data_root = self.temporary_root / "data"
+            data_root.mkdir(parents=True, exist_ok=True)
+            environment = os.environ.copy()
+            environment.pop("S3_BUCKET", None)
+            environment.update(
+                {
+                    "HELIX_HTTP_ADDR": f"127.0.0.1:{self.port}",
+                    "HELIX_GRPC_ADDR": f"127.0.0.1:{self.grpc_port}",
+                    "HELIX_DATA_DIR": str(data_root),
+                    "DB_PATH": f"python-parity-{self.label}/",
+                }
+            )
+            self.process = subprocess.Popen(
+                [str(self.runtime.path)],
+                cwd=WORKSPACE_ROOT,
+                env=environment,
+                stdout=self.log_file,
+                stderr=subprocess.STDOUT,
+            )
+        else:
+            _run(
+                [
+                    "docker",
+                    "run",
+                    "--detach",
+                    "--rm",
+                    "--name",
+                    self.container,
+                    # A new Docker volume is root-owned. The published image's
+                    # non-root UID cannot initialize it without a helper image.
+                    "--user",
+                    "0",
+                    "--publish",
+                    f"127.0.0.1:{self.port}:8080",
+                    "--env",
+                    "HELIX_DATA_DIR=/var/lib/helix",
+                    "--mount",
+                    f"type=volume,source={self.volume},target=/var/lib/helix",
+                    self.runtime.reference,
+                ]
+            )
+        self._wait_ready()
+
+    def restart(self) -> None:
+        self.stop()
+        self.start()
+
+    def stop(self) -> None:
+        if isinstance(self.runtime, BinaryRuntime):
+            if self.process is not None and self.process.poll() is None:
+                self.process.terminate()
+                try:
+                    self.process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    self.process.kill()
+                    self.process.wait(timeout=10)
+            self.process = None
+            if self.log_file is not None:
+                self.log_file.close()
+                self.log_file = None
+        else:
+            subprocess.run(
+                ["docker", "rm", "--force", self.container],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+    def cleanup(self) -> None:
+        self.stop()
+        if isinstance(self.runtime, ImageRuntime):
+            subprocess.run(
+                ["docker", "volume", "rm", "--force", self.volume],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+    def _wait_ready(self) -> None:
+        deadline = monotonic() + 120.0
+        while monotonic() < deadline:
+            try:
+                with urllib.request.urlopen(f"{self.url}/readyz", timeout=1.0) as response:
+                    if response.status == 200:
+                        return
+            except OSError:
+                pass
+            if self.process is not None and self.process.poll() is not None:
+                raise RuntimeError(f"server exited with {self.process.returncode}:\n{self._logs()}")
+            sleep(0.1)
+        raise TimeoutError(f"server did not become ready at {self.url}:\n{self._logs()}")
+
+    def _logs(self) -> str:
+        if isinstance(self.runtime, ImageRuntime):
+            result = subprocess.run(
+                ["docker", "logs", self.container],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            return result.stdout + result.stderr
+        log_path = self.temporary_root / f"{self.label}.log"
+        return log_path.read_text(encoding="utf-8", errors="replace") if log_path.exists() else ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the full Python sync/async corpus against a HelixDB server"
+    )
+    runtime = parser.add_mutually_exclusive_group(required=True)
+    runtime.add_argument("--server-binary", type=Path)
+    runtime.add_argument("--image")
+    parser.add_argument(
+        "--baseline-results",
+        type=Path,
+        help="Rust server parity result directory to compare against",
+    )
+    arguments = parser.parse_args()
+
+    selected: Runtime
+    if arguments.server_binary is not None:
+        binary = arguments.server_binary.resolve()
+        if not binary.is_file():
+            raise FileNotFoundError(f"server binary does not exist: {binary}")
+        selected = BinaryRuntime(binary)
+        runtime_label = f"current source binary {binary}"
+    else:
+        selected = ImageRuntime(arguments.image)
+        inspected = subprocess.run(
+            [
+                "docker",
+                "image",
+                "inspect",
+                "--format",
+                '{{.Id}} {{join .RepoDigests ","}}',
+                arguments.image,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        runtime_label = f"image {arguments.image} ({inspected})"
+
+    fixtures = sorted(
+        [*base_runtime_fixtures(), *node_permutation_fixtures()],
+        key=lambda fixture: fixture[0],
+    )
+    if len(fixtures) != EXPECTED_RUNTIME:
+        raise RuntimeError(
+            f"Python runtime fixture count was {len(fixtures)}, expected {EXPECTED_RUNTIME}"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="helixdb-python-server-parity-") as root:
+        temporary_root = Path(root)
+        sync_runtime = RuntimeController(selected, "sync", temporary_root / "sync")
+        async_runtime = RuntimeController(selected, "async", temporary_root / "async")
+        sync_runtime.temporary_root.mkdir(parents=True)
+        async_runtime.temporary_root.mkdir(parents=True)
+        try:
+            sync_runtime.prepare()
+            sync_runtime.start()
+            sync_results = _run_sync_corpus(sync_runtime, fixtures)
+        finally:
+            sync_runtime.cleanup()
+
+        try:
+            async_runtime.prepare()
+            async_runtime.start()
+            async_results = asyncio.run(_run_async_corpus(async_runtime, fixtures))
+        finally:
+            async_runtime.cleanup()
+
+    if sync_results != async_results:
+        mismatches = [
+            name
+            for name in sorted(sync_results)
+            if sync_results.get(name) != async_results.get(name)
+        ]
+        raise RuntimeError(
+            f"sync/async Python server parity failed for {len(mismatches)} fixture(s): "
+            + ", ".join(
+                f"{name} (sync={sync_results.get(name)!r}, async={async_results.get(name)!r})"
+                for name in mismatches
+            )
+        )
+    if arguments.baseline_results is not None:
+        _assert_rust_baseline(arguments.baseline_results, sync_results)
+    print(
+        "Python sync/async server parity passed for "
+        f"{len(fixtures)} fixtures against {runtime_label}"
+    )
+
+
+def _assert_rust_baseline(baseline_root: Path, python_results: dict[str, object]) -> None:
+    baseline_files = sorted(baseline_root.rglob("*.json"))
+    if len(baseline_files) != EXPECTED_RUNTIME:
+        raise RuntimeError(
+            f"Rust baseline contained {len(baseline_files)} fixtures, expected {EXPECTED_RUNTIME}"
+        )
+
+    baseline = {
+        path.stem: _normalize_response(json.loads(path.read_text(encoding="utf-8")))
+        for path in baseline_files
+    }
+    if baseline.keys() != python_results.keys():
+        missing = sorted(baseline.keys() - python_results.keys())
+        extra = sorted(python_results.keys() - baseline.keys())
+        raise RuntimeError(
+            "Python server parity fixture names differ from the Rust baseline: "
+            f"missing={missing}, extra={extra}"
+        )
+    mismatches = [name for name in sorted(baseline) if baseline[name] != python_results[name]]
+    if mismatches:
+        raise RuntimeError(
+            f"Python/Rust server parity failed for {len(mismatches)} fixture(s): "
+            + ", ".join(mismatches)
+        )
+
+
+def _run_sync_corpus(
+    runtime: RuntimeController,
+    fixtures: list[tuple[str, QueryRequest]],
+) -> dict[str, object]:
+    client = Client(runtime.url)
+    results: dict[str, object] = {}
+    try:
+        for name, request in fixtures:
+            response = _query_with_conflict_retry_sync(client, request)
+            _await_index_operations_sync(client, response)
+            results[name] = _normalize_response(response)
+            if name == "905-read-text-drop-candidates":
+                runtime.restart()
+                reopened = _query_with_conflict_retry_sync(client, request)
+                if _normalize_response(reopened) != results[name]:
+                    raise RuntimeError(f"sync fixture {name} changed after server restart")
+        _assert_post_drop_sync(client, fixtures)
+    finally:
+        client.close()
+    return results
+
+
+async def _run_async_corpus(
+    runtime: RuntimeController,
+    fixtures: list[tuple[str, QueryRequest]],
+) -> dict[str, object]:
+    client = AsyncClient(runtime.url)
+    results: dict[str, object] = {}
+    try:
+        for name, request in fixtures:
+            response = await _query_with_conflict_retry_async(client, request)
+            await _await_index_operations_async(client, response)
+            results[name] = _normalize_response(response)
+            if name == "905-read-text-drop-candidates":
+                runtime.restart()
+                reopened = await _query_with_conflict_retry_async(client, request)
+                if _normalize_response(reopened) != results[name]:
+                    raise RuntimeError(f"async fixture {name} changed after server restart")
+        await _assert_post_drop_async(client, fixtures)
+        overlap_request = _required_fixture(fixtures, "002-read-count-all-users")
+        overlap_results = await asyncio.gather(*(client.query(overlap_request) for _ in range(8)))
+        if any(result != overlap_results[0] for result in overlap_results[1:]):
+            raise RuntimeError("overlapping async server reads returned different results")
+
+        writes = [
+            QueryRequest.write(
+                write_batch()
+                .var_as(
+                    "created",
+                    g().add_n("AsyncServerParityConcurrent", {"sequence": sequence}),
+                )
+                .returning(["created"])
+            )
+            for sequence in range(8)
+        ]
+        await asyncio.gather(
+            *(_query_with_conflict_retry_async(client, request) for request in writes)
+        )
+        concurrent_read = QueryRequest.read(
+            read_batch()
+            .var_as("count", g().n_with_label("AsyncServerParityConcurrent").count())
+            .returning(["count"])
+        )
+        reads = await asyncio.gather(*(client.query(concurrent_read) for _ in range(8)))
+        if any(result != reads[0] for result in reads[1:]):
+            raise RuntimeError("overlapping async server reads were inconsistent")
+    finally:
+        await client.close()
+    return results
+
+
+def _query_with_conflict_retry_sync(client: Client, request: QueryRequest) -> object:
+    for attempt in range(TRANSACTION_CONFLICT_ATTEMPTS):
+        try:
+            return client.query(request)
+        except HelixError as error:
+            if (
+                error.kind != "Remote"
+                or error.status_code != 409
+                or attempt + 1 == TRANSACTION_CONFLICT_ATTEMPTS
+            ):
+                raise
+            sleep(0.01 * 2**attempt)
+    raise AssertionError("sync transaction conflict retry loop exhausted")
+
+
+async def _query_with_conflict_retry_async(client: AsyncClient, request: QueryRequest) -> object:
+    for attempt in range(TRANSACTION_CONFLICT_ATTEMPTS):
+        try:
+            return await client.query(request)
+        except HelixError as error:
+            if (
+                error.kind != "Remote"
+                or error.status_code != 409
+                or attempt + 1 == TRANSACTION_CONFLICT_ATTEMPTS
+            ):
+                raise
+            await asyncio.sleep(0.01 * 2**attempt)
+    raise AssertionError("async transaction conflict retry loop exhausted")
+
+
+def _await_index_operations_sync(client: Client, response: object) -> None:
+    for operation_id in sorted(_collect_operation_ids(response)):
+        deadline = monotonic() + 60.0
+        while True:
+            status_response = client.query(_index_status_request(operation_id))
+            status = status_response.get("status", {}).get("status")
+            if status == "succeeded":
+                break
+            if status not in {"queued", "running"}:
+                raise RuntimeError(
+                    f"operation {operation_id} reached unexpected status {status}: "
+                    f"{status_response}"
+                )
+            if monotonic() >= deadline:
+                raise TimeoutError(f"operation {operation_id} did not finish within 60s")
+            sleep(0.01)
+
+
+async def _await_index_operations_async(client: AsyncClient, response: object) -> None:
+    for operation_id in sorted(_collect_operation_ids(response)):
+        deadline = monotonic() + 60.0
+        while True:
+            status_response = await client.query(_index_status_request(operation_id))
+            status = status_response.get("status", {}).get("status")
+            if status == "succeeded":
+                break
+            if status not in {"queued", "running"}:
+                raise RuntimeError(
+                    f"operation {operation_id} reached unexpected status {status}: "
+                    f"{status_response}"
+                )
+            if monotonic() >= deadline:
+                raise TimeoutError(f"operation {operation_id} did not finish within 60s")
+            await asyncio.sleep(0.01)
+
+
+def _index_status_request(operation_id: str) -> QueryRequest:
+    return QueryRequest.read(
+        read_batch().var_as("status", g().get_index_operation(operation_id)).returning(["status"])
+    )
+
+
+def _assert_post_drop_sync(client: Client, fixtures: list[tuple[str, QueryRequest]]) -> None:
+    for name in ("025-read-text-search-nodes", "027-read-text-search-edges"):
+        try:
+            client.query(_required_fixture(fixtures, name))
+        except HelixError as error:
+            if "index_not_found" in str(error):
+                continue
+            raise
+        raise RuntimeError(f"sync {name} unexpectedly succeeded after index DROP")
+
+
+async def _assert_post_drop_async(
+    client: AsyncClient, fixtures: list[tuple[str, QueryRequest]]
+) -> None:
+    for name in ("025-read-text-search-nodes", "027-read-text-search-edges"):
+        try:
+            await client.query(_required_fixture(fixtures, name))
+        except HelixError as error:
+            if "index_not_found" in str(error):
+                continue
+            raise
+        raise RuntimeError(f"async {name} unexpectedly succeeded after index DROP")
+
+
+def _required_fixture(fixtures: list[tuple[str, QueryRequest]], name: str) -> QueryRequest:
+    for fixture_name, request in fixtures:
+        if fixture_name == name:
+            return request
+    raise RuntimeError(f"missing fixture {name}")
+
+
+def _collect_operation_ids(value: object, ids: set[str] | None = None) -> set[str]:
+    ids = set() if ids is None else ids
+    if isinstance(value, list):
+        for entry in value:
+            _collect_operation_ids(entry, ids)
+    elif isinstance(value, dict):
+        if value.get("kind") in {"accepted", "existing_operation"} and isinstance(
+            value.get("operation_id"), str
+        ):
+            ids.add(value["operation_id"])
+        for entry in value.values():
+            _collect_operation_ids(entry, ids)
+    return ids
+
+
+def _normalize_operation_ids(value: object) -> object:
+    if isinstance(value, list):
+        return [_normalize_operation_ids(entry) for entry in value]
+    if not isinstance(value, dict):
+        return value
+    normalized = {key: _normalize_operation_ids(entry) for key, entry in value.items()}
+    if normalized.get("kind") in {"accepted", "existing_operation"} and (
+        "operation_id" in normalized
+    ):
+        normalized["operation_id"] = "<operation-id>"
+    return normalized
+
+
+def _normalize_response(value: object) -> object:
+    """Normalize nondeterministic operation UUIDs and opaque entity ID offsets."""
+
+    operation_normalized = _normalize_operation_ids(value)
+    entity_ids = sorted(_collect_entity_ids(operation_normalized))
+    replacements = {entity_id: f"<entity-id:{index}>" for index, entity_id in enumerate(entity_ids)}
+    return _replace_entity_ids(operation_normalized, replacements)
+
+
+def _collect_entity_ids(value: object, ids: set[int] | None = None) -> set[int]:
+    ids = set() if ids is None else ids
+    if isinstance(value, list):
+        for entry in value:
+            _collect_entity_ids(entry, ids)
+    elif isinstance(value, dict):
+        for key, entry in value.items():
+            if key in {"$id", "$from", "$to"} and isinstance(entry, int):
+                ids.add(entry)
+            else:
+                _collect_entity_ids(entry, ids)
+    return ids
+
+
+def _replace_entity_ids(value: object, replacements: dict[int, str]) -> object:
+    if isinstance(value, list):
+        return [_replace_entity_ids(entry, replacements) for entry in value]
+    if not isinstance(value, dict):
+        return value
+    return {
+        key: (
+            replacements[entry]
+            if key in {"$id", "$from", "$to"} and isinstance(entry, int) and entry in replacements
+            else _replace_entity_ids(entry, replacements)
+        )
+        for key, entry in value.items()
+    }
+
+
+def _unused_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return listener.getsockname()[1]
+
+
+def _run(arguments: list[str]) -> None:
+    subprocess.run(arguments, check=True, stdout=subprocess.DEVNULL)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/src/helixdb/__init__.py
+++ b/sdks/python/src/helixdb/__init__.py
@@ -1,5 +1,6 @@
 """HelixDB Python SDK."""
 
+from .async_client import AsyncClient, AsyncQueryBuilder, AsyncQueryExecutionRequest
 from .client import (
     Client,
     Disk,
@@ -7,8 +8,8 @@ from .client import (
     HelixDBClient,
     HelixDbSource,
     HelixError,
-    InMemory,
     HybridCache,
+    InMemory,
     MemoryCache,
     ObjectStorage,
     QueryBuilder,
@@ -23,10 +24,10 @@ from .graph import (
     EdgeScore,
     ExternalId,
     FoundPath,
-    GraphEdge,
-    GraphEdgeId,
     GraphCommunity,
     GraphCycle,
+    GraphEdge,
+    GraphEdgeId,
     GraphKind,
     GraphMetadataSelection,
     GraphNode,
@@ -40,20 +41,23 @@ from .graph import (
     MissingSourcePath,
     MissingTargetPath,
     NativeGraph,
-    NoPath,
     NodeDegree,
     NodePosition,
     NodeScore,
+    NoPath,
     PathEdge,
     PathResult,
-    TraversalResult,
     TraversalOptions,
+    TraversalResult,
     TraversedEdge,
     external_id_from_json,
     external_id_to_json,
 )
 
 __all__ = [
+    "AsyncClient",
+    "AsyncQueryBuilder",
+    "AsyncQueryExecutionRequest",
     "Client",
     "Disk",
     "EmbeddedCacheConfig",

--- a/sdks/python/src/helixdb/_client_common.py
+++ b/sdks/python/src/helixdb/_client_common.py
@@ -32,9 +32,7 @@ class HelixError(Exception):
         self.__cause__ = cause
 
     @classmethod
-    def network(
-        cls, message: str, *, cause: BaseException | None = None
-    ) -> "HelixError":
+    def network(cls, message: str, *, cause: BaseException | None = None) -> "HelixError":
         return cls(
             "Network",
             f"error communicating with server: {message}",
@@ -52,9 +50,7 @@ class HelixError(Exception):
         )
 
     @classmethod
-    def serialization(
-        cls, message: str, *, cause: BaseException | None = None
-    ) -> "HelixError":
+    def serialization(cls, message: str, *, cause: BaseException | None = None) -> "HelixError":
         return cls(
             "Serialization",
             f"error serializing data: {message}",
@@ -63,12 +59,8 @@ class HelixError(Exception):
         )
 
     @classmethod
-    def invalid_url(
-        cls, message: str, *, cause: BaseException | None = None
-    ) -> "HelixError":
-        return cls(
-            "InvalidUrl", f"invalid url: {message}", details=message, cause=cause
-        )
+    def invalid_url(cls, message: str, *, cause: BaseException | None = None) -> "HelixError":
+        return cls("InvalidUrl", f"invalid url: {message}", details=message, cause=cause)
 
     @classmethod
     def invalid_request(cls, message: str) -> "HelixError":
@@ -86,9 +78,7 @@ class HelixError(Exception):
         )
 
     @classmethod
-    def embedded(
-        cls, message: str, *, cause: BaseException | None = None
-    ) -> "HelixError":
+    def embedded(cls, message: str, *, cause: BaseException | None = None) -> "HelixError":
         return cls(
             "Embedded",
             f"embedded HelixDB error: {message}",
@@ -128,9 +118,7 @@ class ExecuteOptions:
         if self.warm_only:
             prepared["x-helix-warm"] = "true"
         if self.await_durability is not None:
-            prepared["x-helix-await-durable"] = (
-                "true" if self.await_durability else "false"
-            )
+            prepared["x-helix-await-durable"] = "true" if self.await_durability else "false"
         return prepared
 
 
@@ -138,8 +126,17 @@ def validate_base_url(url: str | None) -> str:
     """Validate and return a server base URL using the synchronous contract."""
 
     base_url = url or DEFAULT_URL
-    parsed = urlparse(base_url)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+    try:
+        parsed = urlparse(base_url)
+        hostname = parsed.hostname
+        parsed.port
+    except ValueError as exc:
+        raise HelixError.invalid_url(str(exc), cause=exc) from exc
+    if (
+        parsed.scheme not in {"http", "https"}
+        or hostname is None
+        or any(character.isspace() for character in base_url)
+    ):
         raise HelixError.invalid_url("missing scheme or host")
     return base_url
 
@@ -152,16 +149,25 @@ def prepare_request(
 ) -> PreparedRequest:
     """Serialize a query and resolve the common HelixDB HTTP request."""
 
+    body = serialize_query(query)
     try:
         url = urljoin(base_url.rstrip("/") + "/", QUERY_PATH)
-        body = query.to_json_bytes()
     except Exception as exc:
-        raise HelixError.serialization(str(exc), cause=exc) from exc
+        raise HelixError.invalid_url(str(exc), cause=exc) from exc
 
     prepared_headers = dict(headers)
     if api_key is not None:
         prepared_headers["Authorization"] = f"Bearer {api_key}"
     return PreparedRequest(url, tuple(prepared_headers.items()), body)
+
+
+def serialize_query(query: QueryRequest) -> bytes:
+    """Serialize one query with the shared sync and async error contract."""
+
+    try:
+        return query.to_json_bytes()
+    except Exception as exc:
+        raise HelixError.serialization(str(exc), cause=exc) from exc
 
 
 def decode_response(response_body: bytes) -> Any:
@@ -181,9 +187,7 @@ def remote_details(response_body: bytes, fallback: str) -> str:
     return response_body.decode("utf-8", errors="replace") or fallback
 
 
-def parse_execute_options(
-    options: Mapping[str, Any], *, embedded: bool
-) -> ExecuteOptions:
+def parse_execute_options(options: Mapping[str, Any], *, embedded: bool) -> ExecuteOptions:
     """Validate ``execute`` keyword options without changing caller-owned state."""
 
     if embedded and options:
@@ -196,9 +200,7 @@ def parse_execute_options(
     writer_only = bool(remaining.pop("writer_only", False))
     warm_only = bool(remaining.pop("warm_only", False))
     await_durability = (
-        bool(remaining.pop("await_durability"))
-        if "await_durability" in remaining
-        else None
+        bool(remaining.pop("await_durability")) if "await_durability" in remaining else None
     )
     if remaining:
         unknown = ", ".join(sorted(remaining))

--- a/sdks/python/src/helixdb/_client_common.py
+++ b/sdks/python/src/helixdb/_client_common.py
@@ -1,0 +1,206 @@
+"""Shared request and error contracts for HelixDB Python clients."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+from urllib.parse import urljoin, urlparse
+
+from .dsl import QueryRequest
+
+DEFAULT_URL = "http://localhost:6969"
+QUERY_PATH = "/v2/query"
+
+
+class HelixError(Exception):
+    """Error raised by the HelixDB clients."""
+
+    def __init__(
+        self,
+        kind: str,
+        message: str,
+        *,
+        details: str | None = None,
+        status_code: int | None = None,
+        cause: BaseException | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.details = details
+        self.status_code = status_code
+        self.__cause__ = cause
+
+    @classmethod
+    def network(
+        cls, message: str, *, cause: BaseException | None = None
+    ) -> "HelixError":
+        return cls(
+            "Network",
+            f"error communicating with server: {message}",
+            details=message,
+            cause=cause,
+        )
+
+    @classmethod
+    def remote(cls, details: str, *, status_code: int | None = None) -> "HelixError":
+        return cls(
+            "Remote",
+            f"got error from server: {details}",
+            details=details,
+            status_code=status_code,
+        )
+
+    @classmethod
+    def serialization(
+        cls, message: str, *, cause: BaseException | None = None
+    ) -> "HelixError":
+        return cls(
+            "Serialization",
+            f"error serializing data: {message}",
+            details=message,
+            cause=cause,
+        )
+
+    @classmethod
+    def invalid_url(
+        cls, message: str, *, cause: BaseException | None = None
+    ) -> "HelixError":
+        return cls(
+            "InvalidUrl", f"invalid url: {message}", details=message, cause=cause
+        )
+
+    @classmethod
+    def invalid_request(cls, message: str) -> "HelixError":
+        return cls("InvalidRequest", f"invalid request: {message}", details=message)
+
+    @classmethod
+    def embedded_unavailable(
+        cls, message: str, *, cause: BaseException | None = None
+    ) -> "HelixError":
+        return cls(
+            "EmbeddedUnavailable",
+            f"embedded bindings unavailable: {message}",
+            details=message,
+            cause=cause,
+        )
+
+    @classmethod
+    def embedded(
+        cls, message: str, *, cause: BaseException | None = None
+    ) -> "HelixError":
+        return cls(
+            "Embedded",
+            f"embedded HelixDB error: {message}",
+            details=message,
+            cause=cause,
+        )
+
+
+@dataclass(frozen=True)
+class PreparedRequest:
+    """Immutable wire request shared by synchronous and asynchronous transports."""
+
+    url: str
+    headers: tuple[tuple[str, str], ...]
+    body: bytes
+
+    def header_map(self) -> dict[str, str]:
+        """Return a transport-owned mutable header map."""
+
+        return dict(self.headers)
+
+
+@dataclass(frozen=True)
+class ExecuteOptions:
+    """Validated server routing options for one query."""
+
+    writer_only: bool = False
+    warm_only: bool = False
+    await_durability: bool | None = None
+
+    def apply(self, headers: Mapping[str, str]) -> dict[str, str]:
+        """Add configured routing headers to a copy of ``headers``."""
+
+        prepared = dict(headers)
+        if self.writer_only:
+            prepared["x-helix-require-writer"] = "true"
+        if self.warm_only:
+            prepared["x-helix-warm"] = "true"
+        if self.await_durability is not None:
+            prepared["x-helix-await-durable"] = (
+                "true" if self.await_durability else "false"
+            )
+        return prepared
+
+
+def validate_base_url(url: str | None) -> str:
+    """Validate and return a server base URL using the synchronous contract."""
+
+    base_url = url or DEFAULT_URL
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise HelixError.invalid_url("missing scheme or host")
+    return base_url
+
+
+def prepare_request(
+    base_url: str,
+    api_key: str | None,
+    headers: Mapping[str, str],
+    query: QueryRequest,
+) -> PreparedRequest:
+    """Serialize a query and resolve the common HelixDB HTTP request."""
+
+    try:
+        url = urljoin(base_url.rstrip("/") + "/", QUERY_PATH)
+        body = query.to_json_bytes()
+    except Exception as exc:
+        raise HelixError.serialization(str(exc), cause=exc) from exc
+
+    prepared_headers = dict(headers)
+    if api_key is not None:
+        prepared_headers["Authorization"] = f"Bearer {api_key}"
+    return PreparedRequest(url, tuple(prepared_headers.items()), body)
+
+
+def decode_response(response_body: bytes) -> Any:
+    """Decode the shared empty-or-JSON response contract."""
+
+    if not response_body:
+        return None
+    try:
+        return json.loads(response_body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise HelixError.serialization(str(exc), cause=exc) from exc
+
+
+def remote_details(response_body: bytes, fallback: str) -> str:
+    """Prefer a server response body while tolerating invalid UTF-8."""
+
+    return response_body.decode("utf-8", errors="replace") or fallback
+
+
+def parse_execute_options(
+    options: Mapping[str, Any], *, embedded: bool
+) -> ExecuteOptions:
+    """Validate ``execute`` keyword options without changing caller-owned state."""
+
+    if embedded and options:
+        unknown = ", ".join(sorted(options))
+        raise HelixError.invalid_request(
+            f"embedded mode does not support execute option(s): {unknown}"
+        )
+
+    remaining = dict(options)
+    writer_only = bool(remaining.pop("writer_only", False))
+    warm_only = bool(remaining.pop("warm_only", False))
+    await_durability = (
+        bool(remaining.pop("await_durability"))
+        if "await_durability" in remaining
+        else None
+    )
+    if remaining:
+        unknown = ", ".join(sorted(remaining))
+        raise TypeError(f"unknown execute option(s): {unknown}")
+    return ExecuteOptions(writer_only, warm_only, await_durability)

--- a/sdks/python/src/helixdb/async_client.py
+++ b/sdks/python/src/helixdb/async_client.py
@@ -74,7 +74,23 @@ _RequestBackend = _ServerRequestBackend | _EmbeddedRequestBackend
 
 
 class AsyncClient:
-    """Asynchronous client for running queries against HelixDB."""
+    """Asynchronous client for running queries against HelixDB.
+
+    The client owns its reusable HTTP connection pool and any injected
+    transport, so close it with ``async with`` or :meth:`close`.
+
+    >>> import asyncio
+    >>> import httpx
+    >>> from helixdb import AsyncClient, QueryRequest, read_batch
+    >>> async def example():
+    ...     async def handler(request):
+    ...         return httpx.Response(200, json={"count": 0})
+    ...     transport = httpx.MockTransport(handler)
+    ...     async with AsyncClient(transport=transport) as client:
+    ...         return await client.query(QueryRequest.read(read_batch()))
+    >>> asyncio.run(example())
+    {'count': 0}
+    """
 
     def __init__(
         self,
@@ -267,18 +283,26 @@ class AsyncQueryBuilder:
     _headers: dict[str, str] = field(default_factory=lambda: {"Content-Type": "application/json"})
 
     def writer_only(self) -> "AsyncQueryBuilder":
+        """Require the authoritative writer for this server request."""
+
         self._headers["x-helix-require-writer"] = "true"
         return self
 
     def warm_only(self) -> "AsyncQueryBuilder":
+        """Warm eligible backends without returning a query result."""
+
         self._headers["x-helix-warm"] = "true"
         return self
 
     def should_await_durability(self, should: bool) -> "AsyncQueryBuilder":
+        """Control whether the server waits for durable write acknowledgement."""
+
         self._headers["x-helix-await-durable"] = "true" if should else "false"
         return self
 
     def query(self, query: QueryRequest) -> "AsyncQueryExecutionRequest":
+        """Freeze the builder headers and attach a query body."""
+
         return AsyncQueryExecutionRequest(
             self._backend,
             tuple(self._headers.items()),

--- a/sdks/python/src/helixdb/async_client.py
+++ b/sdks/python/src/helixdb/async_client.py
@@ -1,0 +1,364 @@
+"""Asynchronous HTTP and embedded client for HelixDB query routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from typing import Any
+
+import httpx
+
+from ._client_common import (
+    HelixError,
+    decode_response,
+    parse_execute_options,
+    prepare_request,
+    remote_details,
+    validate_base_url,
+)
+from .client import (
+    EmbeddedCacheConfig,
+    HelixDbSource,
+    _native_helixdb,
+    _to_native_cache,
+    _to_native_source,
+)
+from .dsl import QueryRequest
+
+Timeout = float | httpx.Timeout | None
+
+
+@dataclass(frozen=True)
+class _ServerBackend:
+    base_url: str
+    api_key: str | None
+    http_client: httpx.AsyncClient
+    timeout: Timeout
+
+
+@dataclass(frozen=True)
+class _EmbeddedBackend:
+    native: Any
+
+
+class _ClosedBackend(Enum):
+    CLOSED = "closed"
+
+
+_OpenBackend = _ServerBackend | _EmbeddedBackend
+_Backend = _OpenBackend | _ClosedBackend
+
+
+@dataclass
+class _ClientState:
+    backend: _Backend
+
+
+@dataclass(frozen=True)
+class _ServerRequestBackend:
+    state: _ClientState
+    base_url: str
+    api_key: str | None
+    http_client: httpx.AsyncClient
+    timeout: Timeout
+
+
+@dataclass(frozen=True)
+class _EmbeddedRequestBackend:
+    state: _ClientState
+    native: Any
+
+
+_RequestBackend = _ServerRequestBackend | _EmbeddedRequestBackend
+
+
+class AsyncClient:
+    """Asynchronous client for running queries against HelixDB."""
+
+    def __init__(
+        self,
+        url: str | None = None,
+        *,
+        api_key: str | None = None,
+        timeout: Timeout = None,
+        limits: httpx.Limits | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        client_options: dict[str, Any] = {
+            "follow_redirects": True,
+            "timeout": timeout,
+        }
+        if limits is not None:
+            client_options["limits"] = limits
+        if transport is not None:
+            client_options["transport"] = transport
+        self._state = _ClientState(
+            _ServerBackend(
+                validate_base_url(url),
+                api_key,
+                httpx.AsyncClient(**client_options),
+                timeout,
+            )
+        )
+
+    @classmethod
+    def _from_backend(cls, backend: _OpenBackend) -> "AsyncClient":
+        client = object.__new__(cls)
+        client._state = _ClientState(backend)
+        return client
+
+    @classmethod
+    def server(
+        cls,
+        url: str | None = None,
+        *,
+        api_key: str | None = None,
+        timeout: Timeout = None,
+        limits: httpx.Limits | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> "AsyncClient":
+        """Create a server client with one reusable HTTP connection pool."""
+
+        return cls(
+            url,
+            api_key=api_key,
+            timeout=timeout,
+            limits=limits,
+            transport=transport,
+        )
+
+    @classmethod
+    async def embedded(
+        cls,
+        source: HelixDbSource,
+        *,
+        cache: EmbeddedCacheConfig | None = None,
+    ) -> "AsyncClient":
+        """Open an asynchronous embedded writer client."""
+
+        native_db, native_source, native_cache, native_cache_mode = _native_helixdb()
+        try:
+            native = await (
+                native_db.open(_to_native_source(native_source, source))
+                if cache is None
+                else native_db.open_with_config(
+                    _to_native_source(native_source, source),
+                    _to_native_cache(native_cache, native_cache_mode, cache),
+                )
+            )
+        except HelixError:
+            raise
+        except Exception as exc:
+            raise HelixError.embedded(str(exc), cause=exc) from exc
+        return cls._from_backend(_EmbeddedBackend(native))
+
+    @classmethod
+    async def embedded_reader(
+        cls,
+        source: HelixDbSource,
+        *,
+        cache: EmbeddedCacheConfig | None = None,
+    ) -> "AsyncClient":
+        """Open an asynchronous embedded reader client."""
+
+        native_db, native_source, native_cache, native_cache_mode = _native_helixdb()
+        try:
+            native = await (
+                native_db.open_reader(_to_native_source(native_source, source))
+                if cache is None
+                else native_db.open_reader_with_config(
+                    _to_native_source(native_source, source),
+                    _to_native_cache(native_cache, native_cache_mode, cache),
+                )
+            )
+        except HelixError:
+            raise
+        except Exception as exc:
+            raise HelixError.embedded(str(exc), cause=exc) from exc
+        return cls._from_backend(_EmbeddedBackend(native))
+
+    def with_api_key(self, api_key: str | None = None) -> "AsyncClient":
+        """Set or clear the bearer API key sent on future server requests."""
+
+        backend = self._state.backend
+        if isinstance(backend, _ServerBackend):
+            self._state.backend = replace(backend, api_key=api_key)
+        elif backend is _ClosedBackend.CLOSED:
+            raise HelixError.invalid_request("client is closed")
+        return self
+
+    def _request_backend(self) -> _RequestBackend:
+        backend = self._state.backend
+        if isinstance(backend, _ServerBackend):
+            return _ServerRequestBackend(
+                self._state,
+                backend.base_url,
+                backend.api_key,
+                backend.http_client,
+                backend.timeout,
+            )
+        if isinstance(backend, _EmbeddedBackend):
+            return _EmbeddedRequestBackend(self._state, backend.native)
+        raise HelixError.invalid_request("client is closed")
+
+    def request_builder(self) -> "AsyncQueryBuilder":
+        """Start an immutable asynchronous query request."""
+
+        return AsyncQueryBuilder(self._request_backend())
+
+    async def query(self, request: QueryRequest, *, timeout: Timeout = None) -> Any:
+        """Execute and decode one query."""
+
+        return await self.request_builder().query(request).send(timeout=timeout)
+
+    async def execute(self, request: QueryRequest, **options: Any) -> Any:
+        """Execute one query with server routing and timeout options."""
+
+        remaining = dict(options)
+        timeout = remaining.pop("timeout", None)
+        request_backend = self._request_backend()
+        embedded = isinstance(request_backend, _EmbeddedRequestBackend)
+        parsed = parse_execute_options(remaining, embedded=embedded)
+        builder = AsyncQueryBuilder(request_backend)
+        builder._headers = parsed.apply(builder._headers)
+        return await builder.query(request).send(timeout=timeout)
+
+    @property
+    def base_url(self) -> str:
+        backend = self._state.backend
+        if isinstance(backend, _ServerBackend):
+            return backend.base_url
+        if isinstance(backend, _EmbeddedBackend):
+            return "embedded://helixdb"
+        raise HelixError.invalid_request("client is closed")
+
+    async def close(self) -> None:
+        """Close the owned HTTP transport or embedded database handle once."""
+
+        backend = self._state.backend
+        if backend is _ClosedBackend.CLOSED:
+            return
+        self._state.backend = _ClosedBackend.CLOSED
+        if isinstance(backend, _ServerBackend):
+            try:
+                await backend.http_client.aclose()
+            except Exception as exc:
+                raise HelixError.network(str(exc), cause=exc) from exc
+            return
+        try:
+            await backend.native.close()
+        except Exception as exc:
+            raise HelixError.embedded(str(exc), cause=exc) from exc
+
+    async def __aenter__(self) -> "AsyncClient":
+        self._request_backend()
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        await self.close()
+
+
+@dataclass
+class AsyncQueryBuilder:
+    """Builder for one asynchronous server or embedded request."""
+
+    _backend: _RequestBackend
+    _headers: dict[str, str] = field(
+        default_factory=lambda: {"Content-Type": "application/json"}
+    )
+
+    def writer_only(self) -> "AsyncQueryBuilder":
+        self._headers["x-helix-require-writer"] = "true"
+        return self
+
+    def warm_only(self) -> "AsyncQueryBuilder":
+        self._headers["x-helix-warm"] = "true"
+        return self
+
+    def should_await_durability(self, should: bool) -> "AsyncQueryBuilder":
+        self._headers["x-helix-await-durable"] = "true" if should else "false"
+        return self
+
+    def query(self, query: QueryRequest) -> "AsyncQueryExecutionRequest":
+        return AsyncQueryExecutionRequest(
+            self._backend,
+            tuple(self._headers.items()),
+            query,
+        )
+
+
+@dataclass(frozen=True)
+class AsyncQueryExecutionRequest:
+    """Complete asynchronous query request ready to send."""
+
+    _backend: _RequestBackend
+    _headers: tuple[tuple[str, str], ...]
+    _query: QueryRequest
+
+    def _ensure_open(self) -> None:
+        if self._backend.state.backend is _ClosedBackend.CLOSED:
+            raise HelixError.invalid_request("client is closed")
+
+    async def send_bytes(self, *, timeout: Timeout = None) -> bytes:
+        """Execute the request and retain the raw response body."""
+
+        self._ensure_open()
+        if isinstance(self._backend, _EmbeddedRequestBackend):
+            if timeout is not None:
+                raise HelixError.invalid_request(
+                    "embedded queries do not support client timeouts; use asyncio.timeout"
+                )
+            server_options = [
+                name for name, _ in self._headers if name.lower() != "content-type"
+            ]
+            if server_options:
+                raise HelixError.invalid_request(
+                    "embedded queries do not support server request options: "
+                    + ", ".join(server_options)
+                )
+            try:
+                return bytes(
+                    await self._backend.native.query_json(self._query.to_json_bytes())
+                )
+            except Exception as exc:
+                raise HelixError.embedded(str(exc), cause=exc) from exc
+
+        prepared = prepare_request(
+            self._backend.base_url,
+            self._backend.api_key,
+            dict(self._headers),
+            self._query,
+        )
+        request_timeout = self._backend.timeout if timeout is None else timeout
+        try:
+            async with self._backend.http_client.stream(
+                "POST",
+                prepared.url,
+                headers=prepared.header_map(),
+                content=prepared.body,
+                timeout=request_timeout,
+            ) as response:
+                response_body = await response.aread()
+                status = response.status_code
+                reason = response.reason_phrase or f"unknown error with code: {status}"
+        except httpx.RequestError as exc:
+            raise HelixError.network(str(exc), cause=exc) from exc
+
+        if status != 200:
+            raise HelixError.remote(
+                remote_details(response_body, reason),
+                status_code=status,
+            )
+        return response_body
+
+    async def send(self, *, timeout: Timeout = None) -> Any:
+        """Execute and decode the response body."""
+
+        return decode_response(await self.send_bytes(timeout=timeout))
+
+
+__all__ = [
+    "AsyncClient",
+    "AsyncQueryBuilder",
+    "AsyncQueryExecutionRequest",
+]

--- a/sdks/python/src/helixdb/async_client.py
+++ b/sdks/python/src/helixdb/async_client.py
@@ -14,6 +14,7 @@ from ._client_common import (
     parse_execute_options,
     prepare_request,
     remote_details,
+    serialize_query,
     validate_base_url,
 )
 from .client import (
@@ -263,9 +264,7 @@ class AsyncQueryBuilder:
     """Builder for one asynchronous server or embedded request."""
 
     _backend: _RequestBackend
-    _headers: dict[str, str] = field(
-        default_factory=lambda: {"Content-Type": "application/json"}
-    )
+    _headers: dict[str, str] = field(default_factory=lambda: {"Content-Type": "application/json"})
 
     def writer_only(self) -> "AsyncQueryBuilder":
         self._headers["x-helix-require-writer"] = "true"
@@ -308,18 +307,16 @@ class AsyncQueryExecutionRequest:
                 raise HelixError.invalid_request(
                     "embedded queries do not support client timeouts; use asyncio.timeout"
                 )
-            server_options = [
-                name for name, _ in self._headers if name.lower() != "content-type"
-            ]
+            server_options = [name for name, _ in self._headers if name.lower() != "content-type"]
             if server_options:
                 raise HelixError.invalid_request(
                     "embedded queries do not support server request options: "
                     + ", ".join(server_options)
                 )
             try:
-                return bytes(
-                    await self._backend.native.query_json(self._query.to_json_bytes())
-                )
+                return bytes(await self._backend.native.query_json(serialize_query(self._query)))
+            except HelixError:
+                raise
             except Exception as exc:
                 raise HelixError.embedded(str(exc), cause=exc) from exc
 

--- a/sdks/python/src/helixdb/client.py
+++ b/sdks/python/src/helixdb/client.py
@@ -8,17 +8,20 @@ from typing import Any, Literal
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from . import _client_common
 from ._client_common import (
-    DEFAULT_URL,
-    QUERY_PATH,
     HelixError,
     decode_response,
     parse_execute_options,
     prepare_request,
     remote_details,
+    serialize_query,
     validate_base_url,
 )
 from .dsl import QueryRequest
+
+DEFAULT_URL = _client_common.DEFAULT_URL
+QUERY_PATH = _client_common.QUERY_PATH
 
 
 class Client:
@@ -93,11 +96,9 @@ class Client:
             return self.request_builder()
         if self._mode == "embedded":
             if self._native is None:
-                raise HelixError(
-                    "EmbeddedUnavailable", "embedded HelixDB native handle is missing"
-                )
+                raise HelixError("EmbeddedUnavailable", "embedded HelixDB native handle is missing")
             try:
-                response = _run_native(self._native.query_json(request.to_json_bytes()))
+                response = _run_native(self._native.query_json(serialize_query(request)))
             except HelixError:
                 raise
             except Exception as exc:
@@ -134,13 +135,9 @@ class Client:
     def _graph_response(self, request: QueryRequest, native_spec: Any) -> Any:
         if self._mode == "embedded":
             if self._native is None:
-                raise HelixError(
-                    "EmbeddedUnavailable", "embedded HelixDB native handle is missing"
-                )
+                raise HelixError("EmbeddedUnavailable", "embedded HelixDB native handle is missing")
             try:
-                return _run_native(
-                    self._native.graph(request.to_json_bytes(), native_spec)
-                )
+                return _run_native(self._native.graph(request.to_json_bytes(), native_spec))
             except HelixError:
                 raise
             except Exception as exc:
@@ -250,9 +247,7 @@ class QueryExecutionRequest:
     query: QueryRequest
 
     def send_bytes(self) -> bytes:
-        prepared = prepare_request(
-            self.base_url, self.api_key, self.headers, self.query
-        )
+        prepared = prepare_request(self.base_url, self.api_key, self.headers, self.query)
         request = Request(
             prepared.url,
             data=prepared.body,
@@ -263,14 +258,9 @@ class QueryExecutionRequest:
             with urlopen(request) as response:  # nosec B310: user controls Helix endpoint.
                 status = response.getcode()
                 response_body = response.read()
-                reason = (
-                    getattr(response, "reason", "")
-                    or f"unknown error with code: {status}"
-                )
+                reason = getattr(response, "reason", "") or f"unknown error with code: {status}"
         except HTTPError as exc:
-            details = (
-                exc.read().decode("utf-8", errors="replace") or exc.reason or str(exc)
-            )
+            details = exc.read().decode("utf-8", errors="replace") or exc.reason or str(exc)
             raise HelixError.remote(details, status_code=exc.code) from exc
         except URLError as exc:
             raise HelixError.network(str(exc.reason), cause=exc) from exc
@@ -301,9 +291,7 @@ def _native_helixdb() -> tuple[Any, Any, Any | None, Any | None]:
     )
 
 
-def _to_native_cache(
-    native_cache: Any, native_mode: Any, cache: EmbeddedCacheConfig
-) -> Any:
+def _to_native_cache(native_cache: Any, native_mode: Any, cache: EmbeddedCacheConfig) -> Any:
     if native_cache is None or native_mode is None:
         raise HelixError.embedded_unavailable(
             "native bindings do not expose embedded cache configuration"

--- a/sdks/python/src/helixdb/client.py
+++ b/sdks/python/src/helixdb/client.py
@@ -4,90 +4,21 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-import json
 from typing import Any, Literal
 from urllib.error import HTTPError, URLError
-from urllib.parse import urljoin, urlparse
 from urllib.request import Request, urlopen
 
+from ._client_common import (
+    DEFAULT_URL,
+    QUERY_PATH,
+    HelixError,
+    decode_response,
+    parse_execute_options,
+    prepare_request,
+    remote_details,
+    validate_base_url,
+)
 from .dsl import QueryRequest
-
-DEFAULT_URL = "http://localhost:6969"
-QUERY_PATH = "/v2/query"
-
-
-class HelixError(Exception):
-    """Error raised by the HelixDB client."""
-
-    def __init__(
-        self,
-        kind: str,
-        message: str,
-        *,
-        details: str | None = None,
-        status_code: int | None = None,
-        cause: BaseException | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.kind = kind
-        self.details = details
-        self.status_code = status_code
-        self.__cause__ = cause
-
-    @classmethod
-    def network(cls, message: str, *, cause: BaseException | None = None) -> "HelixError":
-        return cls(
-            "Network",
-            f"error communicating with server: {message}",
-            details=message,
-            cause=cause,
-        )
-
-    @classmethod
-    def remote(cls, details: str, *, status_code: int | None = None) -> "HelixError":
-        return cls(
-            "Remote",
-            f"got error from server: {details}",
-            details=details,
-            status_code=status_code,
-        )
-
-    @classmethod
-    def serialization(cls, message: str, *, cause: BaseException | None = None) -> "HelixError":
-        return cls(
-            "Serialization",
-            f"error serializing data: {message}",
-            details=message,
-            cause=cause,
-        )
-
-    @classmethod
-    def invalid_url(cls, message: str, *, cause: BaseException | None = None) -> "HelixError":
-        return cls("InvalidUrl", f"invalid url: {message}", details=message, cause=cause)
-
-    @classmethod
-    def invalid_request(cls, message: str) -> "HelixError":
-        return cls("InvalidRequest", f"invalid request: {message}", details=message)
-
-    @classmethod
-    def embedded_unavailable(
-        cls, message: str, *, cause: BaseException | None = None
-    ) -> "HelixError":
-        return cls(
-            "EmbeddedUnavailable",
-            f"embedded bindings unavailable: {message}",
-            details=message,
-            cause=cause,
-        )
-
-    @classmethod
-    def embedded(cls, message: str, *, cause: BaseException | None = None) -> "HelixError":
-        return cls(
-            "Embedded",
-            f"embedded HelixDB error: {message}",
-            details=message,
-            cause=cause,
-        )
 
 
 class Client:
@@ -95,10 +26,7 @@ class Client:
 
     def __init__(self, url: str | None = None, *, api_key: str | None = None) -> None:
         self._mode: Literal["server", "embedded"] = "server"
-        self._base_url = url or DEFAULT_URL
-        parsed = urlparse(self._base_url)
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            raise HelixError.invalid_url("missing scheme or host")
+        self._base_url = validate_base_url(url)
         self._api_key = api_key
         self._native: Any | None = None
 
@@ -165,19 +93,16 @@ class Client:
             return self.request_builder()
         if self._mode == "embedded":
             if self._native is None:
-                raise HelixError("EmbeddedUnavailable", "embedded HelixDB native handle is missing")
+                raise HelixError(
+                    "EmbeddedUnavailable", "embedded HelixDB native handle is missing"
+                )
             try:
                 response = _run_native(self._native.query_json(request.to_json_bytes()))
             except HelixError:
                 raise
             except Exception as exc:
                 raise HelixError.embedded(str(exc), cause=exc) from exc
-            if not response:
-                return None
-            try:
-                return json.loads(bytes(response).decode("utf-8"))
-            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-                raise HelixError.serialization(str(exc), cause=exc) from exc
+            return decode_response(bytes(response))
         return self.request_builder().query(request).send()
 
     @property
@@ -187,23 +112,16 @@ class Client:
     def execute(self, request: QueryRequest, **options: Any) -> Any:
         """Convenience wrapper for ``client.query(request)`` with server headers."""
 
+        parsed = parse_execute_options(options, embedded=self._mode == "embedded")
         if self._mode == "embedded":
-            if options:
-                unknown = ", ".join(sorted(options))
-                raise HelixError.invalid_request(
-                    f"embedded mode does not support execute option(s): {unknown}"
-                )
             return self.query(request)
         builder = self.request_builder()
-        if options.pop("writer_only", False):
+        if parsed.writer_only:
             builder.writer_only()
-        if options.pop("warm_only", False):
+        if parsed.warm_only:
             builder.warm_only()
-        if "await_durability" in options:
-            builder.should_await_durability(bool(options.pop("await_durability")))
-        if options:
-            unknown = ", ".join(sorted(options))
-            raise TypeError(f"unknown execute option(s): {unknown}")
+        if parsed.await_durability is not None:
+            builder.should_await_durability(parsed.await_durability)
         return builder.query(request).send()
 
     def graph(self, selection: Any) -> Any:
@@ -216,9 +134,13 @@ class Client:
     def _graph_response(self, request: QueryRequest, native_spec: Any) -> Any:
         if self._mode == "embedded":
             if self._native is None:
-                raise HelixError("EmbeddedUnavailable", "embedded HelixDB native handle is missing")
+                raise HelixError(
+                    "EmbeddedUnavailable", "embedded HelixDB native handle is missing"
+                )
             try:
-                return _run_native(self._native.graph(request.to_json_bytes(), native_spec))
+                return _run_native(
+                    self._native.graph(request.to_json_bytes(), native_spec)
+                )
             except HelixError:
                 raise
             except Exception as exc:
@@ -328,23 +250,27 @@ class QueryExecutionRequest:
     query: QueryRequest
 
     def send_bytes(self) -> bytes:
-        try:
-            url = urljoin(self.base_url.rstrip("/") + "/", QUERY_PATH)
-        except Exception as exc:
-            raise HelixError.invalid_url(str(exc), cause=exc) from exc
-
-        headers = dict(self.headers)
-        if self.api_key is not None:
-            headers["Authorization"] = f"Bearer {self.api_key}"
-
-        request = Request(url, data=self.query.to_json_bytes(), headers=headers, method="POST")
+        prepared = prepare_request(
+            self.base_url, self.api_key, self.headers, self.query
+        )
+        request = Request(
+            prepared.url,
+            data=prepared.body,
+            headers=prepared.header_map(),
+            method="POST",
+        )
         try:
             with urlopen(request) as response:  # nosec B310: user controls Helix endpoint.
                 status = response.getcode()
                 response_body = response.read()
-                reason = getattr(response, "reason", "") or f"unknown error with code: {status}"
+                reason = (
+                    getattr(response, "reason", "")
+                    or f"unknown error with code: {status}"
+                )
         except HTTPError as exc:
-            details = exc.read().decode("utf-8", errors="replace") or exc.reason or str(exc)
+            details = (
+                exc.read().decode("utf-8", errors="replace") or exc.reason or str(exc)
+            )
             raise HelixError.remote(details, status_code=exc.code) from exc
         except URLError as exc:
             raise HelixError.network(str(exc.reason), cause=exc) from exc
@@ -352,18 +278,12 @@ class QueryExecutionRequest:
             raise HelixError.network(str(exc), cause=exc) from exc
 
         if status != 200:
-            details = response_body.decode("utf-8", errors="replace") or reason
+            details = remote_details(response_body, reason)
             raise HelixError.remote(details, status_code=status)
         return response_body
 
     def send(self) -> Any:
-        response_body = self.send_bytes()
-        if not response_body:
-            return None
-        try:
-            return json.loads(response_body)
-        except json.JSONDecodeError as exc:
-            raise HelixError.serialization(str(exc), cause=exc) from exc
+        return decode_response(self.send_bytes())
 
 
 def _native_helixdb() -> tuple[Any, Any, Any | None, Any | None]:

--- a/sdks/python/tests/test_async_client.py
+++ b/sdks/python/tests/test_async_client.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import unittest
+from unittest.mock import patch
+
+import httpx
+from test_client import FakeNativeDB, fake_native_module
+
+from helix_db import AsyncQueryBuilder, AsyncQueryExecutionRequest
+from helixdb import (
+    AsyncClient,
+    Disk,
+    EmbeddedCacheConfig,
+    HelixError,
+    HybridCache,
+    InMemory,
+    QueryRequest,
+    g,
+    read_batch,
+)
+
+
+def read_request() -> QueryRequest:
+    return QueryRequest.read(
+        read_batch().var_as("users", g().n_with_label("User").count()).returning(["users"])
+    )
+
+
+class ControlledStream(httpx.AsyncByteStream):
+    def __init__(self, body: bytes, *, block: bool = False, fail: bool = False) -> None:
+        self.body = body
+        self.block = block
+        self.fail = fail
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.closed = False
+        self.request: httpx.Request | None = None
+
+    async def __aiter__(self):
+        self.started.set()
+        if self.fail:
+            assert self.request is not None
+            raise httpx.ReadTimeout("timed out", request=self.request)
+        if self.block:
+            await self.release.wait()
+        yield self.body
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class SequencedTransport(httpx.AsyncBaseTransport):
+    def __init__(self, first: ControlledStream, *, first_status: int = 200) -> None:
+        self.first = first
+        self.first_status = first_status
+        self.calls = 0
+        self.closed = False
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        if self.calls == 1:
+            self.first.request = request
+            return httpx.Response(self.first_status, stream=self.first)
+        return httpx.Response(200, json={"reused": True})
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
+    async def test_query_posts_query_with_headers_and_timeout(self) -> None:
+        calls: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request)
+            return httpx.Response(200, json={"ok": True})
+
+        async with AsyncClient(
+            "http://127.0.0.1:6969/base",
+            api_key="hx_secret",
+            timeout=5.0,
+            limits=httpx.Limits(max_connections=4, max_keepalive_connections=2),
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            result = await (
+                client.request_builder()
+                .writer_only()
+                .warm_only()
+                .should_await_durability(False)
+                .query(read_request())
+                .send(timeout=0.25)
+            )
+
+        self.assertEqual(result, {"ok": True})
+        request = calls[0]
+        self.assertEqual(str(request.url), "http://127.0.0.1:6969/v2/query")
+        self.assertEqual(request.headers["authorization"], "Bearer hx_secret")
+        self.assertEqual(request.headers["x-helix-require-writer"], "true")
+        self.assertEqual(request.headers["x-helix-warm"], "true")
+        self.assertEqual(request.headers["x-helix-await-durable"], "false")
+        self.assertEqual(request.extensions["timeout"]["read"], 0.25)
+        self.assertEqual(json.loads(request.content)["request_type"], "read")
+
+    async def test_default_timeout_is_disabled(self) -> None:
+        calls: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request)
+            return httpx.Response(200, content=b"")
+
+        async with AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            self.assertIsNone(await client.query(read_request()))
+
+        self.assertTrue(all(value is None for value in calls[0].extensions["timeout"].values()))
+
+    async def test_execute_validates_options_and_updates_api_key(self) -> None:
+        calls: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request)
+            return httpx.Response(200, json={"ok": True})
+
+        client = AsyncClient(transport=httpx.MockTransport(handler)).with_api_key("first")
+        builder = client.request_builder()
+        client.with_api_key("second")
+
+        await builder.query(read_request()).send()
+        await client.execute(
+            read_request(),
+            writer_only=True,
+            warm_only=True,
+            await_durability=True,
+        )
+        with self.assertRaisesRegex(TypeError, "unknown execute option.*unknown"):
+            await client.execute(read_request(), unknown=True)
+        await client.close()
+
+        self.assertEqual(calls[0].headers["authorization"], "Bearer first")
+        self.assertEqual(calls[1].headers["authorization"], "Bearer second")
+        self.assertEqual(calls[1].headers["x-helix-require-writer"], "true")
+        self.assertEqual(calls[1].headers["x-helix-warm"], "true")
+        self.assertEqual(calls[1].headers["x-helix-await-durable"], "true")
+
+    async def test_empty_invalid_remote_and_network_responses_match_sync_contract(
+        self,
+    ) -> None:
+        responses = [
+            httpx.Response(200, content=b""),
+            httpx.Response(200, content=b"not-json"),
+            httpx.Response(409, content=b"conflict"),
+            httpx.Response(503, content=b""),
+        ]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return responses.pop(0)
+
+        async with AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            self.assertIsNone(await client.query(read_request()))
+            with self.assertRaises(HelixError) as invalid:
+                await client.query(read_request())
+            with self.assertRaises(HelixError) as conflict:
+                await client.query(read_request())
+            with self.assertRaises(HelixError) as unavailable:
+                await client.query(read_request())
+
+        self.assertEqual(invalid.exception.kind, "Serialization")
+        self.assertEqual(conflict.exception.kind, "Remote")
+        self.assertEqual(conflict.exception.status_code, 409)
+        self.assertEqual(conflict.exception.details, "conflict")
+        self.assertEqual(unavailable.exception.details, "Service Unavailable")
+
+        async def network_error(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused", request=request)
+
+        async with AsyncClient(transport=httpx.MockTransport(network_error)) as client:
+            with self.assertRaises(HelixError) as network:
+                await client.query(read_request())
+        self.assertEqual(network.exception.kind, "Network")
+        self.assertIsInstance(network.exception.__cause__, httpx.ConnectError)
+
+    async def test_timeout_closes_response_and_client_is_reusable(self) -> None:
+        stream = ControlledStream(b"", fail=True)
+        transport = SequencedTransport(stream)
+
+        async with AsyncClient(transport=transport) as client:
+            with self.assertRaises(HelixError) as timeout:
+                await client.query(read_request())
+            self.assertTrue(stream.closed)
+            self.assertEqual(await client.query(read_request()), {"reused": True})
+
+        self.assertEqual(timeout.exception.kind, "Network")
+        self.assertIsInstance(timeout.exception.__cause__, httpx.ReadTimeout)
+        self.assertTrue(transport.closed)
+
+    async def test_success_and_remote_error_close_response_streams(self) -> None:
+        success_stream = ControlledStream(b'{"ok":true}')
+        success_transport = SequencedTransport(success_stream)
+        async with AsyncClient(transport=success_transport) as client:
+            self.assertEqual(await client.query(read_request()), {"ok": True})
+        self.assertTrue(success_stream.closed)
+
+        error_stream = ControlledStream(b"busy")
+        error_transport = SequencedTransport(error_stream, first_status=503)
+        async with AsyncClient(transport=error_transport) as client:
+            with self.assertRaises(HelixError) as remote:
+                await client.query(read_request())
+            self.assertEqual(await client.query(read_request()), {"reused": True})
+        self.assertEqual(remote.exception.kind, "Remote")
+        self.assertEqual(remote.exception.status_code, 503)
+        self.assertTrue(error_stream.closed)
+
+    async def test_cancellation_closes_response_and_client_is_reusable(self) -> None:
+        stream = ControlledStream(b'{"blocked":true}', block=True)
+        transport = SequencedTransport(stream)
+
+        async with AsyncClient(transport=transport) as client:
+            pending = asyncio.create_task(client.query(read_request()))
+            await stream.started.wait()
+            pending.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await pending
+            self.assertTrue(stream.closed)
+            self.assertEqual(await client.query(read_request()), {"reused": True})
+
+    async def test_context_close_is_idempotent_and_closed_requests_fail(self) -> None:
+        transport = SequencedTransport(ControlledStream(b'{"ok":true}'))
+        client = AsyncClient(transport=transport)
+        pending = client.request_builder().query(read_request())
+
+        async with client as entered:
+            self.assertIs(entered, client)
+            self.assertEqual(client.base_url, "http://localhost:6969")
+
+        await client.close()
+        self.assertTrue(transport.closed)
+        for operation in (
+            lambda: client.request_builder(),
+            lambda: client.with_api_key("closed"),
+            lambda: client.base_url,
+        ):
+            with self.assertRaises(HelixError) as closed:
+                operation()
+            self.assertEqual(closed.exception.kind, "InvalidRequest")
+        with self.assertRaises(HelixError) as closed_request:
+            await pending.send()
+        self.assertEqual(closed_request.exception.kind, "InvalidRequest")
+
+    async def test_invalid_url_fails_before_transport_creation(self) -> None:
+        for url in (
+            "localhost:6969",
+            "ftp://localhost/query",
+            "http://[::1",
+            "http://bad host/query",
+        ):
+            with self.subTest(url=url):
+                with self.assertRaises(HelixError) as invalid:
+                    AsyncClient(url)
+                self.assertEqual(invalid.exception.kind, "InvalidUrl")
+
+    async def test_embedded_writer_queries_overlap_and_close_in_active_loop(
+        self,
+    ) -> None:
+        with patch.dict(sys.modules, {"helixdb_uniffi": fake_native_module()}):
+            client = await AsyncClient.embedded(InMemory("async-embedded"))
+            handle = FakeNativeDB.handle
+            handle.gate = asyncio.Event()
+            tasks = [asyncio.create_task(client.query(read_request())) for _ in range(3)]
+            for _ in range(100):
+                if handle.active == 3:
+                    break
+                await asyncio.sleep(0)
+            self.assertEqual(handle.active, 3)
+            self.assertEqual(handle.max_active, 3)
+            handle.gate.set()
+            self.assertEqual(
+                await asyncio.gather(*tasks),
+                [{"users": 0}, {"users": 0}, {"users": 0}],
+            )
+            await client.close()
+            await client.close()
+
+        self.assertEqual(FakeNativeDB.opened, [("IN_MEMORY", {"database": "async-embedded"})])
+        self.assertTrue(handle.closed)
+
+    async def test_embedded_cancellation_propagates_and_client_is_reusable(self) -> None:
+        with patch.dict(sys.modules, {"helixdb_uniffi": fake_native_module()}):
+            client = await AsyncClient.embedded(InMemory("async-cancellation"))
+            handle = FakeNativeDB.handle
+            handle.gate = asyncio.Event()
+            pending = asyncio.create_task(client.query(read_request()))
+            while handle.active == 0:
+                await asyncio.sleep(0)
+            pending.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await pending
+            self.assertEqual(handle.active, 0)
+            handle.gate.set()
+            self.assertEqual(await client.query(read_request()), {"users": 0})
+            await client.close()
+
+    async def test_serialization_errors_match_in_server_and_embedded_modes(self) -> None:
+        class InvalidRequest:
+            def to_json_bytes(self) -> bytes:
+                raise ValueError("cannot encode")
+
+        async with AsyncClient(transport=httpx.MockTransport(lambda request: None)) as client:
+            with self.assertRaises(HelixError) as server:
+                await client.query(InvalidRequest())  # type: ignore[arg-type]
+
+        with patch.dict(sys.modules, {"helixdb_uniffi": fake_native_module()}):
+            client = await AsyncClient.embedded(InMemory("async-serialization"))
+            with self.assertRaises(HelixError) as embedded:
+                await client.query(InvalidRequest())  # type: ignore[arg-type]
+            await client.close()
+
+        self.assertEqual(server.exception.kind, "Serialization")
+        self.assertEqual(embedded.exception.kind, "Serialization")
+
+    async def test_embedded_reader_cache_errors_and_server_options(self) -> None:
+        cache = EmbeddedCacheConfig(
+            vector_memory_bytes=1024,
+            mode=HybridCache(2048, "/tmp/slate", 4096, "/tmp/object", 8192),
+        )
+        with patch.dict(sys.modules, {"helixdb_uniffi": fake_native_module()}):
+            client = await AsyncClient.embedded_reader(
+                Disk("/tmp/helix", "async-reader"), cache=cache
+            )
+            self.assertEqual(client.base_url, "embedded://helixdb")
+            with self.assertRaises(HelixError) as execute_option:
+                await client.execute(read_request(), writer_only=True)
+            with self.assertRaises(HelixError) as builder_option:
+                await client.request_builder().warm_only().query(read_request()).send()
+            with self.assertRaises(HelixError) as timeout:
+                await client.query(read_request(), timeout=1.0)
+            FakeNativeDB.handle.error = RuntimeError("native failure")
+            with self.assertRaises(HelixError) as embedded:
+                await client.query(read_request())
+            await client.close()
+
+        self.assertEqual(execute_option.exception.kind, "InvalidRequest")
+        self.assertEqual(builder_option.exception.kind, "InvalidRequest")
+        self.assertEqual(timeout.exception.kind, "InvalidRequest")
+        self.assertEqual(embedded.exception.kind, "Embedded")
+        self.assertEqual(FakeNativeDB.opened_readers, [])
+        self.assertEqual(
+            FakeNativeDB.configured_readers[0][0],
+            ("DISK", {"root": "/tmp/helix", "database": "async-reader"}),
+        )
+        self.assertEqual(FakeNativeDB.configured_readers[0][1][0], "CACHE")
+
+    async def test_embedded_unavailable_and_public_exports(self) -> None:
+        with patch.dict(sys.modules, {"helixdb_uniffi": None}):
+            with self.assertRaises(HelixError) as unavailable:
+                await AsyncClient.embedded(InMemory("missing"))
+
+        self.assertEqual(unavailable.exception.kind, "EmbeddedUnavailable")
+        self.assertIsNotNone(AsyncQueryBuilder)
+        self.assertIsNotNone(AsyncQueryExecutionRequest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdks/python/tests/test_async_client.py
+++ b/sdks/python/tests/test_async_client.py
@@ -7,7 +7,7 @@ import unittest
 from unittest.mock import patch
 
 import httpx
-from test_client import FakeNativeDB, fake_native_module
+from test_client import FakeNativeDB, fake_native_module, public_api_members
 
 from helix_db import AsyncQueryBuilder, AsyncQueryExecutionRequest
 from helixdb import (
@@ -71,6 +71,50 @@ class SequencedTransport(httpx.AsyncBaseTransport):
 
 
 class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
+    async def test_public_async_client_api_is_explicitly_accounted_for(self) -> None:
+        self.assertEqual(
+            public_api_members(AsyncClient),
+            {
+                "server",
+                "embedded",
+                "embedded_reader",
+                "with_api_key",
+                "request_builder",
+                "query",
+                "execute",
+                "base_url",
+                "close",
+            },
+        )
+        self.assertEqual(
+            public_api_members(AsyncQueryBuilder),
+            {"writer_only", "warm_only", "should_await_durability", "query"},
+        )
+        self.assertEqual(
+            public_api_members(AsyncQueryExecutionRequest),
+            {"send_bytes", "send"},
+        )
+
+    async def test_server_constructor_and_raw_response(self) -> None:
+        calls: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request)
+            return httpx.Response(200, content=b'{"raw":true}')
+
+        client = AsyncClient.server(
+            "http://127.0.0.1:6969/base",
+            api_key="hx_secret",
+            transport=httpx.MockTransport(handler),
+        )
+        self.assertEqual(client.base_url, "http://127.0.0.1:6969/base")
+        response = await client.request_builder().query(read_request()).send_bytes()
+        await client.close()
+
+        self.assertEqual(response, b'{"raw":true}')
+        self.assertEqual(str(calls[0].url), "http://127.0.0.1:6969/v2/query")
+        self.assertEqual(calls[0].headers["authorization"], "Bearer hx_secret")
+
     async def test_query_posts_query_with_headers_and_timeout(self) -> None:
         calls: list[httpx.Request] = []
 

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import json
-from io import BytesIO
 import sys
 import types
 import unittest
+from io import BytesIO
 from unittest.mock import patch
 from urllib.error import HTTPError
 
@@ -46,10 +47,23 @@ class FakeNativeHandle:
     def __init__(self) -> None:
         self.requests: list[bytes] = []
         self.closed = False
+        self.gate: asyncio.Event | None = None
+        self.active = 0
+        self.max_active = 0
+        self.error: Exception | None = None
 
     async def query_json(self, body: bytes) -> bytes:
         self.requests.append(bytes(body))
-        return b'{"users":0}'
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        try:
+            if self.gate is not None:
+                await self.gate.wait()
+            if self.error is not None:
+                raise self.error
+            return b'{"users":0}'
+        finally:
+            self.active -= 1
 
     async def close(self) -> None:
         self.closed = True
@@ -190,7 +204,10 @@ class ClientTests(unittest.TestCase):
 
         self.assertEqual(result, {"users": 0})
         self.assertEqual(FakeNativeDB.opened, [("IN_MEMORY", {"database": "py-sdk-embedded"})])
-        self.assertEqual(json.loads(FakeNativeDB.handle.requests[0].decode("utf-8"))["request_type"], "read")
+        self.assertEqual(
+            json.loads(FakeNativeDB.handle.requests[0].decode("utf-8"))["request_type"],
+            "read",
+        )
         self.assertTrue(FakeNativeDB.handle.closed)
 
     def test_embedded_reader_uses_native_open_reader(self) -> None:
@@ -252,7 +269,9 @@ class ClientTests(unittest.TestCase):
 
     def test_embedded_execute_rejects_server_options(self) -> None:
         request = QueryRequest.write(
-            write_batch().var_as("created", g().add_n("User", {"name": "Ada"})).returning(["created"])
+            write_batch()
+            .var_as("created", g().add_n("User", {"name": "Ada"}))
+            .returning(["created"])
         )
 
         with patch.dict(sys.modules, {"helixdb_uniffi": fake_native_module()}):
@@ -261,7 +280,10 @@ class ClientTests(unittest.TestCase):
                 client.execute(request, writer_only=True)
 
         self.assertEqual(ctx.exception.kind, "InvalidRequest")
-        self.assertIn("embedded mode does not support execute option(s): writer_only", str(ctx.exception))
+        self.assertIn(
+            "embedded mode does not support execute option(s): writer_only",
+            str(ctx.exception),
+        )
 
 
 if __name__ == "__main__":

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -17,11 +17,24 @@ from helixdb import (
     HybridCache,
     InMemory,
     MemoryCache,
+    QueryBuilder,
+    QueryExecutionRequest,
     QueryRequest,
     g,
     read_batch,
     write_batch,
 )
+
+
+def public_api_members(type_: type) -> set[str]:
+    """Return methods and properties that form a class's named public API."""
+
+    return {
+        name
+        for name, member in vars(type_).items()
+        if not name.startswith("_")
+        and (callable(member) or isinstance(member, (classmethod, staticmethod, property)))
+    }
 
 
 class FakeResponse:
@@ -147,6 +160,71 @@ def fake_native_module() -> types.SimpleNamespace:
 
 
 class ClientTests(unittest.TestCase):
+    def test_public_client_api_is_explicitly_accounted_for(self) -> None:
+        self.assertEqual(
+            public_api_members(Client),
+            {
+                "server",
+                "embedded",
+                "embedded_reader",
+                "with_api_key",
+                "request_builder",
+                "query",
+                "base_url",
+                "execute",
+                "graph",
+                "close",
+            },
+        )
+        self.assertEqual(
+            public_api_members(QueryBuilder),
+            {"writer_only", "warm_only", "should_await_durability", "query"},
+        )
+        self.assertEqual(public_api_members(QueryExecutionRequest), {"send_bytes", "send"})
+
+    def test_server_convenience_methods_and_raw_response(self) -> None:
+        request = QueryRequest.read(read_batch())
+        calls = []
+
+        def fake_urlopen(req):
+            calls.append(req)
+            return FakeResponse()
+
+        client = Client.server("http://127.0.0.1:6969/base", api_key="first")
+        self.assertEqual(client.base_url, "http://127.0.0.1:6969/base")
+        first_request = client.query().query(request)
+        self.assertIs(client.with_api_key("second"), client)
+
+        with patch("helixdb.client.urlopen", fake_urlopen):
+            self.assertEqual(first_request.send_bytes(), b'{"ok":true}')
+            self.assertEqual(
+                client.execute(
+                    request,
+                    writer_only=True,
+                    warm_only=True,
+                    await_durability=True,
+                ),
+                {"ok": True},
+            )
+        client.close()
+
+        self.assertEqual(calls[0].headers["Authorization"], "Bearer first")
+        self.assertEqual(calls[0].full_url, "http://127.0.0.1:6969/v2/query")
+        self.assertEqual(calls[1].headers["Authorization"], "Bearer second")
+        self.assertEqual(calls[1].headers["X-helix-require-writer"], "true")
+        self.assertEqual(calls[1].headers["X-helix-warm"], "true")
+        self.assertEqual(calls[1].headers["X-helix-await-durable"], "true")
+
+    def test_graph_delegates_to_graph_loader(self) -> None:
+        client = Client.server()
+        selection = object()
+        loaded = object()
+
+        with patch("helixdb.graph.load_graph", return_value=loaded) as load_graph:
+            self.assertIs(client.graph(selection), loaded)
+
+        load_graph.assert_called_once_with(client, selection)
+
     def test_query_posts_query_with_headers(self) -> None:
         request = QueryRequest.read(
             read_batch().var_as("count", g().n_with_label("User").count()).returning(["count"])

--- a/sdks/tests/parity/COVERAGE.md
+++ b/sdks/tests/parity/COVERAGE.md
@@ -5,14 +5,22 @@ The parity suite combines coverage tools with explicit contract assertions:
 - Rust's fixture visitor classifies every authoritative AST enum variant. A new
   unclassified variant fails compilation, and the JSON-only corpus must contain
   every classified variant.
-- All four SDKs independently construct 233 executable requests and 15
-  serialization-only requests.
-- All 233 executable requests run through every public embedded client in
-  memory and disk modes and must produce structurally equal results.
-- The real server executes the same corpus in disk mode, with a restart between
-  indexed writes and deletion.
-- Unit tests cover server and embedded success/error states. Language coverage
-  tools guard their current line, branch, function, or statement baselines.
+- All four language SDKs independently construct 233 executable requests and 15
+  serialization-only requests. Both Python clients serialize the same request
+  types.
+- All 233 executable requests run through Rust, TypeScript, Go, synchronous
+  Python, and asynchronous Python embedded clients in memory and disk modes.
+  Disk Python runs include seeded read-only reopen checkpoints.
+- The current-source server executes the same corpus in disk mode for both
+  Python clients, with fresh storage per client and a restart checkpoint.
+- `run_server_parity.py --image` repeats both Python modes against the published
+  image on isolated ports and volumes and records its inspected digest.
+- Async embedded and server acceptance checks overlap read and write batches
+  with `asyncio.gather(...)`.
+- Unit tests cover headers, options, decoding, network failures, timeouts,
+  cancellation, deterministic response cleanup, repeated close, post-close
+  rejection, and client reuse. Language coverage tools guard their current
+  line, branch, function, or statement baselines.
 
 Run the coverage checks from the repository root:
 
@@ -24,3 +32,12 @@ CARGO_TARGET_DIR=/tmp/helix-sdk-rust-coverage cargo llvm-cov --manifest-path sdk
 ```
 
 `npm run test:parity` remains the end-to-end query and embedded runtime contract.
+
+Run published-image parity from the repository root after generating the Rust
+server baseline:
+
+```sh
+python sdks/python/scripts/run_server_parity.py \
+  --image ghcr.io/helixdb/helixdb:v0.0.3 \
+  --baseline-results sdks/tests/parity/results/rust
+```

--- a/sdks/typescript/scripts/parity/run-embedded-parity.ts
+++ b/sdks/typescript/scripts/parity/run-embedded-parity.ts
@@ -17,7 +17,7 @@ const generatorManifest = join(workspaceRoot, "bindings", "uniffi-bindgen", "Car
 const cargoTarget = process.env.CARGO_TARGET_DIR ?? join(workspaceRoot, "target");
 const nativeLibrary = join(cargoTarget, "debug", nativeLibraryName());
 const temp = await mkdtemp(join(tmpdir(), "helixdb-embedded-parity-"));
-const sdks = ["rust", "typescript", "go", "python"] as const;
+const sdks = ["rust", "typescript", "go", "python", "python-async"] as const;
 const storageModes = ["memory", "disk"] as const;
 type Sdk = (typeof sdks)[number];
 type StorageMode = (typeof storageModes)[number];
@@ -159,6 +159,17 @@ try {
       }),
     );
     run(
+      pythonCommand(),
+      [join(pythonRoot, "scripts", "run_embedded_parity.py")],
+      pythonRoot,
+      900_000,
+      embeddedEnv(results[storage]["python-async"], `python-async-sdk-${storage}-parity`, pythonBindings, storage, disks["python-async"], {
+        HELIX_PYTHON_PARITY_MODE: "async",
+        PYTHONPATH: appendPath(pythonBindings, process.env.PYTHONPATH),
+        PYTHONDONTWRITEBYTECODE: "1",
+      }),
+    );
+    run(
       process.execPath,
       [join(typescriptRoot, "dist-dev", "scripts", "parity", "run-embedded-client.js")],
       typescriptRoot,
@@ -183,11 +194,13 @@ try {
   for (const storage of storageModes) {
     const baseline = await jsonFiles(results[storage].rust);
     assertFixtureCount(`Rust ${storage}`, baseline);
-    for (const candidate of ["typescript", "go", "python"] as const) {
+    for (const candidate of ["typescript", "go", "python", "python-async"] as const) {
       await compareResults(results[storage].rust, results[storage][candidate], baseline, `${candidate} ${storage}`);
     }
   }
-  console.log(`embedded memory and disk runtime parity passed for ${EXPECTED_RUNTIME} fixtures across Rust, TypeScript, Go, and Python`);
+  console.log(
+    `embedded memory and disk runtime parity passed for ${EXPECTED_RUNTIME} fixtures across Rust, TypeScript, Go, synchronous Python, and asynchronous Python`,
+  );
 } finally {
   await rm(temp, { recursive: true, force: true });
 }
@@ -199,7 +212,7 @@ function nativeLibraryName(): string {
 }
 
 function pythonCommand(): string {
-  return process.platform === "win32" ? "python" : "python3";
+  return process.env.HELIX_PYTHON ?? (process.platform === "win32" ? "python" : "python3");
 }
 
 function embeddedEnv(

--- a/sdks/typescript/scripts/parity/run-helix.ts
+++ b/sdks/typescript/scripts/parity/run-helix.ts
@@ -62,6 +62,18 @@ try {
   for (const instance of instances) await runInstance(instance, join(temp, instance.label));
   await compareResults(instances[0]!, instances[1]!);
   await compareResults(instances[0]!, instances[2]!);
+  run(
+    pythonCommand(),
+    [
+      join(workspaceRoot, "sdks", "python", "scripts", "run_server_parity.py"),
+      "--server-binary",
+      serverBinary,
+      "--baseline-results",
+      instances[0]!.results,
+    ],
+    workspaceRoot,
+    900_000,
+  );
   console.log(`server disk runtime parity passed for ${EXPECTED_RUNTIME} fixtures with restart coverage`);
 } finally {
   await rm(temp, { recursive: true, force: true });
@@ -296,4 +308,8 @@ function run(command: string, args: string[], cwd: string, timeout: number) {
       .filter(Boolean)
       .join("\n"),
   );
+}
+
+function pythonCommand(): string {
+  return process.env.HELIX_PYTHON ?? (process.platform === "win32" ? "python" : "python3");
 }


### PR DESCRIPTION
## Summary

Implements HEL-802 with a first-class HTTPX-backed async Python client while preserving the synchronous API and wire contract.

- exports `AsyncClient`, `AsyncQueryBuilder`, and `AsyncQueryExecutionRequest` from both import paths
- supports server, embedded writer, and embedded reader clients, async context management, idempotent close, explicit timeouts, connection limits, and injected transports
- shares URL/header/body preparation, option validation, response decoding, and `HelixError` mapping between sync and async paths
- guarantees response cleanup across success, remote errors, timeouts, and cancellation while keeping the client reusable
- awaits native UniFFI operations directly and keeps async graph loading out of scope

## Query parity

- all 233 executable fixtures pass for sync and async Python against the current-source server
- all 233 executable fixtures pass for sync and async Python against `ghcr.io/helixdb/helixdb:v0.0.3`
- all 233 fixtures pass for embedded memory/disk writer and reopened disk reader modes
- all 248 serialization fixtures match the canonical Rust baseline, including 15 serialization-only fixtures
- restart persistence, transaction retries, DDL polling, text/vector lifecycle, post-drop failures, and overlapping async requests are covered

Published image digest tested:

`sha256:07d2349f6797bbb5dd1c92e3bf3e74db86bb4d22a4b2bf0c35ff6b9b17c7d2ef`

## Validation

- 44 Python unit tests; every public sync/async client, builder, and execution-request method is behaviorally covered and guarded against untested API additions
- 76% branch-aware Python coverage; 94% for the async client and 96% for shared client code
- Python doctests and Ruff formatting/linting
- TypeScript typecheck, ESLint, Prettier, unit tests, and build
- docs generation checks with regenerated `llms.txt` files
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

SDK parity CI now installs the editable Python package and exercises sync and async modes on Linux and macOS.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces an HTTPX-backed asynchronous Python client while sharing request preparation, response decoding, and error handling with the synchronous client.

- Adds async server and embedded clients, immutable request builders, context-managed cleanup, timeout and transport configuration, and public exports.
- Extends Python and cross-SDK parity coverage for async execution, concurrency, persistence, and serialization.
- Updates package dependencies, CI checks, SDK documentation, and generated documentation artifacts.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdks/python/src/helixdb/async_client.py | Adds the asynchronous server and embedded client, request builders, timeout handling, response cleanup, and idempotent lifecycle management. |
| sdks/python/src/helixdb/_client_common.py | Centralizes URL validation, request serialization, routing options, response decoding, and error construction for both client implementations. |
| sdks/python/src/helixdb/client.py | Refactors the synchronous client to consume the shared transport-independent request and error contracts. |
| sdks/python/tests/test_async_client.py | Covers the async public API, HTTP and embedded execution, errors, cancellation, cleanup, timeouts, and overlapping requests. |
| .github/workflows/sdk-query-parity.yml | Installs the editable Python package and adds formatting, linting, doctest, unit-test, and branch-coverage checks. |
| sdks/python/scripts/run_server_parity.py | Adds end-to-end synchronous and asynchronous Python fixture execution against binary and containerized servers. |
| sdks/python/scripts/run_embedded_parity.py | Extends embedded parity execution to async writer and reader modes, persistence checks, retries, and concurrent operations. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App as Python application
    participant AC as AsyncClient
    participant Shared as Shared request/response helpers
    participant Backend as HTTPX or embedded UniFFI backend
    App->>AC: await query(request)
    AC->>Shared: serialize and prepare request
    AC->>Backend: await execution
    Backend-->>AC: status and response bytes
    AC->>Shared: decode response or map HelixError
    Shared-->>App: decoded result
    App->>AC: await close()
    AC->>Backend: close owned resources
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(python): cover complete client surf..."](https://github.com/helixdb/helix-db/commit/9b2f5a4f3884d61382e2b9a2d310df040a24a258) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51551391)</sub>

**Context used:**

- Knowledge Base — [Python SDK: Client and Query DSL](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/sdk-python.md)
- Knowledge Base — [Cross-SDK DSL Parity Testing](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/sdk-parity-tests.md)

<!-- /greptile_comment -->