### PR TITLE
ci: use ARM runners for primary jobs

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-2vcpu-ubuntu-2404
+          - blacksmith-8vcpu-ubuntu-2404-arm
           - blacksmith-6vcpu-macos-latest
           - blacksmith-2vcpu-windows-2025
     steps:
@@ -70,7 +70,7 @@ jobs:
 
   coverage:
     name: Coverage (Ubuntu)
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -101,7 +101,7 @@ jobs:
   registry-smoke:
     name: Published TypeScript SDK registry smoke
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cloud-launch-nightly.yml
+++ b/.github/workflows/cloud-launch-nightly.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   planner-matrix:
     name: Planner matrix shard ${{ matrix.shard }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -38,7 +38,7 @@ jobs:
 
   fuzz:
     name: Fuzz ${{ matrix.target }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -75,7 +75,7 @@ jobs:
 
   workload-matrix:
     name: Deterministic workload seeds
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -93,7 +93,7 @@ jobs:
 
   vector-lifecycle:
     name: Bounded 8k vector lifecycle
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cloud-launch-pr.yml
+++ b/.github/workflows/cloud-launch-pr.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   quality:
     name: Format, Clippy, and doctests
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -46,7 +46,7 @@ jobs:
 
   workspace-tests:
     name: Workspace tests
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 30
     env:
       CARGO_BUILD_JOBS: "2"
@@ -66,7 +66,7 @@ jobs:
 
   db-all-targets:
     name: DB all targets
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v6
@@ -76,7 +76,7 @@ jobs:
 
   deterministic-contracts:
     name: Planner, lifecycle, isolation, and transports
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -94,7 +94,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 45
     env:
       HELIX_HYPERSCALE_REPO: ${{ github.workspace }}/helix-hyperscale

--- a/.github/workflows/cloud-launch-prelaunch.yml
+++ b/.github/workflows/cloud-launch-prelaunch.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   release-scale:
     name: Release scale — ${{ matrix.name }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 370
     strategy:
       fail-fast: false
@@ -59,7 +59,7 @@ jobs:
 
   release-contracts:
     name: Stable failpoint and coordinator contracts
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -72,7 +72,7 @@ jobs:
 
   vector-diagnostic:
     name: Vector recall and throughput diagnostic
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -86,7 +86,7 @@ jobs:
 
   sustained:
     name: Ten-run LocalFileSystem and long lifecycle matrix
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6
@@ -105,7 +105,7 @@ jobs:
 
   performance-decision:
     name: Same-host performance, lag, and resource decision
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cloud-launch-vector-100k.yml
+++ b/.github/workflows/cloud-launch-vector-100k.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build-vector-100k:
     name: Build vector 100k contract
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -52,7 +52,7 @@ jobs:
   vector-100k:
     name: Vector 100k create, search, drop, and residue
     needs: build-vector-100k
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     timeout-minutes: 360
     steps:
       - uses: actions/download-artifact@v5

--- a/.github/workflows/sdk-query-parity.yml
+++ b/.github/workflows/sdk-query-parity.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-2vcpu-ubuntu-2404
+          - blacksmith-8vcpu-ubuntu-2404-arm
           - blacksmith-6vcpu-macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-2vcpu-ubuntu-2404
+          - blacksmith-8vcpu-ubuntu-2404-arm
           - blacksmith-6vcpu-macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -132,7 +132,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-2vcpu-ubuntu-2404
+          - blacksmith-8vcpu-ubuntu-2404-arm
           - blacksmith-6vcpu-macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -175,7 +175,7 @@ jobs:
 
   coverage:
     name: SDK coverage
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

- use `blacksmith-8vcpu-ubuntu-2404-arm` for primary Linux CI jobs
- update CLI, SDK parity, coverage, and cloud-launch workflows
- keep x86 vector-kernel coverage and native amd64 Docker builds on x86 runners

## Why

ARM64 should be the primary Linux CI architecture while architecture-specific x86 checks remain explicit.

## Validation

- parsed every workflow YAML file
- ran `git diff --check`
- audited remaining `blacksmith-2vcpu-ubuntu-2404` references; only the three x86 vector-kernel jobs remain

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR migrates primary Linux CI workloads from x86 runners to higher-capacity ARM64 runners while retaining explicit x86 vector-kernel coverage and native amd64 image builds.
- Moves CLI tests, coverage, registry smoke tests, cloud-launch validation, and SDK parity jobs to ARM64.
- Keeps artifact producer and consumer jobs on matching architectures.
- Leaves architecture-specific x86 jobs unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/cli-tests.yml | Moves Linux CLI test, coverage, and registry-smoke jobs to ARM64 without changing their commands or contracts. |
| .github/workflows/cloud-launch-nightly.yml | Moves planner, fuzz, workload, and vector-lifecycle nightly jobs to ARM64 while preserving dedicated architecture-specific coverage elsewhere. |
| .github/workflows/cloud-launch-pr.yml | Moves the primary Rust quality, workspace, database, contract, and migration-parity PR jobs to ARM64. |
| .github/workflows/cloud-launch-prelaunch.yml | Moves release-scale, contract, vector diagnostic, sustained, and performance-decision jobs to ARM64 while leaving macOS final-quality coverage unchanged. |
| .github/workflows/cloud-launch-vector-100k.yml | Moves both the vector test-binary producer and consumer to ARM64, preserving architecture compatibility across the artifact boundary. |
| .github/workflows/sdk-query-parity.yml | Moves Linux SDK parity, generator, embedded-binding, and coverage matrix entries to ARM64 while retaining matching producer-consumer matrices. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: use ARM runners for primary jobs"](https://github.com/helixdb/helix-db/commit/5943b91cd4aebcff1e518c755ff01e51df66d90b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51600320)</sub>

<!-- /greptile_comment -->