### PR TITLE
Fix vector and full text prefiltering SDK examples

### DIFF
--- a/docs/database/helix-db/query-guides/filtering.mdx
+++ b/docs/database/helix-db/query-guides/filtering.mdx
@@ -342,7 +342,7 @@ Use a source vector search when the whole indexed label and optional tenant part
 is the intended candidate set. Use vector prefiltering when relationships,
 permissions, or earlier filters define membership.
 
-## FTS prefiltering
+## Full Text Search prefiltering
 
 Full-text search (FTS) prefiltering starts with a node or edge traversal, then ranks
 only the unique IDs in that stream by BM25 score. Use it when relationships,
@@ -366,66 +366,118 @@ index before running the request.
 <CodeGroup>
 
 ```rust Rust
-read_batch()
-    .var_as(
-        "matches",
-        g()
-            .n_with_label_where("User", SourcePredicate::eq("username", "alice"))
-            .out(Some("CAN_READ"))
-            .text_search(
-                "Document",
-                "body",
-                "graph databases",
-                5,
-                None,
-            )
-            .value_map(Some(vec!["$id", "title", "$score"])),
-    )
-    .returning(["matches"]);
+use helix_db::dsl::prelude::*;
+
+#[query]
+fn readable_document_matches(
+    username: String,
+    query_text: String,
+    limit: i64,
+) -> ReadBatch {
+    read_batch()
+        .var_as(
+            "matches",
+            g()
+                .n_with_label_where("User", SourcePredicate::eq("username", username))
+                .out(Some("CAN_READ"))
+                .text_search_with("Document", "body", query_text, limit, None)
+                .value_map(Some(vec!["$id", "title", "$score"])),
+        )
+        .returning(["matches"])
+}
+
+let request = readable_document_matches(
+    "alice".to_string(),
+    "graph databases".to_string(),
+    5,
+)?;
 ```
 
 ```ts TypeScript
-readBatch()
+import {
+  SourcePredicate,
+  defineParams,
+  g,
+  param,
+  readBatch,
+} from "@helix-db/helix-db";
+
+const params = defineParams({
+  username: param.string(),
+  query_text: param.string(),
+  limit: param.i64(),
+});
+
+const query = readBatch()
   .varAs(
     "matches",
     g()
-      .nWithLabelWhere("User", SourcePredicate.eq("username", "alice"))
+      .nWithLabelWhere("User", SourcePredicate.eq("username", params.username))
       .out("CAN_READ")
-      .textSearch("Document", "body", "graph databases", 5, null)
+      .textSearchWith("Document", "body", params.query_text, params.limit)
       .valueMap(["$id", "title", "$score"]),
   )
   .returning(["matches"]);
+
+const request = query.toQueryRequest(
+  params,
+  { username: "alice", query_text: "graph databases", limit: 5n },
+  { queryName: "readable_document_matches" },
+);
 ```
 
 ```go Go
-helix.ReadQuery("readable_document_matches").
+q := helix.ReadQuery("readable_document_matches")
+username := q.ParamString("username", "alice")
+queryText := q.ParamString("query_text", "graph databases")
+limit := q.ParamI64("limit", 5)
+
+request := q.
 	VarAs(
 		"matches",
 		helix.G().
-			NWithLabelWhere("User", helix.SourceEq("username", "alice")).
+			NWithLabelWhere("User", helix.SourceEq("username", username)).
 			Out("CAN_READ").
-			TextSearchNodesWithin("Document", "body", "graph databases", 5).
+			TextSearchNodesWithin("Document", "body", queryText, limit).
 			ValueMap("$id", "title", "$score"),
 	).
 	Returning("matches")
 ```
 
 ```python Python
-(
+from helixdb import SourcePredicate, define_params, g, param, read_batch
+
+params = define_params({
+    "username": param.string(),
+    "query_text": param.string(),
+    "limit": param.i64(),
+})
+
+query = (
     read_batch()
     .var_as(
         "matches",
         g()
         .n_with_label_where(
-            "User", SourcePredicate.eq("username", "alice")
+            "User", SourcePredicate.eq("username", params.username)
         )
         .out("CAN_READ")
-        .text_search(
-            "Document", "body", "graph databases", 5
+        .text_search_with(
+            "Document", "body", params.query_text, params.limit
         )
         .value_map(["$id", "title", "$score"]),
     )
     .returning(["matches"])
+)
+
+request = query.to_query_request(
+    params,
+    {
+        "username": "alice",
+        "query_text": "graph databases",
+        "limit": 5,
+    },
+    query_name="readable_document_matches",
 )
 ```
 
