### PR TITLE
perf(db): improve embedded config defaults

### DIFF
--- a/bindings/uniffi/src/helix_db.rs
+++ b/bindings/uniffi/src/helix_db.rs
@@ -378,7 +378,7 @@ mod tests {
                     .slate()
                     .to_writer_settings(None)
                     .flush_interval,
-                Some(std::time::Duration::from_millis(5))
+                Some(std::time::Duration::from_millis(3))
             );
             writer.close().await.expect("writer should close");
 

--- a/bindings/uniffi/src/helix_db.rs
+++ b/bindings/uniffi/src/helix_db.rs
@@ -8,6 +8,8 @@ use crate::runtime;
 const OBJECT_STORE_PART_SIZE_BYTES: usize = 4 * 1024 * 1024;
 const OBJECT_STORE_SCAN_INTERVAL_SECS: u64 = 60 * 60;
 const OBJECT_STORE_MAX_OPEN_FILE_HANDLES: usize = 1_000;
+const EMBEDDED_MEMORY_SLATE_BLOCK_BYTES: u64 = 48 * 1024 * 1024;
+const EMBEDDED_MEMORY_SLATE_METADATA_BYTES: u64 = 16 * 1024 * 1024;
 
 /// Portable cache profile accepted by every embedded SDK.
 #[derive(Clone, Debug, PartialEq, Eq, uniffi::Enum)]
@@ -33,7 +35,7 @@ pub struct EmbeddedCacheConfig {
     pub mode: EmbeddedCacheMode,
 }
 
