### PR TITLE
Document active index inventory MCP tool

### DIFF
--- a/docs/database/helix-cloud/connect/mcp.mdx
+++ b/docs/database/helix-cloud/connect/mcp.mdx
@@ -36,7 +36,7 @@ export const ClaudeCodeLogo = () => (
 
 The hosted HelixDB MCP server gives agents read-only access to your Helix Cloud
 workspaces, projects, databases, query insights, latency, recommendations,
-usage, and dedicated-cluster health.
+active indexes, usage, and dedicated-cluster health.
 
 - It uses browser-based OAuth through WorkOS. You do not create or copy an API key.
 - It returns only resources your Helix user can currently access.
@@ -226,6 +226,7 @@ After connecting, ask your agent to:
 - “Find my slowest queries over the last 24 hours and summarize their planner findings.”
 - “Compare p50, p95, and p99 query latency for this database.”
 - “List current query recommendations, grouped by severity.”
+- “List the active indexes the planner can use for this database.”
 - “Check CPU, memory, storage, and topology for this dedicated cluster.”
 
 ## Available tools
@@ -235,11 +236,33 @@ After connecting, ask your agent to:
 | `helix_list_workspaces` | List active workspaces the signed-in user can access. |
 | `helix_list_projects` | List active projects in an authorized workspace. |
 | `helix_list_databases` | List dedicated clusters and tenant databases in an authorized project. |
+| `helix_list_database_indexes` | List the writer-authoritative active indexes visible to the planner for a cluster or tenant database. |
 | `helix_get_query_insights` | Get query counts, failures, average/maximum latency, and typed planner findings. It does not return percentiles. |
 | `helix_get_query_latency` | Get authoritative p50, p95, p99, and maximum query latency. |
 | `helix_list_query_recommendations` | List structured recommendations without raw recommendation bodies. |
 | `helix_get_database_usage` | Get hourly or daily read and write counts for a cluster or tenant database. |
 | `helix_get_cluster_health` | Get CPU, memory, storage, and topology for a dedicated cluster. Components report availability independently. |
+
+### Active index inventory
+
+`helix_list_database_indexes` accepts a database reference such as
+`tenant:<id>` or `cluster:<id>`. It returns `content_trust`, `database`,
+`observed_at`, and an ordered `indexes` array. Every index contains:
+
+- `index_id`
+- `element`: `node` or `edge`
+- `kind`: `equality`, `range`, `vector`, or `full_text`
+- `label`
+- `property`
+
+The response includes `unique` only for node equality indexes, including when
+its value is `false`. It includes `direction` only for range indexes and
+`tenant_property` only for scoped vector or full-text indexes.
+
+The inventory contains only indexes that are active and visible to the planner
+at `observed_at`. Pending, building, failed, and dropped indexes are not
+included. An empty `indexes` array means no active indexes were visible; it
+does not report lifecycle state for inactive indexes.
 
 ## Troubleshooting
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4175,7 +4175,7 @@ export const ClaudeCodeLogo = () => (
 
 The hosted HelixDB MCP server gives agents read-only access to your Helix Cloud
 workspaces, projects, databases, query insights, latency, recommendations,
-usage, and dedicated-cluster health.
+active indexes, usage, and dedicated-cluster health.
 
 - It uses browser-based OAuth through WorkOS. You do not create or copy an API key.
 - It returns only resources your Helix user can currently access.
@@ -4357,6 +4357,7 @@ After connecting, ask your agent to:
 - “Find my slowest queries over the last 24 hours and summarize their planner findings.”
 - “Compare p50, p95, and p99 query latency for this database.”
 - “List current query recommendations, grouped by severity.”
+- “List the active indexes the planner can use for this database.”
 - “Check CPU, memory, storage, and topology for this dedicated cluster.”
 
 ## Available tools
@@ -4366,11 +4367,33 @@ After connecting, ask your agent to:
 | `helix_list_workspaces` | List active workspaces the signed-in user can access. |
 | `helix_list_projects` | List active projects in an authorized workspace. |
 | `helix_list_databases` | List dedicated clusters and tenant databases in an authorized project. |
+| `helix_list_database_indexes` | List the writer-authoritative active indexes visible to the planner for a cluster or tenant database. |
 | `helix_get_query_insights` | Get query counts, failures, average/maximum latency, and typed planner findings. It does not return percentiles. |
 | `helix_get_query_latency` | Get authoritative p50, p95, p99, and maximum query latency. |
 | `helix_list_query_recommendations` | List structured recommendations without raw recommendation bodies. |
 | `helix_get_database_usage` | Get hourly or daily read and write counts for a cluster or tenant database. |
 | `helix_get_cluster_health` | Get CPU, memory, storage, and topology for a dedicated cluster. Components report availability independently. |
+
+### Active index inventory
+
+`helix_list_database_indexes` accepts a database reference such as
+`tenant:<id>` or `cluster:<id>`. It returns `content_trust`, `database`,
+`observed_at`, and an ordered `indexes` array. Every index contains:
+
+- `index_id`
+- `element`: `node` or `edge`
+- `kind`: `equality`, `range`, `vector`, or `full_text`
+- `label`
+- `property`
+
+The response includes `unique` only for node equality indexes, including when
+its value is `false`. It includes `direction` only for range indexes and
+`tenant_property` only for scoped vector or full-text indexes.
+
+The inventory contains only indexes that are active and visible to the planner
+at `observed_at`. Pending, building, failed, and dropped indexes are not
+included. An empty `indexes` array means no active indexes were visible; it
+does not report lifecycle state for inactive indexes.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- document `helix_list_database_indexes` in the hosted Helix MCP guide
- describe its tenant and dedicated-cluster inputs and exact structured fields
- explain that the inventory is writer-authoritative, active-only, ordered, and does not expose inactive lifecycle states
- regenerate the agent-oriented full documentation index

## Validation

- `npm ci`
- `npm run generate-llms`
- `npm run check`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR documents the hosted MCP tool for inspecting active database indexes and regenerates the agent-oriented documentation corpus.
- Adds `helix_list_database_indexes` to the tool inventory and example workflows.
- Documents database-reference inputs, structured response fields, conditional fields, ordering, and active-only lifecycle semantics.
- Keeps `docs/llms-full.txt` synchronized with the canonical MCP guide.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/database/helix-cloud/connect/mcp.mdx | Adds a consistent, focused description of the active index inventory MCP tool; no actionable issue was identified. |
| docs/llms-full.txt | Regenerates the agent documentation with content synchronized to the canonical MCP page. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Document active index inventory MCP tool"](https://github.com/helixdb/helix-db/commit/c577df1d83e594d45932366d92b470e92ead5497) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52532469)</sub>

<!-- /greptile_comment -->