@@ -458,7 +510,7 @@ helix.ReadQuery("readable_document_matches").
                                 {
                                   "eq": {
                                     "left": { "property": "username" },
-                                    "right": { "constant": { "string": "alice" } }
+                                    "right": { "param": "username" }
                                   }
                                 }
                               ]
@@ -471,10 +523,8 @@ helix.ReadQuery("readable_document_matches").
                   },
                   "label": "Document",
                   "property": "body",
-                  "query_text": {
-                    "value": { "string": "graph databases" }
-                  },
-                  "k": { "literal": 5 }
+                  "query_text": { "expr": { "param": "query_text" } },
+                  "k": { "expr": { "param": "limit" } }
                 }
               },
               "properties": ["$id", "title", "$score"]
@@ -484,15 +534,26 @@ helix.ReadQuery("readable_document_matches").
       }],
       "returns": ["matches"]
     }
+  },
+  "parameters": {
+    "username": "alice",
+    "query_text": "graph databases",
+    "limit": 5
+  },
+  "parameter_types": {
+    "username": "string",
+    "query_text": "string",
+    "limit": "i64"
   }
 }
 ```
 
 </CodeGroup>
 
-Use `TextSearchEdgesWithin` in Go after an edge traversal. Rust, TypeScript, and
-Python select the node or edge wire operation from the current traversal state. Use
-the `*With` forms for parameterized query text, `k`, or tenant values.
+Use `TextSearchEdgesWithin` in Go after an edge traversal. Rust
+`text_search_with`, TypeScript `textSearchWith`, and Python `text_search_with`
+select the node or edge wire operation from the current stream. Their literal forms
+are `text_search` and `textSearch`.
 
 ### Result contract
 

--- a/docs/database/helix-db/query-guides/filtering.mdx
+++ b/docs/database/helix-db/query-guides/filtering.mdx
@@ -129,66 +129,122 @@ This query requires an active three-dimensional cosine vector index on
 <CodeGroup>
 
 ```rust Rust
-read_batch()
-    .var_as(
-        "matches",
-        g()
-            .n_with_label_where("User", SourcePredicate::eq("username", "alice"))
-            .out(Some("OWNS"))
-            .vector_search(
-                "Project",
-                "embedding",
-                vec![1.0f32, 0.0, 0.0],
-                5,
-                None,
-            )
-            .value_map(Some(vec!["$id", "name", "$distance"])),
-    )
-    .returning(["matches"]);
+use helix_db::dsl::prelude::*;
+
+#[query]
+fn owned_project_matches(
+    username: String,
+    query_vector: Vec<f32>,
+    limit: i64,
+) -> ReadBatch {
+    read_batch()
+        .var_as(
+            "matches",
+            g()
+                .n_with_label_where("User", SourcePredicate::eq("username", username))
+                .out(Some("OWNS"))
+                .vector_search_with("Project", "embedding", query_vector, limit, None)
+                .value_map(Some(vec!["$id", "name", "$distance"])),
+        )
+        .returning(["matches"])
+}
+
+let request = owned_project_matches(
+    "alice".to_string(),
+    vec![1.0f32, 0.0, 0.0],
+    5,
+)?;
 ```
 
 ```ts TypeScript