-impl TryFrom<EmbeddedCacheConfig> for db::DbConfig {
+impl TryFrom<EmbeddedCacheConfig> for db::config::CacheConfig {
     type Error = HelixError;
 
     fn try_from(value: EmbeddedCacheConfig) -> Result<Self, Self::Error> {
@@ -47,6 +49,11 @@ impl TryFrom<EmbeddedCacheConfig> for db::DbConfig {
         let mode = match value.mode {
             EmbeddedCacheMode::VectorMemoryOnly => db::config::CacheMode::VectorMemoryOnly,
             EmbeddedCacheMode::Memory => db::config::CacheMode::Memory {
+                slate_db: db::config::SlateMemoryCacheConfig::try_new(
+                    EMBEDDED_MEMORY_SLATE_BLOCK_BYTES,
+                    EMBEDDED_MEMORY_SLATE_METADATA_BYTES,
+                )
+                .expect("embedded memory-cache capacities are nonzero"),
                 slate_warm: Default::default(),
                 fts: None,
             },
@@ -89,7 +96,7 @@ impl TryFrom<EmbeddedCacheConfig> for db::DbConfig {
                 }
             }
         };
-        Ok(db::DbConfig::new().with_cache(db::config::CacheConfig::new(vector_memory, mode)))
+        Ok(db::config::CacheConfig::new(vector_memory, mode))
     }
 }
 
@@ -164,8 +171,10 @@ impl HelixDB {
         source: HelixDbSource,
         cache: EmbeddedCacheConfig,
     ) -> Result<Arc<Self>, HelixError> {
-        let config = cache.try_into()?;
-        let inner = runtime::run(db::HelixDB::open_with_config(source.into(), config)).await??;
+        let cache = cache.try_into()?;
+        let source = db::HelixDbSource::from(source);
+        let config = source.embedded_default_config().with_cache(cache);
+        let inner = runtime::run(db::HelixDB::open_with_config(source, config)).await??;
         Ok(Arc::new(Self::new(inner)))
     }
 
@@ -182,9 +191,10 @@ impl HelixDB {
         source: HelixDbSource,
         cache: EmbeddedCacheConfig,
     ) -> Result<Arc<Self>, HelixError> {
-        let config = cache.try_into()?;
-        let inner =
-            runtime::run(db::HelixDB::open_reader_with_config(source.into(), config)).await??;
+        let cache = cache.try_into()?;
+        let source = db::HelixDbSource::from(source);
+        let config = source.embedded_default_config().with_cache(cache);
+        let inner = runtime::run(db::HelixDB::open_reader_with_config(source, config)).await??;
         Ok(Arc::new(Self::new(inner)))
     }
 
@@ -227,7 +237,10 @@ mod tests {
     use helix_ast::query::QueryRequest;
     use helix_ast::traversal::g;
 
-    use super::{EmbeddedCacheConfig, EmbeddedCacheMode, HelixDB, HelixDbSource};
+    use super::{
+        EmbeddedCacheConfig, EmbeddedCacheMode, HelixDB, HelixDbSource,
+        EMBEDDED_MEMORY_SLATE_BLOCK_BYTES, EMBEDDED_MEMORY_SLATE_METADATA_BYTES,
+    };
     use crate::HelixError;
 
     #[test]
@@ -240,22 +253,27 @@ mod tests {
             (
                 EmbeddedCacheMode::Memory,
                 db::config::CacheMode::Memory {
+                    slate_db: db::config::SlateMemoryCacheConfig::try_new(
+                        EMBEDDED_MEMORY_SLATE_BLOCK_BYTES,
+                        EMBEDDED_MEMORY_SLATE_METADATA_BYTES,
+                    )
+                    .expect("embedded memory-cache capacities are nonzero"),
                     slate_warm: Default::default(),
                     fts: None,
                 },
             ),
         ] {
-            let config: db::DbConfig = EmbeddedCacheConfig {
+            let config: db::config::CacheConfig = EmbeddedCacheConfig {
                 vector_memory_bytes: 1_024,
                 mode,
             }
             .try_into()
             .expect("portable profile should convert");
-            assert_eq!(config.cache().vector_memory().budget().bytes(), Some(1_024));
-            assert_eq!(config.cache().mode(), &expected);
+            assert_eq!(config.vector_memory().budget().bytes(), Some(1_024));
+            assert_eq!(config.mode(), &expected);
         }
 
-        let config: db::DbConfig = EmbeddedCacheConfig {
+        let config: db::config::CacheConfig = EmbeddedCacheConfig {
             vector_memory_bytes: 2_048,
             mode: EmbeddedCacheMode::Hybrid {
                 slate_memory_bytes: 4_096,
@@ -271,7 +289,7 @@ mod tests {
             slate_db,
             object_store,
             ..
-        } = config.cache().mode()
+        } = config.mode()
         else {
             panic!("expected hybrid cache mode");
         };
@@ -285,7 +303,7 @@ mod tests {
 
     #[test]
     fn embedded_cache_profiles_reject_invalid_limits_and_paths() {
-        let error = db::DbConfig::try_from(EmbeddedCacheConfig {
+        let error = db::config::CacheConfig::try_from(EmbeddedCacheConfig {
             vector_memory_bytes: 0,
             mode: EmbeddedCacheMode::Memory,
         })
@@ -315,7 +333,7 @@ mod tests {
                 object_store_disk_bytes: 1,
             },
         ] {
-            assert!(db::DbConfig::try_from(EmbeddedCacheConfig {
+            assert!(db::config::CacheConfig::try_from(EmbeddedCacheConfig {
                 vector_memory_bytes: 1,
                 mode,
             })
@@ -352,6 +370,16 @@ mod tests {
             let writer = HelixDB::open_with_config(source.clone(), cache.clone())
                 .await
                 .expect("configured writer should open");
+            assert_eq!(
+                writer
+                    .inner
+                    .config()
+                    .db()
+                    .slate()
+                    .to_writer_settings(None)
+                    .flush_interval,
+                Some(std::time::Duration::from_millis(5))
+            );
             writer.close().await.expect("writer should close");
 
             let reader = HelixDB::open_reader_with_config(source, cache)

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -86,6 +86,10 @@ name = "write_path_mutations"
 harness = false
 
 [[bench]]
+name = "embedded_write_latency"
+harness = false
+
+[[bench]]
 name = "secondary_equality_hot_path"
 harness = false
 required-features = ["production-coverage"]

--- a/crates/db/benches/embedded_write_latency.rs
+++ b/crates/db/benches/embedded_write_latency.rs
@@ -1,0 +1,100 @@
+//! Acknowledged-write latency for the default embedded storage profiles.
+
+use std::sync::Arc;
+
+use db::{HelixDB, HelixDbSource};
+use helix_ast::prelude::*;
+use helix_ast::query::QueryRequest;
+
+#[global_allocator]
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
+
+fn main() {
+    divan::main();
+}
+
+struct WriteFixture {
+    runtime: tokio::runtime::Runtime,
+    db: Arc<HelixDB>,
+    request: QueryRequest,
+    _disk_root: Option<tempfile::TempDir>,
+}
+
+impl WriteFixture {
+    fn in_memory() -> Self {
+        Self::new(None)
+    }
+
+    fn on_disk() -> Self {
+        Self::new(Some(
+            tempfile::tempdir().expect("embedded benchmark disk root"),
+        ))
+    }
+
+    fn new(disk_root: Option<tempfile::TempDir>) -> Self {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("embedded benchmark runtime starts");
+        let source = match &disk_root {
+            Some(root) => HelixDbSource::Disk {
+                root: root.path().to_path_buf(),
+                database: "embedded-write-latency".to_string(),
+            },
+            None => HelixDbSource::InMemory {
+                database: "embedded-write-latency".to_string(),
+            },
+        };
+        let db = Arc::new(
+            runtime
+                .block_on(HelixDB::open(source))
+                .expect("embedded benchmark database opens"),
+        );
+        let request = QueryRequest::write(
+            write_batch()
+                .var_as(
+                    "node",
+                    g().add_n(
+                        "EmbeddedWrite",
+                        vec![("value", PropertyInput::from("benchmark"))],
+                    ),
+                )
+                .returning(Vec::<String>::new()),
+        );
+        runtime
+            .block_on(db.query(request.clone()))
+            .expect("embedded benchmark warm-up write succeeds");
+        Self {
+            runtime,
+            db,
+            request,
+            _disk_root: disk_root,
+        }
+    }
+}
+
+#[divan::bench]
+fn in_memory(bencher: divan::Bencher<'_, '_>) {
+    let fixture = WriteFixture::in_memory();
+    bencher.bench_local(|| {
+        divan::black_box(
+            fixture
+                .runtime
+                .block_on(fixture.db.query(fixture.request.clone()))
+                .expect("in-memory embedded write succeeds"),
+        )
+    });
+}
+
+#[divan::bench]
+fn on_disk(bencher: divan::Bencher<'_, '_>) {
+    let fixture = WriteFixture::on_disk();
+    bencher.bench_local(|| {
+        divan::black_box(
+            fixture
+                .runtime
+                .block_on(fixture.db.query(fixture.request.clone()))
+                .expect("disk embedded write succeeds"),
+        )
+    });
+}

--- a/crates/db/src/config/cache.rs
+++ b/crates/db/src/config/cache.rs
@@ -113,6 +113,50 @@ impl SlateHybridCacheConfig {
     }
 }
 
+/// Checked capacities for SlateDB's in-memory block and metadata caches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SlateMemoryCacheConfig {
+    block_bytes: NonZeroU64,
+    metadata_bytes: NonZeroU64,
+}
+
+impl SlateMemoryCacheConfig {
+    /// Build independently bounded block and metadata cache tiers.
+    ///
+    /// ```
+    /// use db::config::SlateMemoryCacheConfig;
+    ///
+    /// let cache = SlateMemoryCacheConfig::try_new(48 * 1024 * 1024, 16 * 1024 * 1024)?;
+    /// assert_eq!(cache.total_bytes(), 64 * 1024 * 1024);
+    /// # Ok::<(), db::config::ConfigError>(())
+    /// ```
+    pub fn try_new(block_bytes: u64, metadata_bytes: u64) -> ConfigResult<Self> {
+        Ok(Self {
+            block_bytes: NonZeroU64::new(block_bytes)
+                .ok_or_else(|| ConfigError::new("Slate block cache must be nonzero"))?,
+            metadata_bytes: NonZeroU64::new(metadata_bytes)
+                .ok_or_else(|| ConfigError::new("Slate metadata cache must be nonzero"))?,
+        })
+    }
+
+    /// Resident block-cache capacity.
+    pub const fn block_bytes(self) -> u64 {
+        self.block_bytes.get()
+    }
+
+    /// Resident metadata-cache capacity.
+    pub const fn metadata_bytes(self) -> u64 {
+        self.metadata_bytes.get()
+    }
+
+    /// Combined resident capacity.
+    pub const fn total_bytes(self) -> u64 {
+        self.block_bytes
+            .get()
+            .saturating_add(self.metadata_bytes.get())
+    }
+}
+
 const DEFAULT_SLATE_WARM_CONCURRENCY: usize = 4;
 const DEFAULT_SLATE_WARM_SST_LIMIT: usize = 256;
 
@@ -791,8 +835,10 @@ impl Default for VectorMemorySettings {
 pub enum CacheMode {
     /// Keep only vector memory stores enabled.
     VectorMemoryOnly,
-    /// Use SlateDB's default in-memory block/meta cache and optional FTS cache.
+    /// Use bounded in-memory SlateDB block/meta caches and an optional FTS cache.
     Memory {
+        /// SlateDB block and metadata cache capacities.
+        slate_db: SlateMemoryCacheConfig,
         /// SlateDB metadata warm policy.
         slate_warm: SlateWarmConfig,
         /// Optional shared FTS split cache.
@@ -960,6 +1006,11 @@ impl Default for CacheConfig {
         Self::new(
             VectorMemorySettings::default(),
             CacheMode::Memory {
+                slate_db: SlateMemoryCacheConfig::try_new(
+                    slatedb::db_cache::DEFAULT_BLOCK_CACHE_CAPACITY,
+                    slatedb::db_cache::DEFAULT_META_CACHE_CAPACITY,
+                )
+                .expect("default SlateDB cache capacities are nonzero"),
                 slate_warm: SlateWarmConfig::default(),
                 fts: Some(FtsMemoryCacheConfig::default()),
             },

--- a/crates/db/src/config/db.rs
+++ b/crates/db/src/config/db.rs
@@ -1,6 +1,11 @@
 use std::num::{NonZeroU64, NonZeroUsize};
+use std::time::Duration;
 
-use super::cache::{CacheConfig, SlateRuntimeConfig};
+use super::cache::{
+    CacheConfig, CacheMode, FtsMemoryCacheConfig, FtsWarmConfig, SimHasherCacheSettings,
+    SlateMemoryCacheConfig, SlateRuntimeConfig, SlateWarmConfig, VectorMemoryBudget,
+    VectorMemorySettings,
+};
 use super::index_lifecycle_throughput::IndexLifecycleThroughputTuning;
 use super::migrations::MigrationTuning;
 use super::search_index_backfill::SearchIndexBackfillLimits;
@@ -11,6 +16,47 @@ use crate::encoding::v1::values::edges::{
     ENCODING_TYPE_NONE,
 };
 use crate::id_allocator::DEFAULT_LEASE_SIZE;
+
+const MIB: u64 = 1024 * 1024;
+const EMBEDDED_VECTOR_MEMORY_BYTES: u64 = 64 * MIB;
+const EMBEDDED_SIMHASHER_MEMORY_BYTES: usize = 8 * MIB as usize;
+const EMBEDDED_SIMHASHER_ENTRIES: usize = 16;
+const EMBEDDED_FTS_MEMORY_BYTES: u64 = 16 * MIB;
+const EMBEDDED_FTS_GENERATION_GRACE_PERIOD_SECS: u64 = 300;
+const EMBEDDED_IN_MEMORY_SLATE_BLOCK_BYTES: u64 = 16 * MIB;
+const EMBEDDED_IN_MEMORY_SLATE_METADATA_BYTES: u64 = 8 * MIB;
+const EMBEDDED_DISK_SLATE_BLOCK_BYTES: u64 = 48 * MIB;
+const EMBEDDED_DISK_SLATE_METADATA_BYTES: u64 = 16 * MIB;
+const EMBEDDED_L0_SST_BYTES: usize = 16 * MIB as usize;
+const EMBEDDED_MAX_UNFLUSHED_BYTES: usize = 64 * MIB as usize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmbeddedStorageProfile {
+    InMemory,
+    Disk,
+}
+
+impl EmbeddedStorageProfile {
+    const fn flush_interval(self) -> Duration {
+        match self {
+            Self::InMemory => Duration::from_millis(1),
+            Self::Disk => Duration::from_millis(5),
+        }
+    }
+
+    const fn slate_cache(self) -> (u64, u64) {
+        match self {
+            Self::InMemory => (
+                EMBEDDED_IN_MEMORY_SLATE_BLOCK_BYTES,
+                EMBEDDED_IN_MEMORY_SLATE_METADATA_BYTES,
+            ),
+            Self::Disk => (
+                EMBEDDED_DISK_SLATE_BLOCK_BYTES,
+                EMBEDDED_DISK_SLATE_METADATA_BYTES,
+            ),
+        }
+    }
+}
 
 /// Edge storage encoding selected for newly written edge lists.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -192,6 +238,46 @@ impl DbConfig {
             migrations: MigrationTuning::default(),
             open_attribution: None,
         }
+    }
+
+    /// Build source-specific local defaults for an embedded handle.
+    pub(crate) fn embedded_default(profile: EmbeddedStorageProfile) -> Self {
+        let mut slate = slatedb::Settings::default();
+        slate.flush_interval = Some(profile.flush_interval());
+        slate.l0_sst_size_bytes = EMBEDDED_L0_SST_BYTES;
+        slate.max_unflushed_bytes = EMBEDDED_MAX_UNFLUSHED_BYTES;
+
+        let (block_bytes, metadata_bytes) = profile.slate_cache();
+        let vector_memory = VectorMemorySettings::try_new(
+            VectorMemoryBudget::bounded(EMBEDDED_VECTOR_MEMORY_BYTES)
+                .expect("embedded vector cache capacity is nonzero"),
+            5,
+        )
+        .expect("embedded vector cache settings are valid")
+        .with_simhasher_cache(
+            SimHasherCacheSettings::try_new(
+                EMBEDDED_SIMHASHER_MEMORY_BYTES,
+                EMBEDDED_SIMHASHER_ENTRIES,
+            )
+            .expect("embedded SimHasher cache limits are nonzero"),
+        );
+        let cache = CacheConfig::new(
+            vector_memory,
+            CacheMode::Memory {
+                slate_db: SlateMemoryCacheConfig::try_new(block_bytes, metadata_bytes)
+                    .expect("embedded SlateDB cache capacities are nonzero"),
+                slate_warm: SlateWarmConfig::Off,
+                fts: Some(
+                    FtsMemoryCacheConfig::try_new(
+                        EMBEDDED_FTS_MEMORY_BYTES,
+                        FtsWarmConfig::Off,
+                        EMBEDDED_FTS_GENERATION_GRACE_PERIOD_SECS,
+                    )
+                    .expect("embedded FTS cache settings are valid"),
+                ),
+            },
+        );
+        Self::new().with_slate_settings(slate).with_cache(cache)
     }
 
     /// Edge encoding used for newly written edge lists.

--- a/crates/db/src/config/db.rs
+++ b/crates/db/src/config/db.rs
@@ -40,7 +40,7 @@ impl EmbeddedStorageProfile {
     const fn flush_interval(self) -> Duration {
         match self {
             Self::InMemory => Duration::from_millis(1),
-            Self::Disk => Duration::from_millis(5),
+            Self::Disk => Duration::from_millis(3),
         }
     }
 

--- a/crates/db/src/config/db.rs
+++ b/crates/db/src/config/db.rs
@@ -242,10 +242,12 @@ impl DbConfig {
 
     /// Build source-specific local defaults for an embedded handle.
     pub(crate) fn embedded_default(profile: EmbeddedStorageProfile) -> Self {
-        let mut slate = slatedb::Settings::default();
-        slate.flush_interval = Some(profile.flush_interval());
-        slate.l0_sst_size_bytes = EMBEDDED_L0_SST_BYTES;
-        slate.max_unflushed_bytes = EMBEDDED_MAX_UNFLUSHED_BYTES;
+        let slate = slatedb::Settings {
+            flush_interval: Some(profile.flush_interval()),
+            l0_sst_size_bytes: EMBEDDED_L0_SST_BYTES,
+            max_unflushed_bytes: EMBEDDED_MAX_UNFLUSHED_BYTES,
+            ..slatedb::Settings::default()
+        };
 
         let (block_bytes, metadata_bytes) = profile.slate_cache();
         let vector_memory = VectorMemorySettings::try_new(

--- a/crates/db/src/config/mod.rs
+++ b/crates/db/src/config/mod.rs
@@ -15,8 +15,9 @@ pub use crate::index_lifecycle::ValidatedDynamicIndexDefinition;
 pub use cache::{
     CacheConfig, CacheMode, CacheWarmMode, FtsHybridCacheConfig, FtsMemoryCacheConfig,
     FtsWarmConfig, ObjectStoreWarmLevel, SimHasherCacheSettings, SlateHybridCacheConfig,
-    SlateObjectStoreCacheSettings, SlateRuntimeConfig, SlateWarmConfig, VectorMemoryBudget,
-    VectorMemoryHydrationMode, VectorMemorySettings, DEFAULT_VECTOR_MEMORY_BUDGET_BYTES,
+    SlateMemoryCacheConfig, SlateObjectStoreCacheSettings, SlateRuntimeConfig, SlateWarmConfig,
+    VectorMemoryBudget, VectorMemoryHydrationMode, VectorMemorySettings,
+    DEFAULT_VECTOR_MEMORY_BUDGET_BYTES,
 };
 pub use db::{DbConfig, EdgeEncoding, EdgeUpdatePolicy, HelixConfig, OpenAttribution};
 pub use definition_differences::{DefinitionDifference, NonEmptyDefinitionDifferences};

--- a/crates/db/src/config/tests.rs
+++ b/crates/db/src/config/tests.rs
@@ -6,9 +6,9 @@ use super::{
     HelixConfig, NonEmptyPathBuf, ObjectStoreWarmLevel, RangeIndexDirection, RuntimeIndexCatalog,
     SearchIndexBackfillLimits, SecondaryIndexDefinition, SecondaryIndexElementType,
     SecondaryIndexKind, SecondaryIndexLifecycleBatchRows, SimHasherCacheSettings,
-    SlateHybridCacheConfig, SlateObjectStoreCacheSettings, TextAnalyzerKind, TextElementType,
-    TextIndexDefinition, VectorElementType, VectorIndexDefinition, VectorMemoryBudget,
-    VectorMemoryHydrationMode, VectorMemorySettings,
+    SlateHybridCacheConfig, SlateMemoryCacheConfig, SlateObjectStoreCacheSettings,
+    TextAnalyzerKind, TextElementType, TextIndexDefinition, VectorElementType,
+    VectorIndexDefinition, VectorMemoryBudget, VectorMemoryHydrationMode, VectorMemorySettings,
 };
 use crate::index_lifecycle::{
     IndexElementKind, IndexIdentityFamily, ValidatedDynamicIndexDefinition,
@@ -396,6 +396,8 @@ fn cache_constructor_edges_and_accessors_are_explicit_contracts() {
     );
     assert_eq!(slate_hybrid.disk().bytes(), 256);
     assert!(SlateHybridCacheConfig::try_new(64, "", 256).is_err());
+    assert!(SlateMemoryCacheConfig::try_new(0, 1).is_err());
+    assert!(SlateMemoryCacheConfig::try_new(1, 0).is_err());
     assert!(super::SlateWarmConfig::background(0, 1).is_err());
     assert!(super::SlateWarmConfig::blocking(1, 0).is_err());
     assert!(FtsWarmConfig::background(0, None).is_err());
@@ -413,6 +415,7 @@ fn cache_config_represents_vector_only_memory_and_hybrid_states() {
     let memory = CacheConfig::new(
         VectorMemorySettings::default(),
         CacheMode::Memory {
+            slate_db: SlateMemoryCacheConfig::try_new(48, 16).expect("valid Slate memory cache"),
             slate_warm: Default::default(),
             fts: Some(FtsMemoryCacheConfig::default()),
         },

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -38,7 +38,7 @@ pub use config::{DbConfig, HelixConfig};
 
 #[cfg(any(test, feature = "production-coverage"))]
 use config::ValidatedDynamicIndexDefinition;
-use config::{runtime_catalog, CacheMode, RuntimeIndexCatalog};
+use config::{db::EmbeddedStorageProfile, runtime_catalog, CacheMode, RuntimeIndexCatalog};
 use error::{HelixDbError, Result};
 use execution::interpreter::{ExecutionResult, Interpreter};
 use foyer::{
@@ -56,8 +56,9 @@ use helix_planner::{
 use id_allocator::{EdgeIdAllocator, NodeIdAllocator};
 use serde_json::Value as JsonValue;
 use slatedb::db_cache::{
+    foyer::{FoyerCache, FoyerCacheOptions},
     foyer_hybrid::{FoyerHybridCache, FoyerHybridCacheMetrics},
-    CacheUsageSnapshot, CachedEntry, DbCache,
+    CacheUsageSnapshot, CachedEntry, DbCache, SplitCache,
 };
 #[cfg(test)]
 use slatedb::object_store::memory::InMemory;
@@ -260,6 +261,21 @@ pub enum HelixDbSource {
 }
 
 impl HelixDbSource {
+    /// Build the bounded defaults used by an embedded handle for this source.
+    ///
+    /// Local storage uses a shorter durability cadence and smaller cache/write-buffer
+    /// bounds than remote object storage. Object storage retains the general runtime
+    /// defaults because its latency and request-cost tradeoffs are different.
+    pub fn embedded_default_config(&self) -> DbConfig {
+        match self {
+            Self::InMemory { .. } | Self::InMemoryToken { .. } => {
+                DbConfig::embedded_default(EmbeddedStorageProfile::InMemory)
+            }
+            Self::Disk { .. } => DbConfig::embedded_default(EmbeddedStorageProfile::Disk),
+            Self::ObjectStorage { .. } => DbConfig::new(),
+        }
+    }
+
     fn into_parts(self) -> Result<(String, Arc<dyn ObjectStore>)> {
         match self {
             Self::InMemory { database } => {
@@ -739,7 +755,8 @@ enum CloseState {
 impl HelixDB {
     /// Open a read/write database handle.
     pub async fn open(source: HelixDbSource) -> Result<Self> {
-        Self::open_with_config(source, DbConfig::new()).await
+        let config = source.embedded_default_config();
+        Self::open_with_config(source, config).await
     }
 
     /// Open a read/write database handle backed by a caller-provided object store.
@@ -884,11 +901,10 @@ impl HelixDB {
 
         match config.cache().mode() {
             CacheMode::VectorMemoryOnly => builder = builder.with_db_cache_disabled(),
-            CacheMode::Memory { .. } => {}
-            CacheMode::Hybrid { .. } => {
+            CacheMode::Memory { .. } | CacheMode::Hybrid { .. } => {
                 let Some(cache) = &slate_db_cache else {
                     return Err(HelixDbError::Config(
-                        "hybrid cache mode must build a SlateDB cache".into(),
+                        "configured SlateDB cache mode must build a cache".into(),
                     ));
                 };
                 builder = builder.with_db_cache(Arc::clone(cache));
@@ -936,7 +952,8 @@ impl HelixDB {
 
     /// Open a read-only database handle.
     pub async fn open_reader(source: HelixDbSource) -> Result<Self> {
-        Self::open_reader_with_config(source, DbConfig::new()).await
+        let config = source.embedded_default_config();
+        Self::open_reader_with_config(source, config).await
     }
 
     /// Open a read-only database handle with explicit tuning config.
@@ -1020,11 +1037,10 @@ impl HelixDB {
             );
         match config.cache().mode() {
             CacheMode::VectorMemoryOnly => builder = builder.with_db_cache_disabled(),
-            CacheMode::Memory { .. } => {}
-            CacheMode::Hybrid { .. } => {
+            CacheMode::Memory { .. } | CacheMode::Hybrid { .. } => {
                 let Some(cache) = &slate_db_cache else {
                     return Err(HelixDbError::Config(
-                        "hybrid cache mode must build a SlateDB cache".into(),
+                        "configured SlateDB cache mode must build a cache".into(),
                     ));
                 };
                 builder = builder.with_db_cache(Arc::clone(cache));
@@ -2597,7 +2613,25 @@ fn foyer_disk_block_size(disk_capacity_bytes: usize) -> usize {
 
 async fn build_slate_db_cache(config: &CacheMode) -> Result<Option<Arc<dyn DbCache>>> {
     match config {
-        CacheMode::VectorMemoryOnly | CacheMode::Memory { .. } => Ok(None),
+        CacheMode::VectorMemoryOnly => Ok(None),
+        CacheMode::Memory { slate_db, .. } => {
+            let block_cache: Arc<dyn DbCache> =
+                Arc::new(FoyerCache::new_with_opts(FoyerCacheOptions {
+                    max_capacity: slate_db.block_bytes(),
+                    ..Default::default()
+                }));
+            let metadata_cache: Arc<dyn DbCache> =
+                Arc::new(FoyerCache::new_with_opts(FoyerCacheOptions {
+                    max_capacity: slate_db.metadata_bytes(),
+                    ..Default::default()
+                }));
+            Ok(Some(Arc::new(
+                SplitCache::new()
+                    .with_block_cache(Some(block_cache))
+                    .with_meta_cache(Some(metadata_cache))
+                    .build(),
+            )))
+        }
         CacheMode::Hybrid { slate_db, .. } => {
             let metrics = FoyerHybridCacheMetrics::new();
             let cache = HybridCacheBuilder::new()
@@ -2710,6 +2744,81 @@ mod tests {
         );
     }
 
+    #[test]
+    fn embedded_sources_select_bounded_local_defaults() {
+        for (source, flush_interval, block_bytes, metadata_bytes) in [
+            (
+                HelixDbSource::InMemory {
+                    database: "memory-defaults".to_string(),
+                },
+                Duration::from_millis(1),
+                16 * 1024 * 1024,
+                8 * 1024 * 1024,
+            ),
+            (
+                HelixDbSource::Disk {
+                    root: PathBuf::from("/tmp/helix-embedded-default-contract"),
+                    database: "disk-defaults".to_string(),
+                },
+                Duration::from_millis(5),
+                48 * 1024 * 1024,
+                16 * 1024 * 1024,
+            ),
+        ] {
+            let config = source.embedded_default_config();
+            let slate = config.slate().to_writer_settings(None);
+            assert_eq!(slate.flush_interval, Some(flush_interval));
+            assert_eq!(slate.l0_sst_size_bytes, 16 * 1024 * 1024);
+            assert_eq!(slate.max_unflushed_bytes, 64 * 1024 * 1024);
+            assert_eq!(
+                config.cache().vector_memory().budget().bytes(),
+                Some(64 * 1024 * 1024)
+            );
+            assert_eq!(
+                config.cache().vector_memory().simhasher_cache().bytes(),
+                8 * 1024 * 1024
+            );
+            let CacheMode::Memory {
+                slate_db,
+                slate_warm,
+                fts: Some(fts),
+            } = config.cache().mode()
+            else {
+                panic!("embedded local defaults must use bounded memory caches");
+            };
+            assert_eq!(slate_db.block_bytes(), block_bytes);
+            assert_eq!(slate_db.metadata_bytes(), metadata_bytes);
+            assert_eq!(slate_warm, &crate::config::SlateWarmConfig::Off);
+            assert_eq!(fts.memory_bytes(), 16 * 1024 * 1024);
+            assert_eq!(fts.warm(), &crate::config::FtsWarmConfig::Off);
+        }
+
+        let object_storage = HelixDbSource::ObjectStorage {
+            database: "remote-defaults".to_string(),
+            bucket: "bucket".to_string(),
+            region: "region".to_string(),
+            endpoint: None,
+            allow_http: false,
+        }
+        .embedded_default_config();
+        assert_eq!(
+            object_storage
+                .slate()
+                .to_writer_settings(None)
+                .flush_interval,
+            Some(Duration::from_millis(100))
+        );
+        assert_eq!(
+            object_storage.cache().vector_memory().budget().bytes(),
+            Some(256 * 1024 * 1024)
+        );
+        let CacheMode::Memory { slate_db, .. } = object_storage.cache().mode() else {
+            panic!("object storage retains the general memory-cache profile");
+        };
+        assert_eq!(slate_db.block_bytes(), 512 * 1024 * 1024);
+        assert_eq!(slate_db.metadata_bytes(), 128 * 1024 * 1024);
+    }
+
     #[tokio::test]
     async fn cache_stats_are_publishable_without_cache_io() {
         let db = HelixDB::open(HelixDbSource::InMemory {
@@ -2725,20 +2834,43 @@ mod tests {
             CacheTierSnapshot::disabled(CacheUsageSemantics::AllocatedBlocks)
         );
         assert!(matches!(
+            snapshot.slate_memory.state,
+            CacheTierState::Ready {
+                capacity_bytes: Some(25_165_824),
+                ..
+            }
+        ));
+        assert!(matches!(
             snapshot.fts_memory.state,
             CacheTierState::Ready {
                 used_bytes: 0,
-                capacity_bytes: Some(_),
+                capacity_bytes: Some(16_777_216),
             }
         ));
         assert!(matches!(
             snapshot.vector_memory.state,
             CacheTierState::Ready {
                 used_bytes: 0,
-                capacity_bytes: Some(_),
+                capacity_bytes: Some(67_108_864),
             }
         ));
         db.close().await.expect("close database");
+
+        let root = tempfile::tempdir().expect("disk cache-stats root");
+        let db = HelixDB::open(HelixDbSource::Disk {
+            root: root.path().to_path_buf(),
+            database: "disk-cache-stats-contract".to_string(),
+        })
+        .await
+        .expect("open disk database");
+        assert!(matches!(
+            db.cache_stats().slate_memory.state,
+            CacheTierState::Ready {
+                capacity_bytes: Some(67_108_864),
+                ..
+            }
+        ));
+        db.close().await.expect("close disk database");
     }
 
     #[tokio::test]

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -2787,7 +2787,7 @@ mod tests {
                     root: PathBuf::from("/tmp/helix-embedded-default-contract"),
                     database: "disk-defaults".to_string(),
                 },
-                Duration::from_millis(5),
+                Duration::from_millis(3),
                 48 * 1024 * 1024,
                 16 * 1024 * 1024,
             ),

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -390,6 +390,7 @@ impl std::ops::Deref for HelixWriter {
 
 struct VectorMemoryRefreshTask {
     shutdown: watch::Sender<bool>,
+    initial_refresh: watch::Receiver<bool>,
     handle: JoinHandle<()>,
 }
 
@@ -1956,13 +1957,30 @@ impl HelixDB {
         Ok(summary)
     }
 
-    /// Wait for any currently owned startup warm tasks to finish.
+    /// Wait for owned startup warm tasks and the initial vector refresh to finish.
     pub async fn wait_for_startup_cache_warm(&self) {
         if let Some(task) = self.inner.caches.startup_tasks.slate.lock().await.take() {
             task.wait().await;
         }
         if let Some(task) = self.inner.caches.startup_tasks.fts.lock().await.take() {
             task.wait().await;
+        }
+        let initial_vector_refresh = self
+            .inner
+            .caches
+            .vector_memory
+            .refresh_task
+            .lock()
+            .await
+            .as_ref()
+            .map(|task| task.initial_refresh.clone());
+        let Some(mut initial_vector_refresh) = initial_vector_refresh else {
+            return;
+        };
+        while !*initial_vector_refresh.borrow() {
+            if initial_vector_refresh.changed().await.is_err() {
+                break;
+            }
         }
     }
 
@@ -2160,7 +2178,9 @@ impl HelixDB {
         let budget = settings.budget();
         let interval = Duration::from_secs(settings.poll_interval_secs());
         let (shutdown, mut shutdown_rx) = watch::channel(false);
+        let (initial_refresh_tx, initial_refresh) = watch::channel(false);
         let handle = tokio::spawn(async move {
+            let mut initial_refresh_tx = Some(initial_refresh_tx);
             loop {
                 if *shutdown_rx.borrow() {
                     break;
@@ -2175,6 +2195,9 @@ impl HelixDB {
                 drop(database);
                 if let Err(err) = result {
                     tracing::warn!(error = %err, "failed to refresh vector memory stores");
+                }
+                if let Some(initial_refresh_tx) = initial_refresh_tx.take() {
+                    let _ = initial_refresh_tx.send(true);
                 }
                 tokio::select! {
                     changed = shutdown_rx.changed() => {
@@ -2192,7 +2215,11 @@ impl HelixDB {
             }
         });
         *self.inner.caches.vector_memory.refresh_task.lock().await =
-            Some(VectorMemoryRefreshTask { shutdown, handle });
+            Some(VectorMemoryRefreshTask {
+                shutdown,
+                initial_refresh,
+                handle,
+            });
         Ok(())
     }
 
@@ -2935,11 +2962,11 @@ mod tests {
         db.wait_for_startup_cache_warm().await;
         let fts = db.fts_cache_state().await.expect("FTS cache state");
         assert!(fts.enabled);
-        assert_eq!(fts.resolved_memory_budget_bytes, 64 * 1024 * 1024);
+        assert_eq!(fts.resolved_memory_budget_bytes, 16 * 1024 * 1024);
         let slate = db.slate_cache_state().await;
-        assert!(slate.enabled);
-        assert_eq!(slate.warm_mode, Some(config::CacheWarmMode::Background));
-        assert_eq!(slate.last_warm.expect("warm completed").sst_count, 0);
+        assert!(!slate.enabled);
+        assert_eq!(slate.warm_mode, Some(config::CacheWarmMode::Off));
+        assert!(slate.last_warm.is_none());
         assert_eq!(
             db.warm_fts_cache()
                 .await

--- a/docs/database/helix-db/start-here/local-development/embedded-database.mdx
+++ b/docs/database/helix-db/start-here/local-development/embedded-database.mdx
@@ -124,7 +124,7 @@ caches:
 | Vector memory | 64 MiB | 64 MiB | 256 MiB |
 | SlateDB block / metadata | 16 MiB / 8 MiB | 48 MiB / 16 MiB | 512 MiB / 128 MiB |
 | Full-text search | 16 MiB | 16 MiB | 64 MiB |
-| Startup warming | Off | Off | Background |
+| SlateDB / FTS startup warming | Off | Off | Background |
 | Disk cache | Disabled | Disabled | Disabled |
 
 The local profiles also use a 16 MiB L0 target and a 64 MiB unflushed-data ceiling.

--- a/docs/database/helix-db/start-here/local-development/embedded-database.mdx
+++ b/docs/database/helix-db/start-here/local-development/embedded-database.mdx
@@ -120,7 +120,7 @@ caches:
 
 | Setting | In-memory | Disk | Object storage |
 | --- | --- | --- | --- |
-| Durable-write flush interval | 1 ms | 5 ms | 100 ms |
+| Durable-write flush interval | 1 ms | 3 ms | 100 ms |
 | Vector memory | 64 MiB | 64 MiB | 256 MiB |
 | SlateDB block / metadata | 16 MiB / 8 MiB | 48 MiB / 16 MiB | 512 MiB / 128 MiB |
 | Full-text search | 16 MiB | 16 MiB | 64 MiB |

--- a/docs/database/helix-db/start-here/local-development/embedded-database.mdx
+++ b/docs/database/helix-db/start-here/local-development/embedded-database.mdx
@@ -114,16 +114,22 @@ const client = await Client.embedded({
 
 ## Configure caches
 
-Cache configuration is optional and fixed when the handle opens. Omit it to use these
-defaults:
+Cache configuration is optional and fixed when the handle opens. Local defaults are
+bounded and demand-filled so a small embedded database does not reserve server-sized
+caches:
 
-| Setting | Default |
-| --- | --- |
-| Profile | Memory |
-| Vector memory | 256 MiB, hydrated and refreshed in the background |
-| SlateDB | Default in-memory block and metadata caches, warmed in the background |
-| Full-text search | 64 MiB in-memory split cache, warmed in the background |
-| Disk cache | Disabled |
+| Setting | In-memory | Disk | Object storage |
+| --- | --- | --- | --- |
+| Durable-write flush interval | 1 ms | 5 ms | 100 ms |
+| Vector memory | 64 MiB | 64 MiB | 256 MiB |
+| SlateDB block / metadata | 16 MiB / 8 MiB | 48 MiB / 16 MiB | 512 MiB / 128 MiB |
+| Full-text search | 16 MiB | 16 MiB | 64 MiB |
+| Startup warming | Off | Off | Background |
+| Disk cache | Disabled | Disabled | Disabled |
+
+The local profiles also use a 16 MiB L0 target and a 64 MiB unflushed-data ceiling.
+The flush interval is the batching delay before storage I/O; filesystem and device
+latency still apply.
 
 Pass an explicit cache configuration to change the vector-memory budget or enable
 bounded disk caches:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -785,7 +785,7 @@ caches:
 
 | Setting | In-memory | Disk | Object storage |
 | --- | --- | --- | --- |
-| Durable-write flush interval | 1 ms | 5 ms | 100 ms |
+| Durable-write flush interval | 1 ms | 3 ms | 100 ms |
 | Vector memory | 64 MiB | 64 MiB | 256 MiB |
 | SlateDB block / metadata | 16 MiB / 8 MiB | 48 MiB / 16 MiB | 512 MiB / 128 MiB |
 | Full-text search | 16 MiB | 16 MiB | 64 MiB |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -779,16 +779,22 @@ const client = await Client.embedded({
 
 ## Configure caches
 
-Cache configuration is optional and fixed when the handle opens. Omit it to use these
-defaults:
+Cache configuration is optional and fixed when the handle opens. Local defaults are
+bounded and demand-filled so a small embedded database does not reserve server-sized
+caches:
 
-| Setting | Default |
-| --- | --- |
-| Profile | Memory |
-| Vector memory | 256 MiB, hydrated and refreshed in the background |
-| SlateDB | Default in-memory block and metadata caches, warmed in the background |
-| Full-text search | 64 MiB in-memory split cache, warmed in the background |
-| Disk cache | Disabled |
+| Setting | In-memory | Disk | Object storage |
+| --- | --- | --- | --- |
+| Durable-write flush interval | 1 ms | 5 ms | 100 ms |
+| Vector memory | 64 MiB | 64 MiB | 256 MiB |
+| SlateDB block / metadata | 16 MiB / 8 MiB | 48 MiB / 16 MiB | 512 MiB / 128 MiB |
+| Full-text search | 16 MiB | 16 MiB | 64 MiB |
+| Startup warming | Off | Off | Background |
+| Disk cache | Disabled | Disabled | Disabled |
+
+The local profiles also use a 16 MiB L0 target and a 64 MiB unflushed-data ceiling.
+The flush interval is the batching delay before storage I/O; filesystem and device
+latency still apply.
 
 Pass an explicit cache configuration to change the vector-memory budget or enable
 bounded disk caches:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -789,7 +789,7 @@ caches:
 | Vector memory | 64 MiB | 64 MiB | 256 MiB |
 | SlateDB block / metadata | 16 MiB / 8 MiB | 48 MiB / 16 MiB | 512 MiB / 128 MiB |
 | Full-text search | 16 MiB | 16 MiB | 64 MiB |
-| Startup warming | Off | Off | Background |
+| SlateDB / FTS startup warming | Off | Off | Background |
 | Disk cache | Disabled | Disabled | Disabled |
 
 The local profiles also use a 16 MiB L0 target and a 64 MiB unflushed-data ceiling.


### PR DESCRIPTION
## Summary

- add storage-specific defaults for in-memory, local-disk, and object-storage databases
- lower durable WAL flush intervals to 1 ms in memory and 3 ms on local disk while retaining the 100 ms object-storage default
- bound embedded SlateDB, vector, SimHash, and full-text caches and disable embedded startup warming
- wait for the initial vector cache refresh before startup completes
- add durable-write benchmarks, configuration tests, UniFFI coverage, and embedded configuration documentation

## Why

SlateDB's general 100 ms WAL flush default was also used by embedded databases. Embedded transactions await durability, so local writes inherited roughly 100 ms of batching latency. Embedded handles also inherited server-sized cache capacities totaling roughly 992 MiB.

The new defaults keep object-storage behavior unchanged while giving local storage lower latency and bounded memory use.

## Impact

- in-memory embedded cache capacity: 112 MiB
- disk embedded cache capacity: 152 MiB
- local benchmark median durable-write latency:
  - in memory: 101.5 ms to 2.39 ms
  - disk: 101.8 ms to 4.04 ms
- object-storage flush and cache defaults remain unchanged

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run check-llms`
- `cargo bench -p db --bench embedded_write_latency -- on_disk --sample-count 20 --sample-size 1`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces source-specific embedded database defaults to reduce local durable-write latency and bound cache memory while retaining existing object-storage behavior.
- Adds bounded SlateDB, vector, SimHash, and full-text cache profiles for in-memory and disk sources.
- Applies shorter local WAL flush intervals and source-aware defaults across Rust and UniFFI open paths.
- Adds configuration coverage, durable-write benchmarks, and embedded-database documentation.
- Tracks completion of the first vector-cache refresh, although default open paths do not await it.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/db/src/config/db.rs | Defines source-specific embedded flush, write-buffer, and bounded-cache defaults; background vector hydration leaves the stated startup-readiness guarantee incomplete. |
| crates/db/src/lib.rs | Routes embedded opens through source-aware defaults, installs bounded SlateDB caches, and tracks initial vector refresh completion. |
| bindings/uniffi/src/helix_db.rs | Preserves source-specific non-cache defaults while applying caller-provided cache profiles to UniFFI opens. |
| crates/db/src/config/cache.rs | Adds validated block and metadata capacities to in-memory SlateDB cache configuration. |
| crates/db/benches/embedded_write_latency.rs | Adds acknowledged-write latency benchmarks for in-memory and local-disk embedded databases. |
| docs/database/helix-db/start-here/local-development/embedded-database.mdx | Documents the new embedded storage-specific durability and cache defaults. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Embedded open] --> B{Storage source}
  B -->|In memory| C[1 ms flush and 112 MiB cache profile]
  B -->|Local disk| D[3 ms flush and 152 MiB cache profile]
  B -->|Object storage| E[General 100 ms defaults]
  C --> F[Open SlateDB]
  D --> F
  E --> F
  F --> G[Start background vector refresh]
  G --> H[Open returns]
  H --> I[Optional explicit startup-warm wait]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(db): lower embedded disk flush inte..."](https://github.com/helixdb/helix-db/commit/d4d6deb4d39fc092b98ecd810df14dfad69ba77d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52260773)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->