### PR TITLE
chore(cli): use HelixDB v0.0.4 for local instances

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -183,7 +183,7 @@ crates/cli/
 - `helix feedback` - Send feedback to the Helix team
 
 **Deployment Targets:**
-- Local Docker/Podman containers (`helix start`) — image `ghcr.io/helixdb/helixdb:v0.0.3`
+- Local Docker/Podman containers (`helix start`) — image `ghcr.io/helixdb/helixdb:v0.0.4`
 - Helix Cloud via `helix push`
 
 **Build & Deploy Flow:**
@@ -191,7 +191,7 @@ crates/cli/
 The v3 CLI is a runtime orchestrator — there is no `helix compile`/`helix check` step and no `.hx` query files.
 
 1. Scaffold a project with `helix init` (writes `helix.toml` and a `.helix/` workspace).
-2. Start a local instance with `helix start` — a Docker/Podman container running `ghcr.io/helixdb/helixdb:v0.0.3` (in-memory by default, on-disk with `--disk`). The CLI waits for `GET /healthz` before returning.
+2. Start a local instance with `helix start` — a Docker/Podman container running `ghcr.io/helixdb/helixdb:v0.0.4` (in-memory by default, on-disk with `--disk`). The CLI waits for `GET /healthz` before returning.
 3. Author queries with the Rust, TypeScript, Go, or Python DSL; they serialize to query JSON.
 4. Send queries to a running instance via `POST /v2/query` (`helix query`); validation happens server-side.
 5. For production, deploy a Helix Cloud instance with `helix push`, managing auth/metadata via `helix auth`, `helix sync`, and the `workspace`/`project`/`cluster` commands.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you'd rather wire things up yourself:
    mkdir my-helix-app && cd my-helix-app
    helix init
   ```
-2. **Start a local instance.** Runs `ghcr.io/helixdb/helixdb:v0.0.3` in a background container on port `6969` and waits for `GET /healthz` to report ready.
+2. **Start a local instance.** Runs `ghcr.io/helixdb/helixdb:v0.0.4` in a background container on port `6969` and waits for `GET /healthz` to report ready.
   ```bash
    helix start dev
   ```

--- a/crates/cli/CLAUDE.md
+++ b/crates/cli/CLAUDE.md
@@ -7,7 +7,7 @@ The Helix CLI — binary `helix`, crate `helix-cli` (v3.0.1). It is a **runtime 
 This CLI has **no `helix compile` and no `helix check`**, and there is **no `.hx` query workflow** in it. (Older notes/memory that mention those commands describe the v2 CLI and are stale.) In v3:
 
 - **Queries are JSON requests** sent to a *running* instance via `POST /v2/query` (`helix query`). Validation happens server-side, in the instance.
-- **Local instances are Docker/Podman containers** (image `ghcr.io/helixdb/helixdb:v0.0.3`), managed by `LocalRuntime`. `helix start` starts one; in-memory by default, on-disk (MinIO-backed) with `--disk`.
+- **Local instances are Docker/Podman containers** (image `ghcr.io/helixdb/helixdb:v0.0.4`), managed by `LocalRuntime`. `helix start` starts one; in-memory by default, on-disk (MinIO-backed) with `--disk`.
 - **Enterprise instances deploy to Helix Cloud** via `helix push`, with auth/metadata managed through `helix auth`, `helix sync`, and the `workspace`/`project`/`cluster` commands.
 
 The Rust DSL builder lives in `sdks/rust/` (a client library), not in this CLI.
@@ -133,7 +133,7 @@ Snapshot safety excludes `.git`, `.helix`, `node_modules`, `.next`, `target`, bu
 **Project config — `helix.toml`** (`HelixConfig` in `config.rs`, found via `ProjectContext::find_and_load`):
 
 - `[project]` — `name` (required), optional `id` / `workspace_id`, `queries` (default `db/`), `container_runtime` (`docker` | `podman`, default docker).
-- `[local.<name>]` — `port` (default `6969`), `image` (default `ghcr.io/helixdb/helixdb`), `tag` (default `v0.0.3`), `storage` (`memory` | `disk`, default memory).
+- `[local.<name>]` — `port` (default `6969`), `image` (default `ghcr.io/helixdb/helixdb`), `tag` (default `v0.0.4`), `storage` (`memory` | `disk`, default memory).
 - `[enterprise.<name>]` — `cluster_id` (required), optional `workspace_id`/`project_id`/`gateway_url`, `query_auth_header` (default `Authorization`), `query_auth_env` (default `HELIX_API_KEY`), `availability_mode`, `gateway_node_type`, `db_node_type`, `min_instances`/`max_instances` (default 1), plus a **flattened `DbConfig`**: `vector_config` (m=16, ef_construction=128, ef_search=768, db_max_size_gb=20), `graph_config.secondary_indices`, `mcp`/`bm25` (default true), `schema`, `embedding_model` (default `text-embedding-ada-002`), `graphvis_node_label`.
 
 `HelixConfig::validate` requires a non-empty project name, ≥1 instance, non-empty instance names, and a non-empty `cluster_id` for each enterprise instance. `default_config()` seeds a single in-memory `local.dev`.

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -7,7 +7,7 @@ Command-line interface for managing Helix projects, local development instances,
 - `init`: initialize a project with `helix.toml` and a query example.
 - `chef`: bootstrap a first Helix app with skills, docs MCP, local runtime, starter queries, seed data, and a launched coding agent.
 - `add`: add a local or Helix Cloud instance to an existing project.
-- `start` (alias `run`): run `ghcr.io/helixdb/helixdb:v0.0.3` in the background by default, attached with `--foreground`, with persistent local storage using `--disk`, or against a user-managed S3/S3-compatible prefix using `--storage-uri`.
+- `start` (alias `run`): run `ghcr.io/helixdb/helixdb:v0.0.4` in the background by default, attached with `--foreground`, with persistent local storage using `--disk`, or against a user-managed S3/S3-compatible prefix using `--storage-uri`.
 - `stop` / `restart` / `status`: manage local instances and inspect Helix Cloud config.
 - `logs`: view local container logs or query Helix Cloud historical logs.
 - `query`: send a query request JSON file to `POST /v2/query`.

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 pub const DEFAULT_LOCAL_PORT: u16 = 6969;
 pub const DEFAULT_LOCAL_IMAGE: &str = "ghcr.io/helixdb/helixdb";
-pub const DEFAULT_LOCAL_IMAGE_TAG: &str = "v0.0.3";
+pub const DEFAULT_LOCAL_IMAGE_TAG: &str = "v0.0.4";
 pub const DEFAULT_QUERY_AUTH_HEADER: &str = "Authorization";
 pub const DEFAULT_QUERY_AUTH_ENV: &str = "HELIX_API_KEY";
 pub const DEFAULT_S3_REGION: &str = "us-east-1";
@@ -688,7 +688,7 @@ tag = "latest"
     fn local_config_defaults_to_published_standalone_image() {
         let config = LocalInstanceConfig::default();
 
-        assert_eq!(config.image_ref(), "ghcr.io/helixdb/helixdb:v0.0.3");
+        assert_eq!(config.image_ref(), "ghcr.io/helixdb/helixdb:v0.0.4");
     }
 
     #[test]

--- a/crates/cli/src/local_runtime.rs
+++ b/crates/cli/src/local_runtime.rs
@@ -1076,7 +1076,7 @@ mod tests {
     fn memory_helix_args_match_existing_run_shape() {
         let args = helix_run_args(
             "helix-demo-dev",
-            "ghcr.io/helixdb/helixdb:v0.0.3",
+            "ghcr.io/helixdb/helixdb:v0.0.4",
             9090,
             true,
             None,
@@ -1094,7 +1094,7 @@ mod tests {
                 "helix-demo-dev",
                 "-p",
                 "9090:8080",
-                "ghcr.io/helixdb/helixdb:v0.0.3",
+                "ghcr.io/helixdb/helixdb:v0.0.4",
             ]
             .into_iter()
             .map(String::from)
@@ -1107,7 +1107,7 @@ mod tests {
         let resources = disk_resources();
         let args = helix_run_args(
             "helix-demo-dev",
-            "ghcr.io/helixdb/helixdb:v0.0.3",
+            "ghcr.io/helixdb/helixdb:v0.0.4",
             8080,
             true,
             Some(&resources.network),
@@ -1140,7 +1140,7 @@ mod tests {
         let env = s3_env(&config).unwrap();
         let args = helix_run_args(
             "helix-demo-dev",
-            "ghcr.io/helixdb/helixdb:v0.0.3",
+            "ghcr.io/helixdb/helixdb:v0.0.4",
             8080,
             true,
             None,

--- a/crates/cli/tests/e2e_cli.rs
+++ b/crates/cli/tests/e2e_cli.rs
@@ -97,7 +97,7 @@ fn init_and_add_generate_expected_project_files() {
         config["local"]["dev"]["image"].as_str(),
         Some("ghcr.io/helixdb/helixdb")
     );
-    assert_eq!(config["local"]["dev"]["tag"].as_str(), Some("v0.0.3"));
+    assert_eq!(config["local"]["dev"]["tag"].as_str(), Some("v0.0.4"));
 
     let gitignore = fs::read_to_string(project.join(".gitignore")).unwrap();
     assert!(gitignore.lines().any(|line| line == ".helix/"));

--- a/crates/cli/tests/e2e_runtime.rs
+++ b/crates/cli/tests/e2e_runtime.rs
@@ -99,7 +99,7 @@ fn assert_e2e_count_is_one(output: &str) {
 }
 
 #[test]
-#[ignore = "requires Docker and pulls ghcr.io/helixdb/helixdb:v0.0.3"]
+#[ignore = "requires Docker and pulls ghcr.io/helixdb/helixdb:v0.0.4"]
 fn local_runtime_lifecycle_and_query_smoke() {
     let fixture = CliFixture::new();
     let port = free_port();
@@ -221,7 +221,7 @@ fn local_runtime_lifecycle_and_query_smoke() {
 }
 
 #[test]
-#[ignore = "requires Docker and pulls ghcr.io/helixdb/helixdb:v0.0.3 plus MinIO"]
+#[ignore = "requires Docker and pulls ghcr.io/helixdb/helixdb:v0.0.4 plus MinIO"]
 fn disk_runtime_persists_data_across_stop_and_start() {
     let fixture = CliFixture::new();
     let port = free_port();

--- a/docs/cli/command-reference/query.mdx
+++ b/docs/cli/command-reference/query.mdx
@@ -95,7 +95,7 @@ request out to every eligible database backend and discards their response bodie
 The command succeeds silently on `204 No Content` after at least one backend
 succeeds; partial backend failure does not fail the warm-up. If every target fails,
 the gateway returns the normal deterministic error. A standalone local instance
-warms its single process; the `v0.0.3` runtime returns `200 OK` with the normal
+warms its single process; the `v0.0.4` runtime returns `200 OK` with the normal
 query body. A managed cluster with no eligible warming target returns
 `503 Service Unavailable`.
 

--- a/docs/cli/command-reference/start.mdx
+++ b/docs/cli/command-reference/start.mdx
@@ -37,7 +37,7 @@ helix start [INSTANCE] [OPTIONS]
 
 ## Behavior
 
-- Pulls `ghcr.io/helixdb/helixdb:v0.0.3` (or the image/tag set in `[local.<instance>]`).
+- Pulls `ghcr.io/helixdb/helixdb:v0.0.4` (or the image/tag set in `[local.<instance>]`).
 - Names the container `helix-<project>-<instance>` and publishes the configured port to container port `8080`.
 - Uses Docker or Podman based on `[project] container_runtime` in `helix.toml`.
 - Default storage is in-memory. Passing `--disk` starts a MinIO sidecar, creates the `helix-db` bucket, and runs `helixdb` with S3-compatible storage environment variables.

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -27,7 +27,7 @@ name = "my-helix-app"
 [local.dev]
 port = 6969
 image = "ghcr.io/helixdb/helixdb"
-tag = "v0.0.3"
+tag = "v0.0.4"
 # Optional; defaults to in-memory when omitted.
 # storage = "disk"
 
@@ -55,7 +55,7 @@ One block per local instance. The instance name is the table key (e.g. `[local.d
 |-----|------|---------|-------------|
 | `port` | Number | `6969` | Host port published to container port `8080`. |
 | `image` | String | `ghcr.io/helixdb/helixdb` | Container image used by [`helix start`](/cli/command-reference/start). |
-| `tag` | String | `v0.0.3` | Image tag. |
+| `tag` | String | `v0.0.4` | Image tag. |
 | `storage` | `memory` \| `disk` | `memory` | Local storage mode. `disk` uses a CLI-managed MinIO container and persistent volume. |
 
 You can define as many local instances as you want, each on a different port:

--- a/docs/cli/getting-started.mdx
+++ b/docs/cli/getting-started.mdx
@@ -67,7 +67,7 @@ In a TTY, `helix init` prompts you to pick `local` or `enterprise`. Pass the sub
 helix start dev
 ```
 
-`helix start` pulls `ghcr.io/helixdb/helixdb:v0.0.3`, starts a background container named `helix-<project>-dev`, publishes port `6969`, and waits for `GET /healthz` to report ready before returning.
+`helix start` pulls `ghcr.io/helixdb/helixdb:v0.0.4`, starts a background container named `helix-<project>-dev`, publishes port `6969`, and waits for `GET /healthz` to report ready before returning.
 
 To stream logs in the foreground instead, use `helix start dev --foreground` and stop the container with Ctrl-C.
 

--- a/docs/cli/workflows/local.mdx
+++ b/docs/cli/workflows/local.mdx
@@ -9,7 +9,7 @@ pageType: "Guide"
 
 > For the complete documentation index optimized for AI agents, see [llms.txt](/llms.txt).
 
-Local development runs the prebuilt `ghcr.io/helixdb/helixdb:v0.0.3` container and exposes the standalone server at `POST /v2/query`. By default, storage is in-memory. Use `--disk` when you want persistent local data backed by a CLI-managed MinIO volume.
+Local development runs the prebuilt `ghcr.io/helixdb/helixdb:v0.0.4` container and exposes the standalone server at `POST /v2/query`. By default, storage is in-memory. Use `--disk` when you want persistent local data backed by a CLI-managed MinIO volume.
 
 ## Prerequisites
 

--- a/docs/database/helix-db/start-here/local-development/local-server.mdx
+++ b/docs/database/helix-db/start-here/local-development/local-server.mdx
@@ -7,7 +7,7 @@ pageType: "Guide"
 
 <div className="flex flex-wrap gap-2"><Badge color="blue" size="sm">Guide</Badge></div>
 
-The `ghcr.io/helixdb/helixdb:v0.0.3` image runs the standalone HelixDB server.
+The `ghcr.io/helixdb/helixdb:v0.0.4` image runs the standalone HelixDB server.
 It exposes the same operation-tree request contract used by Helix Cloud at
 `POST /v2/query`; gateway-only Cloud features are not included.
 
@@ -89,7 +89,7 @@ Memory mode is selected by leaving `S3_BUCKET` unset:
 ```bash
 docker run --rm --name helixdb \
   -p 6969:8080 \
-  ghcr.io/helixdb/helixdb:v0.0.3
+  ghcr.io/helixdb/helixdb:v0.0.4
 ```
 
 The standalone server exposes liveness and readiness checks:
@@ -134,7 +134,7 @@ services:
         mc mb --ignore-existing local/helix-db
 
   helix:
-    image: ghcr.io/helixdb/helixdb:v0.0.3
+    image: ghcr.io/helixdb/helixdb:v0.0.4
     restart: unless-stopped
     depends_on:
       minio-init:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -497,7 +497,7 @@ Page type: Guide
 
 <div className="flex flex-wrap gap-2"><Badge color="blue" size="sm">Guide</Badge></div>
 
-The `ghcr.io/helixdb/helixdb:v0.0.3` image runs the standalone HelixDB server.
+The `ghcr.io/helixdb/helixdb:v0.0.4` image runs the standalone HelixDB server.
 It exposes the same operation-tree request contract used by Helix Cloud at
 `POST /v2/query`; gateway-only Cloud features are not included.
 
@@ -573,7 +573,7 @@ Memory mode is selected by leaving `S3_BUCKET` unset:
 ```bash
 docker run --rm --name helixdb \
   -p 6969:8080 \
-  ghcr.io/helixdb/helixdb:v0.0.3
+  ghcr.io/helixdb/helixdb:v0.0.4
 ```
 
 The standalone server exposes liveness and readiness checks:
@@ -616,7 +616,7 @@ services:
         mc mb --ignore-existing local/helix-db
 
   helix:
-    image: ghcr.io/helixdb/helixdb:v0.0.3
+    image: ghcr.io/helixdb/helixdb:v0.0.4
     restart: unless-stopped
     depends_on:
       minio-init:
@@ -5297,7 +5297,7 @@ In a TTY, `helix init` prompts you to pick `local` or `enterprise`. Pass the sub
 helix start dev
 ```
 
-`helix start` pulls `ghcr.io/helixdb/helixdb:v0.0.3`, starts a background container named `helix-<project>-dev`, publishes port `6969`, and waits for `GET /healthz` to report ready before returning.
+`helix start` pulls `ghcr.io/helixdb/helixdb:v0.0.4`, starts a background container named `helix-<project>-dev`, publishes port `6969`, and waits for `GET /healthz` to report ready before returning.
 
 To stream logs in the foreground instead, use `helix start dev --foreground` and stop the container with Ctrl-C.
 
@@ -5397,7 +5397,7 @@ Page type: Guide
 
 <div className="flex flex-wrap gap-2"><Badge color="blue" size="sm">Guide</Badge></div>
 
-Local development runs the prebuilt `ghcr.io/helixdb/helixdb:v0.0.3` container and exposes the standalone server at `POST /v2/query`. By default, storage is in-memory. Use `--disk` when you want persistent local data backed by a CLI-managed MinIO volume.
+Local development runs the prebuilt `ghcr.io/helixdb/helixdb:v0.0.4` container and exposes the standalone server at `POST /v2/query`. By default, storage is in-memory. Use `--disk` when you want persistent local data backed by a CLI-managed MinIO volume.
 
 ## Prerequisites
 
@@ -5672,7 +5672,7 @@ name = "my-helix-app"
 [local.dev]
 port = 6969
 image = "ghcr.io/helixdb/helixdb"
-tag = "v0.0.3"
+tag = "v0.0.4"
 # Optional; defaults to in-memory when omitted.
 # storage = "disk"
 
@@ -5700,7 +5700,7 @@ One block per local instance. The instance name is the table key (e.g. `[local.d
 |-----|------|---------|-------------|
 | `port` | Number | `6969` | Host port published to container port `8080`. |
 | `image` | String | `ghcr.io/helixdb/helixdb` | Container image used by [`helix start`](/cli/command-reference/start). |
-| `tag` | String | `v0.0.3` | Image tag. |
+| `tag` | String | `v0.0.4` | Image tag. |
 | `storage` | `memory` \| `disk` | `memory` | Local storage mode. `disk` uses a CLI-managed MinIO container and persistent volume. |
 
 You can define as many local instances as you want, each on a different port:
@@ -6958,7 +6958,7 @@ request out to every eligible database backend and discards their response bodie
 The command succeeds silently on `204 No Content` after at least one backend
 succeeds; partial backend failure does not fail the warm-up. If every target fails,
 the gateway returns the normal deterministic error. A standalone local instance
-warms its single process; the `v0.0.3` runtime returns `200 OK` with the normal
+warms its single process; the `v0.0.4` runtime returns `200 OK` with the normal
 query body. A managed cluster with no eligible warming target returns
 `503 Service Unavailable`.
 
@@ -7189,7 +7189,7 @@ helix start [INSTANCE] [OPTIONS]
 
 ## Behavior
 
-- Pulls `ghcr.io/helixdb/helixdb:v0.0.3` (or the image/tag set in `[local.<instance>]`).
+- Pulls `ghcr.io/helixdb/helixdb:v0.0.4` (or the image/tag set in `[local.<instance>]`).
 - Names the container `helix-<project>-<instance>` and publishes the configured port to container port `8080`.
 - Uses Docker or Podman based on `[project] container_runtime` in `helix.toml`.
 - Default storage is in-memory. Passing `--disk` starts a MinIO sidecar, creates the `helix-db` bucket, and runs `helixdb` with S3-compatible storage environment variables.

--- a/sdks/tests/parity/COVERAGE.md
+++ b/sdks/tests/parity/COVERAGE.md
@@ -38,6 +38,6 @@ server baseline:
 
 ```sh
 python sdks/python/scripts/run_server_parity.py \
-  --image ghcr.io/helixdb/helixdb:v0.0.3 \
+  --image ghcr.io/helixdb/helixdb:v0.0.4 \
   --baseline-results sdks/tests/parity/results/rust
 ```


### PR DESCRIPTION
## Summary

- update the CLI default local image tag from `v0.0.3` to `v0.0.4`
- update affected assertions, runtime fixtures, README/contributor guidance, CLI and local-server docs, and SDK parity notes
- regenerate `docs/llms-full.txt` from the documentation sources

## Published image

- source commit: `ee7c57611d8865fcce170b84dba08a76d3f8a6c0`
- tags: `ghcr.io/helixdb/helixdb:v0.0.4` and `ghcr.io/helixdb/helixdb:latest`
- digest: `sha256:ba41464c42b3cd58edd0f049e15bd7bea673f6abd217eb0ea5f5160b46a4412f`
- platforms: exactly `linux/amd64` and `linux/arm64`
- both published platform variants passed archive inspection, secret scanning, runtime smoke tests, configuration rejection, graceful shutdown, native-volume persistence, and MinIO/Compose persistence
- `latest` did not previously exist and was created at the same top-level digest after `v0.0.4` verification
- anonymous registry access was verified by downloading and checksum-validating the arm64 manifest, config, and all image layers without credentials

## Validation

- `cargo test --locked -p helix-cli -- --skip enterprise_instance_resolution_covers_explicit_empty_and_ambiguous_states --test-threads=1`
- `cargo clippy --locked --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run check` in `docs`
- exhaustive repository search found no remaining current `v0.0.3` references

The previously observed sync test was explicitly skipped as requested. Coverage was not run.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the CLI’s default local HelixDB image from v0.0.3 to the published v0.0.4 release and synchronizes tests, documentation, generated documentation, and parity guidance.

- New and defaulted local configurations now resolve to `ghcr.io/helixdb/helixdb:v0.0.4`.
- Runtime assertions and CLI end-to-end fixtures expect the new image tag.
- User, contributor, local-server, and SDK parity documentation consistently references v0.0.4.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/cli/src/config.rs | Updates the canonical default local image tag and its unit assertion consistently to v0.0.4. |
| crates/cli/src/local_runtime.rs | Updates runtime argument fixtures to exercise the new default image reference without changing lifecycle behavior. |
| crates/cli/tests/e2e_cli.rs | Aligns generated-project configuration expectations with the v0.0.4 default. |
| crates/cli/tests/e2e_runtime.rs | Updates ignored Docker-dependent test descriptions to identify the image they pull. |
| docs/llms-full.txt | Regenerates the aggregate documentation with source-consistent v0.0.4 references. |
| sdks/tests/parity/COVERAGE.md | Updates the documented runtime parity baseline command to use the published v0.0.4 image. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(cli): use HelixDB v0.0.4 for local..."](https://github.com/helixdb/helix-db/commit/4c4ec3275bafa95d21562e11820c172893da1247) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53328433)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Helix CLI core: parsing, config, and shared plumbing](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/helix-cli-core.md)
- Knowledge Base — [Local Instance Lifecycle (start/stop/restart/status/logs)](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/helix-cli-instance-lifecycle.md)
- Knowledge Base — [Cross-SDK DSL Parity Testing](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/sdk-parity-tests.md)
</details>

<!-- /greptile_comment -->