-readBatch()
+import {
+  SourcePredicate,
+  defineParams,
+  g,
+  param,
+  readBatch,
+} from "@helix-db/helix-db";
+
+const params = defineParams({
+  username: param.string(),
+  query_vector: param.array(param.f32()),
+  limit: param.i64(),
+});
+
+const query = readBatch()
   .varAs(
     "matches",
     g()
-      .nWithLabelWhere("User", SourcePredicate.eq("username", "alice"))
+      .nWithLabelWhere("User", SourcePredicate.eq("username", params.username))
       .out("OWNS")
-      .vectorSearch("Project", "embedding", [1, 0, 0], 5, null)
+      .vectorSearchWith("Project", "embedding", params.query_vector, params.limit)
       .valueMap(["$id", "name", "$distance"]),
   )
   .returning(["matches"]);
+
+const request = query.toQueryRequest(
+  params,
+  { username: "alice", query_vector: [1, 0, 0], limit: 5n },
+  { queryName: "owned_project_matches" },
+);
 ```
 
 ```go Go
-helix.ReadQuery("owned_project_matches").
+q := helix.ReadQuery("owned_project_matches")
+username := q.ParamString("username", "alice")
+queryVector := q.ParamArray(
+	"query_vector",
+	[]float32{1, 0, 0},
+	helix.ParamTypeF32(),
+)
+limit := q.ParamI64("limit", 5)
+
+request := q.
 	VarAs(
 		"matches",
 		helix.G().
-			NWithLabelWhere("User", helix.SourceEq("username", "alice")).
+			NWithLabelWhere("User", helix.SourceEq("username", username)).
 			Out("OWNS").
-			VectorSearchNodesWithin("Project", "embedding", []float32{1, 0, 0}, 5).
+			VectorSearchNodesWithin("Project", "embedding", queryVector, limit).
 			ValueMap("$id", "name", "$distance"),
 	).
 	Returning("matches")
 ```
 
 ```python Python
