### PR TITLE
docs: document FTS prefiltering

### DIFF
--- a/docs/database/helix-db/query-guides/filtering.mdx
+++ b/docs/database/helix-db/query-guides/filtering.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Filtering"
-description: "Narrow traversal streams with predicates and exact vector candidate sets"
+description: "Narrow traversal streams with predicates and exact search candidate sets"
 sidebarTitle: "Filtering"
 pageType: "Guide"
 ---
@@ -8,8 +8,8 @@ pageType: "Guide"
 <div className="flex flex-wrap gap-2"><Badge color="blue" size="sm">Guide</Badge></div>
 
 Use a source predicate to select the initial candidates and `.where(...)` for
-expression-based filtering later in a traversal. Vector prefiltering applies the same
-idea to similarity search by ranking only an exact traversal-defined candidate set.
+expression-based filtering later in a traversal. Vector and full-text search
+prefiltering rank only an exact traversal-defined candidate set.
 
 ## Common predicates
 
@@ -276,6 +276,177 @@ Use a source vector search when the whole indexed label and optional tenant part
 is the intended candidate set. Use vector prefiltering when relationships,
 permissions, or earlier filters define membership.
 
+## FTS prefiltering
+
+Full-text search (FTS) prefiltering starts with a node or edge traversal, then ranks
+only the unique IDs in that stream by BM25 score. Use it when relationships,
+permissions, or earlier predicates define which records are eligible for text search.
+
+The execution order is **graph traversal → exact candidate membership → BM25 ranking
+→ top k**. Results are identical to an exhaustive BM25 search of the selected tenant
+partition, intersected with the candidate IDs, followed by deterministic top-k
+selection. BM25 statistics still come from the full tenant partition.
+
+### Rank a node stream
+
+This request finds documents the current user can read, ranks that exact set for
+`"graph databases"`, and returns the top five.
+
+<Note>
+This query requires an active text index on `Document.body`. Create and activate that
+index before running the request.
+</Note>
+
+<CodeGroup>
+
+```rust Rust
+read_batch()
+    .var_as(
+        "matches",
+        g()
+            .n_with_label_where("User", SourcePredicate::eq("username", "alice"))
+            .out(Some("CAN_READ"))
+            .text_search(
+                "Document",
+                "body",
+                "graph databases",
+                5,
+                None,
+            )
+            .value_map(Some(vec!["$id", "title", "$score"])),
+    )
+    .returning(["matches"]);
+```
+
+```ts TypeScript
+readBatch()
+  .varAs(
+    "matches",
+    g()
+      .nWithLabelWhere("User", SourcePredicate.eq("username", "alice"))
+      .out("CAN_READ")
+      .textSearch("Document", "body", "graph databases", 5, null)
+      .valueMap(["$id", "title", "$score"]),
+  )
+  .returning(["matches"]);
+```
+
+```go Go
+helix.ReadQuery("readable_document_matches").
+	VarAs(
+		"matches",
+		helix.G().
+			NWithLabelWhere("User", helix.SourceEq("username", "alice")).
+			Out("CAN_READ").
+			TextSearchNodesWithin("Document", "body", "graph databases", 5).
+			ValueMap("$id", "title", "$score"),
+	).
+	Returning("matches")
+```
+
+```python Python
+(
+    read_batch()
+    .var_as(
+        "matches",
+        g()
+        .n_with_label_where(
+            "User", SourcePredicate.eq("username", "alice")
+        )
+        .out("CAN_READ")
+        .text_search(
+            "Document", "body", "graph databases", 5
+        )
+        .value_map(["$id", "title", "$score"]),
+    )
+    .returning(["matches"])
+)
+```
+
+```json JSON
+{
+  "request_type": "read",
+  "query_name": "readable_document_matches",
+  "query": {
+    "read": {
+      "entries": [{
+        "query": {
+          "name": "matches",
+          "root": {
+            "value_map": {
+              "input": {
+                "text_search_nodes_within": {
+                  "input": {
+                    "out": {
+                      "input": {
+                        "nodes_where": {
+                          "predicate": {
+                            "and": {
+                              "predicates": [
+                                {
+                                  "eq": {
+                                    "left": { "property": "$label" },
+                                    "right": { "constant": { "string": "User" } }
+                                  }
+                                },
+                                {
+                                  "eq": {
+                                    "left": { "property": "username" },
+                                    "right": { "constant": { "string": "alice" } }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "label": "CAN_READ"
+                    }
+                  },
+                  "label": "Document",
+                  "property": "body",
+                  "query_text": {
+                    "value": { "string": "graph databases" }
+                  },
+                  "k": { "literal": 5 }
+                }
+              },
+              "properties": ["$id", "title", "$score"]
+            }
+          }
+        }
+      }],
+      "returns": ["matches"]
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+Use `TextSearchEdgesWithin` in Go after an edge traversal. Rust, TypeScript, and
+Python select the node or edge wire operation from the current traversal state. Use
+the `*With` forms for parameterized query text, `k`, or tenant values.
+
+### Result contract
+
+- Output IDs are a deduplicated subset of the input IDs.
+- The result contains at most `min(unique candidates, k)` rows.
+- Rows are ordered by BM25 score descending, then entity ID ascending.
+- The selected input row keeps its bindings, path, and sack; `$score` is attached.
+- Empty input returns without opening the text index.
+- A wrong-kind input or more than 1,000,000 unique candidates is a query error.
+- A tenant-partitioned index requires the same tenant value used to build the
+  candidate stream.
+
+### When to search without a prefilter
+
+Use a source text search when the whole indexed label and optional tenant partition
+is the intended candidate set. Do not implement exact FTS filtering as source text
+search followed by `.where(...)`: excluded high-scoring hits can consume the source
+top-k and leave fewer than `k` eligible results. Build the candidate stream first and
+use FTS prefiltering when membership is authoritative.
+
 ## Next steps
 
 <CardGroup cols={2}>
@@ -287,6 +458,9 @@ permissions, or earlier filters define membership.
   </Card>
   <Card title="Vector indexes" icon="circle-nodes" href="/database/helix-db/query-guides/vector-indexes">
     Create the dimensioned index used for ranking.
+  </Card>
+  <Card title="Text indexes" icon="align-left" href="/database/helix-db/query-guides/text-indexes">
+    Create the BM25 index used for full-text ranking.
   </Card>
   <Card title="Project search results" icon="table-columns" href="/database/helix-db/query-guides/projections">
     Preserve ranked hit metadata before continuing a traversal.

--- a/docs/database/helix-db/query-guides/text-indexes.mdx
+++ b/docs/database/helix-db/query-guides/text-indexes.mdx
@@ -92,6 +92,9 @@ by BM25 relevance. Project the rank field before traversing away from a hit.
 ## Next steps
 
 <CardGroup cols={2}>
+  <Card title="FTS prefiltering" icon="filter" href="/database/helix-db/query-guides/filtering#fts-prefiltering">
+    Rank only an exact traversal-defined candidate set.
+  </Card>
   <Card title="Project search results" icon="table-columns" href="/database/helix-db/query-guides/projections">
     Preserve ranked hit metadata before continuing a traversal.
   </Card>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2970,6 +2970,9 @@ by BM25 relevance. Project the rank field before traversing away from a hit.
 
 ## Next steps
 
+  <Card title="FTS prefiltering" icon="filter" href="/database/helix-db/query-guides/filtering#fts-prefiltering">
+    Rank only an exact traversal-defined candidate set.
+  </Card>
   <Card title="Project search results" icon="table-columns" href="/database/helix-db/query-guides/projections">
     Preserve ranked hit metadata before continuing a traversal.
   </Card>
@@ -3152,8 +3155,8 @@ Page type: Guide
 <div className="flex flex-wrap gap-2"><Badge color="blue" size="sm">Guide</Badge></div>
 
 Use a source predicate to select the initial candidates and `.where(...)` for
-expression-based filtering later in a traversal. Vector prefiltering applies the same
-idea to similarity search by ranking only an exact traversal-defined candidate set.
+expression-based filtering later in a traversal. Vector and full-text search
+prefiltering rank only an exact traversal-defined candidate set.
 
 ## Common predicates
 
@@ -3408,6 +3411,171 @@ Use a source vector search when the whole indexed label and optional tenant part
 is the intended candidate set. Use vector prefiltering when relationships,
 permissions, or earlier filters define membership.
 
+## FTS prefiltering
+
+Full-text search (FTS) prefiltering starts with a node or edge traversal, then ranks
+only the unique IDs in that stream by BM25 score. Use it when relationships,
+permissions, or earlier predicates define which records are eligible for text search.
+
+The execution order is **graph traversal → exact candidate membership → BM25 ranking
+→ top k**. Results are identical to an exhaustive BM25 search of the selected tenant
+partition, intersected with the candidate IDs, followed by deterministic top-k
+selection. BM25 statistics still come from the full tenant partition.
+
+### Rank a node stream
+
+This request finds documents the current user can read, ranks that exact set for
+`"graph databases"`, and returns the top five.
+
+This query requires an active text index on `Document.body`. Create and activate that
+index before running the request.
+
+```rust Rust
+read_batch()
+    .var_as(
+        "matches",
+        g()
+            .n_with_label_where("User", SourcePredicate::eq("username", "alice"))
+            .out(Some("CAN_READ"))
+            .text_search(
+                "Document",
+                "body",
+                "graph databases",
+                5,
+                None,
+            )
+            .value_map(Some(vec!["$id", "title", "$score"])),
+    )
+    .returning(["matches"]);
+```
+
+```ts TypeScript
+readBatch()
+  .varAs(
+    "matches",
+    g()
+      .nWithLabelWhere("User", SourcePredicate.eq("username", "alice"))
+      .out("CAN_READ")
+      .textSearch("Document", "body", "graph databases", 5, null)
+      .valueMap(["$id", "title", "$score"]),
+  )
+  .returning(["matches"]);
+```
+
+```go Go
+helix.ReadQuery("readable_document_matches").
+	VarAs(
+		"matches",
+		helix.G().
+			NWithLabelWhere("User", helix.SourceEq("username", "alice")).
+			Out("CAN_READ").
+			TextSearchNodesWithin("Document", "body", "graph databases", 5).
+			ValueMap("$id", "title", "$score"),
+	).
+	Returning("matches")
+```
+
+```python Python
+(
+    read_batch()
+    .var_as(
+        "matches",
+        g()
+        .n_with_label_where(
+            "User", SourcePredicate.eq("username", "alice")
+        )
+        .out("CAN_READ")
+        .text_search(
+            "Document", "body", "graph databases", 5
+        )
+        .value_map(["$id", "title", "$score"]),
+    )
+    .returning(["matches"])
+)
+```
+
+```json JSON
+{
+  "request_type": "read",
+  "query_name": "readable_document_matches",
+  "query": {
+    "read": {
+      "entries": [{
+        "query": {
+          "name": "matches",
+          "root": {
+            "value_map": {
+              "input": {
+                "text_search_nodes_within": {
+                  "input": {
+                    "out": {
+                      "input": {
+                        "nodes_where": {
+                          "predicate": {
+                            "and": {
+                              "predicates": [
+                                {
+                                  "eq": {
+                                    "left": { "property": "$label" },
+                                    "right": { "constant": { "string": "User" } }
+                                  }
+                                },
+                                {
+                                  "eq": {
+                                    "left": { "property": "username" },
+                                    "right": { "constant": { "string": "alice" } }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "label": "CAN_READ"
+                    }
+                  },
+                  "label": "Document",
+                  "property": "body",
+                  "query_text": {
+                    "value": { "string": "graph databases" }
+                  },
+                  "k": { "literal": 5 }
+                }
+              },
+              "properties": ["$id", "title", "$score"]
+            }
+          }
+        }
+      }],
+      "returns": ["matches"]
+    }
+  }
+}
+```
+
+Use `TextSearchEdgesWithin` in Go after an edge traversal. Rust, TypeScript, and
+Python select the node or edge wire operation from the current traversal state. Use
+the `*With` forms for parameterized query text, `k`, or tenant values.
+
+### Result contract
+
+- Output IDs are a deduplicated subset of the input IDs.
+- The result contains at most `min(unique candidates, k)` rows.
+- Rows are ordered by BM25 score descending, then entity ID ascending.
+- The selected input row keeps its bindings, path, and sack; `$score` is attached.
+- Empty input returns without opening the text index.
+- A wrong-kind input or more than 1,000,000 unique candidates is a query error.
+- A tenant-partitioned index requires the same tenant value used to build the
+  candidate stream.
+
+### When to search without a prefilter
+
+Use a source text search when the whole indexed label and optional tenant partition
+is the intended candidate set. Do not implement exact FTS filtering as source text
+search followed by `.where(...)`: excluded high-scoring hits can consume the source
+top-k and leave fewer than `k` eligible results. Build the candidate stream first and
+use FTS prefiltering when membership is authoritative.
+
 ## Next steps
 
   <Card title="Typed parameters" icon="sliders" href="/database/helix-db/query-guides/parameters">
@@ -3418,6 +3586,9 @@ permissions, or earlier filters define membership.
   </Card>
   <Card title="Vector indexes" icon="circle-nodes" href="/database/helix-db/query-guides/vector-indexes">
     Create the dimensioned index used for ranking.
+  </Card>
+  <Card title="Text indexes" icon="align-left" href="/database/helix-db/query-guides/text-indexes">
+    Create the BM25 index used for full-text ranking.
   </Card>
   <Card title="Project search results" icon="table-columns" href="/database/helix-db/query-guides/projections">
     Preserve ranked hit metadata before continuing a traversal.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -38,7 +38,7 @@ Full walkthrough: https://docs.helix-db.com/cli/getting-started
 - [Vector indexes](https://docs.helix-db.com/database/helix-db/query-guides/vector-indexes): Create dimensioned vector indexes and run nearest-neighbor search — Page type: Guide
 - [Text indexes](https://docs.helix-db.com/database/helix-db/query-guides/text-indexes): Create BM25 indexes for ranked full-text search — Page type: Guide
 - [Traverse relationships](https://docs.helix-db.com/database/helix-db/query-guides/traversals): Follow edges, retain row-local bindings, and control duplicate paths — Page type: Guide
-- [Filtering](https://docs.helix-db.com/database/helix-db/query-guides/filtering): Narrow traversal streams with predicates and exact vector candidate sets — Page type: Guide
+- [Filtering](https://docs.helix-db.com/database/helix-db/query-guides/filtering): Narrow traversal streams with predicates and exact search candidate sets — Page type: Guide
 - [Shape query results](https://docs.helix-db.com/database/helix-db/query-guides/projections): Return properties, computed values, aggregates, and correlated binding rows — Page type: Guide
 - [Branch, repeat, and condition queries](https://docs.helix-db.com/database/helix-db/query-guides/advanced): Compose sub-traversals and gate named entries without leaving one transaction — Page type: Guide
 - [Bind typed query parameters](https://docs.helix-db.com/database/helix-db/query-guides/parameters): Keep the operation tree stable while request values change — Page type: Guide


### PR DESCRIPTION
## Summary

- add a public guide for traversal-scoped node and edge FTS prefiltering
- document exact BM25 candidate semantics, ordering, limits, tenant behavior, and source-search underfill
- include Rust, TypeScript, Python, Go, and raw JSON examples
- cross-link the guide from Text Indexes and regenerate the `llms` documentation artifacts

## Why

FTS prefiltering was available in the SDKs but was not discoverable in the public documentation site. This documents when to use restricted search and its correctness contract.

## Validation

- `npm run check` in `docs`
- Mint broken-link, anchor, redirect, and snippet checks
- TypeScript SDK tests
- Go SDK tests
- Python DSL tests
- `cargo test -p helix-ast`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR documents traversal-scoped full-text-search prefiltering and its exact BM25 candidate semantics across all supported SDKs.
- Adds Rust, TypeScript, Go, Python, and raw JSON examples.
- Documents ordering, limits, deduplication, tenant handling, row preservation, and source-search underfill.
- Cross-links the filtering and text-index guides.
- Regenerates the LLM documentation index and full-text artifact.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/database/helix-db/query-guides/filtering.mdx | Adds accurate FTS prefiltering guidance, examples, and runtime-contract details consistent with the SDK and execution implementations. |
| docs/database/helix-db/query-guides/text-indexes.mdx | Adds a valid cross-link from text-index documentation to the new prefiltering section. |
| docs/llms-full.txt | Regenerates the consolidated documentation with the new FTS content using the expected MDX transformations. |
| docs/llms.txt | Updates the filtering guide description consistently with its expanded search coverage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(search): document FTS prefiltering"](https://github.com/helixdb/helix-db/commit/9efe2207af1321b208af1add4033ffee966057ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52529360)</sub>

<!-- /greptile_comment -->