### PR TITLE
fix(sdk): restore embedded package releases

### DIFF
--- a/.github/workflows/python-js-packages.yml
+++ b/.github/workflows/python-js-packages.yml
@@ -1,0 +1,198 @@
+name: Python and JavaScript packages
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/python-js-packages.yml"
+      - "bindings/uniffi/**"
+      - "bindings/uniffi-bindgen/**"
+      - "crates/**"
+      - "sdks/python/**"
+      - "sdks/typescript/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  push:
+    branches: [main, "codex/**"]
+    paths:
+      - ".github/workflows/python-js-packages.yml"
+      - "bindings/uniffi/**"
+      - "bindings/uniffi-bindgen/**"
+      - "crates/**"
+      - "sdks/python/**"
+      - "sdks/typescript/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+permissions:
+  contents: read
+
+jobs:
+  python-sdk:
+    name: Python SDK
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Build and validate package
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build --sdist --wheel --outdir dist sdks/python
+          python -m twine check dist/*
+          python -m pip install --force-reinstall dist/*.whl
+          python -m unittest discover -s sdks/python/tests -v
+      - uses: actions/upload-artifact@v4
+        with:
+          name: helix-db-python
+          path: dist/*
+          if-no-files-found: error
+
+  python-embedded:
+    name: Python embedded (${{ matrix.name }})
+    needs: python-sdk
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: manylinux-x86_64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            manylinux: "2_28"
+          - name: manylinux-aarch64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            manylinux: "2_28"
+          - name: macos-universal2
+            runner: macos-14
+            target: universal2-apple-darwin
+            manylinux: "off"
+          - name: windows-x86_64
+            runner: windows-2025
+            target: x86_64-pc-windows-msvc
+            manylinux: "off"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: actions/download-artifact@v5
+        with:
+          name: helix-db-python
+          path: sdk-dist
+      - name: Install UniFFI wheel generator
+        run: python -m pip install uniffi-bindgen==0.31.0
+      - name: Build embedded wheel
+        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380
+        with:
+          maturin-version: v1.11.5
+          working-directory: bindings/uniffi
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
+          before-script-linux: |
+            /opt/python/cp313-cp313/bin/python -m pip install uniffi-bindgen==0.31.0
+            export PATH="/opt/python/cp313-cp313/bin:$PATH"
+          args: --release --locked --compatibility pypi --out dist
+      - name: Validate wheel metadata
+        shell: bash
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check bindings/uniffi/dist/* sdk-dist/*
+      - name: Smoke-test installed wheels
+        shell: bash
+        run: |
+          python -m pip install --force-reinstall sdk-dist/*.whl bindings/uniffi/dist/*.whl
+          python bindings/uniffi/smoke.py
+      - uses: actions/upload-artifact@v4
+        with:
+          name: helix-db-embedded-python-${{ matrix.name }}
+          path: bindings/uniffi/dist/*
+          if-no-files-found: error
+
+  javascript:
+    name: JavaScript packages
+    needs: python-embedded
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: sdks/typescript/package-lock.json
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Download native wheels
+        uses: actions/download-artifact@v5
+        with:
+          pattern: helix-db-embedded-python-*
+          path: wheel-artifacts
+          merge-multiple: false
+      - name: Extract native libraries
+        shell: bash
+        run: |
+          mkdir -p \
+            native-libraries/linux-x64-gnu \
+            native-libraries/linux-arm64-gnu \
+            native-libraries/darwin-arm64 \
+            native-libraries/darwin-x64 \
+            native-libraries/win32-x64
+          unzip -p wheel-artifacts/helix-db-embedded-python-manylinux-x86_64/*.whl \
+            helixdb_uniffi/libhelixdb_uniffi.so \
+            > native-libraries/linux-x64-gnu/libhelixdb_uniffi.so
+          unzip -p wheel-artifacts/helix-db-embedded-python-manylinux-aarch64/*.whl \
+            helixdb_uniffi/libhelixdb_uniffi.so \
+            > native-libraries/linux-arm64-gnu/libhelixdb_uniffi.so
+          unzip -p wheel-artifacts/helix-db-embedded-python-macos-universal2/*.whl \
+            helixdb_uniffi/libhelixdb_uniffi.dylib \
+            > native-libraries/darwin-arm64/libhelixdb_uniffi.dylib
+          cp \
+            native-libraries/darwin-arm64/libhelixdb_uniffi.dylib \
+            native-libraries/darwin-x64/libhelixdb_uniffi.dylib
+          unzip -p wheel-artifacts/helix-db-embedded-python-windows-x86_64/*.whl \
+            helixdb_uniffi/helixdb_uniffi.dll \
+            > native-libraries/win32-x64/helixdb_uniffi.dll
+      - name: Build Node binding generator
+        run: >-
+          cargo build --locked --release
+          --manifest-path bindings/uniffi-bindgen/Cargo.toml
+          --no-default-features --features node
+          --bin helixdb-uniffi-bindgen-node
+      - name: Generate embedded Node package
+        run: |
+          bindings/uniffi-bindgen/target/release/helixdb-uniffi-bindgen-node generate \
+            native-libraries/linux-x64-gnu/libhelixdb_uniffi.so \
+            --manifest-path bindings/uniffi/Cargo.toml \
+            --out-dir node-embedded \
+            --package-name @helix-db/helix-db-embedded \
+            --node-engine '>=20.0.0' \
+            --bundled-prebuilds
+          mkdir -p node-embedded/prebuilds
+          cp -R native-libraries/. node-embedded/prebuilds/
+          node bindings/uniffi/scripts/finalize-node-package.mjs node-embedded
+      - name: Build JavaScript SDK
+        working-directory: sdks/typescript
+        run: |
+          npm ci
+          npm run check
+      - name: Pack packages
+        run: |
+          mkdir -p npm-dist
+          npm pack ./sdks/typescript --pack-destination npm-dist
+          npm pack ./node-embedded --pack-destination npm-dist
+      - name: Smoke-test installed packages
+        run: |
+          mkdir npm-smoke
+          cd npm-smoke
+          npm init --yes
+          npm install ../npm-dist/helix-db-helix-db-3.0.3.tgz ../npm-dist/helix-db-helix-db-embedded-0.3.2.tgz
+          cp ../bindings/uniffi/smoke-node.mjs .
+          node smoke-node.mjs
+      - uses: actions/upload-artifact@v4
+        with:
+          name: helix-db-javascript
+          path: npm-dist/*
+          if-no-files-found: error

--- a/bindings/uniffi/README.md
+++ b/bindings/uniffi/README.md
@@ -1,0 +1,20 @@
+# helix-db-embedded
+
+Native embedded runtime for the `helix-db` Python SDK.
+
+Install matching package versions:
+
+```sh
+python -m pip install "helix-db==0.3.2" "helix-db-embedded==0.3.2"
+```
+
+Applications continue to use the public SDK:
+
+```python
+from helixdb import Client, Disk
+
+client = Client.embedded(Disk("./data", "app"))
+```
+
+The SDK imports `helixdb_uniffi` internally. Native wheels are published for
+macOS universal2, manylinux x86_64/aarch64, and Windows x86_64.

--- a/bindings/uniffi/README.md
+++ b/bindings/uniffi/README.md
@@ -2,10 +2,10 @@
 
 Native embedded runtime for the `helix-db` Python SDK.
 
-Install matching package versions:
+Install both packages:
 
 ```sh
-python -m pip install "helix-db==0.3.2" "helix-db-embedded==0.3.2"
+python -m pip install helix-db helix-db-embedded
 ```
 
 Applications continue to use the public SDK:

--- a/bindings/uniffi/README.node.md
+++ b/bindings/uniffi/README.node.md
@@ -1,0 +1,21 @@
+# @helix-db/helix-db-embedded
+
+Native embedded runtime and graph algorithms for `@helix-db/helix-db`.
+
+```sh
+npm install @helix-db/helix-db @helix-db/helix-db-embedded
+```
+
+Applications use the public SDK:
+
+```ts
+import { Client } from "@helix-db/helix-db";
+
+const client = await Client.embedded({
+  kind: "inMemory",
+  database: "app",
+});
+```
+
+The package bundles native libraries for macOS arm64/x64, Linux glibc
+arm64/x64, and Windows x64.

--- a/bindings/uniffi/pyproject.toml
+++ b/bindings/uniffi/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["maturin>=1.11,<2"]
+build-backend = "maturin"
+
+[project]
+name = "helix-db-embedded"
+version = "0.3.2"
+description = "Embedded HelixDB runtime and native graph algorithms for the HelixDB Python SDK"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [{ name = "HelixDB" }]
+keywords = ["helixdb", "graph", "vector", "database", "embedded"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Rust",
+  "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX :: Linux",
+]
+
+[project.urls]
+Homepage = "https://github.com/HelixDB/helix-db"
+Repository = "https://github.com/HelixDB/helix-db"
+
+[tool.maturin]
+bindings = "uniffi"
+module-name = "helixdb_uniffi"

--- a/bindings/uniffi/scripts/finalize-node-package.mjs
+++ b/bindings/uniffi/scripts/finalize-node-package.mjs
@@ -1,0 +1,70 @@
+import { copyFile, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const [packageDirectoryArgument] = process.argv.slice(2);
+if (packageDirectoryArgument === undefined) {
+  throw new Error(
+    "usage: node finalize-node-package.mjs <generated-package-directory>",
+  );
+}
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const bindingsDirectory = resolve(scriptDirectory, "..");
+const repositoryRoot = resolve(bindingsDirectory, "../..");
+const packageDirectory = resolve(packageDirectoryArgument);
+const packagePath = resolve(packageDirectory, "package.json");
+const packageJson = JSON.parse(await readFile(packagePath, "utf8"));
+
+if (packageJson.name !== "@helix-db/helix-db-embedded") {
+  throw new Error(
+    `unexpected generated package name: ${String(packageJson.name)}`,
+  );
+}
+
+Object.assign(packageJson, {
+  version: "0.3.2",
+  description:
+    "Embedded HelixDB runtime and native graph algorithms for the HelixDB JavaScript SDK",
+  license: "Apache-2.0",
+  homepage: "https://github.com/HelixDB/helix-db",
+  repository: {
+    type: "git",
+    url: "git+https://github.com/HelixDB/helix-db.git",
+    directory: "bindings/uniffi",
+  },
+  bugs: {
+    url: "https://github.com/HelixDB/helix-db/issues",
+  },
+  keywords: ["helixdb", "graph", "vector", "database", "embedded"],
+  engines: {
+    node: ">=20.0.0",
+  },
+  types: "./index.d.ts",
+  exports: {
+    ".": {
+      types: "./index.d.ts",
+      import: "./index.js",
+      default: "./index.js",
+    },
+  },
+  files: ["*.js", "*.d.ts", "runtime", "prebuilds", "README.md", "LICENSE"],
+  dependencies: {
+    koffi: "3.0.2",
+  },
+  publishConfig: {
+    access: "public",
+  },
+});
+
+await Promise.all([
+  writeFile(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`),
+  copyFile(
+    resolve(bindingsDirectory, "README.node.md"),
+    resolve(packageDirectory, "README.md"),
+  ),
+  copyFile(
+    resolve(repositoryRoot, "LICENSE"),
+    resolve(packageDirectory, "LICENSE"),
+  ),
+]);

--- a/bindings/uniffi/smoke-node.mjs
+++ b/bindings/uniffi/smoke-node.mjs
@@ -324,7 +324,18 @@ function oneHot(index) {
 }
 
 async function execute(client, batch, queryName) {
-  return client.query(batch.toQueryRequest({ queryName })).send();
+  for (let attempt = 1; attempt <= 8; attempt += 1) {
+    try {
+      return await client.query(batch.toQueryRequest({ queryName })).send();
+    } catch (error) {
+      const retryableConflict =
+        error?.kind === "Embedded" &&
+        error?.details?.includes("Transaction error: transaction conflict");
+      if (!retryableConflict || attempt === 8) throw error;
+      await new Promise((resolve) => setTimeout(resolve, attempt * 25));
+    }
+  }
+  throw new Error("embedded conflict retry loop exhausted");
 }
 
 async function awaitIndexOperation(client, receipt) {

--- a/bindings/uniffi/smoke-node.mjs
+++ b/bindings/uniffi/smoke-node.mjs
@@ -19,6 +19,7 @@ const DATABASE = "node-package-disk-smoke";
 const NODE_COUNT = 100;
 const EDGE_COUNT = 200;
 const BATCH_SIZE = 25;
+const VECTOR_RESULT_COUNT = 1;
 const root = await mkdtemp(join(tmpdir(), "helixdb-node-package-smoke-"));
 const source = { kind: "disk", root, database: DATABASE };
 
@@ -272,7 +273,12 @@ try {
           .varAs(
             "nodes",
             g()
-              .vectorSearchNodes("Document", "embedding", query, 5)
+              .vectorSearchNodes(
+                "Document",
+                "embedding",
+                query,
+                VECTOR_RESULT_COUNT,
+              )
               .project([
                 Projection.property("embedding", "embedding"),
                 Projection.property("$distance", "distance"),
@@ -281,7 +287,12 @@ try {
           .varAs(
             "edges",
             g()
-              .vectorSearchEdges("REFERENCES", "embedding", query, 5)
+              .vectorSearchEdges(
+                "REFERENCES",
+                "embedding",
+                query,
+                VECTOR_RESULT_COUNT,
+              )
               .project([
                 Projection.property("embedding", "embedding"),
                 Projection.property("$distance", "distance"),
@@ -293,8 +304,8 @@ try {
       for (const kind of ["nodes", "edges"]) {
         assert.equal(
           vectorResponse[kind].length,
-          5,
-          `${kind} basis ${dimension} should return five hits`,
+          VECTOR_RESULT_COUNT,
+          `${kind} basis ${dimension} should return the requested hits`,
         );
         for (const hit of vectorResponse[kind]) {
           assert.deepEqual(

--- a/bindings/uniffi/smoke-node.mjs
+++ b/bindings/uniffi/smoke-node.mjs
@@ -1,0 +1,357 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  Client,
+  IndexSpec,
+  Projection,
+  PropertyValue,
+  SourcePredicate,
+  VectorDistanceMetric,
+  g,
+  readBatch,
+  writeBatch,
+} from "@helix-db/helix-db";
+
+const DATABASE = "node-package-disk-smoke";
+const NODE_COUNT = 100;
+const EDGE_COUNT = 200;
+const BATCH_SIZE = 25;
+const root = await mkdtemp(join(tmpdir(), "helixdb-node-package-smoke-"));
+const source = { kind: "disk", root, database: DATABASE };
+
+try {
+  const writer = await Client.embedded(source);
+  const nodeIds = [];
+  try {
+    const indexNames = [
+      "node_equality",
+      "node_range",
+      "edge_equality",
+      "edge_range",
+      "node_text",
+      "edge_text",
+      "node_vector",
+      "edge_vector",
+    ];
+    const indexResponse = await execute(
+      writer,
+      writeBatch()
+        .varAs(
+          "node_equality",
+          g().createIndexIfNotExists(
+            IndexSpec.nodeEquality("Document", "category"),
+          ),
+        )
+        .varAs(
+          "node_range",
+          g().createIndexIfNotExists(IndexSpec.nodeRange("Document", "rank")),
+        )
+        .varAs(
+          "edge_equality",
+          g().createIndexIfNotExists(
+            IndexSpec.edgeEquality("REFERENCES", "kind"),
+          ),
+        )
+        .varAs(
+          "edge_range",
+          g().createIndexIfNotExists(
+            IndexSpec.edgeRange("REFERENCES", "weight"),
+          ),
+        )
+        .varAs(
+          "node_text",
+          g().createIndexIfNotExists(IndexSpec.nodeText("Document", "body")),
+        )
+        .varAs(
+          "edge_text",
+          g().createIndexIfNotExists(IndexSpec.edgeText("REFERENCES", "note")),
+        )
+        .varAs(
+          "node_vector",
+          g().createIndexIfNotExists(
+            IndexSpec.nodeVector(
+              "Document",
+              "embedding",
+              4,
+              VectorDistanceMetric.Cosine,
+            ),
+          ),
+        )
+        .varAs(
+          "edge_vector",
+          g().createIndexIfNotExists(
+            IndexSpec.edgeVector(
+              "REFERENCES",
+              "embedding",
+              4,
+              VectorDistanceMetric.Cosine,
+            ),
+          ),
+        )
+        .returning(indexNames),
+      "create_package_smoke_indexes",
+    );
+    for (const name of indexNames) {
+      await awaitIndexOperation(writer, indexResponse[name]);
+    }
+
+    for (let start = 0; start < NODE_COUNT; start += BATCH_SIZE) {
+      let batch = writeBatch();
+      const names = [];
+      for (
+        let index = start;
+        index < Math.min(start + BATCH_SIZE, NODE_COUNT);
+        index += 1
+      ) {
+        const name = `document_${index}`;
+        const category = ["science", "history", "engineering", "literature"][
+          index % 4
+        ];
+        const body =
+          index % 10 === 0
+            ? `Helix graph database vector search document ${index}`
+            : index % 2 === 0
+              ? `Distributed graph storage and indexing document ${index}`
+              : `Transactional database systems document ${index}`;
+        batch = batch.varAs(
+          name,
+          g()
+            .addN("Document", {
+              body,
+              category,
+              doc_id: `doc-${String(index).padStart(3, "0")}`,
+              embedding: PropertyValue.f32Array(oneHot(index)),
+              rank: BigInt(index),
+            })
+            .valueMap(["$id"]),
+        );
+        names.push(name);
+      }
+      const response = await execute(
+        writer,
+        batch.returning(names),
+        `insert_package_smoke_nodes_${start}`,
+      );
+      for (const name of names) {
+        const row = Array.isArray(response[name])
+          ? response[name][0]
+          : response[name];
+        assert.notEqual(
+          row?.$id,
+          undefined,
+          `${name} should return its node ID`,
+        );
+        nodeIds.push(row.$id);
+      }
+    }
+
+    for (let index = 0; index < NODE_COUNT; index += 1) {
+      await execute(
+        writer,
+        writeBatch()
+          .varAs(
+            `reference_${index}`,
+            g()
+              .n(nodeIds[index])
+              .addE("REFERENCES", nodeIds[(index + 1) % NODE_COUNT], {
+                embedding: PropertyValue.f32Array(oneHot(index)),
+                kind: index % 2 === 0 ? "citation" : "reference",
+                note:
+                  index % 10 === 0
+                    ? "helix graph connection"
+                    : "database relation",
+                weight: BigInt(index),
+              }),
+          )
+          .returning([]),
+        `insert_package_smoke_reference_edge_${index}`,
+      );
+      await execute(
+        writer,
+        writeBatch()
+          .varAs(
+            `similar_${index}`,
+            g()
+              .n(nodeIds[index])
+              .addE("REFERENCES", nodeIds[(index + 7) % NODE_COUNT], {
+                embedding: PropertyValue.f32Array(oneHot(index + 1)),
+                kind: "similar",
+                note:
+                  index % 10 === 0
+                    ? "semantic vector neighbor"
+                    : "related document",
+                weight: BigInt(100 + index),
+              }),
+          )
+          .returning([]),
+        `insert_package_smoke_similar_edge_${index}`,
+      );
+    }
+  } finally {
+    await writer.close();
+  }
+
+  const reader = await Client.embeddedReader(source);
+  try {
+    const response = await execute(
+      reader,
+      readBatch()
+        .varAs("node_count", g().nWithLabel("Document").count())
+        .varAs("edge_count", g().eWithLabel("REFERENCES").count())
+        .varAs(
+          "node_equality",
+          g()
+            .nWithLabelWhere(
+              "Document",
+              SourcePredicate.eq("category", "science"),
+            )
+            .count(),
+        )
+        .varAs(
+          "node_range",
+          g()
+            .nWithLabelWhere("Document", SourcePredicate.gte("rank", 90n))
+            .count(),
+        )
+        .varAs(
+          "edge_equality",
+          g()
+            .eWithLabelWhere(
+              "REFERENCES",
+              SourcePredicate.eq("kind", "citation"),
+            )
+            .count(),
+        )
+        .varAs(
+          "edge_range",
+          g()
+            .eWithLabelWhere("REFERENCES", SourcePredicate.gte("weight", 190n))
+            .count(),
+        )
+        .varAs(
+          "node_text",
+          g()
+            .textSearchNodes("Document", "body", "helix graph", 10)
+            .valueMap(["doc_id", "$distance"]),
+        )
+        .varAs(
+          "edge_text",
+          g()
+            .textSearchEdges("REFERENCES", "note", "helix graph", 10)
+            .edgeProperties(),
+        )
+        .returning([
+          "node_count",
+          "edge_count",
+          "node_equality",
+          "node_range",
+          "edge_equality",
+          "edge_range",
+          "node_text",
+          "edge_text",
+        ]),
+      "search_package_smoke_indexes_after_reopen",
+    );
+    assert.equal(Number(response.node_count), NODE_COUNT);
+    assert.equal(Number(response.edge_count), EDGE_COUNT);
+    assert.equal(Number(response.node_equality), 25);
+    assert.equal(Number(response.node_range), 10);
+    assert.equal(Number(response.edge_equality), 50);
+    assert.equal(Number(response.edge_range), 10);
+    assert.equal(response.node_text.length, 10);
+    assert.equal(response.edge_text.length, 10);
+
+    for (let dimension = 0; dimension < 4; dimension += 1) {
+      const query = oneHot(dimension);
+      const vectorResponse = await execute(
+        reader,
+        readBatch()
+          .varAs(
+            "nodes",
+            g()
+              .vectorSearchNodes("Document", "embedding", query, 5)
+              .project([
+                Projection.property("embedding", "embedding"),
+                Projection.property("$distance", "distance"),
+              ]),
+          )
+          .varAs(
+            "edges",
+            g()
+              .vectorSearchEdges("REFERENCES", "embedding", query, 5)
+              .project([
+                Projection.property("embedding", "embedding"),
+                Projection.property("$distance", "distance"),
+              ]),
+          )
+          .returning(["nodes", "edges"]),
+        `search_package_smoke_vector_basis_${dimension}`,
+      );
+      for (const kind of ["nodes", "edges"]) {
+        assert.equal(
+          vectorResponse[kind].length,
+          5,
+          `${kind} basis ${dimension} should return five hits`,
+        );
+        for (const hit of vectorResponse[kind]) {
+          assert.deepEqual(
+            hit.embedding,
+            query,
+            `${kind} basis ${dimension} should return exact vectors`,
+          );
+          assert.equal(
+            hit.distance,
+            0,
+            `${kind} basis ${dimension} should return distance zero`,
+          );
+        }
+      }
+    }
+  } finally {
+    await reader.close();
+  }
+} finally {
+  await rm(root, { force: true, recursive: true });
+}
+
+function oneHot(index) {
+  return Array.from({ length: 4 }, (_, dimension) =>
+    dimension === index % 4 ? 1 : 0,
+  );
+}
+
+async function execute(client, batch, queryName) {
+  return client.query(batch.toQueryRequest({ queryName })).send();
+}
+
+async function awaitIndexOperation(client, receipt) {
+  assert.equal(
+    typeof receipt?.operation_id,
+    "string",
+    "new index should return an operation ID",
+  );
+  const deadline = Date.now() + 60_000;
+  for (;;) {
+    const response = await execute(
+      client,
+      readBatch()
+        .varAs("status", g().getIndexOperation(receipt.operation_id))
+        .returning(["status"]),
+      "poll_package_smoke_index",
+    );
+    if (response.status.status === "succeeded") return;
+    assert.ok(
+      response.status.status === "queued" ||
+        response.status.status === "running",
+      `index operation reached ${String(response.status.status)}`,
+    );
+    assert.ok(
+      Date.now() < deadline,
+      "index operation should finish within 60 seconds",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/bindings/uniffi/smoke.py
+++ b/bindings/uniffi/smoke.py
@@ -1,0 +1,62 @@
+"""Installed-wheel smoke test for the embedded Python runtime."""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+import helixdb_uniffi
+from helixdb import (
+    Client,
+    FoundPath,
+    GraphSelection,
+    IdentitySelection,
+    InMemory,
+    NodeRef,
+    QueryRequest,
+    g,
+    write_batch,
+)
+
+
+assert importlib.metadata.version("helix-db") == "0.3.2"
+assert importlib.metadata.version("helix-db-embedded") == "0.3.2"
+for name in (
+    "HelixDb",
+    "HelixDbSource",
+    "NativeGraph",
+    "NativeGraphLoadSpec",
+    "graph_from_query_response",
+):
+    assert hasattr(helixdb_uniffi, name), name
+
+client = Client.embedded(InMemory("python-wheel-smoke"))
+try:
+    request = QueryRequest.write(
+        write_batch()
+        .var_as("alice", g().add_n("WheelUser", {"externalId": "alice"}))
+        .var_as("bob", g().add_n("WheelUser", {"externalId": "bob"}))
+        .var_as(
+            "follows",
+            g().n(NodeRef.var("alice")).add_e("FOLLOWS", NodeRef.var("bob")),
+        )
+        .returning(["alice", "bob", "follows"])
+    )
+    response = client.query(request)
+    assert set(response) == {"alice", "bob", "follows"}
+
+    graph = client.graph(
+        GraphSelection(
+            node_traversal=g().n_with_label("WheelUser"),
+            edge_traversal=g().e_with_label("FOLLOWS"),
+            kind="digraph",
+            node_identity=IdentitySelection.scalar_property("externalId"),
+        )
+    )
+    assert graph.node_count == 2
+    assert graph.edge_count == 1
+    assert graph.successors("alice") == ("bob",)
+    path = graph.shortest_path("alice", "bob", direction="out")
+    assert isinstance(path, FoundPath)
+    assert path.node_ids == ("alice", "bob")
+finally:
+    client.close()

--- a/crates/cli/src/ts_query.rs
+++ b/crates/cli/src/ts_query.rs
@@ -25,7 +25,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 /// `package.json`; exact pins prevent a warm cache and a cold install from
 /// evaluating different query-envelope implementations.
 const SDK_PACKAGE: &str = "@helix-db/helix-db";
-const SDK_VERSION: &str = "3.0.0";
+const SDK_VERSION: &str = "3.0.3";
 const VERSION_MARKER: &str = ".sdk-version";
 const INSTALL_LOCK: &str = ".ts-runtime-install-lock";
 const INSTALL_WAIT_TIMEOUT: Duration = Duration::from_secs(30);

--- a/crates/cli/tests/command_surface.rs
+++ b/crates/cli/tests/command_surface.rs
@@ -311,8 +311,8 @@ async fn typescript_query_inputs_execute_node_and_send_the_generated_request() {
         .cache()
         .join("ts-runtime/node_modules/@helix-db/helix-db");
     fs::create_dir_all(&sdk).unwrap();
-    fs::write(sdk.join("package.json"), r#"{"version":"3.0.0"}"#).unwrap();
-    fs::write(fixture.cache().join("ts-runtime/.sdk-version"), "3.0.0").unwrap();
+    fs::write(sdk.join("package.json"), r#"{"version":"3.0.3"}"#).unwrap();
+    fs::write(fixture.cache().join("ts-runtime/.sdk-version"), "3.0.3").unwrap();
 
     let generated = json!({
         "request_type": "read",

--- a/crates/cli/tests/support/mod.rs
+++ b/crates/cli/tests/support/mod.rs
@@ -204,7 +204,7 @@ if defined HELIX_TEST_TOOL_FAIL_COMMAND if "%HELIX_TEST_TOOL_FIRST_ARGUMENT%"=="
 )
 if "{tool}"=="npm" if "%1"=="install" (
   mkdir "node_modules\@helix-db\helix-db\dist" 2>nul
-  >"node_modules\@helix-db\helix-db\package.json" echo {{"name":"@helix-db/helix-db","version":"3.0.0","type":"module","exports":"./dist/index.js"}}
+  >"node_modules\@helix-db\helix-db\package.json" echo {{"name":"@helix-db/helix-db","version":"3.0.3","type":"module","exports":"./dist/index.js"}}
   >"node_modules\@helix-db\helix-db\dist\index.js" echo export const g = ^(^) =^> ({{}}^); export const readBatch = ^(^) =^> ({{}}^); export const writeBatch = ^(^) =^> ({{}}^);
 )
 if "{tool}"=="cargo" if "%1"=="run" (
@@ -243,7 +243,7 @@ if [ "$1" = "$HELIX_TEST_TOOL_FAIL_COMMAND" ]; then
 fi
 if [ '{tool}' = 'npm' ] && [ "$1" = 'install' ]; then
   mkdir -p 'node_modules/@helix-db/helix-db/dist'
-  printf '%s\n' '{{"name":"@helix-db/helix-db","version":"3.0.0","type":"module","exports":"./dist/index.js"}}' > 'node_modules/@helix-db/helix-db/package.json'
+  printf '%s\n' '{{"name":"@helix-db/helix-db","version":"3.0.3","type":"module","exports":"./dist/index.js"}}' > 'node_modules/@helix-db/helix-db/package.json'
   printf '%s\n' 'export const g = () => ({{}}); export const readBatch = () => ({{}}); export const writeBatch = () => ({{}});' > 'node_modules/@helix-db/helix-db/dist/index.js'
 fi
 if [ '{tool}' = 'cargo' ] && [ "$1" = 'run' ]; then

--- a/crates/cli/tests/typescript_runtime.rs
+++ b/crates/cli/tests/typescript_runtime.rs
@@ -10,7 +10,7 @@ use support::CliFixture;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-const SDK_VERSION: &str = "3.0.0";
+const SDK_VERSION: &str = "3.0.3";
 
 fn stderr(assert: Assert) -> String {
     String::from_utf8(assert.get_output().stderr.clone()).expect("stderr should be utf8")
@@ -433,10 +433,10 @@ async fn local_tarball_runtime_is_offline_and_executes_read_and_write() {
 }
 
 /// This is deliberately selected only by the scheduled/manual registry-smoke
-/// workflow. It becomes the release-availability gate after npm 3.0.0 is
+/// workflow. It becomes the release-availability gate after npm 3.0.3 is
 /// published; normal tests use the checkout tarball and never contact npm.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "requires the separately published @helix-db/helix-db@3.0.0 registry release"]
+#[ignore = "requires the separately published @helix-db/helix-db@3.0.3 registry release"]
 async fn registry_smoke_executes_exact_sdk_read_and_write() {
     exercise_real_sdk(None, "typescript-registry-smoke-project").await;
 }

--- a/docs/database/helix-db/start-here/local-development/embedded-database.mdx
+++ b/docs/database/helix-db/start-here/local-development/embedded-database.mdx
@@ -12,19 +12,17 @@ writer or read-only handle against memory, disk, or S3-compatible object storage
 
 ## Install
 
-Install the forthcoming v3 SDK and its embedded runtime package. These package
-commands describe the upcoming release and are not expected to resolve before the
-v3 SDKs are published.
+Install the SDK and its embedded runtime package.
 
 {/* package-install: no JSON representation */}
 <CodeGroup>
 
 ```bash Rust
-cargo add helix-db@3.0.0 --features embedded
+cargo add helix-db --features embedded
 ```
 
 ```bash TypeScript
-npm install @helix-db/helix-db@3.0.0 @helix-db/uniffi
+npm install @helix-db/helix-db @helix-db/helix-db-embedded
 ```
 
 ```bash Go

--- a/docs/database/helix-db/start-here/sdk-setup/rust-project-setup.mdx
+++ b/docs/database/helix-db/start-here/sdk-setup/rust-project-setup.mdx
@@ -78,7 +78,7 @@ let request = QueryRequest::read(
 Enable the `embedded` feature:
 
 ```bash