-(
+from helixdb import SourcePredicate, define_params, g, param, read_batch
+
+params = define_params({
+    "username": param.string(),
+    "query_vector": param.array(param.f32()),
+    "limit": param.i64(),
+})
+
+query = (
     read_batch()
     .var_as(
         "matches",
         g()
         .n_with_label_where(
-            "User", SourcePredicate.eq("username", "alice")
+            "User", SourcePredicate.eq("username", params.username)
         )
         .out("OWNS")
-        .vector_search(
-            "Project", "embedding", [1.0, 0.0, 0.0], 5
+        .vector_search_with(
+            "Project", "embedding", params.query_vector, params.limit
         )
         .value_map(["$id", "name", "$distance"]),
     )
     .returning(["matches"])
+)
+
+request = query.to_query_request(
+    params,
+    {
+        "username": "alice",
+        "query_vector": [1.0, 0.0, 0.0],
+        "limit": 5,
+    },
+    query_name="owned_project_matches",
 )
 ```
 
@@ -221,7 +277,7 @@ helix.ReadQuery("owned_project_matches").
                                 {
                                   "eq": {
                                     "left": { "property": "username" },
-                                    "right": { "constant": { "string": "alice" } }
+                                    "right": { "param": "username" }
                                   }
                                 }
                               ]
@@ -234,10 +290,8 @@ helix.ReadQuery("owned_project_matches").
                   },
                   "label": "Project",
                   "property": "embedding",
-                  "query_vector": {
-                    "value": { "f32_array": [1, 0, 0] }
-                  },
-                  "k": { "literal": 5 }
+                  "query_vector": { "expr": { "param": "query_vector" } },
+                  "k": { "expr": { "param": "limit" } }
                 }
               },
               "properties": ["$id", "name", "$distance"]
@@ -247,14 +301,26 @@ helix.ReadQuery("owned_project_matches").
       }],
       "returns": ["matches"]
     }
+  },
+  "parameters": {
+    "username": "alice",
+    "query_vector": [1, 0, 0],
+    "limit": 5
+  },
+  "parameter_types": {
+    "username": "string",
+    "query_vector": { "array": "f32" },
+    "limit": "i64"
   }
 }
 ```
 
 </CodeGroup>
 
-Use `VectorSearchEdgesWithin` in Go after an edge traversal. Rust, TypeScript, and
-Python select the node or edge wire operation from the current traversal state.
+Use `VectorSearchEdgesWithin` in Go after an edge traversal. Rust
+`vector_search_with`, TypeScript `vectorSearchWith`, and Python
+`vector_search_with` select the node or edge wire operation from the current stream.
+Their literal forms are `vector_search` and `vectorSearch`.
 
 ### Requirements
 

--- a/docs/database/helix-db/query-guides/text-indexes.mdx
+++ b/docs/database/helix-db/query-guides/text-indexes.mdx
@@ -92,7 +92,7 @@ by BM25 relevance. Project the rank field before traversing away from a hit.
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="FTS prefiltering" icon="filter" href="/database/helix-db/query-guides/filtering#fts-prefiltering">
+  <Card title="Full Text Search prefiltering" icon="filter" href="/database/helix-db/query-guides/filtering#full-text-search-prefiltering">
     Rank only an exact traversal-defined candidate set.
   </Card>
   <Card title="Project search results" icon="table-columns" href="/database/helix-db/query-guides/projections">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3268,66 +3268,122 @@ This query requires an active three-dimensional cosine vector index on
 `Project.embedding`. Create and activate that index before running the request.
 
 ```rust Rust
-read_batch()
-    .var_as(
-        "matches",
-        g()
-            .n_with_label_where("User", SourcePredicate::eq("username", "alice"))
-            .out(Some("OWNS"))
-            .vector_search(
-                "Project",
-                "embedding",
-                vec![1.0f32, 0.0, 0.0],
-                5,
-                None,
-            )
-            .value_map(Some(vec!["$id", "name", "$distance"])),
-    )
-    .returning(["matches"]);
+use helix_db::dsl::prelude::*;
+
+#[query]
+fn owned_project_matches(
+    username: String,
+    query_vector: Vec<f32>,
+    limit: i64,
+) -> ReadBatch {
+    read_batch()
+        .var_as(
+            "matches",
+            g()
+                .n_with_label_where("User", SourcePredicate::eq("username", username))
+                .out(Some("OWNS"))
+                .vector_search_with("Project", "embedding", query_vector, limit, None)
+                .value_map(Some(vec!["$id", "name", "$distance"])),
+        )
+        .returning(["matches"])
+}
+
+let request = owned_project_matches(
+    "alice".to_string(),
+    vec![1.0f32, 0.0, 0.0],
+    5,
+)?;
 ```
 
 ```ts TypeScript
-readBatch()
+import {
+  SourcePredicate,
+  defineParams,
+  g,
+  param,
+  readBatch,
+} from "@helix-db/helix-db";
+
+const params = defineParams({
+  username: param.string(),
+  query_vector: param.array(param.f32()),
+  limit: param.i64(),
+});
+
+const query = readBatch()
   .varAs(
     "matches",
     g()
-      .nWithLabelWhere("User", SourcePredicate.eq("username", "alice"))
+      .nWithLabelWhere("User", SourcePredicate.eq("username", params.username))
       .out("OWNS")
-      .vectorSearch("Project", "embedding", [1, 0, 0], 5, null)
+      .vectorSearchWith("Project", "embedding", params.query_vector, params.limit)
       .valueMap(["$id", "name", "$distance"]),
   )
   .returning(["matches"]);
+
+const request = query.toQueryRequest(
+  params,
+  { username: "alice", query_vector: [1, 0, 0], limit: 5n },
+  { queryName: "owned_project_matches" },
+);
 ```
 
 ```go Go
-helix.ReadQuery("owned_project_matches").
+q := helix.ReadQuery("owned_project_matches")
+username := q.ParamString("username", "alice")
+queryVector := q.ParamArray(
+	"query_vector",
+	[]float32{1, 0, 0},
+	helix.ParamTypeF32(),
+)
+limit := q.ParamI64("limit", 5)
+
+request := q.
 	VarAs(
 		"matches",
 		helix.G().
-			NWithLabelWhere("User", helix.SourceEq("username", "alice")).
+			NWithLabelWhere("User", helix.SourceEq("username", username)).
 			Out("OWNS").
-			VectorSearchNodesWithin("Project", "embedding", []float32{1, 0, 0}, 5).
+			VectorSearchNodesWithin("Project", "embedding", queryVector, limit).
 			ValueMap("$id", "name", "$distance"),
 	).
 	Returning("matches")
 ```
 
 ```python Python
-(
+from helixdb import SourcePredicate, define_params, g, param, read_batch
+
+params = define_params({
+    "username": param.string(),
+    "query_vector": param.array(param.f32()),
+    "limit": param.i64(),
+})
+
+query = (
     read_batch()
     .var_as(
         "matches",
         g()
         .n_with_label_where(
-            "User", SourcePredicate.eq("username", "alice")
+            "User", SourcePredicate.eq("username", params.username)
         )
         .out("OWNS")
-        .vector_search(
-            "Project", "embedding", [1.0, 0.0, 0.0], 5
+        .vector_search_with(
+            "Project", "embedding", params.query_vector, params.limit
         )
         .value_map(["$id", "name", "$distance"]),
     )
     .returning(["matches"])
+)
+
+request = query.to_query_request(
+    params,
+    {
+        "username": "alice",
+        "query_vector": [1.0, 0.0, 0.0],
+        "limit": 5,
+    },
+    query_name="owned_project_matches",
 )
 ```
 
@@ -3360,7 +3416,7 @@ helix.ReadQuery("owned_project_matches").
                                 {
                                   "eq": {
                                     "left": { "property": "username" },
-                                    "right": { "constant": { "string": "alice" } }
+                                    "right": { "param": "username" }
                                   }
                                 }
                               ]
@@ -3373,10 +3429,8 @@ helix.ReadQuery("owned_project_matches").
                   },
                   "label": "Project",
                   "property": "embedding",
