### PR TITLE
ci: use 2-vCPU runners for Linux jobs

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -70,7 +70,7 @@ jobs:
 
   coverage:
     name: Coverage (Ubuntu)
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-8vcpu-ubuntu-2404-arm
+          - blacksmith-2vcpu-ubuntu-2404-arm
           - blacksmith-6vcpu-macos-latest
           - blacksmith-2vcpu-windows-2025
     steps:
@@ -101,7 +101,7 @@ jobs:
   registry-smoke:
     name: Published TypeScript SDK registry smoke
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cloud-launch-nightly.yml
+++ b/.github/workflows/cloud-launch-nightly.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   planner-matrix:
     name: Planner matrix shard ${{ matrix.shard }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -38,7 +38,7 @@ jobs:
 
   fuzz:
     name: Fuzz ${{ matrix.target }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -75,7 +75,7 @@ jobs:
 
   workload-matrix:
     name: Deterministic workload seeds
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -93,7 +93,7 @@ jobs:
 
   vector-lifecycle:
     name: Bounded 8k vector lifecycle
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cloud-launch-pr.yml
+++ b/.github/workflows/cloud-launch-pr.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   quality:
     name: Format, Clippy, and doctests
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -46,7 +46,7 @@ jobs:
 
   workspace-tests:
     name: Workspace tests
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 30
     env:
       CARGO_BUILD_JOBS: "2"
@@ -66,7 +66,7 @@ jobs:
 
   db-all-targets:
     name: DB all targets
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v6
@@ -76,7 +76,7 @@ jobs:
 
   deterministic-contracts:
     name: Planner, lifecycle, isolation, and transports
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -94,7 +94,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 45
     env:
       HELIX_HYPERSCALE_REPO: ${{ github.workspace }}/helix-hyperscale

--- a/.github/workflows/cloud-launch-prelaunch.yml
+++ b/.github/workflows/cloud-launch-prelaunch.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   release-scale:
     name: Release scale — ${{ matrix.name }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 370
     strategy:
       fail-fast: false
@@ -59,7 +59,7 @@ jobs:
 
   release-contracts:
     name: Stable failpoint and coordinator contracts
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -72,7 +72,7 @@ jobs:
 
   vector-diagnostic:
     name: Vector recall and throughput diagnostic
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -86,7 +86,7 @@ jobs:
 
   sustained:
     name: Ten-run LocalFileSystem and long lifecycle matrix
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6
@@ -105,7 +105,7 @@ jobs:
 
   performance-decision:
     name: Same-host performance, lag, and resource decision
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cloud-launch-vector-100k.yml
+++ b/.github/workflows/cloud-launch-vector-100k.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build-vector-100k:
     name: Build vector 100k contract
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -52,7 +52,7 @@ jobs:
   vector-100k:
     name: Vector 100k create, search, drop, and residue
     needs: build-vector-100k
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 360
     steps:
       - uses: actions/download-artifact@v5

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   quality:
     name: Workspace and tooling quality
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -88,10 +88,10 @@ jobs:
         include:
           - architecture: amd64
             platform: linux/amd64
-            runner: blacksmith-8vcpu-ubuntu-2404
+            runner: blacksmith-2vcpu-ubuntu-2404
           - architecture: arm64
             platform: linux/arm64
-            runner: blacksmith-8vcpu-ubuntu-2404-arm
+            runner: blacksmith-2vcpu-ubuntu-2404-arm
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     env:

--- a/.github/workflows/sdk-query-parity.yml
+++ b/.github/workflows/sdk-query-parity.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-8vcpu-ubuntu-2404-arm
+          - blacksmith-2vcpu-ubuntu-2404-arm
           - blacksmith-6vcpu-macos-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/sdk-query-parity.yml
+++ b/.github/workflows/sdk-query-parity.yml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-8vcpu-ubuntu-2404-arm
+          - blacksmith-2vcpu-ubuntu-2404-arm
           - blacksmith-6vcpu-macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -132,7 +132,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-8vcpu-ubuntu-2404-arm
+          - blacksmith-2vcpu-ubuntu-2404-arm
           - blacksmith-6vcpu-macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -175,7 +175,7 @@ jobs:
 
   coverage:
     name: SDK coverage
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

- move every HelixDB Linux CI job to a 2-vCPU Blacksmith runner
- use `blacksmith-2vcpu-ubuntu-2404-arm` for ARM64 jobs
- use `blacksmith-2vcpu-ubuntu-2404` for architecture-specific x86 jobs
- keep Windows at 2 vCPU and preserve the configured macOS runner sizes

## Why

Use the smallest Linux runners by default and upscale individual jobs only when CI evidence shows a runtime or memory requirement.

## Validation

- parsed every workflow YAML file
- ran `git diff --check`
- audited all workflow runner labels
- confirmed there are no remaining `blacksmith-8vcpu-ubuntu-*` labels

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves all affected Linux CI jobs from 8-vCPU to 2-vCPU Blacksmith runners while preserving each job’s operating-system architecture and existing timeout configuration.
- Uses `blacksmith-2vcpu-ubuntu-2404-arm` for ARM64 workflows.
- Uses `blacksmith-2vcpu-ubuntu-2404` for x86 Linux jobs.
- Leaves Windows and macOS runner sizing unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/cli-tests.yml | Reduces ARM Linux runner size for CLI tests, coverage, and registry smoke without changing job behavior. |
| .github/workflows/cloud-launch-nightly.yml | Moves nightly planner, fuzz, workload, and vector lifecycle jobs to the established 2-vCPU ARM runner. |
| .github/workflows/cloud-launch-pr.yml | Reduces Linux runner size for PR quality and test jobs while retaining existing timeouts and explicit build limits where configured. |
| .github/workflows/cloud-launch-prelaunch.yml | Moves manual release-scale and diagnostic jobs to 2-vCPU ARM runners without changing their commands or contracts. |
| .github/workflows/cloud-launch-vector-100k.yml | Moves both vector-100k build and execution jobs to the established 2-vCPU ARM runner. |
| .github/workflows/docker-image.yml | Preserves explicit amd64 and arm64 runner architecture mapping while reducing both Linux runner sizes. |
| .github/workflows/sdk-query-parity.yml | Moves ARM Linux SDK parity and coverage jobs to the established 2-vCPU runner while preserving macOS sizing. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: use 2-vcpu runners for Linux jobs"](https://github.com/helixdb/helix-db/commit/e17b9ade6d48c2278c7a51d3d939af73ea2477d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51603013)</sub>

<!-- /greptile_comment -->