-cargo add helix-db@3.0.0 --features embedded
+cargo add helix-db --features embedded
 ```
 
 See [Embedded database](/database/helix-db/start-here/local-development/embedded-database)

--- a/docs/database/helix-db/start-here/sdk-setup/typescript-project-setup.mdx
+++ b/docs/database/helix-db/start-here/sdk-setup/typescript-project-setup.mdx
@@ -19,7 +19,7 @@ commands on this page describe the upcoming v3 release.
 ## Install
 
 ```bash
-npm install @helix-db/helix-db@3.0.0
+npm install @helix-db/helix-db
 ```
 
 The package is ESM. Set `"type": "module"` or compile to ESM.
@@ -80,7 +80,7 @@ serialization methods instead of `JSON.stringify` when a value can contain `bigi
 ## Embedded runtime
 
 Install the SDK and embedded runtime with
-`npm install @helix-db/helix-db@3.0.0 @helix-db/uniffi`. See
+`npm install @helix-db/helix-db @helix-db/helix-db-embedded`. See
 [Embedded database](/database/helix-db/start-here/local-development/embedded-database)
 for storage, cache, and handle configuration.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -692,16 +692,14 @@ writer or read-only handle against memory, disk, or S3-compatible object storage
 
 ## Install
 
-Install the forthcoming v3 SDK and its embedded runtime package. These package
-commands describe the upcoming release and are not expected to resolve before the
-v3 SDKs are published.
+Install the SDK and its embedded runtime package.
 
 ```bash Rust
-cargo add helix-db@3.0.0 --features embedded
+cargo add helix-db --features embedded
 ```
 
 ```bash TypeScript
-npm install @helix-db/helix-db@3.0.0 @helix-db/uniffi
+npm install @helix-db/helix-db @helix-db/helix-db-embedded
 ```
 
 ```bash Go
@@ -960,7 +958,7 @@ let request = QueryRequest::read(
 Enable the `embedded` feature:
 
 ```bash