-                  "query_vector": {
-                    "value": { "f32_array": [1, 0, 0] }
-                  },
-                  "k": { "literal": 5 }
+                  "query_vector": { "expr": { "param": "query_vector" } },
+                  "k": { "expr": { "param": "limit" } }
                 }
               },
               "properties": ["$id", "name", "$distance"]
@@ -3386,12 +3440,24 @@ helix.ReadQuery("owned_project_matches").
       }],
       "returns": ["matches"]
     }
+  },
+  "parameters": {
+    "username": "alice",
+    "query_vector": [1, 0, 0],
+    "limit": 5
+  },
+  "parameter_types": {
+    "username": "string",
+    "query_vector": { "array": "f32" },
+    "limit": "i64"
   }
 }
 ```
 
-Use `VectorSearchEdgesWithin` in Go after an edge traversal. Rust, TypeScript, and
-Python select the node or edge wire operation from the current traversal state.
+Use `VectorSearchEdgesWithin` in Go after an edge traversal. Rust
+`vector_search_with`, TypeScript `vectorSearchWith`, and Python
+`vector_search_with` select the node or edge wire operation from the current stream.
+Their literal forms are `vector_search` and `vectorSearch`.
 
 ### Requirements
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2970,7 +2970,7 @@ by BM25 relevance. Project the rank field before traversing away from a hit.
 
 ## Next steps
 
-  <Card title="FTS prefiltering" icon="filter" href="/database/helix-db/query-guides/filtering#fts-prefiltering">
+  <Card title="Full Text Search prefiltering" icon="filter" href="/database/helix-db/query-guides/filtering#full-text-search-prefiltering">
     Rank only an exact traversal-defined candidate set.
   </Card>
   <Card title="Project search results" icon="table-columns" href="/database/helix-db/query-guides/projections">
@@ -3477,7 +3477,7 @@ Use a source vector search when the whole indexed label and optional tenant part
 is the intended candidate set. Use vector prefiltering when relationships,
 permissions, or earlier filters define membership.
 
-## FTS prefiltering
+## Full Text Search prefiltering
 
 Full-text search (FTS) prefiltering starts with a node or edge traversal, then ranks
 only the unique IDs in that stream by BM25 score. Use it when relationships,
@@ -3497,66 +3497,118 @@ This query requires an active text index on `Document.body`. Create and activate
 index before running the request.
 
 ```rust Rust
