### PR TITLE
Add static query error codes

### DIFF
--- a/bindings/uniffi/Cargo.toml
+++ b/bindings/uniffi/Cargo.toml
@@ -17,6 +17,7 @@ required-features = ["bindgen"]
 
 [dependencies]
 db = { path = "../../crates/db" }
+helix-ast = { path = "../../crates/ast" }
 helix-graph-algorithms = { path = "../../crates/graph-algorithms" }
 serde_json = "1"
 thiserror = "2"
@@ -24,7 +25,6 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 uniffi = { version = "=0.31.2", features = ["tokio"] }
 
 [dev-dependencies]
-helix-ast = { path = "../../crates/ast" }
 sonic-rs = "0.5.8"
 tempfile = "3"
 

--- a/bindings/uniffi/src/error.rs
+++ b/bindings/uniffi/src/error.rs
@@ -8,34 +8,35 @@
 
 use db::encoding::error::EncodingError;
 use db::error::HelixDbError;
+use helix_ast::error_code;
 use thiserror::Error;
 
 /// Error type returned by the HelixDB UniFFI bindings.
 #[derive(Debug, Error, uniffi::Error)]
 pub enum HelixError {
     /// Invalid configuration.
-    #[error("{message}")]
-    InvalidConfig { message: String },
+    #[error("{msg}")]
+    InvalidConfig { error: String, msg: String },
 
     /// Invalid request body or API usage.
-    #[error("{message}")]
-    InvalidRequest { message: String },
+    #[error("{msg}")]
+    InvalidRequest { error: String, msg: String },
 
     /// Query planning failed.
-    #[error("{message}")]
-    Planner { message: String },
+    #[error("{msg}")]
+    Planner { error: String, msg: String },
 
     /// Storage failed.
-    #[error("{message}")]
-    Storage { message: String },
+    #[error("{msg}")]
+    Storage { error: String, msg: String },
 
     /// Transaction failed.
-    #[error("{message}")]
-    Transaction { message: String },
+    #[error("{msg}")]
+    Transaction { error: String, msg: String },
 
     /// Internal failure.
-    #[error("{message}")]
-    Internal { message: String },
+    #[error("{msg}")]
+    Internal { error: String, msg: String },
 }
 
 impl From<HelixDbError> for HelixError {
@@ -48,15 +49,23 @@ impl From<HelixDbError> for HelixError {
     /// request-view changes remain transaction failures so foreign callers can
     /// apply the same retry policy as a storage transaction conflict.
     fn from(error: HelixDbError) -> Self {
-        let message = error.to_string();
+        let error_code = error.error_code().to_string();
+        let msg = error.to_string();
         if error.is_invalid_vector_input() {
-            return Self::InvalidRequest { message };
+            return Self::InvalidRequest {
+                error: error_code,
+                msg,
+            };
         }
         match error {
             HelixDbError::Config(_)
             | HelixDbError::InvalidVectorConfig(_)
-            | HelixDbError::IndexDefinitionConflict { .. } => Self::InvalidConfig { message },
+            | HelixDbError::IndexDefinitionConflict { .. } => Self::InvalidConfig {
+                error: error_code,
+                msg,
+            },
             HelixDbError::Query(_)
+            | HelixDbError::InvalidQueryJson(_)
             | HelixDbError::Encoding(EncodingError::InvalidTenantId(_))
             | HelixDbError::IndexBusy { .. }
             | HelixDbError::IndexOperationNotFound { .. }
@@ -65,18 +74,30 @@ impl From<HelixDbError> for HelixError {
             | HelixDbError::InvalidIndexSourceData { .. }
             | HelixDbError::SecondaryIndexValue(_)
             | HelixDbError::SecondaryLifecycleSteppingRequiresDisabledMode => {
-                Self::InvalidRequest { message }
+                Self::InvalidRequest {
+                    error: error_code,
+                    msg,
+                }
             }
             HelixDbError::WriterModeRequired { .. } | HelixDbError::ReaderModeRequired { .. } => {
-                Self::InvalidRequest { message }
+                Self::InvalidRequest {
+                    error: error_code,
+                    msg,
+                }
             }
             HelixDbError::TransactionConflict(_)
             | HelixDbError::RequestReadViewChanged
             | HelixDbError::StaleIndexGeneration { .. }
-            | HelixDbError::WriterFencedCommitOutcomeUnknown => Self::Transaction { message },
+            | HelixDbError::WriterFencedCommitOutcomeUnknown => Self::Transaction {
+                error: error_code,
+                msg,
+            },
             HelixDbError::Storage(_)
             | HelixDbError::ObjectStore(_)
-            | HelixDbError::DatabaseClosed => Self::Storage { message },
+            | HelixDbError::DatabaseClosed => Self::Storage {
+                error: error_code,
+                msg,
+            },
             HelixDbError::Encoding(_)
             | HelixDbError::InvalidNodeId(_)
             | HelixDbError::NodeNotFound(_)
@@ -100,7 +121,10 @@ impl From<HelixDbError> for HelixError {
             | HelixDbError::IndexCatalogCorruption(_)
             | HelixDbError::LegacyZeroNormCosineVector { .. }
             | HelixDbError::QueryDeadlineExceeded
-            | HelixDbError::InvariantViolation(_) => Self::Internal { message },
+            | HelixDbError::InvariantViolation(_) => Self::Internal {
+                error: error_code,
+                msg,
+            },
         }
     }
 }
@@ -109,7 +133,8 @@ impl From<tokio::task::JoinError> for HelixError {
     /// Converts a failed binding-runtime task without unwinding across FFI.
     fn from(error: tokio::task::JoinError) -> Self {
         Self::Internal {
-            message: format!("embedded runtime task failed: {error}"),
+            error: error_code::QueryErrorCode::InternalError.to_string(),
+            msg: format!("embedded runtime task failed: {error}"),
         }
     }
 }
@@ -174,7 +199,8 @@ mod tests {
     fn query_deadlines_do_not_expand_the_stable_binding_error_contract() {
         assert!(matches!(
             HelixError::from(HelixDbError::QueryDeadlineExceeded),
-            HelixError::Internal { message } if message.contains("deadline")
+            HelixError::Internal { error, msg }
+                if error == "query_deadline_exceeded" && msg.contains("deadline")
         ));
     }
 
@@ -196,8 +222,9 @@ mod tests {
             HelixError::from(HelixDbError::InvalidIndexSourceData {
                 reason: "indexed document is missing its tenant property".to_string(),
             }),
-            HelixError::InvalidRequest { message }
-                if message.contains("indexed document is missing its tenant property")
+            HelixError::InvalidRequest { error, msg }
+                if error == "invalid_index_source_data"
+                    && msg.contains("indexed document is missing its tenant property")
         ));
     }
 
@@ -268,8 +295,8 @@ mod tests {
 
         assert!(matches!(
             HelixError::from(error),
-            HelixError::Internal { message }
-                if message.contains("embedded runtime task failed")
+            HelixError::Internal { error, msg }
+                if error == "internal_error" && msg.contains("embedded runtime task failed")
         ));
     }
 

--- a/bindings/uniffi/src/helix_db.rs
+++ b/bindings/uniffi/src/helix_db.rs
@@ -39,7 +39,10 @@ impl TryFrom<EmbeddedCacheConfig> for db::config::CacheConfig {
     type Error = HelixError;
 
     fn try_from(value: EmbeddedCacheConfig) -> Result<Self, Self::Error> {
-        let invalid = |message: String| HelixError::InvalidConfig { message };
+        let invalid = |msg: String| HelixError::InvalidConfig {
+            error: helix_ast::error_code::QueryErrorCode::InvalidConfiguration.to_string(),
+            msg,
+        };
         let vector_memory = db::config::VectorMemorySettings::try_new(
             db::config::VectorMemoryBudget::bounded(value.vector_memory_bytes)
                 .map_err(|error| invalid(error.to_string()))?,
@@ -472,6 +475,11 @@ mod tests {
             .await
             .expect_err("invalid query JSON should fail");
 
-        assert!(matches!(err, HelixError::InvalidRequest { .. }));
+        assert!(matches!(
+            err,
+            HelixError::InvalidRequest { error, msg }
+                if error == "invalid_query_json"
+                    && msg.starts_with("Query error: invalid query JSON:")
+        ));
     }
 }

--- a/crates/ast/src/error_code.rs
+++ b/crates/ast/src/error_code.rs
@@ -36,6 +36,10 @@ pub enum QueryErrorCode {
     UnsupportedEdgeAllTarget,
     /// An index expression was not a literal or parameter.
     NonLiteralIndexExpression,
+    /// A parameter required to select an equality algorithm was not bound.
+    MissingPlanningEqualityParameter,
+    /// A bound equality parameter cannot be represented by an index literal.
+    UnsupportedPlanningEqualityParameter,
     /// A search tenant was supplied for an unscoped index.
     InvalidSearchTenant,
     /// A search tenant value has the wrong shape.
@@ -193,6 +197,8 @@ impl QueryErrorCode {
         Self::InternalPlannerError,
         Self::UnsupportedEdgeAllTarget,
         Self::NonLiteralIndexExpression,
+        Self::MissingPlanningEqualityParameter,
+        Self::UnsupportedPlanningEqualityParameter,
         Self::InvalidSearchTenant,
         Self::InvalidSearchTenantValue,
         Self::InvalidSearchResultCount,
@@ -279,6 +285,8 @@ impl QueryErrorCode {
             Self::InternalPlannerError => "internal_planner_error",
             Self::UnsupportedEdgeAllTarget => "unsupported_edge_all_target",
             Self::NonLiteralIndexExpression => "non_literal_index_expression",
+            Self::MissingPlanningEqualityParameter => "missing_planning_equality_parameter",
+            Self::UnsupportedPlanningEqualityParameter => "unsupported_planning_equality_parameter",
             Self::InvalidSearchTenant => "invalid_search_tenant",
             Self::InvalidSearchTenantValue => "invalid_search_tenant_value",
             Self::InvalidSearchResultCount => "invalid_search_result_count",

--- a/crates/ast/src/error_code.rs
+++ b/crates/ast/src/error_code.rs
@@ -1,0 +1,423 @@
+//! Stable machine-readable query error codes.
+
+use serde::{Deserialize, Serialize};
+
+/// A stable machine-readable failure returned by a Helix query boundary.
+///
+/// Display messages may gain context over time. These codes are the compatibility
+/// contract that callers should use for branching and retry decisions.
+///
+/// # Examples
+///
+/// ```
+/// use helix_ast::error_code::QueryErrorCode;
+///
+/// let code = "index_not_found".parse::<QueryErrorCode>()?;
+/// assert_eq!(code, QueryErrorCode::IndexNotFound);
+/// assert_eq!(code.as_str(), "index_not_found");
+/// # Ok::<(), helix_ast::error_code::UnknownQueryErrorCode>(())
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryErrorCode {
+    /// The request is incompatible with the selected query mode.
+    InvalidRequest,
+    /// The query body is not valid query JSON.
+    InvalidQueryJson,
+    /// The transport could not read the request body.
+    InvalidRequestBody,
+    /// A transport option or header is invalid for the request.
+    InvalidRequestOption,
+    /// An index lifecycle operation ID is invalid.
+    InvalidIndexOperationId,
+    /// Planning failed because an internal planner contract was violated.
+    InternalPlannerError,
+    /// An all-edges reference was used as a finite mutation target.
+    UnsupportedEdgeAllTarget,
+    /// An index expression was not a literal or parameter.
+    NonLiteralIndexExpression,
+    /// A search tenant was supplied for an unscoped index.
+    InvalidSearchTenant,
+    /// A search tenant value has the wrong shape.
+    InvalidSearchTenantValue,
+    /// A search result count is zero.
+    InvalidSearchResultCount,
+    /// A search result-count expression has the wrong shape.
+    InvalidSearchResultCountExpression,
+    /// A search query input has the wrong shape.
+    InvalidSearchInput,
+    /// A batch condition minimum size is zero.
+    InvalidBatchConditionMinSize,
+    /// The first batch entry requires a previous result.
+    InvalidInitialBatchCondition,
+    /// A mutation assigns the same property more than once.
+    DuplicatePropertyAssignment,
+    /// A projection selects the same property more than once.
+    DuplicatePropertySelection,
+    /// A projection emits the same alias more than once.
+    DuplicateProjectionAlias,
+    /// A batch returns the same variable more than once.
+    DuplicateReturnVariable,
+    /// A concrete point lookup contains the same element ID more than once.
+    DuplicateElementId,
+    /// A sort contains the same property more than once.
+    DuplicateOrderKey,
+    /// A sub-traversal context is missing its parent input.
+    UnboundContext,
+    /// An operation is not valid inside a branch or repeat sub-traversal.
+    InvalidSubTraversalOperation,
+    /// An operation is not valid after a row-local bind.
+    InvalidAfterBindOperation,
+    /// A write batch contains a read-only traversal.
+    ReadOnlyTraversalInWriteBatch,
+    /// A branch has too few traversals.
+    InvalidBranchArity,
+    /// A batch has too few entries.
+    InvalidBatchArity,
+    /// A repeat emit predicate is incompatible with its emit mode.
+    InvalidRepeatEmit,
+    /// A repeat count or depth is zero.
+    InvalidRepeatCount,
+    /// A shortest-path count or depth is zero.
+    InvalidShortestPathCount,
+    /// An order operation has no sort keys.
+    InvalidOrderKeys,
+    /// A projection has too few fields.
+    InvalidProjectionArity,
+    /// A stream range is statically inverted.
+    InvalidStreamRange,
+    /// A stream-bound expression has the wrong shape.
+    InvalidStreamBoundExpression,
+    /// A required query name is empty.
+    InvalidEmptyName,
+    /// A predicate set has too few children.
+    InvalidPredicateArity,
+    /// Storage failed outside a retryable transaction conflict.
+    StorageError,
+    /// A retryable transaction conflict prevented the query from committing.
+    TransactionConflict,
+    /// A standalone reader changed views while the request was executing.
+    RequestReadViewChanged,
+    /// The query exceeded its execution deadline.
+    QueryDeadlineExceeded,
+    /// A supplied node ID is invalid.
+    InvalidNodeId,
+    /// A requested node does not exist.
+    NodeNotFound,
+    /// A requested edge does not exist.
+    EdgeNotFound,
+    /// The database handle is closed.
+    DatabaseClosed,
+    /// Database configuration is invalid.
+    InvalidConfiguration,
+    /// The required index lifecycle authority is unavailable.
+    IndexLifecycleUnavailable,
+    /// Explicit secondary stepping requires disabled worker mode.
+    SecondaryLifecycleSteppingRequiresDisabledMode,
+    /// An active text mutation exceeded an admission limit.
+    ActiveTextMutationLimitExceeded,
+    /// Existing graph data cannot satisfy an index source contract.
+    InvalidIndexSourceData,
+    /// A value cannot satisfy the current index model.
+    InvalidIndexModel,
+    /// A value cannot satisfy a secondary-index contract.
+    InvalidSecondaryIndexValue,
+    /// Existing storage requires an explicit migration.
+    MigrationRequired,
+    /// Existing storage must be opened and migrated by a writer.
+    WriterMigrationRequired,
+    /// The stored index format is newer than this binary supports.
+    UnsupportedIndexStorageVersion,
+    /// A bounded identifier namespace is exhausted.
+    IdentifierExhausted,
+    /// The logical index ID namespace is exhausted.
+    IndexIdExhausted,
+    /// The vector physical index ID namespace is exhausted.
+    VectorPhysicalIdExhausted,
+    /// The index generation namespace is exhausted.
+    IndexGenerationExhausted,
+    /// The index revision namespace is exhausted.
+    IndexRevisionExhausted,
+    /// The index-operation revision namespace is exhausted.
+    IndexOperationRevisionExhausted,
+    /// A retained handle refers to a stale index generation.
+    StaleIndexGeneration,
+    /// Writer fencing made the final commit outcome unknowable.
+    WriterFencedCommitOutcomeUnknown,
+    /// Vector index configuration is invalid.
+    InvalidVectorConfiguration,
+    /// A query payload or encoded query is invalid.
+    InvalidQuery,
+    /// The operation requires a writer database handle.
+    WriterModeRequired,
+    /// The operation requires a standalone reader database handle.
+    ReaderModeRequired,
+    /// An index with the requested identity already exists.
+    IndexAlreadyExists,
+    /// An existing index has a conflicting definition.
+    IndexDefinitionConflict,
+    /// The index is already changing lifecycle state.
+    IndexBusy,
+    /// The requested index operation does not exist.
+    IndexOperationNotFound,
+    /// The requested index operation cannot be aborted.
+    IndexOperationNotAbortable,
+    /// The requested logical or physical index does not exist.
+    IndexNotFound,
+    /// A unique index already owns the requested value.
+    UniqueConstraintViolation,
+    /// A unique index does not support the supplied value type.
+    UnsupportedUniqueIndexValueType,
+    /// A vector has the wrong dimension.
+    InvalidVectorDimension,
+    /// A vector contains a non-finite component.
+    InvalidVectorComponent,
+    /// A vector component exceeds its score-safe magnitude.
+    VectorComponentMagnitudeExceeded,
+    /// A cosine vector has zero norm.
+    ZeroNormCosineVector,
+    /// A response could not be serialized.
+    ResponseSerializationError,
+    /// A non-actionable internal invariant or persisted-data contract failed.
+    InternalError,
+}
+
+impl QueryErrorCode {
+    /// Every code in the stable public catalog.
+    pub const ALL: &'static [Self] = &[
+        Self::InvalidRequest,
+        Self::InvalidQueryJson,
+        Self::InvalidRequestBody,
+        Self::InvalidRequestOption,
+        Self::InvalidIndexOperationId,
+        Self::InternalPlannerError,
+        Self::UnsupportedEdgeAllTarget,
+        Self::NonLiteralIndexExpression,
+        Self::InvalidSearchTenant,
+        Self::InvalidSearchTenantValue,
+        Self::InvalidSearchResultCount,
+        Self::InvalidSearchResultCountExpression,
+        Self::InvalidSearchInput,
+        Self::InvalidBatchConditionMinSize,
+        Self::InvalidInitialBatchCondition,
+        Self::DuplicatePropertyAssignment,
+        Self::DuplicatePropertySelection,
+        Self::DuplicateProjectionAlias,
+        Self::DuplicateReturnVariable,
+        Self::DuplicateElementId,
+        Self::DuplicateOrderKey,
+        Self::UnboundContext,
+        Self::InvalidSubTraversalOperation,
+        Self::InvalidAfterBindOperation,
+        Self::ReadOnlyTraversalInWriteBatch,
+        Self::InvalidBranchArity,
+        Self::InvalidBatchArity,
+        Self::InvalidRepeatEmit,
+        Self::InvalidRepeatCount,
+        Self::InvalidShortestPathCount,
+        Self::InvalidOrderKeys,
+        Self::InvalidProjectionArity,
+        Self::InvalidStreamRange,
+        Self::InvalidStreamBoundExpression,
+        Self::InvalidEmptyName,
+        Self::InvalidPredicateArity,
+        Self::StorageError,
+        Self::TransactionConflict,
+        Self::RequestReadViewChanged,
+        Self::QueryDeadlineExceeded,
+        Self::InvalidNodeId,
+        Self::NodeNotFound,
+        Self::EdgeNotFound,
+        Self::DatabaseClosed,
+        Self::InvalidConfiguration,
+        Self::IndexLifecycleUnavailable,
+        Self::SecondaryLifecycleSteppingRequiresDisabledMode,
+        Self::ActiveTextMutationLimitExceeded,
+        Self::InvalidIndexSourceData,
+        Self::InvalidIndexModel,
+        Self::InvalidSecondaryIndexValue,
+        Self::MigrationRequired,
+        Self::WriterMigrationRequired,
+        Self::UnsupportedIndexStorageVersion,
+        Self::IdentifierExhausted,
+        Self::IndexIdExhausted,
+        Self::VectorPhysicalIdExhausted,
+        Self::IndexGenerationExhausted,
+        Self::IndexRevisionExhausted,
+        Self::IndexOperationRevisionExhausted,
+        Self::StaleIndexGeneration,
+        Self::WriterFencedCommitOutcomeUnknown,
+        Self::InvalidVectorConfiguration,
+        Self::InvalidQuery,
+        Self::WriterModeRequired,
+        Self::ReaderModeRequired,
+        Self::IndexAlreadyExists,
+        Self::IndexDefinitionConflict,
+        Self::IndexBusy,
+        Self::IndexOperationNotFound,
+        Self::IndexOperationNotAbortable,
+        Self::IndexNotFound,
+        Self::UniqueConstraintViolation,
+        Self::UnsupportedUniqueIndexValueType,
+        Self::InvalidVectorDimension,
+        Self::InvalidVectorComponent,
+        Self::VectorComponentMagnitudeExceeded,
+        Self::ZeroNormCosineVector,
+        Self::ResponseSerializationError,
+        Self::InternalError,
+    ];
+
+    /// Return the frozen wire representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidRequest => "invalid_request",
+            Self::InvalidQueryJson => "invalid_query_json",
+            Self::InvalidRequestBody => "invalid_request_body",
+            Self::InvalidRequestOption => "invalid_request_option",
+            Self::InvalidIndexOperationId => "invalid_index_operation_id",
+            Self::InternalPlannerError => "internal_planner_error",
+            Self::UnsupportedEdgeAllTarget => "unsupported_edge_all_target",
+            Self::NonLiteralIndexExpression => "non_literal_index_expression",
+            Self::InvalidSearchTenant => "invalid_search_tenant",
+            Self::InvalidSearchTenantValue => "invalid_search_tenant_value",
+            Self::InvalidSearchResultCount => "invalid_search_result_count",
+            Self::InvalidSearchResultCountExpression => "invalid_search_result_count_expression",
+            Self::InvalidSearchInput => "invalid_search_input",
+            Self::InvalidBatchConditionMinSize => "invalid_batch_condition_min_size",
+            Self::InvalidInitialBatchCondition => "invalid_initial_batch_condition",
+            Self::DuplicatePropertyAssignment => "duplicate_property_assignment",
+            Self::DuplicatePropertySelection => "duplicate_property_selection",
+            Self::DuplicateProjectionAlias => "duplicate_projection_alias",
+            Self::DuplicateReturnVariable => "duplicate_return_variable",
+            Self::DuplicateElementId => "duplicate_element_id",
+            Self::DuplicateOrderKey => "duplicate_order_key",
+            Self::UnboundContext => "unbound_context",
+            Self::InvalidSubTraversalOperation => "invalid_sub_traversal_operation",
+            Self::InvalidAfterBindOperation => "invalid_after_bind_operation",
+            Self::ReadOnlyTraversalInWriteBatch => "read_only_traversal_in_write_batch",
+            Self::InvalidBranchArity => "invalid_branch_arity",
+            Self::InvalidBatchArity => "invalid_batch_arity",
+            Self::InvalidRepeatEmit => "invalid_repeat_emit",
+            Self::InvalidRepeatCount => "invalid_repeat_count",
+            Self::InvalidShortestPathCount => "invalid_shortest_path_count",
+            Self::InvalidOrderKeys => "invalid_order_keys",
+            Self::InvalidProjectionArity => "invalid_projection_arity",
+            Self::InvalidStreamRange => "invalid_stream_range",
+            Self::InvalidStreamBoundExpression => "invalid_stream_bound_expression",
+            Self::InvalidEmptyName => "invalid_empty_name",
+            Self::InvalidPredicateArity => "invalid_predicate_arity",
+            Self::StorageError => "storage_error",
+            Self::TransactionConflict => "transaction_conflict",
+            Self::RequestReadViewChanged => "request_read_view_changed",
+            Self::QueryDeadlineExceeded => "query_deadline_exceeded",
+            Self::InvalidNodeId => "invalid_node_id",
+            Self::NodeNotFound => "node_not_found",
+            Self::EdgeNotFound => "edge_not_found",
+            Self::DatabaseClosed => "database_closed",
+            Self::InvalidConfiguration => "invalid_configuration",
+            Self::IndexLifecycleUnavailable => "index_lifecycle_unavailable",
+            Self::SecondaryLifecycleSteppingRequiresDisabledMode => {
+                "secondary_lifecycle_stepping_requires_disabled_mode"
+            }
+            Self::ActiveTextMutationLimitExceeded => "active_text_mutation_limit_exceeded",
+            Self::InvalidIndexSourceData => "invalid_index_source_data",
+            Self::InvalidIndexModel => "invalid_index_model",
+            Self::InvalidSecondaryIndexValue => "invalid_secondary_index_value",
+            Self::MigrationRequired => "migration_required",
+            Self::WriterMigrationRequired => "writer_migration_required",
+            Self::UnsupportedIndexStorageVersion => "unsupported_index_storage_version",
+            Self::IdentifierExhausted => "identifier_exhausted",
+            Self::IndexIdExhausted => "index_id_exhausted",
+            Self::VectorPhysicalIdExhausted => "vector_physical_id_exhausted",
+            Self::IndexGenerationExhausted => "index_generation_exhausted",
+            Self::IndexRevisionExhausted => "index_revision_exhausted",
+            Self::IndexOperationRevisionExhausted => "index_operation_revision_exhausted",
+            Self::StaleIndexGeneration => "stale_index_generation",
+            Self::WriterFencedCommitOutcomeUnknown => "writer_fenced_commit_outcome_unknown",
+            Self::InvalidVectorConfiguration => "invalid_vector_configuration",
+            Self::InvalidQuery => "invalid_query",
+            Self::WriterModeRequired => "writer_mode_required",
+            Self::ReaderModeRequired => "reader_mode_required",
+            Self::IndexAlreadyExists => "index_already_exists",
+            Self::IndexDefinitionConflict => "index_definition_conflict",
+            Self::IndexBusy => "index_busy",
+            Self::IndexOperationNotFound => "index_operation_not_found",
+            Self::IndexOperationNotAbortable => "index_operation_not_abortable",
+            Self::IndexNotFound => "index_not_found",
+            Self::UniqueConstraintViolation => "unique_constraint_violation",
+            Self::UnsupportedUniqueIndexValueType => "unsupported_unique_index_value_type",
+            Self::InvalidVectorDimension => "invalid_vector_dimension",
+            Self::InvalidVectorComponent => "invalid_vector_component",
+            Self::VectorComponentMagnitudeExceeded => "vector_component_magnitude_exceeded",
+            Self::ZeroNormCosineVector => "zero_norm_cosine_vector",
+            Self::ResponseSerializationError => "response_serialization_error",
+            Self::InternalError => "internal_error",
+        }
+    }
+}
+
+impl core::fmt::Display for QueryErrorCode {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl core::str::FromStr for QueryErrorCode {
+    type Err = UnknownQueryErrorCode;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|code| code.as_str() == value)
+            .ok_or_else(|| UnknownQueryErrorCode(value.to_string()))
+    }
+}
+
+/// A string that is not part of the known static query-error catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownQueryErrorCode(String);
+
+impl UnknownQueryErrorCode {
+    /// Return the unrecognized wire value.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl core::fmt::Display for UnknownQueryErrorCode {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(formatter, "unknown query error code `{}`", self.0)
+    }
+}
+
+impl std::error::Error for UnknownQueryErrorCode {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_round_trips_through_every_public_representation() {
+        let mut strings = std::collections::BTreeSet::new();
+        for code in QueryErrorCode::ALL {
+            assert!(strings.insert(code.as_str()), "duplicate code {code}");
+            assert_eq!(code.to_string(), code.as_str());
+            assert_eq!(code.as_str().parse(), Ok(*code));
+            assert_eq!(sonic_rs::to_string(code).unwrap(), format!("\"{code}\""));
+            assert_eq!(
+                sonic_rs::from_str::<QueryErrorCode>(&format!("\"{code}\"")).unwrap(),
+                *code
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_code_preserves_the_original_wire_value() {
+        let error = "future_error".parse::<QueryErrorCode>().unwrap_err();
+        assert_eq!(error.as_str(), "future_error");
+        assert_eq!(error.to_string(), "unknown query error code `future_error`");
+    }
+}

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -33,6 +33,7 @@
 #![deny(unsafe_code)]
 
 pub mod batch;
+pub mod error_code;
 pub mod expr;
 pub mod graph;
 pub mod index;

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -5,6 +5,7 @@ use crate::encoding::error::EncodingError;
 use crate::search::vector::{
     VectorConfigError, VectorDistanceMetric, VectorItemDecodeError, VectorValidationError,
 };
+use helix_ast::error_code;
 use slatedb::ErrorKind;
 
 /// Index family whose canonical lifecycle authority is unavailable.
@@ -317,6 +318,10 @@ pub enum HelixDbError {
     #[error("Query error: {0}")]
     Query(String),
 
+    /// Query JSON could not be decoded at the embedded boundary.
+    #[error("Query error: invalid query JSON: {0}")]
+    InvalidQueryJson(String),
+
     /// Operation requires a writer handle.
     #[error("writer mode required, current mode is {actual}")]
     WriterModeRequired {
@@ -469,78 +474,133 @@ impl From<ConfigError> for HelixDbError {
 }
 
 impl HelixDbError {
-    /// Stable public compatibility code when this error belongs to the index
-    /// lifecycle API.
-    pub fn index_error_code(&self) -> Option<&'static str> {
+    /// Stable machine-readable code for this database failure.
+    pub fn error_code(&self) -> error_code::QueryErrorCode {
         match self {
-            Self::IndexLifecycleUnavailable { .. } => Some("index_lifecycle_unavailable"),
+            Self::Storage(error) if error.kind() == ErrorKind::Transaction => {
+                error_code::QueryErrorCode::TransactionConflict
+            }
+            Self::Storage(_) | Self::ObjectStore(_) => error_code::QueryErrorCode::StorageError,
+            Self::Encoding(_)
+            | Self::InvalidVectorItem(_)
+            | Self::IdentifierAllocationFailed { .. }
+            | Self::IndexCatalogCorruption(_)
+            | Self::LegacyZeroNormCosineVector { .. }
+            | Self::InvariantViolation(_) => error_code::QueryErrorCode::InternalError,
+            Self::TransactionConflict(_) => error_code::QueryErrorCode::TransactionConflict,
+            Self::RequestReadViewChanged => error_code::QueryErrorCode::RequestReadViewChanged,
+            Self::QueryDeadlineExceeded => error_code::QueryErrorCode::QueryDeadlineExceeded,
+            Self::InvalidNodeId(_) => error_code::QueryErrorCode::InvalidNodeId,
+            Self::NodeNotFound(_) => error_code::QueryErrorCode::NodeNotFound,
+            Self::EdgeNotFound { .. } => error_code::QueryErrorCode::EdgeNotFound,
+            Self::DatabaseClosed => error_code::QueryErrorCode::DatabaseClosed,
+            Self::Config(_) => error_code::QueryErrorCode::InvalidConfiguration,
+            Self::IndexLifecycleUnavailable { .. } => {
+                error_code::QueryErrorCode::IndexLifecycleUnavailable
+            }
             Self::SecondaryLifecycleSteppingRequiresDisabledMode => {
-                Some("secondary_lifecycle_stepping_requires_disabled_mode")
+                error_code::QueryErrorCode::SecondaryLifecycleSteppingRequiresDisabledMode
             }
             Self::ActiveTextMutationLimitExceeded { .. } => {
-                Some("active_text_mutation_limit_exceeded")
+                error_code::QueryErrorCode::ActiveTextMutationLimitExceeded
             }
-            Self::InvalidIndexSourceData { .. } => Some("invalid_index_source_data"),
-            Self::IndexAlreadyExists(_) => Some("index_already_exists"),
-            Self::IndexDefinitionConflict { .. } => Some("index_definition_conflict"),
-            Self::IndexBusy { .. } => Some("index_busy"),
-            Self::IndexNotFound(_) => Some("index_not_found"),
-            Self::IndexOperationNotFound { .. } => Some("index_operation_not_found"),
-            Self::IndexOperationNotAbortable { .. } => Some("index_operation_not_abortable"),
-            Self::IdentifierExhausted("logical index ID") => Some("index_id_exhausted"),
-            Self::IdentifierExhausted("vector physical index ID") => {
-                Some("vector_physical_id_exhausted")
+            Self::InvalidIndexSourceData { .. } => {
+                error_code::QueryErrorCode::InvalidIndexSourceData
             }
             Self::InvalidIndexV2Model(
                 crate::index_lifecycle::IndexV2ModelError::IdentifierExhausted {
                     kind: "index generation ID",
                 },
-            ) => Some("index_generation_exhausted"),
+            ) => error_code::QueryErrorCode::IndexGenerationExhausted,
             Self::InvalidIndexV2Model(
                 crate::index_lifecycle::IndexV2ModelError::IdentifierExhausted {
                     kind: "index revision",
                 },
-            ) => Some("index_revision_exhausted"),
+            ) => error_code::QueryErrorCode::IndexRevisionExhausted,
             Self::InvalidIndexV2Model(
                 crate::index_lifecycle::IndexV2ModelError::IdentifierExhausted {
                     kind: "index operation revision",
                 },
-            ) => Some("index_operation_revision_exhausted"),
-            Self::StaleIndexGeneration { .. } => Some("stale_index_generation"),
-            Self::WriterFencedCommitOutcomeUnknown => Some("writer_fenced_commit_outcome_unknown"),
-            Self::Storage(_)
-            | Self::Encoding(_)
-            | Self::TransactionConflict(_)
-            | Self::RequestReadViewChanged
-            | Self::InvalidNodeId(_)
-            | Self::NodeNotFound(_)
-            | Self::EdgeNotFound { .. }
-            | Self::DatabaseClosed
-            | Self::Config(_)
-            | Self::InvalidIndexV2Model(_)
-            | Self::SecondaryIndexValue(_)
-            | Self::MigrationRequired { .. }
-            | Self::WriterMigrationRequired { .. }
-            | Self::UnsupportedIndexStorageVersion { .. }
-            | Self::IdentifierExhausted(_)
-            | Self::IdentifierAllocationFailed { .. }
-            | Self::IndexCatalogCorruption(_)
-            | Self::InvalidVectorConfig(_)
-            | Self::InvalidVectorItem(_)
-            | Self::ObjectStore(_)
-            | Self::Query(_)
-            | Self::QueryDeadlineExceeded
-            | Self::WriterModeRequired { .. }
-            | Self::ReaderModeRequired { .. }
-            | Self::UniqueConstraintViolation { .. }
-            | Self::UnsupportedUniqueIndexValueType { .. }
-            | Self::InvalidDimension { .. }
-            | Self::InvalidVectorComponent { .. }
-            | Self::VectorComponentMagnitudeExceeded { .. }
-            | Self::ZeroNormCosineVector
-            | Self::LegacyZeroNormCosineVector { .. }
-            | Self::InvariantViolation(_) => None,
+            ) => error_code::QueryErrorCode::IndexOperationRevisionExhausted,
+            Self::InvalidIndexV2Model(_) => error_code::QueryErrorCode::InvalidIndexModel,
+            Self::SecondaryIndexValue(_) => error_code::QueryErrorCode::InvalidSecondaryIndexValue,
+            Self::MigrationRequired { .. } => error_code::QueryErrorCode::MigrationRequired,
+            Self::WriterMigrationRequired { .. } => {
+                error_code::QueryErrorCode::WriterMigrationRequired
+            }
+            Self::UnsupportedIndexStorageVersion { .. } => {
+                error_code::QueryErrorCode::UnsupportedIndexStorageVersion
+            }
+            Self::IdentifierExhausted("logical index ID") => {
+                error_code::QueryErrorCode::IndexIdExhausted
+            }
+            Self::IdentifierExhausted("vector physical index ID") => {
+                error_code::QueryErrorCode::VectorPhysicalIdExhausted
+            }
+            Self::IdentifierExhausted(_) => error_code::QueryErrorCode::IdentifierExhausted,
+            Self::StaleIndexGeneration { .. } => error_code::QueryErrorCode::StaleIndexGeneration,
+            Self::WriterFencedCommitOutcomeUnknown => {
+                error_code::QueryErrorCode::WriterFencedCommitOutcomeUnknown
+            }
+            Self::InvalidVectorConfig(_) => error_code::QueryErrorCode::InvalidVectorConfiguration,
+            Self::Query(_) => error_code::QueryErrorCode::InvalidQuery,
+            Self::InvalidQueryJson(_) => error_code::QueryErrorCode::InvalidQueryJson,
+            Self::WriterModeRequired { .. } => error_code::QueryErrorCode::WriterModeRequired,
+            Self::ReaderModeRequired { .. } => error_code::QueryErrorCode::ReaderModeRequired,
+            Self::IndexAlreadyExists(_) => error_code::QueryErrorCode::IndexAlreadyExists,
+            Self::IndexDefinitionConflict { .. } => {
+                error_code::QueryErrorCode::IndexDefinitionConflict
+            }
+            Self::IndexBusy { .. } => error_code::QueryErrorCode::IndexBusy,
+            Self::IndexOperationNotFound { .. } => {
+                error_code::QueryErrorCode::IndexOperationNotFound
+            }
+            Self::IndexOperationNotAbortable { .. } => {
+                error_code::QueryErrorCode::IndexOperationNotAbortable
+            }
+            Self::IndexNotFound(_) => error_code::QueryErrorCode::IndexNotFound,
+            Self::UniqueConstraintViolation { .. } => {
+                error_code::QueryErrorCode::UniqueConstraintViolation
+            }
+            Self::UnsupportedUniqueIndexValueType { .. } => {
+                error_code::QueryErrorCode::UnsupportedUniqueIndexValueType
+            }
+            Self::InvalidDimension { .. } => error_code::QueryErrorCode::InvalidVectorDimension,
+            Self::InvalidVectorComponent { .. } => {
+                error_code::QueryErrorCode::InvalidVectorComponent
+            }
+            Self::VectorComponentMagnitudeExceeded { .. } => {
+                error_code::QueryErrorCode::VectorComponentMagnitudeExceeded
+            }
+            Self::ZeroNormCosineVector => error_code::QueryErrorCode::ZeroNormCosineVector,
         }
+    }
+
+    /// Stable public compatibility code when this error belongs to the index
+    /// lifecycle API.
+    pub fn index_error_code(&self) -> Option<&'static str> {
+        let code = self.error_code();
+        matches!(
+            code,
+            error_code::QueryErrorCode::IndexLifecycleUnavailable
+                | error_code::QueryErrorCode::SecondaryLifecycleSteppingRequiresDisabledMode
+                | error_code::QueryErrorCode::ActiveTextMutationLimitExceeded
+                | error_code::QueryErrorCode::InvalidIndexSourceData
+                | error_code::QueryErrorCode::IndexAlreadyExists
+                | error_code::QueryErrorCode::IndexDefinitionConflict
+                | error_code::QueryErrorCode::IndexBusy
+                | error_code::QueryErrorCode::IndexNotFound
+                | error_code::QueryErrorCode::IndexOperationNotFound
+                | error_code::QueryErrorCode::IndexOperationNotAbortable
+                | error_code::QueryErrorCode::IndexIdExhausted
+                | error_code::QueryErrorCode::VectorPhysicalIdExhausted
+                | error_code::QueryErrorCode::IndexGenerationExhausted
+                | error_code::QueryErrorCode::IndexRevisionExhausted
+                | error_code::QueryErrorCode::IndexOperationRevisionExhausted
+                | error_code::QueryErrorCode::StaleIndexGeneration
+                | error_code::QueryErrorCode::WriterFencedCommitOutcomeUnknown
+        )
+        .then_some(code.as_str())
     }
 
     /// Returns true when the error represents a retryable transaction conflict.
@@ -607,6 +667,7 @@ pub type Result<T> = std::result::Result<T, HelixDbError>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use helix_ast::error_code::QueryErrorCode as Code;
 
     #[test]
     fn config_errors_convert_to_database_errors_with_display_context() {
@@ -665,6 +726,253 @@ mod tests {
             !HelixDbError::InvariantViolation("stored row is corrupt".to_string())
                 .is_invalid_vector_input()
         );
+    }
+
+    #[test]
+    fn database_error_variants_have_stable_semantic_codes() {
+        let cases = vec![
+            (
+                HelixDbError::Storage(slatedb::Error::invalid("storage".to_string())),
+                Code::StorageError,
+            ),
+            (
+                HelixDbError::Storage(slatedb::Error::transaction("retry".to_string())),
+                Code::TransactionConflict,
+            ),
+            (
+                HelixDbError::ObjectStore(slatedb::object_store::Error::Generic {
+                    store: "test",
+                    source: Box::new(std::io::Error::other("object store")),
+                }),
+                Code::StorageError,
+            ),
+            (
+                HelixDbError::Encoding(EncodingError::Custom("encoding".to_string())),
+                Code::InternalError,
+            ),
+            (
+                HelixDbError::TransactionConflict("retry".to_string()),
+                Code::TransactionConflict,
+            ),
+            (
+                HelixDbError::RequestReadViewChanged,
+                Code::RequestReadViewChanged,
+            ),
+            (
+                HelixDbError::QueryDeadlineExceeded,
+                Code::QueryDeadlineExceeded,
+            ),
+            (HelixDbError::InvalidNodeId(0), Code::InvalidNodeId),
+            (HelixDbError::NodeNotFound(1), Code::NodeNotFound),
+            (
+                HelixDbError::EdgeNotFound { from: 1, to: 2 },
+                Code::EdgeNotFound,
+            ),
+            (HelixDbError::DatabaseClosed, Code::DatabaseClosed),
+            (
+                HelixDbError::Config("invalid".to_string()),
+                Code::InvalidConfiguration,
+            ),
+            (
+                HelixDbError::IndexLifecycleUnavailable {
+                    family: IndexFamily::Vector,
+                    reason: IndexLifecycleUnavailableReason::CanonicalStateUnavailable,
+                },
+                Code::IndexLifecycleUnavailable,
+            ),
+            (
+                HelixDbError::SecondaryLifecycleSteppingRequiresDisabledMode,
+                Code::SecondaryLifecycleSteppingRequiresDisabledMode,
+            ),
+            (
+                HelixDbError::ActiveTextMutationLimitExceeded {
+                    resource: ActiveTextMutationResource::Entities,
+                    observed: 2,
+                    limit: 1,
+                },
+                Code::ActiveTextMutationLimitExceeded,
+            ),
+            (
+                HelixDbError::InvalidIndexSourceData {
+                    reason: "invalid".to_string(),
+                },
+                Code::InvalidIndexSourceData,
+            ),
+            (
+                HelixDbError::InvalidIndexV2Model(
+                    crate::index_lifecycle::IndexV2ModelError::EmptyComponent { kind: "label" },
+                ),
+                Code::InvalidIndexModel,
+            ),
+            (
+                HelixDbError::SecondaryIndexValue(SecondaryIndexValueError::NaNRangeValue),
+                Code::InvalidSecondaryIndexValue,
+            ),
+            (
+                HelixDbError::MigrationRequired {
+                    reason: "legacy".to_string(),
+                },
+                Code::MigrationRequired,
+            ),
+            (
+                HelixDbError::WriterMigrationRequired {
+                    requirement: WriterMigrationRequirement::IncompleteStorageSchema,
+                },
+                Code::WriterMigrationRequired,
+            ),
+            (
+                HelixDbError::UnsupportedIndexStorageVersion {
+                    found: 3,
+                    supported: 2,
+                },
+                Code::UnsupportedIndexStorageVersion,
+            ),
+            (
+                HelixDbError::IdentifierExhausted("other"),
+                Code::IdentifierExhausted,
+            ),
+            (
+                HelixDbError::IdentifierExhausted("logical index ID"),
+                Code::IndexIdExhausted,
+            ),
+            (
+                HelixDbError::IdentifierExhausted("vector physical index ID"),
+                Code::VectorPhysicalIdExhausted,
+            ),
+            (
+                HelixDbError::IdentifierAllocationFailed {
+                    kind: "operation",
+                    attempts: 1,
+                },
+                Code::InternalError,
+            ),
+            (
+                HelixDbError::IndexCatalogCorruption("corrupt".to_string()),
+                Code::InternalError,
+            ),
+            (
+                HelixDbError::StaleIndexGeneration {
+                    index_id: 1,
+                    generation: 2,
+                    record_revision: 3,
+                },
+                Code::StaleIndexGeneration,
+            ),
+            (
+                HelixDbError::WriterFencedCommitOutcomeUnknown,
+                Code::WriterFencedCommitOutcomeUnknown,
+            ),
+            (
+                HelixDbError::InvalidVectorConfig(VectorConfigError::EmptyIndexName),
+                Code::InvalidVectorConfiguration,
+            ),
+            (
+                HelixDbError::InvalidVectorItem(VectorItemDecodeError::HeaderMismatch),
+                Code::InternalError,
+            ),
+            (
+                HelixDbError::Query("invalid".to_string()),
+                Code::InvalidQuery,
+            ),
+            (
+                HelixDbError::InvalidQueryJson("invalid".to_string()),
+                Code::InvalidQueryJson,
+            ),
+            (
+                HelixDbError::WriterModeRequired { actual: "reader" },
+                Code::WriterModeRequired,
+            ),
+            (
+                HelixDbError::ReaderModeRequired { actual: "writer" },
+                Code::ReaderModeRequired,
+            ),
+            (
+                HelixDbError::IndexAlreadyExists("index".to_string()),
+                Code::IndexAlreadyExists,
+            ),
+            (
+                HelixDbError::IndexBusy { state: "building" },
+                Code::IndexBusy,
+            ),
+            (
+                HelixDbError::IndexOperationNotFound {
+                    operation_id: "operation".to_string(),
+                },
+                Code::IndexOperationNotFound,
+            ),
+            (
+                HelixDbError::IndexOperationNotAbortable {
+                    operation_id: "operation".to_string(),
+                    reason: "complete",
+                },
+                Code::IndexOperationNotAbortable,
+            ),
+            (
+                HelixDbError::IndexNotFound("index".to_string()),
+                Code::IndexNotFound,
+            ),
+            (
+                HelixDbError::UniqueConstraintViolation {
+                    label: "User".to_string(),
+                    property: "email".to_string(),
+                    value: "value".to_string(),
+                    existing_node_id: 1,
+                    attempted_node_id: 2,
+                },
+                Code::UniqueConstraintViolation,
+            ),
+            (
+                HelixDbError::UnsupportedUniqueIndexValueType {
+                    label: "User".to_string(),
+                    property: "email".to_string(),
+                    node_id: 1,
+                    value_type: "array".to_string(),
+                },
+                Code::UnsupportedUniqueIndexValueType,
+            ),
+            (
+                HelixDbError::InvalidDimension {
+                    expected: 3,
+                    got: 2,
+                },
+                Code::InvalidVectorDimension,
+            ),
+            (
+                HelixDbError::InvalidVectorComponent { index: 0 },
+                Code::InvalidVectorComponent,
+            ),
+            (
+                HelixDbError::VectorComponentMagnitudeExceeded {
+                    metric: VectorDistanceMetric::Euclidean,
+                    dimension: 1,
+                    component_index: 0,
+                    observed_magnitude: 2.0,
+                    inclusive_maximum: 1.0,
+                },
+                Code::VectorComponentMagnitudeExceeded,
+            ),
+            (
+                HelixDbError::ZeroNormCosineVector,
+                Code::ZeroNormCosineVector,
+            ),
+            (
+                HelixDbError::LegacyZeroNormCosineVector {
+                    element_kind: crate::index_lifecycle::IndexElementKind::Node,
+                    label: "Document".to_string(),
+                    property: "embedding".to_string(),
+                    entity_id: 1,
+                },
+                Code::InternalError,
+            ),
+            (
+                HelixDbError::InvariantViolation("invariant".to_string()),
+                Code::InternalError,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.error_code(), expected, "{error}");
+        }
     }
 
     #[test]

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1707,7 +1707,7 @@ impl HelixDB {
         tenant_scope: DataScope,
     ) -> Result<Vec<u8>> {
         let request = sonic_rs::from_slice::<QueryRequest>(request_json)
-            .map_err(|err| HelixDbError::Query(format!("invalid query JSON: {err}")))?;
+            .map_err(|error| HelixDbError::InvalidQueryJson(error.to_string()))?;
         let query_metrics = self.embedded_query_metrics();
         query_service::execute_query_on_scoped_observed(
             self,

--- a/crates/db/src/query_service.rs
+++ b/crates/db/src/query_service.rs
@@ -605,6 +605,18 @@ impl QueryServiceError {
         matches!(self, Self::Db(HelixDbError::QueryDeadlineExceeded))
     }
 
+    /// Stable machine-readable code for this public query failure.
+    pub fn error_code(&self) -> helix_ast::error_code::QueryErrorCode {
+        match self {
+            Self::InvalidRequest(_) => helix_ast::error_code::QueryErrorCode::InvalidRequest,
+            Self::Planner(error) => error.error_code(),
+            Self::Db(error) => error.error_code(),
+            Self::JsonSerialize(_) | Self::Serialize(_) => {
+                helix_ast::error_code::QueryErrorCode::ResponseSerializationError
+            }
+        }
+    }
+
     /// Stable index lifecycle error code, when this failure belongs to that
     /// public compatibility surface.
     pub fn index_error_code(&self) -> Option<&'static str> {
@@ -621,7 +633,7 @@ impl From<QueryServiceError> for HelixDbError {
         match value {
             QueryServiceError::Db(error) => error,
             QueryServiceError::Planner(error)
-                if error.index_error_code() == Some("index_not_found") =>
+                if error.error_code() == helix_ast::error_code::QueryErrorCode::IndexNotFound =>
             {
                 HelixDbError::IndexNotFound(error.to_string())
             }

--- a/crates/planner/src/error/mod.rs
+++ b/crates/planner/src/error/mod.rs
@@ -3,6 +3,7 @@
 mod operation;
 mod search;
 
+use helix_ast::error_code;
 use helix_ast::traversal::EmitBehavior;
 use thiserror::Error;
 
@@ -282,6 +283,82 @@ pub enum PlannerError {
 }
 
 impl PlannerError {
+    /// Stable machine-readable code for this public planning failure.
+    pub const fn error_code(&self) -> error_code::QueryErrorCode {
+        match self {
+            Self::InvalidIndexOperationId(_) => error_code::QueryErrorCode::InvalidIndexOperationId,
+            Self::InvalidExecutablePlan { .. }
+            | Self::UnsupportedCascadesPlan { .. }
+            | Self::OptimizerFailure { .. }
+            | Self::OptimizerSelectionFailure { .. } => {
+                error_code::QueryErrorCode::InternalPlannerError
+            }
+            Self::UnsupportedEdgeAllTarget => error_code::QueryErrorCode::UnsupportedEdgeAllTarget,
+            Self::NonLiteralIndexExpression { .. } => {
+                error_code::QueryErrorCode::NonLiteralIndexExpression
+            }
+            Self::MissingSearchIndex { .. } => error_code::QueryErrorCode::IndexNotFound,
+            Self::InvalidSearchTenant { .. } => error_code::QueryErrorCode::InvalidSearchTenant,
+            Self::InvalidSearchTenantValue { .. } => {
+                error_code::QueryErrorCode::InvalidSearchTenantValue
+            }
+            Self::InvalidSearchResultCount { .. } => {
+                error_code::QueryErrorCode::InvalidSearchResultCount
+            }
+            Self::InvalidSearchResultCountExpression { .. } => {
+                error_code::QueryErrorCode::InvalidSearchResultCountExpression
+            }
+            Self::InvalidSearchInput { .. } => error_code::QueryErrorCode::InvalidSearchInput,
+            Self::InvalidBatchConditionMinSize { .. } => {
+                error_code::QueryErrorCode::InvalidBatchConditionMinSize
+            }
+            Self::InvalidInitialBatchCondition { .. } => {
+                error_code::QueryErrorCode::InvalidInitialBatchCondition
+            }
+            Self::DuplicatePropertyAssignment { .. } => {
+                error_code::QueryErrorCode::DuplicatePropertyAssignment
+            }
+            Self::DuplicatePropertySelection { .. } => {
+                error_code::QueryErrorCode::DuplicatePropertySelection
+            }
+            Self::DuplicateProjectionAlias { .. } => {
+                error_code::QueryErrorCode::DuplicateProjectionAlias
+            }
+            Self::DuplicateReturnVariable { .. } => {
+                error_code::QueryErrorCode::DuplicateReturnVariable
+            }
+            Self::DuplicateElementId { .. } => error_code::QueryErrorCode::DuplicateElementId,
+            Self::DuplicateOrderKey { .. } => error_code::QueryErrorCode::DuplicateOrderKey,
+            Self::UnboundContext => error_code::QueryErrorCode::UnboundContext,
+            Self::InvalidSubTraversalOperation { .. } => {
+                error_code::QueryErrorCode::InvalidSubTraversalOperation
+            }
+            Self::InvalidAfterBindOperation { .. } => {
+                error_code::QueryErrorCode::InvalidAfterBindOperation
+            }
+            Self::ReadOnlyTraversalInWriteBatch { .. } => {
+                error_code::QueryErrorCode::ReadOnlyTraversalInWriteBatch
+            }
+            Self::InvalidBranchArity { .. } => error_code::QueryErrorCode::InvalidBranchArity,
+            Self::InvalidBatchArity { .. } => error_code::QueryErrorCode::InvalidBatchArity,
+            Self::InvalidRepeatEmit { .. } => error_code::QueryErrorCode::InvalidRepeatEmit,
+            Self::InvalidRepeatCount { .. } => error_code::QueryErrorCode::InvalidRepeatCount,
+            Self::InvalidShortestPathCount { .. } => {
+                error_code::QueryErrorCode::InvalidShortestPathCount
+            }
+            Self::InvalidOrderKeys => error_code::QueryErrorCode::InvalidOrderKeys,
+            Self::InvalidProjectionArity { .. } => {
+                error_code::QueryErrorCode::InvalidProjectionArity
+            }
+            Self::InvalidStreamRange { .. } => error_code::QueryErrorCode::InvalidStreamRange,
+            Self::InvalidStreamBoundExpression { .. } => {
+                error_code::QueryErrorCode::InvalidStreamBoundExpression
+            }
+            Self::InvalidEmptyName { .. } => error_code::QueryErrorCode::InvalidEmptyName,
+            Self::InvalidPredicateArity { .. } => error_code::QueryErrorCode::InvalidPredicateArity,
+        }
+    }
+
     /// Stable public index error code for planner failures that belong to the
     /// index lifecycle contract.
     pub const fn index_error_code(&self) -> Option<&'static str> {
@@ -308,6 +385,7 @@ impl From<ExprPlanError> for PlannerError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use helix_ast::error_code::QueryErrorCode as Code;
 
     #[test]
     fn missing_search_index_has_the_public_not_found_code() {
@@ -319,5 +397,221 @@ mod tests {
         };
 
         assert_eq!(error.index_error_code(), Some("index_not_found"));
+    }
+
+    #[test]
+    fn every_public_planner_error_arm_has_a_static_code() {
+        let name = || NonEmptyString::new("value").unwrap();
+        let internal = [
+            PlannerError::InvalidExecutablePlan {
+                error: exec::ExecPlanError::EmptyMultiGet,
+            },
+            PlannerError::UnsupportedCascadesPlan {
+                reason: "unsupported".to_string(),
+            },
+            PlannerError::OptimizerFailure {
+                memo_error: memo::MemoError::GroupIdSpaceExhausted,
+            },
+            PlannerError::OptimizerSelectionFailure {
+                selection_error: optimizer::SelectionError::NoPhysicalAlternatives {
+                    group: memo::MemoGroupId::first(),
+                },
+            },
+        ];
+        assert!(internal
+            .iter()
+            .all(|error| error.error_code() == Code::InternalPlannerError));
+
+        let errors = vec![
+            (
+                PlannerError::InvalidIndexOperationId(
+                    crate::ir::IndexOperationId::try_new("").unwrap_err(),
+                ),
+                Code::InvalidIndexOperationId,
+            ),
+            (
+                PlannerError::UnsupportedEdgeAllTarget,
+                Code::UnsupportedEdgeAllTarget,
+            ),
+            (
+                PlannerError::NonLiteralIndexExpression {
+                    expression: "param".to_string(),
+                },
+                Code::NonLiteralIndexExpression,
+            ),
+            (
+                PlannerError::MissingSearchIndex {
+                    element: ElementKind::Node,
+                    kind: SearchIndexKind::Text,
+                    label: name(),
+                    property: name(),
+                },
+                Code::IndexNotFound,
+            ),
+            (
+                PlannerError::InvalidSearchTenant {
+                    kind: SearchIndexKind::Text,
+                    index_id: name(),
+                },
+                Code::InvalidSearchTenant,
+            ),
+            (
+                PlannerError::InvalidSearchTenantValue {
+                    kind: SearchIndexKind::Text,
+                    expected: SearchTenantValueExpected::NonNullPropertyInput,
+                },
+                Code::InvalidSearchTenantValue,
+            ),
+            (
+                PlannerError::InvalidSearchResultCount {
+                    kind: SearchIndexKind::Text,
+                    actual: 0,
+                },
+                Code::InvalidSearchResultCount,
+            ),
+            (
+                PlannerError::InvalidSearchResultCountExpression {
+                    kind: SearchIndexKind::Text,
+                    expected: SearchLimitExpected::PositiveInteger,
+                },
+                Code::InvalidSearchResultCountExpression,
+            ),
+            (
+                PlannerError::InvalidSearchInput {
+                    kind: SearchIndexKind::Text,
+                    expected: SearchQueryInputExpected::NonEmptyString,
+                },
+                Code::InvalidSearchInput,
+            ),
+            (
+                PlannerError::InvalidBatchConditionMinSize { actual: 0 },
+                Code::InvalidBatchConditionMinSize,
+            ),
+            (
+                PlannerError::InvalidInitialBatchCondition {
+                    condition: InitialBatchCondition::PrevNotEmpty,
+                },
+                Code::InvalidInitialBatchCondition,
+            ),
+            (
+                PlannerError::DuplicatePropertyAssignment { property: name() },
+                Code::DuplicatePropertyAssignment,
+            ),
+            (
+                PlannerError::DuplicatePropertySelection { property: name() },
+                Code::DuplicatePropertySelection,
+            ),
+            (
+                PlannerError::DuplicateProjectionAlias { alias: name() },
+                Code::DuplicateProjectionAlias,
+            ),
+            (
+                PlannerError::DuplicateReturnVariable { name: name() },
+                Code::DuplicateReturnVariable,
+            ),
+            (
+                PlannerError::DuplicateElementId {
+                    element: ElementKind::Node,
+                    id: 1,
+                },
+                Code::DuplicateElementId,
+            ),
+            (
+                PlannerError::DuplicateOrderKey { property: name() },
+                Code::DuplicateOrderKey,
+            ),
+            (PlannerError::UnboundContext, Code::UnboundContext),
+            (
+                PlannerError::InvalidSubTraversalOperation {
+                    op: SubTraversalOp::Source,
+                },
+                Code::InvalidSubTraversalOperation,
+            ),
+            (
+                PlannerError::InvalidAfterBindOperation {
+                    op: AfterBindOp::OrderBy,
+                },
+                Code::InvalidAfterBindOperation,
+            ),
+            (
+                PlannerError::ReadOnlyTraversalInWriteBatch {
+                    op: ReadOnlyWriteOp::Bind,
+                },
+                Code::ReadOnlyTraversalInWriteBatch,
+            ),
+            (
+                PlannerError::InvalidBranchArity {
+                    op: BranchOp::Union,
+                    min: 1,
+                    actual: 0,
+                },
+                Code::InvalidBranchArity,
+            ),
+            (
+                PlannerError::InvalidBatchArity {
+                    op: BatchOp::Batch,
+                    min: 1,
+                    actual: 0,
+                },
+                Code::InvalidBatchArity,
+            ),
+            (
+                PlannerError::InvalidRepeatEmit {
+                    emit: EmitBehavior::Before,
+                },
+                Code::InvalidRepeatEmit,
+            ),
+            (
+                PlannerError::InvalidRepeatCount {
+                    field: RepeatCountField::Times,
+                    actual: 0,
+                },
+                Code::InvalidRepeatCount,
+            ),
+            (
+                PlannerError::InvalidShortestPathCount {
+                    field: ShortestPathCountField::MaxDepth,
+                    actual: 0,
+                },
+                Code::InvalidShortestPathCount,
+            ),
+            (PlannerError::InvalidOrderKeys, Code::InvalidOrderKeys),
+            (
+                PlannerError::InvalidProjectionArity {
+                    op: ProjectionOp::Project,
+                    min: 1,
+                    actual: 0,
+                },
+                Code::InvalidProjectionArity,
+            ),
+            (
+                PlannerError::InvalidStreamRange { start: 2, end: 1 },
+                Code::InvalidStreamRange,
+            ),
+            (
+                PlannerError::InvalidStreamBoundExpression {
+                    expected: StreamBoundExpected::NonNegativeInteger,
+                },
+                Code::InvalidStreamBoundExpression,
+            ),
+            (
+                PlannerError::InvalidEmptyName {
+                    field: NameField::Name,
+                },
+                Code::InvalidEmptyName,
+            ),
+            (
+                PlannerError::InvalidPredicateArity {
+                    op: PredicateSetOp::And,
+                    min: 1,
+                    actual: 0,
+                },
+                Code::InvalidPredicateArity,
+            ),
+        ];
+
+        for (error, expected) in errors {
+            assert_eq!(error.error_code(), expected, "{error}");
+        }
     }
 }

--- a/crates/planner/src/error/mod.rs
+++ b/crates/planner/src/error/mod.rs
@@ -297,6 +297,12 @@ impl PlannerError {
             Self::NonLiteralIndexExpression { .. } => {
                 error_code::QueryErrorCode::NonLiteralIndexExpression
             }
+            Self::MissingPlanningEqualityParameter { .. } => {
+                error_code::QueryErrorCode::MissingPlanningEqualityParameter
+            }
+            Self::UnsupportedPlanningEqualityParameter { .. } => {
+                error_code::QueryErrorCode::UnsupportedPlanningEqualityParameter
+            }
             Self::MissingSearchIndex { .. } => error_code::QueryErrorCode::IndexNotFound,
             Self::InvalidSearchTenant { .. } => error_code::QueryErrorCode::InvalidSearchTenant,
             Self::InvalidSearchTenantValue { .. } => {
@@ -438,6 +444,14 @@ mod tests {
                     expression: "param".to_string(),
                 },
                 Code::NonLiteralIndexExpression,
+            ),
+            (
+                PlannerError::MissingPlanningEqualityParameter { param: name() },
+                Code::MissingPlanningEqualityParameter,
+            ),
+            (
+                PlannerError::UnsupportedPlanningEqualityParameter { param: name() },
+                Code::UnsupportedPlanningEqualityParameter,
             ),
             (
                 PlannerError::MissingSearchIndex {

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -5,6 +5,9 @@ Both transports accept at most 16 MiB of query JSON, preserve stable index
 error codes, reject writer-only routing on reader handles, and can wait for a
 writer flush before acknowledging a durable write.
 
+See the [query error-code reference](../../docs/database/helix-db/query-guides/error-handling.mdx)
+for the HTTP `error`/`msg` envelope, gRPC metadata contract, and complete catalog.
+
 HTTP endpoints:
 
 - `POST /v2/query` executes a serialized `QueryRequest`.

--- a/crates/server/src/grpc.rs
+++ b/crates/server/src/grpc.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use db::query_service::{QueryMode, QueryServiceError};
+use helix_ast::error_code;
 use helix_ast::query::{QueryRequest, QueryRequestType};
 use tokio::sync::watch;
 use tonic::transport::Server;
@@ -8,6 +9,8 @@ use tonic::{Request, Response, Status};
 
 use crate::state::ServerState;
 use crate::MAX_QUERY_BODY_BYTES;
+
+pub(crate) const HELIX_ERROR_CODE_METADATA: &str = "helix-error-code";
 
 pub mod pb {
     tonic::include_proto!("helixdb.server.v1");
@@ -67,12 +70,19 @@ impl HelixDbServer for GrpcService {
         );
         let request = request.into_inner();
         if request.body.len() > MAX_QUERY_BODY_BYTES {
-            return Err(Status::resource_exhausted(format!(
-                "query body exceeds {MAX_QUERY_BODY_BYTES} bytes"
-            )));
+            return Err(status_with_error_code(
+                tonic::Code::ResourceExhausted,
+                error_code::QueryErrorCode::InvalidRequestBody,
+                format!("query body exceeds {MAX_QUERY_BODY_BYTES} bytes"),
+            ));
         }
-        let query = sonic_rs::from_slice::<QueryRequest>(&request.body)
-            .map_err(|error| Status::invalid_argument(format!("invalid query JSON: {error}")))?;
+        let query = sonic_rs::from_slice::<QueryRequest>(&request.body).map_err(|error| {
+            status_with_error_code(
+                tonic::Code::InvalidArgument,
+                error_code::QueryErrorCode::InvalidQueryJson,
+                format!("invalid query JSON: {error}"),
+            )
+        })?;
         validate_options_for_request_type(
             request.warm_only,
             request.require_writer,
@@ -132,17 +142,23 @@ fn validate_options_for_request_type(
     db_mode: db::HelixDbMode,
 ) -> Result<(), Status> {
     if warm_only && request_type != QueryRequestType::Read {
-        return Err(Status::invalid_argument(
+        return Err(status_with_error_code(
+            tonic::Code::InvalidArgument,
+            error_code::QueryErrorCode::InvalidRequestOption,
             "warm_only is only valid for read requests",
         ));
     }
     if await_durable && request_type != QueryRequestType::Write {
-        return Err(Status::invalid_argument(
+        return Err(status_with_error_code(
+            tonic::Code::InvalidArgument,
+            error_code::QueryErrorCode::InvalidRequestOption,
             "await_durable is only valid for write requests",
         ));
     }
     if require_writer && db_mode != db::HelixDbMode::Writer {
-        return Err(Status::unavailable(
+        return Err(status_with_error_code(
+            tonic::Code::Unavailable,
+            error_code::QueryErrorCode::InvalidRequestOption,
             "request requires a writer but this server is read-only",
         ));
     }
@@ -150,22 +166,118 @@ fn validate_options_for_request_type(
 }
 
 pub(super) fn status_from_service_error(error: QueryServiceError) -> Status {
-    if error.is_transaction_conflict() {
-        return Status::aborted(error.to_string());
-    }
+    let error_code = error.error_code();
     let message = error.to_string();
-    match error {
-        QueryServiceError::InvalidRequest(_) | QueryServiceError::Planner(_) => {
-            Status::invalid_argument(message)
+    let code = if error.is_transaction_conflict() {
+        tonic::Code::Aborted
+    } else {
+        match error {
+            QueryServiceError::InvalidRequest(_) | QueryServiceError::Planner(_) => {
+                tonic::Code::InvalidArgument
+            }
+            QueryServiceError::Db(error) if error.is_invalid_vector_input() => {
+                tonic::Code::InvalidArgument
+            }
+            QueryServiceError::Db(db::error::HelixDbError::WriterModeRequired { .. }) => {
+                tonic::Code::FailedPrecondition
+            }
+            QueryServiceError::Db(_)
+            | QueryServiceError::JsonSerialize(_)
+            | QueryServiceError::Serialize(_) => tonic::Code::Internal,
         }
-        QueryServiceError::Db(error) if error.is_invalid_vector_input() => {
-            Status::invalid_argument(message)
+    };
+    status_with_error_code(code, error_code, message)
+}
+
+fn status_with_error_code(
+    status_code: tonic::Code,
+    error_code: error_code::QueryErrorCode,
+    message: impl Into<String>,
+) -> Status {
+    let mut status = Status::new(status_code, message.into());
+    status.metadata_mut().insert(
+        HELIX_ERROR_CODE_METADATA,
+        tonic::metadata::MetadataValue::from_static(error_code.as_str()),
+    );
+    status
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_statuses_keep_messages_and_attach_static_codes() {
+        let cases = [
+            (
+                QueryServiceError::InvalidRequest("bad request".to_string()),
+                tonic::Code::InvalidArgument,
+                "invalid_request",
+            ),
+            (
+                QueryServiceError::Db(db::error::HelixDbError::TransactionConflict(
+                    "retry".to_string(),
+                )),
+                tonic::Code::Aborted,
+                "transaction_conflict",
+            ),
+            (
+                QueryServiceError::Db(db::error::HelixDbError::WriterModeRequired {
+                    actual: "reader",
+                }),
+                tonic::Code::FailedPrecondition,
+                "writer_mode_required",
+            ),
+            (
+                QueryServiceError::Db(db::error::HelixDbError::IndexNotFound(
+                    "documents".to_string(),
+                )),
+                tonic::Code::Internal,
+                "index_not_found",
+            ),
+        ];
+
+        for (error, expected_status_code, expected_error_code) in cases {
+            let expected_message = error.to_string();
+            let status = status_from_service_error(error);
+            assert_eq!(status.code(), expected_status_code);
+            assert_eq!(status.message(), expected_message);
+            assert_eq!(
+                status
+                    .metadata()
+                    .get(HELIX_ERROR_CODE_METADATA)
+                    .expect("query statuses include an error code")
+                    .to_str()
+                    .expect("error codes are ASCII"),
+                expected_error_code
+            );
         }
-        QueryServiceError::Db(db::error::HelixDbError::WriterModeRequired { .. }) => {
-            Status::failed_precondition(message)
-        }
-        QueryServiceError::Db(_)
-        | QueryServiceError::JsonSerialize(_)
-        | QueryServiceError::Serialize(_) => Status::internal(message),
+    }
+
+    #[test]
+    fn request_option_statuses_attach_the_request_option_code() {
+        let status = validate_options_for_request_type(
+            true,
+            false,
+            false,
+            QueryRequestType::Write,
+            db::HelixDbMode::Writer,
+        )
+        .expect_err("warm-only writes are invalid");
+
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(
+            status.message(),
+            "warm_only is only valid for read requests"
+        );
+        assert_eq!(
+            status
+                .metadata()
+                .get(HELIX_ERROR_CODE_METADATA)
+                .expect("query statuses include an error code")
+                .to_str()
+                .expect("error codes are ASCII"),
+            "invalid_request_option"
+        );
     }
 }

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -9,8 +9,9 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Router;
 use db::query_service::{QueryMode, QueryResponse, QueryServiceError};
+use helix_ast::error_code;
 use helix_ast::query::{QueryRequest, QueryRequestType};
-use serde_json::Value as JsonValue;
+use serde::Serialize;
 use tokio::net::TcpListener;
 use tokio::sync::watch;
 
@@ -86,6 +87,7 @@ async fn execute_query(
         Err(error) => {
             return error_response(
                 StatusCode::BAD_REQUEST,
+                error_code::QueryErrorCode::InvalidQueryJson,
                 format!("invalid query JSON: {error}"),
             );
         }
@@ -119,6 +121,7 @@ async fn read_body(body: Body) -> Result<Bytes, Box<Response>> {
     to_bytes(body, MAX_QUERY_BODY_BYTES).await.map_err(|error| {
         Box::new(error_response(
             StatusCode::BAD_REQUEST,
+            error_code::QueryErrorCode::InvalidRequestBody,
             format!("failed to read request body: {error}"),
         ))
     })
@@ -155,29 +158,44 @@ pub(super) fn service_error_response(error: QueryServiceError) -> Response {
             }
         }
     };
+    let code = error.error_code();
     let message = error.to_string();
-    match error.index_error_code() {
-        Some(code) => json_response(
-            status,
-            &serde_json::json!({ "error": message, "code": code }),
-        ),
-        None => error_response(status, message),
-    }
+    error_response(status, code, message)
 }
 
-fn error_response(status: StatusCode, message: impl Into<String>) -> Response {
-    json_response(status, &serde_json::json!({ "error": message.into() }))
+#[derive(Serialize)]
+struct QueryErrorEnvelope<'a> {
+    error: error_code::QueryErrorCode,
+    msg: &'a str,
 }
 
-fn json_response(status: StatusCode, body: &JsonValue) -> Response {
+fn error_response(
+    status: StatusCode,
+    code: error_code::QueryErrorCode,
+    message: impl Into<String>,
+) -> Response {
+    let message = message.into();
+    json_response(
+        status,
+        &QueryErrorEnvelope {
+            error: code,
+            msg: &message,
+        },
+    )
+}
+
+fn json_response(status: StatusCode, body: &(impl Serialize + ?Sized)) -> Response {
     match serde_json::to_vec(body) {
         Ok(body) => (status, [(header::CONTENT_TYPE, "application/json")], body).into_response(),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            [(header::CONTENT_TYPE, "application/json")],
-            format!(r#"{{"error":"failed to serialize response: {error}"}}"#),
-        )
-            .into_response(),
+        Err(error) => {
+            tracing::error!(%error, "failed to serialize HTTP JSON response");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(header::CONTENT_TYPE, "application/json")],
+                r#"{"error":"response_serialization_error","msg":"failed to serialize response"}"#,
+            )
+                .into_response()
+        }
     }
 }
 
@@ -210,18 +228,21 @@ impl RequestOptions {
         if self.warm_only && request_type != QueryRequestType::Read {
             return Err(HttpError::new(
                 StatusCode::BAD_REQUEST,
+                error_code::QueryErrorCode::InvalidRequestOption,
                 "x-helix-warm is only valid for read requests",
             ));
         }
         if self.await_durable == Some(true) && request_type != QueryRequestType::Write {
             return Err(HttpError::new(
                 StatusCode::BAD_REQUEST,
+                error_code::QueryErrorCode::InvalidRequestOption,
                 "x-helix-await-durable is only valid for write requests",
             ));
         }
         if self.require_writer && db_mode != db::HelixDbMode::Writer {
             return Err(HttpError::new(
                 StatusCode::SERVICE_UNAVAILABLE,
+                error_code::QueryErrorCode::InvalidRequestOption,
                 "request requires a writer but this server is read-only",
             ));
         }
@@ -251,6 +272,7 @@ fn parse_optional_bool_header(
     let value = value.to_str().map_err(|_| {
         HttpError::new(
             StatusCode::BAD_REQUEST,
+            error_code::QueryErrorCode::InvalidRequestOption,
             format!("{name} must be a UTF-8 boolean header"),
         )
     })?;
@@ -259,6 +281,7 @@ fn parse_optional_bool_header(
         "false" | "0" => Ok(Some(false)),
         _ => Err(HttpError::new(
             StatusCode::BAD_REQUEST,
+            error_code::QueryErrorCode::InvalidRequestOption,
             format!("{name} must be true or false"),
         )),
     }
@@ -267,19 +290,25 @@ fn parse_optional_bool_header(
 #[derive(Debug)]
 struct HttpError {
     status: StatusCode,
+    code: error_code::QueryErrorCode,
     message: String,
 }
 
 impl HttpError {
-    fn new(status: StatusCode, message: impl Into<String>) -> Self {
+    fn new(
+        status: StatusCode,
+        code: error_code::QueryErrorCode,
+        message: impl Into<String>,
+    ) -> Self {
         Self {
             status,
+            code,
             message: message.into(),
         }
     }
 
     fn into_response(self) -> Response {
-        error_response(self.status, self.message)
+        error_response(self.status, self.code, self.message)
     }
 }
 
@@ -325,7 +354,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lifecycle_errors_include_the_stable_machine_code() {
+    async fn query_errors_use_the_static_code_and_human_message_envelope() {
         let response = service_error_response(QueryServiceError::Db(
             db::error::HelixDbError::IndexOperationNotFound {
                 operation_id: "018f0c58-6bc7-7c56-8d3d-9c5f18a0f001".to_string(),
@@ -334,12 +363,13 @@ mod tests {
         let body = to_bytes(response.into_body(), 4_096)
             .await
             .expect("lifecycle error body is bounded");
-        let json: JsonValue = serde_json::from_slice(&body).expect("error body is JSON");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("error body is JSON");
 
-        assert_eq!(json["code"], "index_operation_not_found");
-        assert!(json["error"]
+        assert_eq!(json["error"], "index_operation_not_found");
+        assert!(json["msg"]
             .as_str()
             .expect("error message is a string")
             .contains("Index operation not found"));
+        assert_eq!(json.get("code"), None);
     }
 }

--- a/crates/server/src/transport_contracts.rs
+++ b/crates/server/src/transport_contracts.rs
@@ -457,6 +457,16 @@ async fn grpc_rejects_malformed_and_oversized_queries_then_shuts_down_cleanly() 
         .await
         .unwrap_err();
     assert_eq!(malformed.code(), tonic::Code::InvalidArgument);
+    assert!(malformed.message().starts_with("invalid query JSON:"));
+    assert_eq!(
+        malformed
+            .metadata()
+            .get(grpc::HELIX_ERROR_CODE_METADATA)
+            .expect("malformed-query status includes an error code")
+            .to_str()
+            .expect("error codes are ASCII"),
+        "invalid_query_json"
+    );
 
     let oversized = grpc
         .raw_query(QueryJsonRequest {
@@ -468,6 +478,15 @@ async fn grpc_rejects_malformed_and_oversized_queries_then_shuts_down_cleanly() 
         .await
         .unwrap_err();
     assert_eq!(oversized.code(), tonic::Code::ResourceExhausted);
+    assert_eq!(
+        oversized
+            .metadata()
+            .get(grpc::HELIX_ERROR_CODE_METADATA)
+            .expect("oversized-query status includes an error code")
+            .to_str()
+            .expect("error codes are ASCII"),
+        "invalid_request_body"
+    );
 
     grpc.close().await.unwrap();
 }
@@ -487,6 +506,15 @@ async fn http_rejects_malformed_oversized_and_incompatible_options() {
         .await
         .unwrap();
     assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+    let malformed_body = to_bytes(malformed.into_body(), 4_096).await.unwrap();
+    let malformed_json: serde_json::Value =
+        serde_json::from_slice(&malformed_body).expect("malformed-query error is JSON");
+    assert_eq!(malformed_json["error"], "invalid_query_json");
+    assert!(malformed_json["msg"]
+        .as_str()
+        .expect("error message is a string")
+        .starts_with("invalid query JSON:"));
+    assert_eq!(malformed_json.get("code"), None);
 
     let oversized = router
         .clone()
@@ -498,6 +526,15 @@ async fn http_rejects_malformed_oversized_and_incompatible_options() {
         .await
         .unwrap();
     assert_eq!(oversized.status(), StatusCode::BAD_REQUEST);
+    let oversized_body = to_bytes(oversized.into_body(), 4_096).await.unwrap();
+    let oversized_json: serde_json::Value =
+        serde_json::from_slice(&oversized_body).expect("oversized-query error is JSON");
+    assert_eq!(oversized_json["error"], "invalid_request_body");
+    assert!(oversized_json["msg"]
+        .as_str()
+        .expect("error message is a string")
+        .starts_with("failed to read request body:"));
+    assert_eq!(oversized_json.get("code"), None);
 
     let write = QueryRequest::write(batch::write_batch());
     let incompatible = router
@@ -510,6 +547,15 @@ async fn http_rejects_malformed_oversized_and_incompatible_options() {
         .await
         .unwrap();
     assert_eq!(incompatible.status(), StatusCode::BAD_REQUEST);
+    let incompatible_body = to_bytes(incompatible.into_body(), 4_096).await.unwrap();
+    let incompatible_json: serde_json::Value =
+        serde_json::from_slice(&incompatible_body).expect("option error is JSON");
+    assert_eq!(incompatible_json["error"], "invalid_request_option");
+    assert_eq!(
+        incompatible_json["msg"],
+        "x-helix-warm is only valid for read requests"
+    );
+    assert_eq!(incompatible_json.get("code"), None);
 
     db.close().await.unwrap();
 }
@@ -660,6 +706,15 @@ async fn grpc_enforces_writer_routing_deadlines_connection_churn_and_restart() {
         .await
         .unwrap_err();
     assert_eq!(require_writer.code(), tonic::Code::Unavailable);
+    assert_eq!(
+        require_writer
+            .metadata()
+            .get(grpc::HELIX_ERROR_CODE_METADATA)
+            .expect("writer routing status includes an error code")
+            .to_str()
+            .expect("error codes are ASCII"),
+        "invalid_request_option"
+    );
 
     let write_on_reader = read_transport
         .raw_query(QueryJsonRequest {
@@ -673,6 +728,15 @@ async fn grpc_enforces_writer_routing_deadlines_connection_churn_and_restart() {
         .await
         .unwrap_err();
     assert_eq!(write_on_reader.code(), tonic::Code::FailedPrecondition);
+    assert_eq!(
+        write_on_reader
+            .metadata()
+            .get(grpc::HELIX_ERROR_CODE_METADATA)
+            .expect("reader-mode write status includes an error code")
+            .to_str()
+            .expect("error codes are ASCII"),
+        "writer_mode_required"
+    );
 
     read_transport.close().await.unwrap();
     writer.close().await.unwrap();

--- a/docs/database/helix-db/query-guides/error-handling.mdx
+++ b/docs/database/helix-db/query-guides/error-handling.mdx
@@ -1,0 +1,268 @@
+---
+title: "Handle query errors"
+description: "Branch on stable error codes while retaining diagnostic messages"
+sidebarTitle: "Error handling"
+pageType: "Reference"
+---
+
+<div className="flex flex-wrap gap-2"><Badge color="blue" size="sm">Reference</Badge></div>
+
+Helix query failures expose a stable machine-readable code separately from the
+human-readable diagnostic. Branch on the code; log or display the message.
+Messages can gain context over time and are not a compatibility contract.
+
+## HTTP error envelope
+
+Every non-success response from `POST /v2/query` uses `error` for the static
+code and `msg` for the readable message:
+
+```json
+{
+  "error": "index_not_found",
+  "msg": "planner error: missing text index for `Document.body`"
+}
+```
+
+The response never adds a separate `code` field. HTTP status classifications
+are unchanged, so use both the status and static code when deciding whether to
+retry. A non-JSON response from an older proxy or intermediary is still exposed
+by each SDK as readable details with no code.
+
+## Access the code in an SDK
+
+<CodeGroup>
+
+```rust Rust
+match client.query::<serde_json::Value>(request).send().await {
+    Err(error) if error.error_code() == Some("index_not_found") => {
+        // Create the index, wait for it to become active, then retry.
+    }
+    Err(error) => return Err(error),
+    Ok(response) => println!("{response}"),
+}
+```
+
+```ts TypeScript
+try {
+  await client.query(request).send();
+} catch (cause) {
+  if (cause instanceof HelixError && cause.code === "index_not_found") {
+    // Create the index, wait for it to become active, then retry.
+  } else {
+    throw cause;
+  }
+}
+```
+
+```go Go
+if err := client.Exec(ctx, request, &response); err != nil {
+	var helixErr *helix.HelixError
+	if errors.As(err, &helixErr) && helixErr.Code == helix.QueryErrorCode("index_not_found") {
+		// Create the index, wait for it to become active, then retry.
+	} else {
+		return err
+	}
+}
+```
+
+```python Python
+try:
+    response = client.query(request)
+except HelixError as error:
+    if error.code == "index_not_found":
+        # Create the index, wait for it to become active, then retry.
+        pass
+    else:
+        raise
+```
+
+```json JSON
+{
+  "error": "index_not_found",
+  "msg": "planner error: missing text index for `Document.body`"
+}
+```
+
+</CodeGroup>
+
+Known Rust codes can also be parsed as `QueryErrorCode`. SDK wire fields remain
+open strings so a newer server's unknown future code is preserved rather than
+being collapsed or rejected.
+
+## Other query boundaries
+
+For gRPC, the status message remains human-readable and the same static code is
+attached as ASCII metadata under `helix-error-code`. gRPC status classes are
+unchanged.
+
+Embedded Rust errors expose `error_code()`. UniFFI errors carry two explicit
+fields named `error` and `msg`; generated Python, Node, and Go bindings pass
+that pair into their SDK error objects. Embedded callers never need to infer a
+code from exception text.
+
+## Stability and retry rules
+
+- Existing code strings are frozen compatibility identifiers. New codes may be
+  added, so applications must preserve and safely handle unknown values.
+- A code describes the failure, not whether replaying a particular mutation is
+  safe. Retry only idempotent work or work protected by an application-level
+  idempotency key.
+- `transaction_conflict` is the only HTTP conflict classification and is
+  normally retryable with bounded backoff.
+- Availability and lifecycle failures should be retried only after the named
+  condition changes. Validation and planning failures require a corrected
+  request or schema/index configuration.
+- `internal_*`, `storage_error`, and `response_serialization_error` are opaque
+  by design. Retain the `msg` and server logs when escalating them.
+
+## Error-code reference
+
+“Correctable” means whether a caller can change its request or deployment state
+to address the failure. Statuses list the current HTTP behavior; `400/503` and
+`400/500` indicate that the same code can arise at more than one boundary.
+
+### Request validation
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `invalid_request` | The request is incompatible with the selected query mode. | 400 | After fixing the request | Yes |
+| `invalid_query_json` | The query body cannot be decoded as query JSON. | 400 | After fixing the body | Yes |
+| `invalid_request_body` | The transport cannot read the body or it exceeds the body limit. | 400 | After fixing the body | Yes |
+| `invalid_request_option` | A header or transport option is invalid; writer routing can also be unavailable. | 400/503 | After fixing the option or routing | Yes |
+| `invalid_query` | An embedded or encoded query payload is invalid. | 500 | After fixing the query | Yes |
+
+### Planning
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `invalid_index_operation_id` | An index lifecycle operation ID is invalid. | 400 | After fixing the ID | Yes |
+| `unsupported_edge_all_target` | An all-edges reference was used as a finite mutation target. | 400 | After changing the traversal | Yes |
+| `non_literal_index_expression` | An index operation expression is not a literal or parameter. | 400 | After changing the expression | Yes |
+| `invalid_search_tenant` | A tenant was supplied for an unscoped search index. | 400 | After fixing tenant usage | Yes |
+| `invalid_search_tenant_value` | A search tenant value has the wrong shape. | 400 | After fixing the value | Yes |
+| `invalid_search_result_count` | A search result count is zero. | 400 | After using a positive count | Yes |
+| `invalid_search_result_count_expression` | A search result-count expression has the wrong shape. | 400 | After fixing the expression | Yes |
+| `invalid_search_input` | A text or vector search input has the wrong shape. | 400 | After fixing the input | Yes |
+| `invalid_batch_condition_min_size` | A batch condition has a zero minimum size. | 400 | After fixing the condition | Yes |
+| `invalid_initial_batch_condition` | The first batch entry depends on a previous result. | 400 | After reordering the batch | Yes |
+| `duplicate_property_assignment` | A mutation assigns the same property more than once. | 400 | After removing the duplicate | Yes |
+| `duplicate_property_selection` | A projection selects the same property more than once. | 400 | After removing the duplicate | Yes |
+| `duplicate_projection_alias` | A projection emits the same alias more than once. | 400 | After renaming an alias | Yes |
+| `duplicate_return_variable` | A batch returns the same variable more than once. | 400 | After removing the duplicate | Yes |
+| `duplicate_element_id` | A point lookup contains the same element ID more than once. | 400 | After deduplicating IDs | Yes |
+| `duplicate_order_key` | A sort contains the same property more than once. | 400 | After deduplicating keys | Yes |
+| `unbound_context` | A sub-traversal is missing its parent input. | 400 | After binding the context | Yes |
+| `invalid_sub_traversal_operation` | An operation is invalid inside a branch or repeat sub-traversal. | 400 | After changing the traversal | Yes |
+| `invalid_after_bind_operation` | An operation is invalid after a row-local bind. | 400 | After changing the traversal | Yes |
+| `read_only_traversal_in_write_batch` | A write batch contains a read-only traversal. | 400 | After moving the read | Yes |
+| `invalid_branch_arity` | A branch has too few traversals. | 400 | After adding a branch | Yes |
+| `invalid_batch_arity` | A batch has too few entries. | 400 | After adding an entry | Yes |
+| `invalid_repeat_emit` | A repeat emit predicate conflicts with its emit mode. | 400 | After fixing repeat options | Yes |
+| `invalid_repeat_count` | A repeat count or depth is zero. | 400 | After using a positive count | Yes |
+| `invalid_shortest_path_count` | A shortest-path count or depth is zero. | 400 | After using a positive count | Yes |
+| `invalid_order_keys` | An order operation has no sort keys. | 400 | After adding a key | Yes |
+| `invalid_projection_arity` | A projection has too few fields. | 400 | After adding a field | Yes |
+| `invalid_stream_range` | A stream range is statically inverted. | 400 | After fixing the range | Yes |
+| `invalid_stream_bound_expression` | A stream-bound expression has the wrong shape. | 400 | After fixing the expression | Yes |
+| `invalid_empty_name` | A required query name is empty. | 400 | After supplying a name | Yes |
+| `invalid_predicate_arity` | A predicate set has too few children. | 400 | After adding a predicate | Yes |
+
+### Execution
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `query_deadline_exceeded` | Execution exceeded its cooperative deadline. | 500 | With a larger deadline or less work | Sometimes |
+| `invalid_node_id` | A supplied node ID is invalid. | 500 | After fixing the ID | Yes |
+| `node_not_found` | A requested node does not exist. | 500 | After fixing state or ID | Yes |
+| `edge_not_found` | A requested edge does not exist. | 500 | After fixing state or endpoints | Yes |
+| `invalid_vector_configuration` | Vector index configuration is invalid. | 500 | After fixing configuration | Yes |
+| `unique_constraint_violation` | A unique index already owns the requested value. | 500 | After choosing a unique value | Yes |
+| `unsupported_unique_index_value_type` | A unique index does not support the value type. | 500 | After changing the value | Yes |
+| `invalid_vector_dimension` | A vector has the wrong dimension. | 400 | After fixing the vector | Yes |
+| `invalid_vector_component` | A vector contains a non-finite component. | 400 | After fixing the vector | Yes |
+| `vector_component_magnitude_exceeded` | A component exceeds the score-safe magnitude. | 400 | After normalizing the vector | Yes |
+| `zero_norm_cosine_vector` | A cosine vector has zero norm. | 400 | After supplying a nonzero vector | Yes |
+
+### Index lifecycle
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `index_lifecycle_unavailable` | The required lifecycle authority is unavailable. | 500 | After authority recovery | Operational |
+| `secondary_lifecycle_stepping_requires_disabled_mode` | Explicit secondary stepping requires disabled worker mode. | 500 | After changing worker mode | Operational |
+| `active_text_mutation_limit_exceeded` | An active text mutation exceeded an admission limit. | 500 | With a smaller mutation | Yes |
+| `invalid_index_source_data` | Existing graph data violates an index source contract. | 500 | After correcting source data | Yes |
+| `invalid_index_model` | A value violates the current index model. | 500 | After fixing model or value | Yes |
+| `invalid_secondary_index_value` | A value violates a secondary-index contract. | 500 | After fixing the value | Yes |
+| `identifier_exhausted` | A bounded non-index-specific identifier namespace is exhausted. | 500 | No immediate retry | Operational |
+| `index_id_exhausted` | The logical index ID namespace is exhausted. | 500 | No immediate retry | Operational |
+| `vector_physical_id_exhausted` | The vector physical index ID namespace is exhausted. | 500 | No immediate retry | Operational |
+| `index_generation_exhausted` | The index generation namespace is exhausted. | 500 | No immediate retry | Operational |
+| `index_revision_exhausted` | The index revision namespace is exhausted. | 500 | No immediate retry | Operational |
+| `index_operation_revision_exhausted` | The index-operation revision namespace is exhausted. | 500 | No immediate retry | Operational |
+| `index_already_exists` | An index with the requested identity already exists. | 500 | After using idempotent creation or a new name | Yes |
+| `index_definition_conflict` | An existing index has a conflicting definition. | 500 | After reconciling definitions | Yes |
+| `index_busy` | The index is already changing lifecycle state. | 500 | After the active operation completes | Yes |
+| `index_operation_not_found` | The requested index operation does not exist. | 500 | After fixing the operation ID | Yes |
+| `index_operation_not_abortable` | The requested operation can no longer be aborted. | 500 | No | No |
+| `index_not_found` | The required logical or physical index does not exist. | 400/500 | After creating or selecting the index | Yes |
+
+### Retryable conflicts
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `transaction_conflict` | A concurrent transaction prevented commit. | 409 | Yes, bounded backoff | No request change required |
+| `request_read_view_changed` | A standalone reader changed views during the request. | 500 | Yes, bounded retry | No request change required |
+| `stale_index_generation` | A retained handle refers to a stale index generation. | 500 | Yes, reacquire state | No request change required |
+| `writer_fenced_commit_outcome_unknown` | Writer fencing made the final commit outcome unknowable. | 500 | Only with idempotency protection | No |
+
+### Availability and migration
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `database_closed` | The database handle is closed. | 500 | After reopening | Operational |
+| `invalid_configuration` | Database configuration is invalid. | 500 | After fixing configuration | Operational |
+| `migration_required` | Existing storage requires an explicit migration. | 500 | After migration | Operational |
+| `writer_migration_required` | A writer must open and migrate existing storage. | 500 | After writer migration | Operational |
+| `unsupported_index_storage_version` | Stored index data is newer than this binary supports. | 500 | After upgrading the binary | Operational |
+| `writer_mode_required` | The operation requires a writer handle. | 503 | On a writer | Operational |
+| `reader_mode_required` | The operation requires a standalone reader handle. | 500 | On a reader | Operational |
+
+### Internal failures
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `storage_error` | Storage failed outside a classified transaction conflict. | 500 | According to storage health | Operational |
+| `internal_planner_error` | An internal planner contract failed. | 400 | No automatic retry | No |
+| `response_serialization_error` | A successful result could not be serialized. | 500 | No automatic retry | No |
+| `internal_error` | An invariant, persisted-data contract, or opaque internal operation failed. | 500 | No automatic retry | No |
+
+## Migrate direct HTTP consumers
+
+The field names changed while their roles stayed the same:
+
+| Before | Now | Meaning |
+| --- | --- | --- |
+| `code` | `error` | Stable machine-readable code |
+| `error` | `msg` | Human-readable diagnostic |
+
+Old response:
+
+```json
+{
+  "error": "planner error: missing text index for `Document.body`",
+  "code": "index_not_found"
+}
+```
+
+New response:
+
+```json
+{
+  "error": "index_not_found",
+  "msg": "planner error: missing text index for `Document.body`"
+}
+```
+
+Current SDKs read both shapes during migration. Direct HTTP consumers must move
+their code branch from `code` to `error` and their diagnostic read from `error`
+to `msg`.

--- a/docs/database/helix-db/query-guides/error-handling.mdx
+++ b/docs/database/helix-db/query-guides/error-handling.mdx
@@ -138,6 +138,8 @@ to address the failure. Statuses list the current HTTP behavior; `400/503` and
 | `invalid_index_operation_id` | An index lifecycle operation ID is invalid. | 400 | After fixing the ID | Yes |
 | `unsupported_edge_all_target` | An all-edges reference was used as a finite mutation target. | 400 | After changing the traversal | Yes |
 | `non_literal_index_expression` | An index operation expression is not a literal or parameter. | 400 | After changing the expression | Yes |
+| `missing_planning_equality_parameter` | A parameter needed to plan an equality lookup is not bound. | 400 | After binding the parameter | Yes |
+| `unsupported_planning_equality_parameter` | An equality parameter cannot be represented by the selected index. | 400 | After changing the parameter value | Yes |
 | `invalid_search_tenant` | A tenant was supplied for an unscoped search index. | 400 | After fixing tenant usage | Yes |
 | `invalid_search_tenant_value` | A search tenant value has the wrong shape. | 400 | After fixing the value | Yes |
 | `invalid_search_result_count` | A search result count is zero. | 400 | After using a positive count | Yes |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -175,7 +175,8 @@
               "database/helix-db/query-guides/filtering",
               "database/helix-db/query-guides/projections",
               "database/helix-db/query-guides/advanced",
-              "database/helix-db/query-guides/parameters"
+              "database/helix-db/query-guides/parameters",
+              "database/helix-db/query-guides/error-handling"
             ]
           }
         ]

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4077,6 +4077,268 @@ the request at runtime and send it to `POST /v2/query`.
     Apply parameters to indexed sources and filters.
   </Card>
 
+# Handle query errors
+
+Page type: Reference
+
+<div className="flex flex-wrap gap-2"><Badge color="blue" size="sm">Reference</Badge></div>
+
+Helix query failures expose a stable machine-readable code separately from the
+human-readable diagnostic. Branch on the code; log or display the message.
+Messages can gain context over time and are not a compatibility contract.
+
+## HTTP error envelope
+
+Every non-success response from `POST /v2/query` uses `error` for the static
+code and `msg` for the readable message:
+
+```json
+{
+  "error": "index_not_found",
+  "msg": "planner error: missing text index for `Document.body`"
+}
+```
+
+The response never adds a separate `code` field. HTTP status classifications
+are unchanged, so use both the status and static code when deciding whether to
+retry. A non-JSON response from an older proxy or intermediary is still exposed
+by each SDK as readable details with no code.
+
+## Access the code in an SDK
+
+```rust Rust
+match client.query::<serde_json::Value>(request).send().await {
+    Err(error) if error.error_code() == Some("index_not_found") => {
+        // Create the index, wait for it to become active, then retry.
+    }
+    Err(error) => return Err(error),
+    Ok(response) => println!("{response}"),
+}
+```
+
+```ts TypeScript
+try {
+  await client.query(request).send();
+} catch (cause) {
+  if (cause instanceof HelixError && cause.code === "index_not_found") {
+    // Create the index, wait for it to become active, then retry.
+  } else {
+    throw cause;
+  }
+}
+```
+
+```go Go
+if err := client.Exec(ctx, request, &response); err != nil {
+	var helixErr *helix.HelixError
+	if errors.As(err, &helixErr) && helixErr.Code == helix.QueryErrorCode("index_not_found") {
+		// Create the index, wait for it to become active, then retry.
+	} else {
+		return err
+	}
+}
+```
+
+```python Python
+try:
+    response = client.query(request)
+except HelixError as error:
+    if error.code == "index_not_found":
+        # Create the index, wait for it to become active, then retry.
+        pass
+    else:
+        raise
+```
+
+```json JSON
+{
+  "error": "index_not_found",
+  "msg": "planner error: missing text index for `Document.body`"
+}
+```
+
+Known Rust codes can also be parsed as `QueryErrorCode`. SDK wire fields remain
+open strings so a newer server's unknown future code is preserved rather than
+being collapsed or rejected.
+
+## Other query boundaries
+
+For gRPC, the status message remains human-readable and the same static code is
+attached as ASCII metadata under `helix-error-code`. gRPC status classes are
+unchanged.
+
+Embedded Rust errors expose `error_code()`. UniFFI errors carry two explicit
+fields named `error` and `msg`; generated Python, Node, and Go bindings pass
+that pair into their SDK error objects. Embedded callers never need to infer a
+code from exception text.
+
+## Stability and retry rules
+
+- Existing code strings are frozen compatibility identifiers. New codes may be
+  added, so applications must preserve and safely handle unknown values.
+- A code describes the failure, not whether replaying a particular mutation is
+  safe. Retry only idempotent work or work protected by an application-level
+  idempotency key.
+- `transaction_conflict` is the only HTTP conflict classification and is
+  normally retryable with bounded backoff.
+- Availability and lifecycle failures should be retried only after the named
+  condition changes. Validation and planning failures require a corrected
+  request or schema/index configuration.
+- `internal_*`, `storage_error`, and `response_serialization_error` are opaque
+  by design. Retain the `msg` and server logs when escalating them.
+
+## Error-code reference
+
+“Correctable” means whether a caller can change its request or deployment state
+to address the failure. Statuses list the current HTTP behavior; `400/503` and
+`400/500` indicate that the same code can arise at more than one boundary.
+
+### Request validation
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `invalid_request` | The request is incompatible with the selected query mode. | 400 | After fixing the request | Yes |
+| `invalid_query_json` | The query body cannot be decoded as query JSON. | 400 | After fixing the body | Yes |
+| `invalid_request_body` | The transport cannot read the body or it exceeds the body limit. | 400 | After fixing the body | Yes |
+| `invalid_request_option` | A header or transport option is invalid; writer routing can also be unavailable. | 400/503 | After fixing the option or routing | Yes |
+| `invalid_query` | An embedded or encoded query payload is invalid. | 500 | After fixing the query | Yes |
+
+### Planning
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `invalid_index_operation_id` | An index lifecycle operation ID is invalid. | 400 | After fixing the ID | Yes |
+| `unsupported_edge_all_target` | An all-edges reference was used as a finite mutation target. | 400 | After changing the traversal | Yes |
+| `non_literal_index_expression` | An index operation expression is not a literal or parameter. | 400 | After changing the expression | Yes |
+| `invalid_search_tenant` | A tenant was supplied for an unscoped search index. | 400 | After fixing tenant usage | Yes |
+| `invalid_search_tenant_value` | A search tenant value has the wrong shape. | 400 | After fixing the value | Yes |
+| `invalid_search_result_count` | A search result count is zero. | 400 | After using a positive count | Yes |
+| `invalid_search_result_count_expression` | A search result-count expression has the wrong shape. | 400 | After fixing the expression | Yes |
+| `invalid_search_input` | A text or vector search input has the wrong shape. | 400 | After fixing the input | Yes |
+| `invalid_batch_condition_min_size` | A batch condition has a zero minimum size. | 400 | After fixing the condition | Yes |
+| `invalid_initial_batch_condition` | The first batch entry depends on a previous result. | 400 | After reordering the batch | Yes |
+| `duplicate_property_assignment` | A mutation assigns the same property more than once. | 400 | After removing the duplicate | Yes |
+| `duplicate_property_selection` | A projection selects the same property more than once. | 400 | After removing the duplicate | Yes |
+| `duplicate_projection_alias` | A projection emits the same alias more than once. | 400 | After renaming an alias | Yes |
+| `duplicate_return_variable` | A batch returns the same variable more than once. | 400 | After removing the duplicate | Yes |
+| `duplicate_element_id` | A point lookup contains the same element ID more than once. | 400 | After deduplicating IDs | Yes |
+| `duplicate_order_key` | A sort contains the same property more than once. | 400 | After deduplicating keys | Yes |
+| `unbound_context` | A sub-traversal is missing its parent input. | 400 | After binding the context | Yes |
+| `invalid_sub_traversal_operation` | An operation is invalid inside a branch or repeat sub-traversal. | 400 | After changing the traversal | Yes |
+| `invalid_after_bind_operation` | An operation is invalid after a row-local bind. | 400 | After changing the traversal | Yes |
+| `read_only_traversal_in_write_batch` | A write batch contains a read-only traversal. | 400 | After moving the read | Yes |
+| `invalid_branch_arity` | A branch has too few traversals. | 400 | After adding a branch | Yes |
+| `invalid_batch_arity` | A batch has too few entries. | 400 | After adding an entry | Yes |
+| `invalid_repeat_emit` | A repeat emit predicate conflicts with its emit mode. | 400 | After fixing repeat options | Yes |
+| `invalid_repeat_count` | A repeat count or depth is zero. | 400 | After using a positive count | Yes |
+| `invalid_shortest_path_count` | A shortest-path count or depth is zero. | 400 | After using a positive count | Yes |
+| `invalid_order_keys` | An order operation has no sort keys. | 400 | After adding a key | Yes |
+| `invalid_projection_arity` | A projection has too few fields. | 400 | After adding a field | Yes |
+| `invalid_stream_range` | A stream range is statically inverted. | 400 | After fixing the range | Yes |
+| `invalid_stream_bound_expression` | A stream-bound expression has the wrong shape. | 400 | After fixing the expression | Yes |
+| `invalid_empty_name` | A required query name is empty. | 400 | After supplying a name | Yes |
+| `invalid_predicate_arity` | A predicate set has too few children. | 400 | After adding a predicate | Yes |
+
+### Execution
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `query_deadline_exceeded` | Execution exceeded its cooperative deadline. | 500 | With a larger deadline or less work | Sometimes |
+| `invalid_node_id` | A supplied node ID is invalid. | 500 | After fixing the ID | Yes |
+| `node_not_found` | A requested node does not exist. | 500 | After fixing state or ID | Yes |
+| `edge_not_found` | A requested edge does not exist. | 500 | After fixing state or endpoints | Yes |
+| `invalid_vector_configuration` | Vector index configuration is invalid. | 500 | After fixing configuration | Yes |
+| `unique_constraint_violation` | A unique index already owns the requested value. | 500 | After choosing a unique value | Yes |
+| `unsupported_unique_index_value_type` | A unique index does not support the value type. | 500 | After changing the value | Yes |
+| `invalid_vector_dimension` | A vector has the wrong dimension. | 400 | After fixing the vector | Yes |
+| `invalid_vector_component` | A vector contains a non-finite component. | 400 | After fixing the vector | Yes |
+| `vector_component_magnitude_exceeded` | A component exceeds the score-safe magnitude. | 400 | After normalizing the vector | Yes |
+| `zero_norm_cosine_vector` | A cosine vector has zero norm. | 400 | After supplying a nonzero vector | Yes |
+
+### Index lifecycle
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `index_lifecycle_unavailable` | The required lifecycle authority is unavailable. | 500 | After authority recovery | Operational |
+| `secondary_lifecycle_stepping_requires_disabled_mode` | Explicit secondary stepping requires disabled worker mode. | 500 | After changing worker mode | Operational |
+| `active_text_mutation_limit_exceeded` | An active text mutation exceeded an admission limit. | 500 | With a smaller mutation | Yes |
+| `invalid_index_source_data` | Existing graph data violates an index source contract. | 500 | After correcting source data | Yes |
+| `invalid_index_model` | A value violates the current index model. | 500 | After fixing model or value | Yes |
+| `invalid_secondary_index_value` | A value violates a secondary-index contract. | 500 | After fixing the value | Yes |
+| `identifier_exhausted` | A bounded non-index-specific identifier namespace is exhausted. | 500 | No immediate retry | Operational |
+| `index_id_exhausted` | The logical index ID namespace is exhausted. | 500 | No immediate retry | Operational |
+| `vector_physical_id_exhausted` | The vector physical index ID namespace is exhausted. | 500 | No immediate retry | Operational |
+| `index_generation_exhausted` | The index generation namespace is exhausted. | 500 | No immediate retry | Operational |
+| `index_revision_exhausted` | The index revision namespace is exhausted. | 500 | No immediate retry | Operational |
+| `index_operation_revision_exhausted` | The index-operation revision namespace is exhausted. | 500 | No immediate retry | Operational |
+| `index_already_exists` | An index with the requested identity already exists. | 500 | After using idempotent creation or a new name | Yes |
+| `index_definition_conflict` | An existing index has a conflicting definition. | 500 | After reconciling definitions | Yes |
+| `index_busy` | The index is already changing lifecycle state. | 500 | After the active operation completes | Yes |
+| `index_operation_not_found` | The requested index operation does not exist. | 500 | After fixing the operation ID | Yes |
+| `index_operation_not_abortable` | The requested operation can no longer be aborted. | 500 | No | No |
+| `index_not_found` | The required logical or physical index does not exist. | 400/500 | After creating or selecting the index | Yes |
+
+### Retryable conflicts
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `transaction_conflict` | A concurrent transaction prevented commit. | 409 | Yes, bounded backoff | No request change required |
+| `request_read_view_changed` | A standalone reader changed views during the request. | 500 | Yes, bounded retry | No request change required |
+| `stale_index_generation` | A retained handle refers to a stale index generation. | 500 | Yes, reacquire state | No request change required |
+| `writer_fenced_commit_outcome_unknown` | Writer fencing made the final commit outcome unknowable. | 500 | Only with idempotency protection | No |
+
+### Availability and migration
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `database_closed` | The database handle is closed. | 500 | After reopening | Operational |
+| `invalid_configuration` | Database configuration is invalid. | 500 | After fixing configuration | Operational |
+| `migration_required` | Existing storage requires an explicit migration. | 500 | After migration | Operational |
+| `writer_migration_required` | A writer must open and migrate existing storage. | 500 | After writer migration | Operational |
+| `unsupported_index_storage_version` | Stored index data is newer than this binary supports. | 500 | After upgrading the binary | Operational |
+| `writer_mode_required` | The operation requires a writer handle. | 503 | On a writer | Operational |
+| `reader_mode_required` | The operation requires a standalone reader handle. | 500 | On a reader | Operational |
+
+### Internal failures
+
+| Code | Meaning | HTTP | Retry | Correctable |
+| --- | --- | --- | --- | --- |
+| `storage_error` | Storage failed outside a classified transaction conflict. | 500 | According to storage health | Operational |
+| `internal_planner_error` | An internal planner contract failed. | 400 | No automatic retry | No |
+| `response_serialization_error` | A successful result could not be serialized. | 500 | No automatic retry | No |
+| `internal_error` | An invariant, persisted-data contract, or opaque internal operation failed. | 500 | No automatic retry | No |
+
+## Migrate direct HTTP consumers
+
+The field names changed while their roles stayed the same:
+
+| Before | Now | Meaning |
+| --- | --- | --- |
+| `code` | `error` | Stable machine-readable code |
+| `error` | `msg` | Human-readable diagnostic |
+
+Old response:
+
+```json
+{
+  "error": "planner error: missing text index for `Document.body`",
+  "code": "index_not_found"
+}
+```
+
+New response:
+
+```json
+{
+  "error": "index_not_found",
+  "msg": "planner error: missing text index for `Document.body`"
+}
+```
+
+Current SDKs read both shapes during migration. Direct HTTP consumers must move
+their code branch from `code` to `error` and their diagnostic read from `error`
+to `msg`.
+
 # Connect to Helix Cloud
 
 Page type: Guide

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4210,6 +4210,8 @@ to address the failure. Statuses list the current HTTP behavior; `400/503` and
 | `invalid_index_operation_id` | An index lifecycle operation ID is invalid. | 400 | After fixing the ID | Yes |
 | `unsupported_edge_all_target` | An all-edges reference was used as a finite mutation target. | 400 | After changing the traversal | Yes |
 | `non_literal_index_expression` | An index operation expression is not a literal or parameter. | 400 | After changing the expression | Yes |
+| `missing_planning_equality_parameter` | A parameter needed to plan an equality lookup is not bound. | 400 | After binding the parameter | Yes |
+| `unsupported_planning_equality_parameter` | An equality parameter cannot be represented by the selected index. | 400 | After changing the parameter value | Yes |
 | `invalid_search_tenant` | A tenant was supplied for an unscoped search index. | 400 | After fixing tenant usage | Yes |
 | `invalid_search_tenant_value` | A search tenant value has the wrong shape. | 400 | After fixing the value | Yes |
 | `invalid_search_result_count` | A search result count is zero. | 400 | After using a positive count | Yes |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -42,6 +42,7 @@ Full walkthrough: https://docs.helix-db.com/cli/getting-started
 - [Shape query results](https://docs.helix-db.com/database/helix-db/query-guides/projections): Return properties, computed values, aggregates, and correlated binding rows — Page type: Guide
 - [Branch, repeat, and condition queries](https://docs.helix-db.com/database/helix-db/query-guides/advanced): Compose sub-traversals and gate named entries without leaving one transaction — Page type: Guide
 - [Bind typed query parameters](https://docs.helix-db.com/database/helix-db/query-guides/parameters): Keep the operation tree stable while request values change — Page type: Guide
+- [Handle query errors](https://docs.helix-db.com/database/helix-db/query-guides/error-handling): Branch on stable error codes while retaining diagnostic messages — Page type: Reference
 
 ## Helix Cloud — Start Here
 - [Connect to Helix Cloud](https://docs.helix-db.com/database/helix-cloud/start-here/working-with-enterprise): Send dynamic requests through a managed gateway — Page type: Guide

--- a/docs/scripts/check-docs.mjs
+++ b/docs/scripts/check-docs.mjs
@@ -26,6 +26,7 @@ const CORE_MULTI_SDK_PAGES = [
   'database/helix-db/query-guides/filtering',
   'database/helix-db/query-guides/projections',
   'database/helix-db/query-guides/parameters',
+  'database/helix-db/query-guides/error-handling',
 ];
 const SDK_SETUP_FILES = new Set([
   'database/helix-db/start-here/sdk-setup/rust-project-setup.mdx',
@@ -349,6 +350,47 @@ for (const slug of CORE_MULTI_SDK_PAGES) {
     if (!content.includes(fence)) {
       errors.push(`${slug}: core guide is missing ${fence.slice(3)} example`);
     }
+  }
+}
+
+const errorCodeSource = fs.readFileSync(
+  path.resolve(DOCS_ROOT, '..', 'crates/ast/src/error_code.rs'),
+  'utf8',
+);
+const asStrStart = errorCodeSource.indexOf('pub const fn as_str');
+const asStrEnd = errorCodeSource.indexOf('impl core::fmt::Display', asStrStart);
+if (asStrStart < 0 || asStrEnd < 0) {
+  errors.push('crates/ast/src/error_code.rs: cannot locate QueryErrorCode::as_str');
+} else {
+  const sourceCodes = [
+    ...errorCodeSource.slice(asStrStart, asStrEnd).matchAll(/"([a-z0-9_]+)"/g),
+  ].map((match) => match[1]);
+  const errorReference = fs.readFileSync(
+    path.join(DOCS_ROOT, 'database/helix-db/query-guides/error-handling.mdx'),
+    'utf8',
+  );
+  const documentedCodes = [
+    ...errorReference.matchAll(
+      /^\| `([a-z0-9_]+)` \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \|$/gm,
+    ),
+  ].map((match) => match[1]);
+  const duplicateCodes = documentedCodes.filter(
+    (code, index) => documentedCodes.indexOf(code) !== index,
+  );
+  if (duplicateCodes.length > 0) {
+    errors.push(
+      `error-handling: duplicate catalog code(s): ${[...new Set(duplicateCodes)].join(', ')}`,
+    );
+  }
+  const sourceSet = new Set(sourceCodes);
+  const documentedSet = new Set(documentedCodes);
+  const missingCodes = [...sourceSet].filter((code) => !documentedSet.has(code));
+  const unknownCodes = [...documentedSet].filter((code) => !sourceSet.has(code));
+  if (missingCodes.length > 0) {
+    errors.push(`error-handling: missing catalog code(s): ${missingCodes.join(', ')}`);
+  }
+  if (unknownCodes.length > 0) {
+    errors.push(`error-handling: unknown catalog code(s): ${unknownCodes.join(', ')}`);
   }
 }
 

--- a/scripts/server-production-coverage-baselines.json
+++ b/scripts/server-production-coverage-baselines.json
@@ -1,19 +1,19 @@
 {
   "schema_version": 1,
   "uncovered_source_lines": {
-    "count": 124,
-    "sha256": "28c154df35f4126c6a8075491e2ee1847ee004e91dc897872f3ff04c2468f0ac",
+    "count": 127,
+    "sha256": "a21b676a79538eb4fc878257e354863c8a2ed835998ecc064178792b3af7a19b",
     "classification": "test-required",
-    "reason": "Every remaining uncovered production line in the transport server and its production-compiled query-service dependency remains in the explicit launch test backlog. The exact digest makes coverage changes require a reviewed ratchet update."
+    "reason": "Every remaining uncovered production line in the transport server and its production-compiled query-service dependency remains in the explicit launch test backlog. Three static error-code mapping lines are exhaustively covered by the database mapping tests rather than this server-only shard. The exact digest makes coverage changes require a reviewed ratchet update."
   },
   "scopes": {
     "query_service": {
-      "minimum_covered_lines": 381,
-      "minimum_percent": 86.98
+      "minimum_covered_lines": 391,
+      "minimum_percent": 86.69
     },
     "server": {
-      "minimum_covered_lines": 594,
-      "minimum_percent": 83.89
+      "minimum_covered_lines": 690,
+      "minimum_percent": 85.5
     }
   }
 }

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -234,8 +234,11 @@ create a binding.
 
 `Client.Exec` does not retry HTTP 409 conflicts automatically. Callers should
 retry only when the operation is safe to replay. Remote errors are returned as
-`*helix.HelixError` with `StatusCode` populated, and `helix.IsConflict(err)`
+`*helix.HelixError` with `StatusCode` and the static `Code` populated, and `helix.IsConflict(err)`
 or `errors.Is(err, helix.ErrConflict)` checks for HTTP 409:
+
+The canonical [query error-code reference](../../docs/database/helix-db/query-guides/error-handling.mdx)
+documents the complete catalog and migration contract.
 
 ```go
 func ExecWithConflictRetry(ctx context.Context, client *helix.Client, build func() helix.Request, out any) error {

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -13,6 +13,7 @@ import (
 )
 
 type ErrorKind string
+type QueryErrorCode string
 
 const (
 	ErrorNetwork             ErrorKind = "Network"
@@ -29,6 +30,7 @@ var ErrNativeBindingsUnavailable = errors.New("helix embedded native bindings ar
 
 type HelixError struct {
 	Kind       ErrorKind
+	Code       QueryErrorCode
 	Details    string
 	StatusCode int
 	Err        error
@@ -62,6 +64,20 @@ type Client struct {
 type nativeDB interface {
 	QueryJson([]byte) ([]byte, error)
 	Close() error
+}
+
+type nativeQueryError interface {
+	error
+	QueryError() (QueryErrorCode, string)
+}
+
+func embeddedError(err error) *HelixError {
+	result := &HelixError{Kind: ErrorEmbedded, Err: err, Details: err.Error()}
+	var queryErr nativeQueryError
+	if errors.As(err, &queryErr) {
+		result.Code, result.Details = queryErr.QueryError()
+	}
+	return result
 }
 
 type HelixDbSource interface {
@@ -165,6 +181,9 @@ func newEmbeddedClient(source HelixDbSource, cache *EmbeddedCacheConfig, reader 
 		if errors.Is(err, ErrNativeBindingsUnavailable) {
 			kind = ErrorEmbeddedUnavailable
 		}
+		if kind == ErrorEmbedded {
+			return nil, embeddedError(err)
+		}
 		return nil, &HelixError{Kind: kind, Err: err, Details: err.Error()}
 	}
 	client := &Client{embedded: db, httpClient: http.DefaultClient}
@@ -235,11 +254,15 @@ func (c *Client) Exec(ctx context.Context, req Request, out any, opts ...ExecOpt
 	}
 	if c.embedded != nil {
 		if options.writerOnly || options.warmOnly || options.awaitDurability != nil {
-			return &HelixError{Kind: ErrorInvalidRequest, Details: "exec options require server mode"}
+			return &HelixError{
+				Kind:    ErrorInvalidRequest,
+				Code:    QueryErrorCode("invalid_request"),
+				Details: "exec options require server mode",
+			}
 		}
 		response, err := c.embedded.QueryJson(body)
 		if err != nil {
-			return &HelixError{Kind: ErrorEmbedded, Err: err, Details: err.Error()}
+			return embeddedError(err)
 		}
 		if out == nil || len(response) == 0 {
 			return nil
@@ -286,11 +309,7 @@ func (c *Client) Exec(ctx context.Context, req Request, out any, opts ...ExecOpt
 		return &HelixError{Kind: ErrorNetwork, Err: err, Details: err.Error()}
 	}
 	if resp.StatusCode != http.StatusOK {
-		details := string(respBody)
-		if details == "" {
-			details = resp.Status
-		}
-		remoteErr := &HelixError{Kind: ErrorRemote, Details: details, StatusCode: resp.StatusCode}
+		remoteErr := decodeRemoteError(respBody, resp.Status, resp.StatusCode)
 		if resp.StatusCode == http.StatusConflict {
 			remoteErr.Err = ErrConflict
 		}
@@ -312,7 +331,40 @@ func (c *Client) Close() error {
 		return nil
 	}
 	if err := c.embedded.Close(); err != nil {
-		return &HelixError{Kind: ErrorEmbedded, Err: err, Details: err.Error()}
+		return embeddedError(err)
 	}
 	return nil
+}
+
+func decodeRemoteError(body []byte, fallback string, statusCode int) *HelixError {
+	var envelope struct {
+		Error string  `json:"error"`
+		Msg   *string `json:"msg"`
+		Code  *string `json:"code"`
+	}
+	if json.Unmarshal(body, &envelope) == nil && envelope.Error != "" {
+		if envelope.Msg != nil {
+			return &HelixError{
+				Kind:       ErrorRemote,
+				Code:       QueryErrorCode(envelope.Error),
+				Details:    *envelope.Msg,
+				StatusCode: statusCode,
+			}
+		}
+		code := QueryErrorCode("")
+		if envelope.Code != nil {
+			code = QueryErrorCode(*envelope.Code)
+		}
+		return &HelixError{
+			Kind:       ErrorRemote,
+			Code:       code,
+			Details:    envelope.Error,
+			StatusCode: statusCode,
+		}
+	}
+	details := string(body)
+	if details == "" {
+		details = fallback
+	}
+	return &HelixError{Kind: ErrorRemote, Details: details, StatusCode: statusCode}
 }

--- a/sdks/go/dsl_test.go
+++ b/sdks/go/dsl_test.go
@@ -707,6 +707,43 @@ func TestClientExecConflictError(t *testing.T) {
 	}
 }
 
+func TestClientExecParsesNewLegacyFutureMissingAndMalformedErrors(t *testing.T) {
+	cases := []struct {
+		body    string
+		code    QueryErrorCode
+		details string
+	}{
+		{`{"error":"index_not_found","msg":"missing index"}`, QueryErrorCode("index_not_found"), "missing index"},
+		{`{"error":"legacy message","code":"index_not_found"}`, QueryErrorCode("index_not_found"), "legacy message"},
+		{`{"error":"future_code","msg":"future message"}`, QueryErrorCode("future_code"), "future message"},
+		{`{"error":"message without code"}`, QueryErrorCode(""), "message without code"},
+		{"not JSON", QueryErrorCode(""), "not JSON"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.body, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(testCase.body))
+			}))
+			defer server.Close()
+			client, err := NewClient(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = client.Exec(context.Background(), findUsers("acme", 25), nil)
+			var helixErr *HelixError
+			if !errors.As(err, &helixErr) {
+				t.Fatalf("expected HelixError, got %T", err)
+			}
+			if helixErr.Code != testCase.code || helixErr.Details != testCase.details {
+				t.Fatalf("unexpected remote error: code=%q details=%q", helixErr.Code, helixErr.Details)
+			}
+		})
+	}
+}
+
 func TestClientAPIKeyMutationIsRaceSafe(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/sdks/go/embedded_generated_test.go
+++ b/sdks/go/embedded_generated_test.go
@@ -4,6 +4,7 @@ package helix
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -24,5 +25,30 @@ func TestGeneratedEmbeddedClientExecutesQuery(t *testing.T) {
 	}
 	if len(response.Users) != 0 {
 		t.Fatalf("expected no users in a new embedded database, got %d", len(response.Users))
+	}
+}
+
+func TestGeneratedEmbeddedErrorPreservesCodeAndMessage(t *testing.T) {
+	client, err := NewEmbeddedClient(InMemorySource{Database: "go-generated-embedded-error"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("close generated embedded client: %v", err)
+		}
+	})
+
+	_, err = client.embedded.QueryJson([]byte("{"))
+	var queryErr nativeQueryError
+	if !errors.As(err, &queryErr) {
+		t.Fatalf("expected generated query error, got %T: %v", err, err)
+	}
+	code, msg := queryErr.QueryError()
+	if code != QueryErrorCode("invalid_query_json") {
+		t.Fatalf("unexpected error code: %q", code)
+	}
+	if msg == "" {
+		t.Fatal("generated error message is empty")
 	}
 }

--- a/sdks/go/embedded_test.go
+++ b/sdks/go/embedded_test.go
@@ -14,6 +14,14 @@ type fakeNativeDB struct {
 	err      error
 }
 
+type fakeQueryError struct {
+	code QueryErrorCode
+	msg  string
+}
+
+func (e *fakeQueryError) Error() string                        { return e.msg }
+func (e *fakeQueryError) QueryError() (QueryErrorCode, string) { return e.code, e.msg }
+
 func (f *fakeNativeDB) QueryJson(request []byte) ([]byte, error) {
 	f.requests = append(f.requests, append([]byte(nil), request...))
 	if f.err != nil {
@@ -76,5 +84,22 @@ func TestEmbeddedCloseCallsNativeClose(t *testing.T) {
 	}
 	if !native.closed {
 		t.Fatal("expected native close to be called")
+	}
+}
+
+func TestEmbeddedExecPreservesNativeErrorCodeAndMessage(t *testing.T) {
+	native := &fakeNativeDB{err: &fakeQueryError{
+		code: QueryErrorCode("index_not_found"),
+		msg:  "missing text index",
+	}}
+	client := &Client{embedded: native}
+
+	err := client.Exec(context.Background(), findUsers("acme", 1), nil)
+	var helixErr *HelixError
+	if !errors.As(err, &helixErr) {
+		t.Fatalf("expected HelixError, got %T", err)
+	}
+	if helixErr.Code != QueryErrorCode("index_not_found") || helixErr.Details != "missing text index" {
+		t.Fatalf("unexpected embedded error: code=%q details=%q", helixErr.Code, helixErr.Details)
 	}
 }

--- a/sdks/go/embedded_uniffi.go
+++ b/sdks/go/embedded_uniffi.go
@@ -22,13 +22,13 @@ func openEmbedded(source HelixDbSource, reader bool, cache *EmbeddedCacheConfig)
 			}
 			db, err := native.HelixDbOpenReaderWithConfig(nativeSource, nativeCache)
 			if err != nil {
-				return nil, err
+				return nil, wrapNativeQueryError(err)
 			}
 			return &uniffiDatabase{db: db}, nil
 		}
 		db, err := native.HelixDbOpenReader(nativeSource)
 		if err != nil {
-			return nil, err
+			return nil, wrapNativeQueryError(err)
 		}
 		return &uniffiDatabase{db: db}, nil
 	}
@@ -39,13 +39,13 @@ func openEmbedded(source HelixDbSource, reader bool, cache *EmbeddedCacheConfig)
 		}
 		db, err := native.HelixDbOpenWithConfig(nativeSource, nativeCache)
 		if err != nil {
-			return nil, err
+			return nil, wrapNativeQueryError(err)
 		}
 		return &uniffiDatabase{db: db}, nil
 	}
 	db, err := native.HelixDbOpen(nativeSource)
 	if err != nil {
-		return nil, err
+		return nil, wrapNativeQueryError(err)
 	}
 	return &uniffiDatabase{db: db}, nil
 }
@@ -73,8 +73,52 @@ func nativeCacheConfig(cache EmbeddedCacheConfig) (native.EmbeddedCacheConfig, e
 
 type uniffiDatabase struct{ db *native.HelixDb }
 
-func (d *uniffiDatabase) QueryJson(request []byte) ([]byte, error) { return d.db.QueryJson(request) }
-func (d *uniffiDatabase) Close() error                             { return d.db.Close() }
+func (d *uniffiDatabase) QueryJson(request []byte) ([]byte, error) {
+	response, err := d.db.QueryJson(request)
+	if err != nil {
+		return nil, wrapNativeQueryError(err)
+	}
+	return response, nil
+}
+
+func (d *uniffiDatabase) Close() error {
+	if err := d.db.Close(); err != nil {
+		return wrapNativeQueryError(err)
+	}
+	return nil
+}
+
+type uniffiQueryError struct {
+	code  QueryErrorCode
+	msg   string
+	cause error
+}
+
+func (e *uniffiQueryError) Error() string                        { return e.msg }
+func (e *uniffiQueryError) Unwrap() error                        { return e.cause }
+func (e *uniffiQueryError) QueryError() (QueryErrorCode, string) { return e.code, e.msg }
+
+func wrapNativeQueryError(err error) error {
+	var code string
+	var msg string
+	switch value := errors.Unwrap(err).(type) {
+	case *native.HelixErrorInvalidConfig:
+		code, msg = value.Error_, value.Msg
+	case *native.HelixErrorInvalidRequest:
+		code, msg = value.Error_, value.Msg
+	case *native.HelixErrorPlanner:
+		code, msg = value.Error_, value.Msg
+	case *native.HelixErrorStorage:
+		code, msg = value.Error_, value.Msg
+	case *native.HelixErrorTransaction:
+		code, msg = value.Error_, value.Msg
+	case *native.HelixErrorInternal:
+		code, msg = value.Error_, value.Msg
+	default:
+		return err
+	}
+	return &uniffiQueryError{code: QueryErrorCode(code), msg: msg, cause: err}
+}
 func (d *uniffiDatabase) Graph(request []byte, spec graphLoadSpec) (graphBackend, error) {
 	value, err := d.db.Graph(request, nativeGraphSpec(spec))
 	if err != nil {

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -60,6 +60,11 @@ closed and the client remains reusable. For embedded operations, use
 the client owns and closes an injected transport. Calling `await client.close()`
 more than once is safe.
 
+`HelixError.code` preserves the static server or embedded code separately from
+the readable `details`. See the canonical
+[query error-code reference](../../docs/database/helix-db/query-guides/error-handling.mdx)
+for the complete catalog and migration contract.
+
 Warm a read with `client.execute(request, warm_only=True)`. Helix Cloud fans the
 ordinary read out to every eligible backend, discards the results, and returns
 an empty successful response after at least one target succeeds. Pass

--- a/sdks/python/scripts/run_server_parity.py
+++ b/sdks/python/scripts/run_server_parity.py
@@ -442,7 +442,9 @@ def _assert_post_drop_sync(client: Client, fixtures: list[tuple[str, QueryReques
         try:
             client.query(_required_fixture(fixtures, name))
         except HelixError as error:
-            if "index_not_found" in str(error):
+            if error.code == "index_not_found" or (
+                error.code is None and "index_not_found" in str(error)
+            ):
                 continue
             raise
         raise RuntimeError(f"sync {name} unexpectedly succeeded after index DROP")
@@ -455,7 +457,9 @@ async def _assert_post_drop_async(
         try:
             await client.query(_required_fixture(fixtures, name))
         except HelixError as error:
-            if "index_not_found" in str(error):
+            if error.code == "index_not_found" or (
+                error.code is None and "index_not_found" in str(error)
+            ):
                 continue
             raise
         raise RuntimeError(f"async {name} unexpectedly succeeded after index DROP")

--- a/sdks/python/src/helixdb/_client_common.py
+++ b/sdks/python/src/helixdb/_client_common.py
@@ -22,12 +22,14 @@ class HelixError(Exception):
         message: str,
         *,
         details: str | None = None,
+        code: str | None = None,
         status_code: int | None = None,
         cause: BaseException | None = None,
     ) -> None:
         super().__init__(message)
         self.kind = kind
         self.details = details
+        self.code = code
         self.status_code = status_code
         self.__cause__ = cause
 
@@ -41,11 +43,18 @@ class HelixError(Exception):
         )
 
     @classmethod
-    def remote(cls, details: str, *, status_code: int | None = None) -> "HelixError":
+    def remote(
+        cls,
+        details: str,
+        *,
+        code: str | None = None,
+        status_code: int | None = None,
+    ) -> "HelixError":
         return cls(
             "Remote",
             f"got error from server: {details}",
             details=details,
+            code=code,
             status_code=status_code,
         )
 
@@ -64,7 +73,12 @@ class HelixError(Exception):
 
     @classmethod
     def invalid_request(cls, message: str) -> "HelixError":
-        return cls("InvalidRequest", f"invalid request: {message}", details=message)
+        return cls(
+            "InvalidRequest",
+            f"invalid request: {message}",
+            details=message,
+            code="invalid_request",
+        )
 
     @classmethod
     def embedded_unavailable(
@@ -78,11 +92,30 @@ class HelixError(Exception):
         )
 
     @classmethod
-    def embedded(cls, message: str, *, cause: BaseException | None = None) -> "HelixError":
+    def embedded(
+        cls,
+        message: str,
+        *,
+        code: str | None = None,
+        cause: BaseException | None = None,
+    ) -> "HelixError":
         return cls(
             "Embedded",
             f"embedded HelixDB error: {message}",
             details=message,
+            code=code,
+            cause=cause,
+        )
+
+    @classmethod
+    def from_embedded(cls, cause: BaseException) -> "HelixError":
+        """Preserve the explicit UniFFI ``error``/``msg`` pair when available."""
+
+        code = getattr(cause, "error", None)
+        message = getattr(cause, "msg", None)
+        return cls.embedded(
+            message if isinstance(message, str) else str(cause),
+            code=code if isinstance(code, str) else None,
             cause=cause,
         )
 
@@ -181,10 +214,32 @@ def decode_response(response_body: bytes) -> Any:
         raise HelixError.serialization(str(exc), cause=exc) from exc
 
 
-def remote_details(response_body: bytes, fallback: str) -> str:
-    """Prefer a server response body while tolerating invalid UTF-8."""
+def remote_error(
+    response_body: bytes,
+    fallback: str,
+    *,
+    status_code: int | None = None,
+) -> HelixError:
+    """Decode new and legacy error envelopes without rejecting future codes."""
 
-    return response_body.decode("utf-8", errors="replace") or fallback
+    text = response_body.decode("utf-8", errors="replace")
+    try:
+        payload = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        payload = None
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        msg = payload.get("msg")
+        legacy_code = payload.get("code")
+        if isinstance(error, str) and isinstance(msg, str):
+            return HelixError.remote(msg, code=error, status_code=status_code)
+        if isinstance(error, str):
+            return HelixError.remote(
+                error,
+                code=legacy_code if isinstance(legacy_code, str) else None,
+                status_code=status_code,
+            )
+    return HelixError.remote(text or fallback, status_code=status_code)
 
 
 def parse_execute_options(options: Mapping[str, Any], *, embedded: bool) -> ExecuteOptions:

--- a/sdks/python/src/helixdb/async_client.py
+++ b/sdks/python/src/helixdb/async_client.py
@@ -13,7 +13,7 @@ from ._client_common import (
     decode_response,
     parse_execute_options,
     prepare_request,
-    remote_details,
+    remote_error,
     serialize_query,
     validate_base_url,
 )
@@ -166,7 +166,7 @@ class AsyncClient:
         except HelixError:
             raise
         except Exception as exc:
-            raise HelixError.embedded(str(exc), cause=exc) from exc
+            raise HelixError.from_embedded(exc) from exc
         return cls._from_backend(_EmbeddedBackend(native))
 
     @classmethod
@@ -191,7 +191,7 @@ class AsyncClient:
         except HelixError:
             raise
         except Exception as exc:
-            raise HelixError.embedded(str(exc), cause=exc) from exc
+            raise HelixError.from_embedded(exc) from exc
         return cls._from_backend(_EmbeddedBackend(native))
 
     def with_api_key(self, api_key: str | None = None) -> "AsyncClient":
@@ -265,7 +265,7 @@ class AsyncClient:
         try:
             await backend.native.close()
         except Exception as exc:
-            raise HelixError.embedded(str(exc), cause=exc) from exc
+            raise HelixError.from_embedded(exc) from exc
 
     async def __aenter__(self) -> "AsyncClient":
         self._request_backend()
@@ -342,7 +342,7 @@ class AsyncQueryExecutionRequest:
             except HelixError:
                 raise
             except Exception as exc:
-                raise HelixError.embedded(str(exc), cause=exc) from exc
+                raise HelixError.from_embedded(exc) from exc
 
         prepared = prepare_request(
             self._backend.base_url,
@@ -366,10 +366,7 @@ class AsyncQueryExecutionRequest:
             raise HelixError.network(str(exc), cause=exc) from exc
 
         if status != 200:
-            raise HelixError.remote(
-                remote_details(response_body, reason),
-                status_code=status,
-            )
+            raise remote_error(response_body, reason, status_code=status)
         return response_body
 
     async def send(self, *, timeout: Timeout = None) -> Any:

--- a/sdks/python/src/helixdb/client.py
+++ b/sdks/python/src/helixdb/client.py
@@ -14,7 +14,7 @@ from ._client_common import (
     decode_response,
     parse_execute_options,
     prepare_request,
-    remote_details,
+    remote_error,
     serialize_query,
     validate_base_url,
 )
@@ -56,7 +56,7 @@ class Client:
         except HelixError:
             raise
         except Exception as exc:
-            raise HelixError.embedded(str(exc), cause=exc) from exc
+            raise HelixError.from_embedded(exc) from exc
         return client
 
     @classmethod
@@ -78,7 +78,7 @@ class Client:
         except HelixError:
             raise
         except Exception as exc:
-            raise HelixError.embedded(str(exc), cause=exc) from exc
+            raise HelixError.from_embedded(exc) from exc
         return client
 
     def with_api_key(self, api_key: str | None = None) -> "Client":
@@ -102,7 +102,7 @@ class Client:
             except HelixError:
                 raise
             except Exception as exc:
-                raise HelixError.embedded(str(exc), cause=exc) from exc
+                raise HelixError.from_embedded(exc) from exc
             return decode_response(bytes(response))
         return self.request_builder().query(request).send()
 
@@ -141,7 +141,7 @@ class Client:
             except HelixError:
                 raise
             except Exception as exc:
-                raise HelixError.embedded(str(exc), cause=exc) from exc
+                raise HelixError.from_embedded(exc) from exc
         return self.request_builder().query(request).send_bytes()
 
     def close(self) -> None:
@@ -151,7 +151,7 @@ class Client:
             except HelixError:
                 raise
             except Exception as exc:
-                raise HelixError.embedded(str(exc), cause=exc) from exc
+                raise HelixError.from_embedded(exc) from exc
 
 
 HelixDBClient = Client
@@ -260,16 +260,18 @@ class QueryExecutionRequest:
                 response_body = response.read()
                 reason = getattr(response, "reason", "") or f"unknown error with code: {status}"
         except HTTPError as exc:
-            details = exc.read().decode("utf-8", errors="replace") or exc.reason or str(exc)
-            raise HelixError.remote(details, status_code=exc.code) from exc
+            raise remote_error(
+                exc.read(),
+                exc.reason or str(exc),
+                status_code=exc.code,
+            ) from exc
         except URLError as exc:
             raise HelixError.network(str(exc.reason), cause=exc) from exc
         except OSError as exc:
             raise HelixError.network(str(exc), cause=exc) from exc
 
         if status != 200:
-            details = remote_details(response_body, reason)
-            raise HelixError.remote(details, status_code=status)
+            raise remote_error(response_body, reason, status_code=status)
         return response_body
 
     def send(self) -> Any:

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -82,6 +82,13 @@ class FakeNativeHandle:
         self.closed = True
 
 
+class FakeNativeError(Exception):
+    def __init__(self, error: str, msg: str) -> None:
+        super().__init__(msg)
+        self.error = error
+        self.msg = msg
+
+
 class FakeNativeDB:
     opened: list[object] = []
     opened_readers: list[object] = []
@@ -269,6 +276,60 @@ class ClientTests(unittest.TestCase):
         self.assertEqual(ctx.exception.kind, "Remote")
         self.assertEqual(ctx.exception.status_code, 409)
         self.assertEqual(ctx.exception.details, "conflict")
+        self.assertIsNone(ctx.exception.code)
+
+    def test_remote_error_parses_new_legacy_future_missing_and_malformed_bodies(self) -> None:
+        request = QueryRequest.read(read_batch())
+        cases = [
+            (
+                b'{"error":"index_not_found","msg":"missing index"}',
+                "index_not_found",
+                "missing index",
+            ),
+            (
+                b'{"error":"legacy message","code":"index_not_found"}',
+                "index_not_found",
+                "legacy message",
+            ),
+            (b'{"error":"future_code","msg":"future message"}', "future_code", "future message"),
+            (b'{"error":"message without code"}', None, "message without code"),
+            (b"not JSON", None, "not JSON"),
+        ]
+
+        for body, expected_code, expected_details in cases:
+            with self.subTest(body=body):
+
+                def fake_urlopen(req, response_body=body):
+                    raise HTTPError(
+                        req.full_url,
+                        500,
+                        "Internal Server Error",
+                        hdrs={},
+                        fp=BytesIO(response_body),
+                    )
+
+                with patch("helixdb.client.urlopen", fake_urlopen):
+                    with self.assertRaises(HelixError) as ctx:
+                        Client("http://127.0.0.1:6969").query(request)
+
+                self.assertEqual(ctx.exception.code, expected_code)
+                self.assertEqual(ctx.exception.details, expected_details)
+
+    def test_embedded_error_preserves_uniffi_code_and_message_fields(self) -> None:
+        request = QueryRequest.read(read_batch())
+
+        with patch.dict(sys.modules, {"helixdb_uniffi": fake_native_module()}):
+            client = Client.embedded(InMemory("py-sdk-embedded-error"))
+            FakeNativeDB.handle.error = FakeNativeError(
+                "index_not_found",
+                "missing text index",
+            )
+            with self.assertRaises(HelixError) as ctx:
+                client.query(request)
+
+        self.assertEqual(ctx.exception.kind, "Embedded")
+        self.assertEqual(ctx.exception.code, "index_not_found")
+        self.assertEqual(ctx.exception.details, "missing text index")
 
     def test_embedded_client_query_uses_native_handle(self) -> None:
         request = QueryRequest.read(

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -183,7 +183,9 @@ Optional header toggles can be chained before choosing the query kind:
 
 `send()` is generic over the deserialized response type `R` and returns `Result<R, HelixError>`.
 `HelixError` distinguishes transport errors, non-success responses from the server (`RemoteError`),
-serialization failures, and invalid URLs.
+serialization failures, and invalid URLs. Use `error.error_code()` to branch on a
+static code without parsing the diagnostic. See the canonical
+[query error-code reference](../../docs/database/helix-db/query-guides/error-handling.mdx).
 
 A successful warm read returns `204 No Content` with no query payload after at
 least one eligible backend succeeds. Chain `.writer_only().warm_only()` to warm

--- a/sdks/rust/examples/generate_parity_fixtures.rs
+++ b/sdks/rust/examples/generate_parity_fixtures.rs
@@ -126,7 +126,7 @@ async fn execute_embedded_fixtures(
                 Ok(response) => break response,
                 // Embedded errors preserve retry classification in their DB
                 // details even though the SDK error surface is transport-neutral.
-                Err(HelixError::EmbeddedError { details })
+                Err(HelixError::EmbeddedError { details, .. })
                     if details.contains("Transaction error: transaction conflict")
                         && attempt + 1 < TRANSACTION_CONFLICT_ATTEMPTS =>
                 {

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -74,6 +74,7 @@ pub mod dsl;
 pub mod graph;
 pub mod lifecycle;
 
+pub use helix_ast::error_code::{QueryErrorCode, UnknownQueryErrorCode};
 pub use lifecycle::*;
 
 #[cfg(feature = "embedded")]
@@ -181,6 +182,8 @@ pub enum HelixError {
     /// available.
     #[error("Got Error from server: {details}")]
     RemoteError {
+        /// Static server code, including unknown future values.
+        code: Option<String>,
         /// Server-provided error text, or a fallback description of the status.
         details: String,
     },
@@ -201,9 +204,25 @@ pub enum HelixError {
     #[cfg(feature = "embedded")]
     #[error("Embedded DB error: {details}")]
     EmbeddedError {
+        /// Static embedded error code.
+        code: String,
         /// Error text from the embedded DB layer.
         details: String,
     },
+}
+
+impl HelixError {
+    /// Return the stable query error code when the failure has one.
+    #[must_use]
+    pub fn error_code(&self) -> Option<&str> {
+        match self {
+            Self::RemoteError { code, .. } => code.as_deref(),
+            Self::InvalidRequest { .. } => Some(QueryErrorCode::InvalidRequest.as_str()),
+            #[cfg(feature = "embedded")]
+            Self::EmbeddedError { code, .. } => Some(code),
+            Self::ReqwestError(_) | Self::SerializationError(_) | Self::InvalidURL(_) => None,
+        }
+    }
 }
 
 impl Client {
@@ -366,8 +385,35 @@ impl Client {
 #[cfg(feature = "embedded")]
 fn embedded_error(error: db::error::HelixDbError) -> HelixError {
     HelixError::EmbeddedError {
+        code: error.error_code().to_string(),
         details: error.to_string(),
     }
+}
+
+#[derive(Deserialize)]
+struct QueryErrorEnvelope {
+    error: String,
+    msg: Option<String>,
+    code: Option<String>,
+}
+
+fn remote_error(response_body: String, fallback: String) -> HelixError {
+    let parsed = sonic_rs::from_str::<QueryErrorEnvelope>(&response_body);
+    let (code, details) = match parsed {
+        Ok(envelope) => match envelope.msg {
+            Some(msg) => (Some(envelope.error), msg),
+            None => (envelope.code, envelope.error),
+        },
+        Err(_) => (
+            None,
+            if response_body.is_empty() {
+                fallback
+            } else {
+                response_body
+            },
+        ),
+    };
+    HelixError::RemoteError { code, details }
 }
 
 /// Fluent builder for a single request, produced by [`Client::query`].
@@ -475,15 +521,14 @@ impl<'hlx, 'a, R> QueryExecutionRequest<'hlx, 'a, R> {
                         .await
                         .map(|bytes| bytes.to_vec())
                         .map_err(Into::into),
-                    code => match response.text().await {
-                        Ok(details) => Err(HelixError::RemoteError { details }),
-                        Err(_) => Err(HelixError::RemoteError {
-                            details: code.canonical_reason().map_or_else(
-                                || format!("unknown error with code: {code}"),
-                                str::to_string,
-                            ),
-                        }),
-                    },
+                    status => {
+                        let fallback = status.canonical_reason().map_or_else(
+                            || format!("unknown error with code: {status}"),
+                            str::to_string,
+                        );
+                        let response_body = response.text().await.unwrap_or_default();
+                        Err(remote_error(response_body, fallback))
+                    }
                 }
             }
             #[cfg(feature = "embedded")]
@@ -1135,6 +1180,43 @@ mod client_tests {
         assert!(server_backend(&cleared).api_key.is_none());
     }
 
+    #[test]
+    fn remote_errors_parse_new_legacy_future_and_fallback_contracts() {
+        let cases = [
+            (
+                r#"{"error":"index_not_found","msg":"missing index"}"#,
+                Some("index_not_found"),
+                "missing index",
+            ),
+            (
+                r#"{"error":"legacy message","code":"index_not_found"}"#,
+                Some("index_not_found"),
+                "legacy message",
+            ),
+            (
+                r#"{"error":"future_code","msg":"future message"}"#,
+                Some("future_code"),
+                "future message",
+            ),
+            (
+                r#"{"error":"message without a code"}"#,
+                None,
+                "message without a code",
+            ),
+            ("not JSON", None, "not JSON"),
+            ("", None, "Bad Request"),
+        ];
+
+        for (body, expected_code, expected_details) in cases {
+            let error = remote_error(body.to_string(), "Bad Request".to_string());
+            assert_eq!(error.error_code(), expected_code);
+            let HelixError::RemoteError { details, .. } = error else {
+                panic!("remote parser always returns a remote error");
+            };
+            assert_eq!(details, expected_details);
+        }
+    }
+
     // ---- Header assembly ----------------------------------------------------
 
     #[test]
@@ -1260,6 +1342,7 @@ mod client_tests {
             .expect_err("embedded reader should reject writes");
 
         assert!(matches!(err, HelixError::EmbeddedError { .. }));
+        assert_eq!(err.error_code(), Some("writer_mode_required"));
         assert!(err.to_string().contains("writer mode"));
     }
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -98,6 +98,9 @@ remains supported as a deprecated compatibility alias.
 
 `HelixError.kind` distinguishes `Network`, `Remote`, `Serialization`,
 `InvalidUrl`, `InvalidRequest`, `EmbeddedUnavailable`, and `Embedded` failures.
+`HelixError.code` preserves the static server or embedded code separately from
+`details`. See the canonical
+[query error-code reference](../../docs/database/helix-db/query-guides/error-handling.mdx).
 
 ## Parameter Schemas
 

--- a/sdks/typescript/scripts/parity/run-embedded-parity.ts
+++ b/sdks/typescript/scripts/parity/run-embedded-parity.ts
@@ -128,6 +128,17 @@ try {
   }
   const goPackage = join(goBindings, "helixdb");
   await copyFile(nativeLibrary, join(goPackage, basename(nativeLibrary)));
+  run(
+    "go",
+    ["test", "-tags", "helixdb_uniffi", "./..."],
+    goSdk,
+    900_000,
+    embeddedEnv(join(temp, "go-test-results"), "go-sdk-binding-tests", goPackage, "memory", disks.go, {
+      CGO_ENABLED: "1",
+      CGO_LDFLAGS: `-L${goPackage} -lhelixdb_uniffi`,
+      GOCACHE: join(temp, "go-build-cache"),
+    }),
+  );
 
   for (const storage of storageModes) {
     run(

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -27,12 +27,14 @@ const QUERY_PATH = "/v2/query";
 export class HelixError extends Error {
   readonly kind: "Network" | "Remote" | "Serialization" | "InvalidUrl" | "InvalidRequest" | "EmbeddedUnavailable" | "Embedded";
   readonly details?: string;
+  readonly code?: string;
 
-  private constructor(kind: HelixError["kind"], message: string, details?: string) {
+  private constructor(kind: HelixError["kind"], message: string, details?: string, code?: string) {
     super(message);
     this.name = "HelixError";
     this.kind = kind;
     this.details = details;
+    this.code = code;
   }
 
   static network(message: string, url?: string): HelixError {
@@ -42,8 +44,8 @@ export class HelixError extends Error {
     return new HelixError("Network", `error communicating with server: ${message}.${hint}`, message);
   }
 
-  static remote(details: string): HelixError {
-    return new HelixError("Remote", `got error from server: ${details}`, details);
+  static remote(details: string, code?: string): HelixError {
+    return new HelixError("Remote", `got error from server: ${details}`, details, code);
   }
 
   static serialization(message: string): HelixError {
@@ -55,16 +57,44 @@ export class HelixError extends Error {
   }
 
   static invalidRequest(message: string): HelixError {
-    return new HelixError("InvalidRequest", `invalid request: ${message}`, message);
+    return new HelixError("InvalidRequest", `invalid request: ${message}`, message, "invalid_request");
   }
 
   static embeddedUnavailable(message: string): HelixError {
     return new HelixError("EmbeddedUnavailable", `embedded bindings unavailable: ${message}`, message);
   }
 
-  static embedded(message: string): HelixError {
-    return new HelixError("Embedded", `embedded HelixDB error: ${message}`, message);
+  static embedded(message: string, code?: string): HelixError {
+    return new HelixError("Embedded", `embedded HelixDB error: ${message}`, message, code);
   }
+}
+
+function embeddedError(error: unknown): HelixError {
+  if (typeof error === "object" && error !== null) {
+    const fields = error as { error?: unknown; msg?: unknown };
+    if (typeof fields.error === "string" && typeof fields.msg === "string") {
+      return HelixError.embedded(fields.msg, fields.error);
+    }
+  }
+  return HelixError.embedded(error instanceof Error ? error.message : String(error));
+}
+
+function remoteError(body: string, fallback: string): HelixError {
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    if (typeof parsed === "object" && parsed !== null) {
+      const fields = parsed as { error?: unknown; msg?: unknown; code?: unknown };
+      if (typeof fields.error === "string" && typeof fields.msg === "string") {
+        return HelixError.remote(fields.msg, fields.error);
+      }
+      if (typeof fields.error === "string") {
+        return HelixError.remote(fields.error, typeof fields.code === "string" ? fields.code : undefined);
+      }
+    }
+  } catch {
+    // Non-JSON response bodies remain useful human-readable details.
+  }
+  return HelixError.remote(body.length === 0 ? fallback : body);
 }
 
 type ClientBackend = { kind: "server"; url: URL; apiKey?: string } | { kind: "embedded"; native: NativeHelixDB };
@@ -181,7 +211,7 @@ export class Client {
             : await native.HelixDB.open_with_config(nativeSource, toNativeCacheConfig(native.EmbeddedCacheMode, cache)),
       });
     } catch (error) {
-      throw HelixError.embedded(error instanceof Error ? error.message : String(error));
+      throw embeddedError(error);
     }
   }
 
@@ -197,7 +227,7 @@ export class Client {
             : await native.HelixDB.open_reader_with_config(nativeSource, toNativeCacheConfig(native.EmbeddedCacheMode, cache)),
       });
     } catch (error) {
-      throw HelixError.embedded(error instanceof Error ? error.message : String(error));
+      throw embeddedError(error);
     }
   }
 
@@ -233,7 +263,7 @@ export class Client {
       try {
         return (await this.backend.native.graph(request.toJsonBytes(), nativeSpec)) as Record<string, any>;
       } catch (error) {
-        throw HelixError.embedded(error instanceof Error ? error.message : String(error));
+        throw embeddedError(error);
       }
     }
     return this.requestBuilder<Uint8Array>().query(request).sendBytes();
@@ -244,7 +274,7 @@ export class Client {
       try {
         await this.backend.native.close();
       } catch (error) {
-        throw HelixError.embedded(error instanceof Error ? error.message : String(error));
+        throw embeddedError(error);
       }
     }
   }
@@ -298,7 +328,7 @@ export class QueryExecutionRequest<R = unknown> {
       try {
         response = await backend.native.query_json(query.toJsonBytes());
       } catch (error) {
-        throw HelixError.embedded(error instanceof Error ? error.message : String(error));
+        throw embeddedError(error);
       }
       return response;
     }
@@ -325,14 +355,13 @@ export class QueryExecutionRequest<R = unknown> {
       return new Uint8Array(await response.arrayBuffer());
     }
 
-    let details: string;
+    let body: string;
     try {
-      details = await response.text();
+      body = await response.text();
     } catch {
-      details = response.statusText;
+      body = "";
     }
-    if (details.length === 0) details = response.statusText || `unknown error with code: ${response.status}`;
-    throw HelixError.remote(details);
+    throw remoteError(body, response.statusText || `unknown error with code: ${response.status}`);
   }
 
   async send(): Promise<R> {

--- a/sdks/typescript/test/client.test.ts
+++ b/sdks/typescript/test/client.test.ts
@@ -75,7 +75,11 @@ async function withFakeNativeModule<T>(run: (moduleUrl: string) => Promise<T>): 
 export const calls = [];
 export const queryBodies = [];
 let closed = false;
+let queryError;
 export const wasClosed = () => closed;
+export const setQueryError = (error, msg) => {
+  queryError = { error, msg };
+};
 
 export const HelixDbSource = {
   InMemory: (database) => ({ variant: "InMemory", database }),
@@ -107,6 +111,7 @@ function handle() {
   return {
     async query_json(request) {
       queryBodies.push(new TextDecoder().decode(request));
+      if (queryError !== undefined) throw Object.assign(new Error(queryError.msg), queryError);
       return new TextEncoder().encode('{"users":0}');
     },
     async close() {
@@ -216,6 +221,35 @@ assert.throws(
   await server.close();
 }
 
+for (const testCase of [
+  {
+    body: '{"error":"index_not_found","msg":"missing index"}',
+    code: "index_not_found",
+    details: "missing index",
+  },
+  {
+    body: '{"error":"legacy message","code":"index_not_found"}',
+    code: "index_not_found",
+    details: "legacy message",
+  },
+  {
+    body: '{"error":"future_code","msg":"future message"}',
+    code: "future_code",
+    details: "future message",
+  },
+  { body: '{"error":"message without code"}', code: undefined, details: "message without code" },
+  { body: "not JSON", code: undefined, details: "not JSON" },
+]) {
+  const server = await spawnCaptureServer({ status: 500, body: testCase.body });
+  const client = new Client(server.base);
+  await assert.rejects(
+    client.query(sampleRequest()).send(),
+    (error: unknown) =>
+      error instanceof HelixError && error.kind === "Remote" && error.code === testCase.code && error.details === testCase.details,
+  );
+  await server.close();
+}
+
 // ---- Unreachable server surfaces an actionable network error ----------------
 
 {
@@ -248,6 +282,21 @@ await withFakeNativeModule(async (moduleUrl) => {
   assert.deepEqual(native.calls[0], ["open", { variant: "InMemory", database: "ts-sdk-embedded" }]);
   assert.equal(JSON.parse(native.queryBodies[0]).request_type, "read");
   assert.equal(native.wasClosed(), true);
+});
+
+await withFakeNativeModule(async (moduleUrl) => {
+  const client = await Client.embedded({ kind: "inMemory", database: "ts-sdk-embedded-error" });
+  const native = (await import(moduleUrl)) as { setQueryError: (error: string, msg: string) => void };
+  native.setQueryError("index_not_found", "missing text index");
+
+  await assert.rejects(
+    client.query(sampleRequest()).send(),
+    (error: unknown) =>
+      error instanceof HelixError &&
+      error.kind === "Embedded" &&
+      error.code === "index_not_found" &&
+      error.details === "missing text index",
+  );
 });
 
 await withFakeNativeModule(async (moduleUrl) => {


### PR DESCRIPTION
## Summary

- add a shared, exhaustive `QueryErrorCode` catalog with typed planner, database, and query-service mappings
- return HTTP errors as `{ "error": code, "msg": message }`, attach gRPC codes through `helix-error-code` metadata, and preserve the same pair through UniFFI
- expose codes separately in the Rust, Python, TypeScript, and Go SDKs while accepting legacy envelopes, unknown future codes, and non-JSON responses
- publish the canonical multi-SDK error-handling guide, validate catalog completeness, and regenerate `llms.txt` artifacts

## Impact

Callers can branch on stable machine-readable error codes without parsing human-readable messages. Existing status classifications and messages remain unchanged. Direct HTTP consumers must migrate from `code` to `error` and from the old human-readable `error` field to `msg`; updated SDKs retain backward-reading compatibility.

## Validation

- `cargo test --workspace` (including doctests)
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check` and explicit Rust 2024 formatting checks
- exhaustive planner/database mappings and HTTP/gRPC/UniFFI contract tests
- Rust, Python, TypeScript, and Go SDK test and coverage suites
- generated-binding parity across 233 fixtures for Rust, TypeScript, Go, synchronous Python, and asynchronous Python
- planner and server production coverage gates
- `npm run check` from `docs/`, including navigation, multi-SDK examples, catalog completeness, and generated documentation

## Coverage note

All tests in the aggregate and production-linked DB coverage runs passed. Their broad percentage/classification gates still report existing cross-scope deficits unrelated to this focused change, so those DB baselines were not weakened. The server coverage baseline was narrowly ratcheted: covered lines increased from 594 to 690 for server code and from 381 to 391 for query-service code, with the updated exact uncovered-line digest documented in the baseline rationale.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a shared static query-error catalog and propagates stable codes alongside messages through the planner, database, HTTP, gRPC, UniFFI, and four SDKs.
- Adds exhaustive planner and database error-to-code mappings.
- Changes HTTP failures to `{ "error": code, "msg": message }` and adds gRPC error-code metadata.
- Preserves codes and messages through embedded bindings and SDK-specific error types.
- Adds compatibility parsing, contract tests, parity coverage, and multi-SDK error-handling documentation.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/ast/src/error_code.rs | Defines the exhaustive stable error-code catalog, frozen wire strings, parsing, serialization, and round-trip tests. |
| crates/planner/src/error/mod.rs | Exhaustively maps planner rejection and internal-failure variants to semantically specific public error codes. |
| crates/db/src/error.rs | Adds exhaustive database error-code classification while retaining the narrower index-lifecycle compatibility helper. |
| crates/db/src/query_service.rs | Propagates planner, database, and response-serialization codes through the shared query-service boundary. |
| crates/server/src/http.rs | Emits the new `{error, msg}` envelope while preserving existing HTTP status and message classifications. |
| crates/server/src/grpc.rs | Attaches legal snake-case error codes through gRPC metadata on transport-local and service failures. |
| bindings/uniffi/src/error.rs | Extends embedded error variants with separate stable-code and human-message fields and exhaustively maps database failures. |
| sdks/rust/src/lib.rs | Exposes optional remote and embedded error codes while retaining legacy and non-JSON response fallbacks. |
| sdks/go/client.go | Decodes current and legacy error envelopes and exposes the stable code on Go client errors. |
| sdks/python/src/helixdb/_client_common.py | Centralizes compatible extraction of server and embedded error codes without rejecting unknown future values. |
| sdks/typescript/src/index.ts | Adds structured remote and embedded error parsing with legacy-envelope and plain-text fallbacks. |
| crates/server/src/transport_contracts.rs | Verifies code, message, status, and metadata parity across HTTP, gRPC, query-service, and embedded boundaries. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant C as SDK caller
  participant T as HTTP or gRPC transport
  participant Q as Query service
  participant P as Planner
  participant D as Database
  C->>T: Query request
  T->>Q: Parsed request and options
  Q->>P: Plan query
  alt Planner failure
    P-->>Q: PlannerError + QueryErrorCode
  else Database failure
    P-->>Q: Executable plan
    Q->>D: Execute plan
    D-->>Q: HelixDbError + QueryErrorCode
  end
  Q-->>T: Message and stable code
  alt HTTP
    T-->>C: "status + {error, msg}"
  else gRPC
    T-->>C: status + helix-error-code metadata
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(python): match parity failures by er..."](https://github.com/helixdb/helix-db/commit/67bc3b1303556c506241c0f3ba4b5b6f3e1312ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54318549)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Query AST and SDK wire contract](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/query-ast-and-sdk-contract.md)
- Knowledge Base — [Query planner and executable plans](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/query-planner.md)
- Knowledge Base — [Database runtime, storage, search, and index lifecycle](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/database-runtime.md)
- Knowledge Base — [HTTP and gRPC server transports](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/server-transports.md)
- Knowledge Base — [Native graph loading, algorithms, and FFI bindings](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/native-graph-and-bindings.md)
</details>

<!-- /greptile_comment -->