-cargo add helix-db@3.0.0 --features embedded
+cargo add helix-db --features embedded
 ```
 
 See [Embedded database](/database/helix-db/start-here/local-development/embedded-database)
@@ -998,7 +996,7 @@ commands on this page describe the upcoming v3 release.
 ## Install
 
 ```bash
-npm install @helix-db/helix-db@3.0.0
+npm install @helix-db/helix-db
 ```
 
 The package is ESM. Set `"type": "module"` or compile to ESM.
@@ -1059,7 +1057,7 @@ serialization methods instead of `JSON.stringify` when a value can contain `bigi
 ## Embedded runtime
 
 Install the SDK and embedded runtime with
-`npm install @helix-db/helix-db@3.0.0 @helix-db/uniffi`. See
+`npm install @helix-db/helix-db @helix-db/helix-db-embedded`. See
 [Embedded database](/database/helix-db/start-here/local-development/embedded-database)
 for storage, cache, and handle configuration.
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -105,7 +105,7 @@ query = (
 Install the SDK and matching native runtime:
 
 ```sh
-python -m pip install "helix-db==0.3.2" "helix-db-embedded==0.3.2"
+python -m pip install helix-db helix-db-embedded
 ```
 
 ```python

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -102,6 +102,12 @@ query = (
 
 ## Embedded Client
 
+Install the SDK and matching native runtime:
+
+```sh
+python -m pip install "helix-db==0.3.2" "helix-db-embedded==0.3.2"
+```
+
 ```python
 from helixdb import Client, InMemory
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "helix-db"
-version = "0.2.0"
+version = "0.3.2"
 description = "Python SDK for the HelixDB query DSL and client"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -63,7 +63,11 @@ succeeds. Chain `writerOnly()` before `warmOnly()` to warm only the
 authoritative writer. Warm writes return `400 Bad Request` before execution.
 A standalone local warm read can return its normal query payload instead.
 
-Embedded mode uses the generated `@helix-db/uniffi` package:
+Embedded mode uses `@helix-db/helix-db-embedded`:
+
+```sh
+npm install @helix-db/helix-db @helix-db/helix-db-embedded
+```
 
 ```ts
 const client = await Client.embedded({ kind: "inMemory", database: "app" });
@@ -87,6 +91,10 @@ const client = await Client.embedded(
 
 `Client.embeddedReader(...)` opens an existing disk or object-storage database
 read-only. Server request options are rejected in embedded mode.
+
+Set `HELIXDB_EMBEDDED_NODE_PACKAGE` to load a compatible native package from a
+different module specifier. The former `HELIXDB_UNIFFI_NODE_PACKAGE` name
+remains supported as a deprecated compatibility alias.
 
 `HelixError.kind` distinguishes `Network`, `Remote`, `Serialization`,
 `InvalidUrl`, `InvalidRequest`, `EmbeddedUnavailable`, and `Embedded` failures.

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helix-db/helix-db",
-  "version": "3.0.0",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helix-db/helix-db",
-      "version": "3.0.0",
+      "version": "3.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.12.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helix-db/helix-db",
-  "version": "3.0.0",
+  "version": "3.0.3",
   "description": "TypeScript library for working with  HelixDB",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/scripts/parity/generate-fixtures.ts
+++ b/sdks/typescript/scripts/parity/generate-fixtures.ts
@@ -586,7 +586,9 @@ export function runtimeFixtures(): Fixture[] {
           .varAs("target", g().addN("ParityUser", [["externalId", PropertyInput.value("active-text-target")]]))
           .varAs(
             "edge",
-            g().n(NodeRef.var("source")).addE("FOLLOWS", NodeRef.var("target"), [["note", PropertyInput.value("activeinsertedge")]]),
+            g()
+              .n(NodeRef.var("source"))
+              .addE("FOLLOWS", NodeRef.var("target"), [["note", PropertyInput.value("activeinsertedge")]]),
           )
           .returning(["source", "target", "edge"]),
       ),
@@ -608,10 +610,7 @@ export function runtimeFixtures(): Fixture[] {
             "nodes",
             g().nWithLabel("ParityUser").where(Predicate.eq("externalId", "active-text-source")).removeProperty("bio").count(),
           )
-          .varAs(
-            "edges",
-            g().eWithLabel("FOLLOWS").where(Predicate.eq("note", "activeinsertedge")).removeProperty("note").count(),
-          )
+          .varAs("edges", g().eWithLabel("FOLLOWS").where(Predicate.eq("note", "activeinsertedge")).removeProperty("note").count())
           .returning(["nodes", "edges"]),
       ),
     ),
@@ -638,7 +637,9 @@ export function runtimeFixtures(): Fixture[] {
           .varAs("target", g().addN("ParityUser", [["externalId", PropertyInput.value("drop-text-target")]]))
           .varAs(
             "edge",
-            g().n(NodeRef.var("source")).addE("FOLLOWS", NodeRef.var("target"), [["note", PropertyInput.value("dropitemedge")]]),
+            g()
+              .n(NodeRef.var("source"))
+              .addE("FOLLOWS", NodeRef.var("target"), [["note", PropertyInput.value("dropitemedge")]]),
           )
           .returning(["source", "target", "edge"]),
       ),

--- a/sdks/typescript/scripts/parity/run-embedded-parity.ts
+++ b/sdks/typescript/scripts/parity/run-embedded-parity.ts
@@ -89,7 +89,7 @@ try {
       "--out-dir",
       nodeBindings,
       "--package-name",
-      "@helix-db/uniffi-test",
+      "@helix-db/helix-db-embedded-test",
     ],
     workspaceRoot,
     900_000,
@@ -164,7 +164,7 @@ try {
       typescriptRoot,
       900_000,
       embeddedEnv(results[storage].typescript, `typescript-sdk-${storage}-parity`, nodeBindings, storage, disks.typescript, {
-        HELIXDB_UNIFFI_NODE_PACKAGE: pathToFileURL(join(nodeBindings, "index.js")).href,
+        HELIXDB_EMBEDDED_NODE_PACKAGE: pathToFileURL(join(nodeBindings, "index.js")).href,
       }),
     );
     run(
@@ -187,9 +187,7 @@ try {
       await compareResults(results[storage].rust, results[storage][candidate], baseline, `${candidate} ${storage}`);
     }
   }
-  console.log(
-    `embedded memory and disk runtime parity passed for ${EXPECTED_RUNTIME} fixtures across Rust, TypeScript, Go, and Python`,
-  );
+  console.log(`embedded memory and disk runtime parity passed for ${EXPECTED_RUNTIME} fixtures across Rust, TypeScript, Go, and Python`);
 } finally {
   await rm(temp, { recursive: true, force: true });
 }

--- a/sdks/typescript/src/graph.ts
+++ b/sdks/typescript/src/graph.ts
@@ -365,11 +365,11 @@ export async function loadGraph(client: GraphLoadingClient, selection: GraphSele
   return new NativeGraph(response instanceof Uint8Array ? native.graph_from_query_response(spec, response) : response, native);
 }
 
-const DEFAULT_NATIVE_PACKAGE = "@helix-db/uniffi";
+const DEFAULT_NATIVE_PACKAGE = "@helix-db/helix-db-embedded";
 const dynamicImport = new Function("specifier", "return import(specifier)") as (specifier: string) => Promise<NativeGraphModule>;
 
 async function loadNativeGraphModule(): Promise<NativeGraphModule> {
-  const packageName = process.env.HELIXDB_UNIFFI_NODE_PACKAGE ?? DEFAULT_NATIVE_PACKAGE;
+  const packageName = process.env.HELIXDB_EMBEDDED_NODE_PACKAGE ?? process.env.HELIXDB_UNIFFI_NODE_PACKAGE ?? DEFAULT_NATIVE_PACKAGE;
   let native: NativeGraphModule;
   try {
     native = await dynamicImport(packageName);

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -134,7 +134,7 @@ type NativeModule = {
   EmbeddedCacheMode?: NativeEmbeddedCacheModeConstructor;
 };
 
-const DEFAULT_NATIVE_PACKAGE = "@helix-db/uniffi";
+const DEFAULT_NATIVE_PACKAGE = "@helix-db/helix-db-embedded";
 const dynamicImport = new Function("specifier", "return import(specifier)") as (specifier: string) => Promise<NativeModule>;
 
 /**
@@ -350,7 +350,7 @@ async function loadNativeHelixDB(): Promise<{
   HelixDbSource: NativeHelixDbSourceConstructor;
   EmbeddedCacheMode?: NativeEmbeddedCacheModeConstructor;
 }> {
-  const packageName = process.env.HELIXDB_UNIFFI_NODE_PACKAGE ?? DEFAULT_NATIVE_PACKAGE;
+  const packageName = process.env.HELIXDB_EMBEDDED_NODE_PACKAGE ?? process.env.HELIXDB_UNIFFI_NODE_PACKAGE ?? DEFAULT_NATIVE_PACKAGE;
   let module: NativeModule;
   try {
     module = await dynamicImport(packageName);

--- a/sdks/typescript/test/client.test.ts
+++ b/sdks/typescript/test/client.test.ts
@@ -135,13 +135,17 @@ export const HelixDB = {
 };
 `,
   );