-read_batch()
-    .var_as(
-        "matches",
-        g()
-            .n_with_label_where("User", SourcePredicate::eq("username", "alice"))
-            .out(Some("CAN_READ"))
-            .text_search(
-                "Document",
-                "body",
-                "graph databases",
-                5,
-                None,
-            )
-            .value_map(Some(vec!["$id", "title", "$score"])),
-    )
-    .returning(["matches"]);
+use helix_db::dsl::prelude::*;
+
+#[query]
+fn readable_document_matches(
+    username: String,
+    query_text: String,
+    limit: i64,
+) -> ReadBatch {
+    read_batch()
+        .var_as(
+            "matches",
+            g()
+                .n_with_label_where("User", SourcePredicate::eq("username", username))
+                .out(Some("CAN_READ"))
+                .text_search_with("Document", "body", query_text, limit, None)
+                .value_map(Some(vec!["$id", "title", "$score"])),
+        )
+        .returning(["matches"])
+}
+
+let request = readable_document_matches(
+    "alice".to_string(),
+    "graph databases".to_string(),
+    5,
+)?;
 ```
 
 ```ts TypeScript
-readBatch()
+import {
+  SourcePredicate,
+  defineParams,
+  g,
+  param,
+  readBatch,
+} from "@helix-db/helix-db";
+
+const params = defineParams({
+  username: param.string(),
+  query_text: param.string(),
+  limit: param.i64(),
+});
+
+const query = readBatch()
   .varAs(
     "matches",
     g()
-      .nWithLabelWhere("User", SourcePredicate.eq("username", "alice"))
+      .nWithLabelWhere("User", SourcePredicate.eq("username", params.username))
       .out("CAN_READ")
-      .textSearch("Document", "body", "graph databases", 5, null)
+      .textSearchWith("Document", "body", params.query_text, params.limit)
       .valueMap(["$id", "title", "$score"]),
   )
   .returning(["matches"]);
+
+const request = query.toQueryRequest(
+  params,
+  { username: "alice", query_text: "graph databases", limit: 5n },
+  { queryName: "readable_document_matches" },
+);
 ```
 
 ```go Go
-helix.ReadQuery("readable_document_matches").
+q := helix.ReadQuery("readable_document_matches")
+username := q.ParamString("username", "alice")
+queryText := q.ParamString("query_text", "graph databases")
+limit := q.ParamI64("limit", 5)
+
+request := q.
 	VarAs(
 		"matches",
 		helix.G().
-			NWithLabelWhere("User", helix.SourceEq("username", "alice")).
+			NWithLabelWhere("User", helix.SourceEq("username", username)).
 			Out("CAN_READ").
-			TextSearchNodesWithin("Document", "body", "graph databases", 5).
+			TextSearchNodesWithin("Document", "body", queryText, limit).
 			ValueMap("$id", "title", "$score"),
 	).
 	Returning("matches")
 ```
 
 ```python Python