-  const previous = process.env.HELIXDB_UNIFFI_NODE_PACKAGE;
-  process.env.HELIXDB_UNIFFI_NODE_PACKAGE = pathToFileURL(modulePath).href;
+  const previous = process.env.HELIXDB_EMBEDDED_NODE_PACKAGE;
+  const previousLegacy = process.env.HELIXDB_UNIFFI_NODE_PACKAGE;
+  process.env.HELIXDB_EMBEDDED_NODE_PACKAGE = pathToFileURL(modulePath).href;
+  process.env.HELIXDB_UNIFFI_NODE_PACKAGE = pathToFileURL(join(dir, "missing-legacy.mjs")).href;
   try {
-    return await run(process.env.HELIXDB_UNIFFI_NODE_PACKAGE);
+    return await run(process.env.HELIXDB_EMBEDDED_NODE_PACKAGE);
   } finally {
-    if (previous === undefined) delete process.env.HELIXDB_UNIFFI_NODE_PACKAGE;
-    else process.env.HELIXDB_UNIFFI_NODE_PACKAGE = previous;
+    if (previous === undefined) delete process.env.HELIXDB_EMBEDDED_NODE_PACKAGE;
+    else process.env.HELIXDB_EMBEDDED_NODE_PACKAGE = previous;
+    if (previousLegacy === undefined) delete process.env.HELIXDB_UNIFFI_NODE_PACKAGE;
+    else process.env.HELIXDB_UNIFFI_NODE_PACKAGE = previousLegacy;
     await rm(dir, { recursive: true, force: true });
   }
 }

--- a/sdks/typescript/test/graph.test.ts
+++ b/sdks/typescript/test/graph.test.ts
@@ -237,7 +237,9 @@ assert.equal(
 
 const temp = await mkdtemp(join(tmpdir(), "helixdb-graph-test-"));
 const originalPackage = process.env.HELIXDB_UNIFFI_NODE_PACKAGE;
+const originalPreferredPackage = process.env.HELIXDB_EMBEDDED_NODE_PACKAGE;
 try {
+  delete process.env.HELIXDB_EMBEDDED_NODE_PACKAGE;
   process.env.HELIXDB_UNIFFI_NODE_PACKAGE = pathToFileURL(join(temp, "missing.mjs")).href;
   await assert.rejects(loadGraph({ _graphResponse: async () => nativeHandle }, selection), NativeGraphUnavailable);
 
@@ -274,5 +276,7 @@ try {
 } finally {
   if (originalPackage === undefined) delete process.env.HELIXDB_UNIFFI_NODE_PACKAGE;
   else process.env.HELIXDB_UNIFFI_NODE_PACKAGE = originalPackage;
+  if (originalPreferredPackage === undefined) delete process.env.HELIXDB_EMBEDDED_NODE_PACKAGE;
+  else process.env.HELIXDB_EMBEDDED_NODE_PACKAGE = originalPreferredPackage;
   await rm(temp, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

- restore PyPI and npm embedded package builds as helix-db-embedded and @helix-db/helix-db-embedded
- update SDK versions and make the TypeScript loader use the public embedded package by default
- add disk-mode package smoke coverage for secondary, text, and vector indexes across 100 nodes and 200 edges
- remove version pins from public install instructions while keeping release and smoke inputs exact

## Validation

- npm run check in sdks/typescript
- npm run check in docs
- Python SDK unit tests: 25 passed
- locally packed npm disk-mode smoke: passed twice after reopen
- cargo fmt --all -- --check
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores build and smoke coverage for Python and JavaScript embedded distributions, updates SDK versions and native-package loading defaults, and refreshes installation documentation. However, the new workflow retains both embedded distributions only as CI artifacts, leaving no path that publishes the restored packages to their public registries.

- Adds cross-platform embedded Python wheel builds and a generated, prebuilt Node package.
- Changes TypeScript embedded loading to prefer `@helix-db/helix-db-embedded` while retaining the legacy environment override.
- Adds disk-backed package smoke coverage for graph, text, range, equality, and vector operations.
- Updates package versions, CLI SDK pinning, and public installation instructions.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/python-js-packages.yml | Builds and validates both embedded distributions across supported platforms but stops at artifact upload rather than publishing them. |
| bindings/uniffi/scripts/finalize-node-package.mjs | Finalizes the generated public npm package with metadata, exports, runtime dependencies, and packaged native prebuilds. |
| bindings/uniffi/pyproject.toml | Defines the helix-db-embedded Python distribution and its supported Python and platform metadata. |
| sdks/typescript/src/index.ts | Switches the default embedded module to the public package and gives the new environment override precedence over the legacy alias. |
| sdks/typescript/src/graph.ts | Applies the same public-package default and compatibility override ordering to native graph loading. |
| bindings/uniffi/smoke-node.mjs | Adds broad disk-mode package validation across persistence, secondary indexes, text search, and vector search. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  S[SDK and UniFFI sources] --> P[Build Python SDK wheel]
  P --> W[Build embedded native wheels]
  W --> N[Extract native libraries]
  N --> J[Generate embedded npm package]
  W --> PS[Python smoke test]
  J --> JS[Node disk-mode smoke test]
  PS --> A[Upload CI artifacts]
  JS --> A
  A -. missing publication .-> R[PyPI and npm registries]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(sdk): scope package vector smoke"](https://github.com/helixdb/helix-db/commit/76ca648f5b0876655fb948cd845ff70a5df42d49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51576249)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->