-(
+from helixdb import SourcePredicate, define_params, g, param, read_batch
+
+params = define_params({
+    "username": param.string(),
+    "query_text": param.string(),
+    "limit": param.i64(),
+})
+
+query = (
     read_batch()
     .var_as(
         "matches",
         g()
         .n_with_label_where(
-            "User", SourcePredicate.eq("username", "alice")
+            "User", SourcePredicate.eq("username", params.username)
         )
         .out("CAN_READ")
-        .text_search(
-            "Document", "body", "graph databases", 5
+        .text_search_with(
+            "Document", "body", params.query_text, params.limit
         )
         .value_map(["$id", "title", "$score"]),
     )
     .returning(["matches"])
+)
+
+request = query.to_query_request(
+    params,
+    {
+        "username": "alice",
+        "query_text": "graph databases",
+        "limit": 5,
+    },
+    query_name="readable_document_matches",
 )
 ```
 
@@ -3589,7 +3641,7 @@ helix.ReadQuery("readable_document_matches").
                                 {
                                   "eq": {
                                     "left": { "property": "username" },
-                                    "right": { "constant": { "string": "alice" } }
+                                    "right": { "param": "username" }
                                   }
                                 }
                               ]
@@ -3602,10 +3654,8 @@ helix.ReadQuery("readable_document_matches").
                   },
                   "label": "Document",
                   "property": "body",
-                  "query_text": {
-                    "value": { "string": "graph databases" }
-                  },
-                  "k": { "literal": 5 }
+                  "query_text": { "expr": { "param": "query_text" } },
+                  "k": { "expr": { "param": "limit" } }
                 }
               },
               "properties": ["$id", "title", "$score"]
@@ -3615,13 +3665,24 @@ helix.ReadQuery("readable_document_matches").
       }],
       "returns": ["matches"]
     }
+  },
+  "parameters": {
+    "username": "alice",
+    "query_text": "graph databases",
+    "limit": 5
+  },
+  "parameter_types": {
+    "username": "string",
+    "query_text": "string",
+    "limit": "i64"
   }
 }
 ```
 
-Use `TextSearchEdgesWithin` in Go after an edge traversal. Rust, TypeScript, and
-Python select the node or edge wire operation from the current traversal state. Use
-the `*With` forms for parameterized query text, `k`, or tenant values.
+Use `TextSearchEdgesWithin` in Go after an edge traversal. Rust
+`text_search_with`, TypeScript `textSearchWith`, and Python `text_search_with`
+select the node or edge wire operation from the current stream. Their literal forms
+are `text_search` and `textSearch`.
 
 ### Result contract
 


### PR DESCRIPTION
## Summary

- replace vector prefiltering examples with complete typed runtime requests for Rust, TypeScript, Go, Python, and JSON
- align Full Text Search prefiltering examples with the same SDK request pattern
- rename the FTS heading and update its cross-link
- regenerate `docs/llms-full.txt`

## Why

The existing examples used literal convenience forms and did not show consistent, executable runtime-parameter request construction across the SDKs. This made the prefiltering guidance misleading for SDK users.

## Validation

- `npm run generate-llms` after the final rebase
- `git diff --check`
- earlier on the same change set: docs check; Rust formatting, Clippy, and workspace tests; TypeScript, Python, and Go SDK tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces vector and Full Text Search prefiltering snippets with typed runtime-request examples across the supported SDKs, updates the FTS heading and link, and regenerates the consolidated LLM documentation.

- Adds complete Rust, TypeScript, Go, Python, and raw JSON request construction.
- Moves query-specific values into typed runtime parameters.
- Renames the FTS section and updates its cross-link.
- Regenerates `docs/llms-full.txt`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/database/helix-db/query-guides/filtering.mdx | Adds typed vector and text prefiltering examples, but the raw vector JSON uses integer tokens for an `array<f32>` parameter and is rejected during typed normalization. |
| docs/database/helix-db/query-guides/text-indexes.mdx | Renames the prefiltering card and updates its anchor to match the new heading. |
| docs/llms-full.txt | Regenerates consolidated documentation and reproduces the invalid raw vector parameter example from the source guide. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix full text prefilter SDK exampl..."](https://github.com/helixdb/helix-db/commit/2dacb0983753314789135008675b1bd1e8b52a05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52533496)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->