### PR TITLE
Infer empty return shapes

### DIFF
--- a/crates/db/src/execution/interpreter/mod.rs
+++ b/crates/db/src/execution/interpreter/mod.rs
@@ -30,7 +30,7 @@ pub mod production_contracts;
 
 pub use types::{
     ElementRef, ExecutionResult, ExecutionRow, ExecutionScalar, ExecutionValue, FoldedStream,
-    RowPath, RowSack, RowVirtualProperties,
+    ReturnedValue, RowPath, RowSack, RowVirtualProperties,
 };
 use types::{ExecutionValueSlot, ExecutionValueStore};
 
@@ -160,7 +160,7 @@ impl<'db> Interpreter<'db> {
         {
             return Err(error);
         }
-        let result = self.ctx.finish(plan.root(), plan.returns());
+        let result = self.ctx.finish(plan.root(), plan.executable_returns());
         if result.is_ok()
             && matches!(
                 request_mode,

--- a/crates/db/src/execution/interpreter/mod.rs
+++ b/crates/db/src/execution/interpreter/mod.rs
@@ -32,7 +32,7 @@ pub mod production_contracts;
 
 pub use types::{
     ElementRef, ExecutionResult, ExecutionRow, ExecutionScalar, ExecutionValue, FoldedStream,
-    RowPath, RowSack, RowVirtualProperties,
+    ReturnedValue, RowPath, RowSack, RowVirtualProperties,
 };
 use types::{ExecutionValueSlot, ExecutionValueStore};
 
@@ -168,7 +168,7 @@ impl<'db> Interpreter<'db> {
         {
             return Err(error);
         }
-        let result = self.ctx.finish(plan.root(), plan.returns());
+        let result = self.ctx.finish(plan.root(), plan.executable_returns());
         if result.is_ok()
             && matches!(
                 request_mode,

--- a/crates/db/src/execution/interpreter/runtime_context.rs
+++ b/crates/db/src/execution/interpreter/runtime_context.rs
@@ -272,6 +272,8 @@ pub(in crate::execution::interpreter) struct ExecutionContext<'db> {
     pub(in crate::execution::interpreter) tenant_scope: crate::encoding::keys::tenant::DataScope,
     pub(in crate::execution::interpreter) params: ParamBindingsOwnership,
     pub(in crate::execution::interpreter) variables: ExecutionValueStore<ir::NonEmptyString>,
+    pub(in crate::execution::interpreter) variable_return_shapes:
+        Arc<BTreeMap<ir::NonEmptyString, exec::ReturnShape>>,
     pub(in crate::execution::interpreter) step_outputs: ExecutionValueStore<exec::ExecStepId>,
     pub(in crate::execution::interpreter) step_output_uses: StepOutputUsePlan,
     pub(in crate::execution::interpreter) request_read_scope:
@@ -341,6 +343,7 @@ impl<'db> ExecutionContext<'db> {
             tenant_scope,
             params: ParamBindingsOwnership::Unique(params),
             variables: ExecutionValueStore::default(),
+            variable_return_shapes: Arc::default(),
             step_outputs: ExecutionValueStore::default(),
             step_output_uses: StepOutputUsePlan::default(),
             request_read_scope: super::read_view::RequestReadScopeState::Disabled,

--- a/crates/db/src/execution/interpreter/scheduler.rs
+++ b/crates/db/src/execution/interpreter/scheduler.rs
@@ -7,6 +7,7 @@
 
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 
 use futures::future;
 
@@ -128,6 +129,7 @@ impl<'db> ExecutionContext<'db> {
             tenant_scope: self.tenant_scope,
             params: self.params.shallow_snapshot(),
             variables: self.variables.shallow_snapshot(),
+            variable_return_shapes: Arc::clone(&self.variable_return_shapes),
             step_outputs,
             step_output_uses,
             request_read_scope: self.clone_parallel_request_read_scope(),

--- a/crates/db/src/execution/interpreter/state.rs
+++ b/crates/db/src/execution/interpreter/state.rs
@@ -12,21 +12,32 @@ impl<'db> ExecutionContext<'db> {
     pub(in crate::execution::interpreter) fn finish(
         &mut self,
         root: exec::ExecStepId,
-        returns: &ir::ReturnPlan,
+        returns: &exec::ExecutableReturns,
     ) -> Result<ExecutionResult> {
         self.step_output_uses.remove(&root);
         let last = self.step_outputs.remove(&root);
         let returns = match returns {
-            ir::ReturnPlan::None => BTreeMap::new(),
-            ir::ReturnPlan::Variables(names) => names
+            exec::ExecutableReturns::None => BTreeMap::new(),
+            exec::ExecutableReturns::Variables(returns) => returns
                 .as_ref()
                 .iter()
-                .map(|name| {
-                    self.variables
-                        .get(name)
-                        .cloned()
-                        .map(|value| (name.clone(), value))
-                        .ok_or_else(|| missing_variable("return variable", name))
+                .map(|planned| {
+                    let value = match self.variables.get(planned.name()).cloned() {
+                        Some(value) if value.is_empty() => match planned.shape() {
+                            exec::ReturnShape::List => ReturnedValue::EmptyList,
+                            exec::ReturnShape::Object => ReturnedValue::EmptyObject,
+                            exec::ReturnShape::Scalar => ReturnedValue::Present(value),
+                        },
+                        Some(value) => ReturnedValue::Present(value),
+                        None => match planned.shape() {
+                            exec::ReturnShape::List => ReturnedValue::EmptyList,
+                            exec::ReturnShape::Object => ReturnedValue::EmptyObject,
+                            exec::ReturnShape::Scalar => {
+                                return Err(missing_variable("return variable", planned.name()));
+                            }
+                        },
+                    };
+                    Ok((planned.name().clone(), value))
                 })
                 .collect::<Result<BTreeMap<_, _>>>()?,
         };
@@ -140,11 +151,16 @@ mod tests {
         test_support::name(value)
     }
 
-    fn return_variables(names: Vec<&str>) -> ir::ReturnPlan {
-        ir::ReturnPlan::Variables(
-            ir::ReturnVariables::new(
-                ir::AtLeast::<_, 1>::try_from_vec(names.into_iter().map(name).collect())
-                    .expect("non-empty return variable list"),
+    fn return_variables(returns: Vec<(&str, exec::ReturnShape)>) -> exec::ExecutableReturns {
+        exec::ExecutableReturns::Variables(
+            exec::ExecutableReturnVariables::new(
+                ir::AtLeast::<_, 1>::try_from_vec(
+                    returns
+                        .into_iter()
+                        .map(|(variable, shape)| exec::ExecutableReturn::new(name(variable), shape))
+                        .collect(),
+                )
+                .expect("non-empty return variable list"),
             )
             .expect("unique return variables"),
         )
@@ -167,7 +183,13 @@ mod tests {
             .insert(ignored.clone(), ExecutionValue::Stream(Vec::new()));
 
         let result = ctx
-            .finish(root, &return_variables(vec!["all", "selected"]))
+            .finish(
+                root,
+                &return_variables(vec![
+                    ("all", exec::ReturnShape::Scalar),
+                    ("selected", exec::ReturnShape::Scalar),
+                ]),
+            )
             .unwrap();
 
         assert_eq!(result.last, Some(ExecutionValue::Stream(vec![row(7)])));
@@ -177,10 +199,13 @@ mod tests {
             Some(&ExecutionValue::Stream(Vec::new()))
         );
         assert_eq!(result.returns.len(), 2);
-        assert_eq!(result.returns.get(&all), Some(&ExecutionValue::Count(11)));
+        assert_eq!(
+            result.returns.get(&all),
+            Some(&ReturnedValue::Present(ExecutionValue::Count(11)))
+        );
         assert_eq!(
             result.returns.get(&selected),
-            Some(&ExecutionValue::Bool(true))
+            Some(&ReturnedValue::Present(ExecutionValue::Bool(true)))
         );
         assert!(!result.returns.contains_key(&ignored));
     }
@@ -195,7 +220,7 @@ mod tests {
         ctx.variables
             .insert(bound.clone(), ExecutionValue::Stream(vec![row(1), row(2)]));
 
-        let result = ctx.finish(root, &ir::ReturnPlan::None).unwrap();
+        let result = ctx.finish(root, &exec::ExecutableReturns::None).unwrap();
 
         assert_eq!(result.last, Some(ExecutionValue::Count(3)));
         assert!(result.returns.is_empty());
@@ -211,12 +236,64 @@ mod tests {
         let mut ctx = ExecutionContext::new(&db, context::ParamBindings::default());
 
         let err = ctx
-            .finish(step_id(1), &return_variables(vec!["missing"]))
+            .finish(
+                step_id(1),
+                &return_variables(vec![("missing", exec::ReturnShape::Scalar)]),
+            )
             .unwrap_err();
 
         assert!(err
             .to_string()
             .contains("return variable `missing` is not bound"));
+    }
+
+    #[tokio::test]
+    async fn finish_normalizes_only_empty_list_and_object_returns() {
+        let db = test_support::open_db("state-finish-empty-shapes").await;
+        let root = step_id(1);
+        let list = name("list");
+        let object = name("object");
+        let scalar = name("scalar");
+        let missing_list = name("missing_list");
+        let missing_object = name("missing_object");
+        let mut ctx = ExecutionContext::new(&db, context::ParamBindings::default());
+        ctx.variables
+            .insert(list.clone(), ExecutionValue::Stream(Vec::new()));
+        ctx.variables
+            .insert(object.clone(), ExecutionValue::Scalars(Vec::new()));
+        ctx.variables
+            .insert(scalar.clone(), ExecutionValue::Count(0));
+
+        let result = ctx
+            .finish(
+                root,
+                &return_variables(vec![
+                    ("list", exec::ReturnShape::List),
+                    ("object", exec::ReturnShape::Object),
+                    ("scalar", exec::ReturnShape::Scalar),
+                    ("missing_list", exec::ReturnShape::List),
+                    ("missing_object", exec::ReturnShape::Object),
+                ]),
+            )
+            .unwrap();
+
+        assert_eq!(result.returns.get(&list), Some(&ReturnedValue::EmptyList));
+        assert_eq!(
+            result.returns.get(&object),
+            Some(&ReturnedValue::EmptyObject)
+        );
+        assert_eq!(
+            result.returns.get(&scalar),
+            Some(&ReturnedValue::Present(ExecutionValue::Count(0)))
+        );
+        assert_eq!(
+            result.returns.get(&missing_list),
+            Some(&ReturnedValue::EmptyList)
+        );
+        assert_eq!(
+            result.returns.get(&missing_object),
+            Some(&ReturnedValue::EmptyObject)
+        );
     }
 
     #[tokio::test]

--- a/crates/db/src/execution/interpreter/state.rs
+++ b/crates/db/src/execution/interpreter/state.rs
@@ -5,6 +5,7 @@
 //! execution observable.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use super::*;
 
@@ -22,8 +23,13 @@ impl<'db> ExecutionContext<'db> {
                 .as_ref()
                 .iter()
                 .map(|planned| {
+                    let shape = self
+                        .variable_return_shapes
+                        .get(planned.name())
+                        .copied()
+                        .unwrap_or_else(|| planned.shape());
                     let value = match self.variables.get(planned.name()).cloned() {
-                        Some(value) if value.is_empty() => match planned.shape() {
+                        Some(value) if value.is_empty() => match shape {
                             exec::ReturnShape::List => ReturnedValue::EmptyList,
                             exec::ReturnShape::Object => ReturnedValue::EmptyObject,
                             exec::ReturnShape::Scalar => ReturnedValue::Present(value),
@@ -75,9 +81,13 @@ impl<'db> ExecutionContext<'db> {
                 self.step_outputs.insert(step.id, value);
             }
             (ir::BatchOutputPlan::Bind(name), false) => {
+                Arc::make_mut(&mut self.variable_return_shapes)
+                    .insert(name.clone(), step.inferred_return_shape());
                 self.variables.insert(name.clone(), value);
             }
             (ir::BatchOutputPlan::Bind(name), true) => {
+                Arc::make_mut(&mut self.variable_return_shapes)
+                    .insert(name.clone(), step.inferred_return_shape());
                 let (variable, step_output) = ExecutionValueSlot::from(value).fork();
                 self.variables.insert_slot(name.clone(), variable);
                 self.step_outputs.insert_slot(step.id, step_output);
@@ -293,6 +303,34 @@ mod tests {
         assert_eq!(
             result.returns.get(&missing_object),
             Some(&ReturnedValue::EmptyObject)
+        );
+    }
+
+    #[tokio::test]
+    async fn finish_prefers_the_shape_of_the_executed_binding() {
+        let db = test_support::open_db("state-finish-executed-shape").await;
+        let result = name("result");
+        let mut step = test_support::step(
+            1,
+            Vec::new(),
+            exec::ExecOp::Count {
+                plan: Box::new(exec::ExecCountPlan::Constant(0)),
+            },
+        );
+        step.output = ir::BatchOutputPlan::Bind(result.clone());
+        let mut ctx = ExecutionContext::new(&db, context::ParamBindings::default());
+        ctx.record_step_value(&step, ExecutionValue::Count(0));
+
+        let execution = ctx
+            .finish(
+                step.id,
+                &return_variables(vec![("result", exec::ReturnShape::Object)]),
+            )
+            .unwrap();
+
+        assert_eq!(
+            execution.returns.get(&result),
+            Some(&ReturnedValue::Present(ExecutionValue::Count(0)))
         );
     }
 

--- a/crates/db/src/execution/interpreter/state.rs
+++ b/crates/db/src/execution/interpreter/state.rs
@@ -144,7 +144,7 @@ fn missing_variable(kind: &str, name: &ir::NonEmptyString) -> HelixDbError {
 mod tests {
     use std::num::NonZeroUsize;
 
-    use helix_planner::context;
+    use helix_planner::{context, properties};
 
     use super::test_support;
     use super::*;
@@ -307,30 +307,89 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finish_prefers_the_shape_of_the_executed_binding() {
-        let db = test_support::open_db("state-finish-executed-shape").await;
-        let result = name("result");
-        let mut step = test_support::step(
+    async fn finish_uses_the_executed_shape_only_for_empty_values() {
+        let db = test_support::open_db("state-finish-executed-shapes").await;
+        let empty_scalar = name("empty_scalar");
+        let present_scalar = name("present_scalar");
+        let empty_object = name("empty_object");
+        let present_object = name("present_object");
+        let empty_list = name("empty_list");
+        let present_list = name("present_list");
+        let mut empty_scalar_step = test_support::step(
             1,
             Vec::new(),
             exec::ExecOp::Count {
                 plan: Box::new(exec::ExecCountPlan::Constant(0)),
             },
         );
-        step.output = ir::BatchOutputPlan::Bind(result.clone());
+        empty_scalar_step.output = ir::BatchOutputPlan::Bind(empty_scalar.clone());
+        let mut present_scalar_step = empty_scalar_step.clone();
+        present_scalar_step.id = step_id(2);
+        present_scalar_step.output = ir::BatchOutputPlan::Bind(present_scalar.clone());
+        let mut empty_object_step = test_support::step(3, Vec::new(), exec::ExecOp::Noop);
+        empty_object_step.delivered.cardinality = properties::CardinalityBounds::zero_to(Some(1));
+        empty_object_step.output = ir::BatchOutputPlan::Bind(empty_object.clone());
+        let mut present_object_step = empty_object_step.clone();
+        present_object_step.id = step_id(4);
+        present_object_step.output = ir::BatchOutputPlan::Bind(present_object.clone());
+        let mut empty_list_step = test_support::step(5, Vec::new(), exec::ExecOp::Noop);
+        empty_list_step.output = ir::BatchOutputPlan::Bind(empty_list.clone());
+        let mut present_list_step = empty_list_step.clone();
+        present_list_step.id = step_id(6);
+        present_list_step.output = ir::BatchOutputPlan::Bind(present_list.clone());
         let mut ctx = ExecutionContext::new(&db, context::ParamBindings::default());
-        ctx.record_step_value(&step, ExecutionValue::Count(0));
+        ctx.record_step_value(&empty_scalar_step, ExecutionValue::Count(0));
+        ctx.record_step_value(&present_scalar_step, ExecutionValue::Count(7));
+        ctx.record_step_value(&empty_object_step, ExecutionValue::Stream(Vec::new()));
+        ctx.record_step_value(&present_object_step, ExecutionValue::Stream(vec![row(1)]));
+        ctx.record_step_value(&empty_list_step, ExecutionValue::Stream(Vec::new()));
+        ctx.record_step_value(
+            &present_list_step,
+            ExecutionValue::Stream(vec![row(2), row(3)]),
+        );
 
         let execution = ctx
             .finish(
-                step.id,
-                &return_variables(vec![("result", exec::ReturnShape::Object)]),
+                present_list_step.id,
+                &return_variables(vec![
+                    ("empty_scalar", exec::ReturnShape::Object),
+                    ("present_scalar", exec::ReturnShape::Object),
+                    ("empty_object", exec::ReturnShape::List),
+                    ("present_object", exec::ReturnShape::List),
+                    ("empty_list", exec::ReturnShape::Object),
+                    ("present_list", exec::ReturnShape::Object),
+                ]),
             )
             .unwrap();
 
         assert_eq!(
-            execution.returns.get(&result),
+            execution.returns.get(&empty_scalar),
             Some(&ReturnedValue::Present(ExecutionValue::Count(0)))
+        );
+        assert_eq!(
+            execution.returns.get(&present_scalar),
+            Some(&ReturnedValue::Present(ExecutionValue::Count(7)))
+        );
+        assert_eq!(
+            execution.returns.get(&empty_object),
+            Some(&ReturnedValue::EmptyObject)
+        );
+        assert_eq!(
+            execution.returns.get(&present_object),
+            Some(&ReturnedValue::Present(ExecutionValue::Stream(vec![row(
+                1
+            )])))
+        );
+        assert_eq!(
+            execution.returns.get(&empty_list),
+            Some(&ReturnedValue::EmptyList)
+        );
+        assert_eq!(
+            execution.returns.get(&present_list),
+            Some(&ReturnedValue::Present(ExecutionValue::Stream(vec![
+                row(2),
+                row(3),
+            ])))
         );
     }
 

--- a/crates/db/src/execution/interpreter/stream/tests/terminals.rs
+++ b/crates/db/src/execution/interpreter/stream/tests/terminals.rs
@@ -1,4 +1,4 @@
-use super::super::super::{ExecutionContext, FoldedStream};
+use super::super::super::{ExecutionContext, FoldedStream, ReturnedValue};
 use super::support::*;
 
 #[tokio::test]
@@ -97,7 +97,10 @@ async fn planner_emitted_terminal_chain_executes_through_db_facade() {
         .await
         .expect("planner-emitted terminal chain executes");
 
-    assert_eq!(result.returns.get(&output), Some(&ExecutionValue::Count(1)));
+    assert_eq!(
+        result.returns.get(&output),
+        Some(&ReturnedValue::Present(ExecutionValue::Count(1)))
+    );
 }
 
 #[tokio::test]

--- a/crates/db/src/execution/interpreter/stream/tests/terminals.rs
+++ b/crates/db/src/execution/interpreter/stream/tests/terminals.rs
@@ -1,4 +1,4 @@
-use super::super::super::{ExecutionContext, FoldedStream};
+use super::super::super::{ExecutionContext, FoldedStream, ReturnedValue};
 use super::support::*;
 
 #[tokio::test]
@@ -93,7 +93,10 @@ async fn planner_emitted_terminal_chain_executes_through_db_facade() {
         .await
         .expect("planner-emitted terminal chain executes");
 
-    assert_eq!(result.returns.get(&output), Some(&ExecutionValue::Count(1)));
+    assert_eq!(
+        result.returns.get(&output),
+        Some(&ReturnedValue::Present(ExecutionValue::Count(1)))
+    );
 }
 
 #[tokio::test]

--- a/crates/db/src/execution/interpreter/types.rs
+++ b/crates/db/src/execution/interpreter/types.rs
@@ -340,6 +340,20 @@ pub enum ExecutionValue {
     IndexOperationStatus(crate::index_lifecycle::IndexOperationStatus),
 }
 
+/// Normalized value for one declared query return.
+///
+/// Empty collection and object results are distinct variants so response
+/// serialization cannot lose the planner-inferred shape.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ReturnedValue {
+    /// Preserve the existing serialization for a present value.
+    Present(ExecutionValue),
+    /// Serialize an empty collection as `[]`.
+    EmptyList,
+    /// Serialize an absent at-most-one value as `null`.
+    EmptyObject,
+}
+
 /// Runtime ownership for a value retained by interpreter state.
 ///
 /// Linear pipelines stay uniquely owned. A value becomes shared only when two
@@ -539,7 +553,7 @@ pub struct ExecutionResult {
     /// Values bound by batch outputs and variable operations.
     pub variables: BTreeMap<ir::NonEmptyString, ExecutionValue>,
     /// Requested return values, keyed by the planner return list.
-    pub returns: BTreeMap<ir::NonEmptyString, ExecutionValue>,
+    pub returns: BTreeMap<ir::NonEmptyString, ReturnedValue>,
 }
 
 #[cfg(test)]

--- a/crates/db/src/query_service.rs
+++ b/crates/db/src/query_service.rs
@@ -18,7 +18,9 @@ use serde_json::Value as JsonValue;
 use crate::encoding::keys::tenant::DataScope;
 use crate::encoding::property::property_value::PropertyValue as DbPropertyValue;
 use crate::error::HelixDbError;
-use crate::execution::interpreter::{ElementRef, ExecutionResult, ExecutionScalar, ExecutionValue};
+use crate::execution::interpreter::{
+    ElementRef, ExecutionResult, ExecutionScalar, ExecutionValue, ReturnedValue,
+};
 use crate::execution_control::ExecutionControl;
 use crate::HelixDB;
 
@@ -405,7 +407,7 @@ impl QueryResponse {
         let returns = result
             .returns
             .into_iter()
-            .map(|(name, value)| Ok((name.into_string(), execution_value_to_json(value)?)))
+            .map(|(name, value)| Ok((name.into_string(), returned_value_to_json(value)?)))
             .collect::<std::result::Result<BTreeMap<_, _>, QueryServiceError>>()?;
         Ok(Self {
             returns,
@@ -435,6 +437,16 @@ impl Serialize for QueryResponse {
         S: Serializer,
     {
         self.returns.serialize(serializer)
+    }
+}
+
+fn returned_value_to_json(
+    value: ReturnedValue,
+) -> std::result::Result<JsonValue, QueryServiceError> {
+    match value {
+        ReturnedValue::Present(value) => execution_value_to_json(value),
+        ReturnedValue::EmptyList => Ok(JsonValue::Array(Vec::new())),
+        ReturnedValue::EmptyObject => Ok(JsonValue::Null),
     }
 }
 
@@ -646,7 +658,7 @@ impl QueryResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use helix_ast::batch::{read_batch, write_batch};
+    use helix_ast::batch::{read_batch, write_batch, BatchCondition};
     use helix_ast::expr::Predicate;
     use helix_ast::graph::{EdgeRef, NodeRef};
     use helix_ast::index::IndexSpec;
@@ -1785,6 +1797,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn query_response_uses_planner_shape_only_for_empty_returns() {
+        let db = Arc::new(
+            HelixDB::open(HelixDbSource::InMemory {
+                database: "query-service-empty-return-shapes".to_string(),
+            })
+            .await
+            .expect("writer should open"),
+        );
+        let service = HelixQueryService::new(db);
+
+        let created = service
+            .execute_query(QueryRequest::write(
+                write_batch()
+                    .var_as(
+                        "created",
+                        g().add_n("User", Vec::<(&str, PropertyInput)>::new()),
+                    )
+                    .returning(["created"]),
+            ))
+            .await
+            .expect("fixture write should execute");
+        assert_eq!(
+            created.to_json_bytes().unwrap(),
+            br#"{"created":[{"$id":0}]}"#
+        );
+
+        let response = service
+            .execute_query(QueryRequest::read(
+                read_batch()
+                    .var_as("present_object", g().n(NodeRef::id(0)))
+                    .var_as("present_list", g().n_with_label("User"))
+                    .var_as("missing_object", g().n(NodeRef::id(999)))
+                    .var_as("missing_list", g().n_with_label("Missing"))
+                    .var_as("bounded_object", g().n_with_label("Missing").limit(1usize))
+                    .var_as("empty_fold", g().n(NodeRef::id(999)).fold())
+                    .var_as("seed", g().n_with_label("Missing"))
+                    .var_as_if(
+                        "skipped_object",
+                        BatchCondition::PrevNotEmpty,
+                        g().n(NodeRef::id(0)),
+                    )
+                    .var_as("count", g().n_with_label("Missing").count())
+                    .returning([
+                        "present_object",
+                        "missing_object",
+                        "missing_list",
+                        "bounded_object",
+                        "empty_fold",
+                        "skipped_object",
+                        "count",
+                        "present_list",
+                    ]),
+            ))
+            .await
+            .expect("shape read should execute");
+
+        assert_eq!(
+            response.to_json_bytes().unwrap(),
+            br#"{"bounded_object":null,"count":0,"empty_fold":[],"missing_list":[],"missing_object":null,"present_list":[{"$id":0}],"present_object":[{"$id":0}],"skipped_object":null}"#
+        );
+
+        let mutation = service
+            .execute_query(QueryRequest::write(
+                write_batch()
+                    .var_as("missing_mutation", g().n(NodeRef::id(999)).drop())
+                    .returning(["missing_mutation"]),
+            ))
+            .await
+            .expect("empty mutation should remain successful");
+        assert_eq!(
+            mutation.to_json_bytes().unwrap(),
+            br#"{"missing_mutation":[]}"#
+        );
+
+        let empty_returns = service
+            .execute_query(QueryRequest::read(
+                read_batch().var_as("ignored", g().n(NodeRef::id(999))),
+            ))
+            .await
+            .expect("empty return declaration should execute");
+        assert_eq!(empty_returns.to_json_bytes().unwrap(), br#"{}"#);
+    }
+
+    #[tokio::test]
     async fn query_service_wrappers_delegate_execute_warm_and_scoped_reads() {
         let db = Arc::new(
             HelixDB::open(HelixDbSource::InMemory {
@@ -1889,19 +1985,21 @@ mod tests {
             returns: BTreeMap::from([
                 (
                     name("users"),
-                    ExecutionValue::Scalars(vec![ExecutionScalar::Object(BTreeMap::from([(
-                        "name".to_string(),
-                        PropertyValue::String("alice".to_string()),
-                    )]))]),
+                    ReturnedValue::Present(ExecutionValue::Scalars(vec![ExecutionScalar::Object(
+                        BTreeMap::from([(
+                            "name".to_string(),
+                            PropertyValue::String("alice".to_string()),
+                        )]),
+                    )])),
                 ),
                 (
                     name("rows"),
-                    ExecutionValue::Stream(vec![{
+                    ReturnedValue::Present(ExecutionValue::Stream(vec![{
                         let mut row = ExecutionRow::empty();
                         row.current = Some(ElementRef::Node(7));
                         row.bindings = BTreeMap::from([(name("friend"), ElementRef::Edge(9))]);
                         row
-                    }]),
+                    }])),
                 ),
             ]),
         };
@@ -1933,21 +2031,25 @@ mod tests {
             returns: BTreeMap::from([
                 (
                     name("node"),
-                    ExecutionValue::Stream(vec![row(ElementRef::Node(7))]),
+                    ReturnedValue::Present(ExecutionValue::Stream(vec![row(ElementRef::Node(7))])),
                 ),
                 (
                     name("ranked_edge"),
-                    ExecutionValue::Stream(vec![row_with_virtual_properties(
-                        ElementRef::Edge(9),
-                        RowVirtualProperties::from_one(distance, PropertyValue::F64(0.25)),
-                    )]),
+                    ReturnedValue::Present(ExecutionValue::Stream(vec![
+                        row_with_virtual_properties(
+                            ElementRef::Edge(9),
+                            RowVirtualProperties::from_one(distance, PropertyValue::F64(0.25)),
+                        ),
+                    ])),
                 ),
                 (
                     name("scored_node"),
-                    ExecutionValue::Stream(vec![row_with_virtual_properties(
-                        ElementRef::Node(11),
-                        RowVirtualProperties::from_one(score, PropertyValue::F64(1.5)),
-                    )]),
+                    ReturnedValue::Present(ExecutionValue::Stream(vec![
+                        row_with_virtual_properties(
+                            ElementRef::Node(11),
+                            RowVirtualProperties::from_one(score, PropertyValue::F64(1.5)),
+                        ),
+                    ])),
                 ),
             ]),
         };
@@ -1979,15 +2081,20 @@ mod tests {
             returns: BTreeMap::from([
                 (
                     name("folded"),
-                    ExecutionValue::FoldedStream(FoldedStream::new(vec![folded_row])),
+                    ReturnedValue::Present(ExecutionValue::FoldedStream(FoldedStream::new(vec![
+                        folded_row,
+                    ]))),
                 ),
-                (name("exists"), ExecutionValue::Bool(true)),
+                (
+                    name("exists"),
+                    ReturnedValue::Present(ExecutionValue::Bool(true)),
+                ),
                 (
                     name("scalars"),
-                    ExecutionValue::Scalars(vec![
+                    ReturnedValue::Present(ExecutionValue::Scalars(vec![
                         ExecutionScalar::String("ready".to_string()),
                         ExecutionScalar::Value(PropertyValue::I64(7)),
-                    ]),
+                    ])),
                 ),
             ]),
         };

--- a/crates/db/src/query_service.rs
+++ b/crates/db/src/query_service.rs
@@ -1905,7 +1905,23 @@ mod tests {
             .expect("writer should open"),
         );
         let service = HelixQueryService::new(db);
-        let batch = read_batch()
+        let created = service
+            .execute_query(QueryRequest::write(
+                write_batch()
+                    .var_as(
+                        "created",
+                        g().add_n("User", Vec::<(&str, PropertyInput)>::new()),
+                    )
+                    .returning(["created"]),
+            ))
+            .await
+            .expect("fixture write should execute");
+        assert_eq!(
+            created.to_json_bytes().unwrap(),
+            br#"{"created":[{"$id":0}]}"#
+        );
+
+        let empty_scalar_batch = read_batch()
             .var_as("result", g().n_with_label("Missing").count())
             .for_each_param(
                 "items",
@@ -1915,7 +1931,7 @@ mod tests {
 
         let skipped = service
             .execute_query(
-                QueryRequest::read(batch.clone())
+                QueryRequest::read(empty_scalar_batch.clone())
                     .with_parameter_value("items", QueryValue::Array(Vec::new())),
             )
             .await
@@ -1923,13 +1939,30 @@ mod tests {
         assert_eq!(skipped.to_json_bytes().unwrap(), br#"{"result":0}"#);
 
         let executed = service
-            .execute_query(QueryRequest::read(batch).with_parameter_value(
+            .execute_query(QueryRequest::read(empty_scalar_batch).with_parameter_value(
                 "items",
                 QueryValue::Array(vec![QueryValue::Object(BTreeMap::new())]),
             ))
             .await
             .expect("non-empty for_each should replace the earlier binding");
         assert_eq!(executed.to_json_bytes().unwrap(), br#"{"result":null}"#);
+
+        let present_scalar = service
+            .execute_query(
+                QueryRequest::read(
+                    read_batch()
+                        .var_as("result", g().n_with_label("User").count())
+                        .for_each_param(
+                            "items",
+                            read_batch().var_as("result", g().n(NodeRef::id(999))),
+                        )
+                        .returning(["result"]),
+                )
+                .with_parameter_value("items", QueryValue::Array(Vec::new())),
+            )
+            .await
+            .expect("empty for_each should not rewrite a non-empty scalar");
+        assert_eq!(present_scalar.to_json_bytes().unwrap(), br#"{"result":1}"#);
     }
 
     #[tokio::test]

--- a/crates/db/src/query_service.rs
+++ b/crates/db/src/query_service.rs
@@ -18,7 +18,9 @@ use serde_json::Value as JsonValue;
 use crate::encoding::keys::tenant::DataScope;
 use crate::encoding::property::property_value::PropertyValue as DbPropertyValue;
 use crate::error::HelixDbError;
-use crate::execution::interpreter::{ElementRef, ExecutionResult, ExecutionScalar, ExecutionValue};
+use crate::execution::interpreter::{
+    ElementRef, ExecutionResult, ExecutionScalar, ExecutionValue, ReturnedValue,
+};
 use crate::execution_control::ExecutionControl;
 use crate::HelixDB;
 
@@ -405,7 +407,7 @@ impl QueryResponse {
         let returns = result
             .returns
             .into_iter()
-            .map(|(name, value)| Ok((name.into_string(), execution_value_to_json(value)?)))
+            .map(|(name, value)| Ok((name.into_string(), returned_value_to_json(value)?)))
             .collect::<std::result::Result<BTreeMap<_, _>, QueryServiceError>>()?;
         Ok(Self {
             returns,
@@ -435,6 +437,16 @@ impl Serialize for QueryResponse {
         S: Serializer,
     {
         self.returns.serialize(serializer)
+    }
+}
+
+fn returned_value_to_json(
+    value: ReturnedValue,
+) -> std::result::Result<JsonValue, QueryServiceError> {
+    match value {
+        ReturnedValue::Present(value) => execution_value_to_json(value),
+        ReturnedValue::EmptyList => Ok(JsonValue::Array(Vec::new())),
+        ReturnedValue::EmptyObject => Ok(JsonValue::Null),
     }
 }
 
@@ -658,7 +670,7 @@ impl QueryResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use helix_ast::batch::{read_batch, write_batch};
+    use helix_ast::batch::{read_batch, write_batch, BatchCondition};
     use helix_ast::expr::Predicate;
     use helix_ast::graph::{EdgeRef, NodeRef};
     use helix_ast::index::IndexSpec;
@@ -1800,6 +1812,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn query_response_uses_planner_shape_only_for_empty_returns() {
+        let db = Arc::new(
+            HelixDB::open(HelixDbSource::InMemory {
+                database: "query-service-empty-return-shapes".to_string(),
+            })
+            .await
+            .expect("writer should open"),
+        );
+        let service = HelixQueryService::new(db);
+
+        let created = service
+            .execute_query(QueryRequest::write(
+                write_batch()
+                    .var_as(
+                        "created",
+                        g().add_n("User", Vec::<(&str, PropertyInput)>::new()),
+                    )
+                    .returning(["created"]),
+            ))
+            .await
+            .expect("fixture write should execute");
+        assert_eq!(
+            created.to_json_bytes().unwrap(),
+            br#"{"created":[{"$id":0}]}"#
+        );
+
+        let response = service
+            .execute_query(QueryRequest::read(
+                read_batch()
+                    .var_as("present_object", g().n(NodeRef::id(0)))
+                    .var_as("present_list", g().n_with_label("User"))
+                    .var_as("missing_object", g().n(NodeRef::id(999)))
+                    .var_as("missing_list", g().n_with_label("Missing"))
+                    .var_as("bounded_object", g().n_with_label("Missing").limit(1usize))
+                    .var_as("empty_fold", g().n(NodeRef::id(999)).fold())
+                    .var_as("seed", g().n_with_label("Missing"))
+                    .var_as_if(
+                        "skipped_object",
+                        BatchCondition::PrevNotEmpty,
+                        g().n(NodeRef::id(0)),
+                    )
+                    .var_as("count", g().n_with_label("Missing").count())
+                    .returning([
+                        "present_object",
+                        "missing_object",
+                        "missing_list",
+                        "bounded_object",
+                        "empty_fold",
+                        "skipped_object",
+                        "count",
+                        "present_list",
+                    ]),
+            ))
+            .await
+            .expect("shape read should execute");
+
+        assert_eq!(
+            response.to_json_bytes().unwrap(),
+            br#"{"bounded_object":null,"count":0,"empty_fold":[],"missing_list":[],"missing_object":null,"present_list":[{"$id":0}],"present_object":[{"$id":0}],"skipped_object":null}"#
+        );
+
+        let mutation = service
+            .execute_query(QueryRequest::write(
+                write_batch()
+                    .var_as("missing_mutation", g().n(NodeRef::id(999)).drop())
+                    .returning(["missing_mutation"]),
+            ))
+            .await
+            .expect("empty mutation should remain successful");
+        assert_eq!(
+            mutation.to_json_bytes().unwrap(),
+            br#"{"missing_mutation":[]}"#
+        );
+
+        let empty_returns = service
+            .execute_query(QueryRequest::read(
+                read_batch().var_as("ignored", g().n(NodeRef::id(999))),
+            ))
+            .await
+            .expect("empty return declaration should execute");
+        assert_eq!(empty_returns.to_json_bytes().unwrap(), br#"{}"#);
+    }
+
+    #[tokio::test]
     async fn query_service_wrappers_delegate_execute_warm_and_scoped_reads() {
         let db = Arc::new(
             HelixDB::open(HelixDbSource::InMemory {
@@ -1904,19 +2000,21 @@ mod tests {
             returns: BTreeMap::from([
                 (
                     name("users"),
-                    ExecutionValue::Scalars(vec![ExecutionScalar::Object(BTreeMap::from([(
-                        "name".to_string(),
-                        PropertyValue::String("alice".to_string()),
-                    )]))]),
+                    ReturnedValue::Present(ExecutionValue::Scalars(vec![ExecutionScalar::Object(
+                        BTreeMap::from([(
+                            "name".to_string(),
+                            PropertyValue::String("alice".to_string()),
+                        )]),
+                    )])),
                 ),
                 (
                     name("rows"),
-                    ExecutionValue::Stream(vec![{
+                    ReturnedValue::Present(ExecutionValue::Stream(vec![{
                         let mut row = ExecutionRow::empty();
                         row.current = Some(ElementRef::Node(7));
                         row.bindings = BTreeMap::from([(name("friend"), ElementRef::Edge(9))]);
                         row
-                    }]),
+                    }])),
                 ),
             ]),
         };
@@ -1948,21 +2046,25 @@ mod tests {
             returns: BTreeMap::from([
                 (
                     name("node"),
-                    ExecutionValue::Stream(vec![row(ElementRef::Node(7))]),
+                    ReturnedValue::Present(ExecutionValue::Stream(vec![row(ElementRef::Node(7))])),
                 ),
                 (
                     name("ranked_edge"),
-                    ExecutionValue::Stream(vec![row_with_virtual_properties(
-                        ElementRef::Edge(9),
-                        RowVirtualProperties::from_one(distance, PropertyValue::F64(0.25)),
-                    )]),
+                    ReturnedValue::Present(ExecutionValue::Stream(vec![
+                        row_with_virtual_properties(
+                            ElementRef::Edge(9),
+                            RowVirtualProperties::from_one(distance, PropertyValue::F64(0.25)),
+                        ),
+                    ])),
                 ),
                 (
                     name("scored_node"),
-                    ExecutionValue::Stream(vec![row_with_virtual_properties(
-                        ElementRef::Node(11),
-                        RowVirtualProperties::from_one(score, PropertyValue::F64(1.5)),
-                    )]),
+                    ReturnedValue::Present(ExecutionValue::Stream(vec![
+                        row_with_virtual_properties(
+                            ElementRef::Node(11),
+                            RowVirtualProperties::from_one(score, PropertyValue::F64(1.5)),
+                        ),
+                    ])),
                 ),
             ]),
         };
@@ -1994,15 +2096,20 @@ mod tests {
             returns: BTreeMap::from([
                 (
                     name("folded"),
-                    ExecutionValue::FoldedStream(FoldedStream::new(vec![folded_row])),
+                    ReturnedValue::Present(ExecutionValue::FoldedStream(FoldedStream::new(vec![
+                        folded_row,
+                    ]))),
                 ),
-                (name("exists"), ExecutionValue::Bool(true)),
+                (
+                    name("exists"),
+                    ReturnedValue::Present(ExecutionValue::Bool(true)),
+                ),
                 (
                     name("scalars"),
-                    ExecutionValue::Scalars(vec![
+                    ReturnedValue::Present(ExecutionValue::Scalars(vec![
                         ExecutionScalar::String("ready".to_string()),
                         ExecutionScalar::Value(PropertyValue::I64(7)),
-                    ]),
+                    ])),
                 ),
             ]),
         };

--- a/crates/db/src/query_service.rs
+++ b/crates/db/src/query_service.rs
@@ -1896,6 +1896,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn query_response_uses_the_shape_of_the_binding_that_executed() {
+        let db = Arc::new(
+            HelixDB::open(HelixDbSource::InMemory {
+                database: "query-service-runtime-return-shape".to_string(),
+            })
+            .await
+            .expect("writer should open"),
+        );
+        let service = HelixQueryService::new(db);
+        let batch = read_batch()
+            .var_as("result", g().n_with_label("Missing").count())
+            .for_each_param(
+                "items",
+                read_batch().var_as("result", g().n(NodeRef::id(999))),
+            )
+            .returning(["result"]);
+
+        let skipped = service
+            .execute_query(
+                QueryRequest::read(batch.clone())
+                    .with_parameter_value("items", QueryValue::Array(Vec::new())),
+            )
+            .await
+            .expect("empty for_each should preserve the earlier binding");
+        assert_eq!(skipped.to_json_bytes().unwrap(), br#"{"result":0}"#);
+
+        let executed = service
+            .execute_query(QueryRequest::read(batch).with_parameter_value(
+                "items",
+                QueryValue::Array(vec![QueryValue::Object(BTreeMap::new())]),
+            ))
+            .await
+            .expect("non-empty for_each should replace the earlier binding");
+        assert_eq!(executed.to_json_bytes().unwrap(), br#"{"result":null}"#);
+    }
+
+    #[tokio::test]
     async fn query_service_wrappers_delegate_execute_warm_and_scoped_reads() {
         let db = Arc::new(
             HelixDB::open(HelixDbSource::InMemory {

--- a/crates/db/tests/production_contracts.rs
+++ b/crates/db/tests/production_contracts.rs
@@ -2943,7 +2943,7 @@ async fn public_query_boundary_restricts_node_and_edge_text_search_to_the_curren
         .as_array()
         .unwrap()
         .iter()
-        .filter(|id| matches!(id.as_u64(), Some(1 | 2 | 3)))
+        .filter(|id| matches!(id.as_u64(), Some(1..=3)))
         .take(2)
         .cloned()
         .collect::<Vec<_>>();

--- a/crates/db/tests/production_contracts.rs
+++ b/crates/db/tests/production_contracts.rs
@@ -9,7 +9,9 @@ use std::{cmp::Ordering, collections::BTreeMap, num::NonZeroUsize, sync::Arc, ti
 
 use db::config::{self, VectorIndexDefinition};
 use db::encoding::v1::values::vectors::{decode_layer0_neighbors, encode_layer0_neighbors};
-use db::execution::interpreter::{ElementRef, ExecutionResult, ExecutionScalar, ExecutionValue};
+use db::execution::interpreter::{
+    ElementRef, ExecutionResult, ExecutionScalar, ExecutionValue, ReturnedValue,
+};
 use db::search::vector::distance::{Cosine, Distance, Euclidean, Manhattan};
 use db::search::vector::unaligned_vector::{SimHashError, UnalignedVector};
 use db::search::vector::{
@@ -151,7 +153,7 @@ fn public_query_response_exposes_telemetry_safe_planner_diagnostics() {
             )]),
             returns: BTreeMap::from([(
                 helix_planner::ir::NonEmptyString::from_static("count"),
-                ExecutionValue::Count(0),
+                ReturnedValue::Present(ExecutionValue::Count(0)),
             )]),
         },
         helix_planner::diagnostics::PlannerDiagnostics {
@@ -2950,7 +2952,7 @@ async fn public_query_boundary_restricts_node_and_edge_text_search_to_the_curren
         serde_json::Value::Array(expected_nodes)
     );
     assert_eq!(response["single_node"], serde_json::json!([2]));
-    assert_eq!(response["empty_nodes"], serde_json::json!([]));
+    assert_eq!(response["empty_nodes"], serde_json::Value::Null);
     assert!(response["node_sacks"]
         .as_array()
         .unwrap()

--- a/crates/planner/src/exec.rs
+++ b/crates/planner/src/exec.rs
@@ -10,6 +10,7 @@ mod metrics;
 mod op;
 mod order;
 mod plan;
+mod returns;
 pub mod selected;
 mod validation;
 
@@ -36,6 +37,9 @@ pub use self::metrics::PlannerMetrics;
 pub use self::op::*;
 pub use self::order::*;
 pub use self::plan::{ExecutablePlan, ExecutableSubplan};
+pub use self::returns::{
+    ExecutableReturn, ExecutableReturnVariables, ExecutableReturns, ReturnShape,
+};
 #[cfg(test)]
 pub(in crate::exec) use self::selected::lowering::SelectedExecutableRejectionReason;
 pub use self::selected::*;

--- a/crates/planner/src/exec.rs
+++ b/crates/planner/src/exec.rs
@@ -11,6 +11,7 @@ mod metrics;
 mod op;
 mod order;
 mod plan;
+mod returns;
 pub mod selected;
 mod validation;
 
@@ -39,6 +40,9 @@ pub use self::metrics::PlannerMetrics;
 pub use self::op::*;
 pub use self::order::*;
 pub use self::plan::{ExecutablePlan, ExecutableSubplan};
+pub use self::returns::{
+    ExecutableReturn, ExecutableReturnVariables, ExecutableReturns, ReturnShape,
+};
 #[cfg(test)]
 pub(in crate::exec) use self::selected::lowering::SelectedExecutableRejectionReason;
 pub use self::selected::*;

--- a/crates/planner/src/exec/error.rs
+++ b/crates/planner/src/exec/error.rs
@@ -35,6 +35,8 @@ pub enum ExecPlanError {
     DuplicateStepId { id: ExecStepId },
     /// Root step was not present.
     MissingRoot { root: ExecStepId },
+    /// Requested return variable has no executable binding.
+    MissingReturnBinding { name: ir::NonEmptyString },
     /// Dependency step was not present.
     MissingDependency {
         step: ExecStepId,
@@ -119,6 +121,9 @@ impl std::fmt::Display for ExecPlanError {
             }
             Self::DuplicateStepId { id } => write!(f, "duplicate exec step id {}", id.get()),
             Self::MissingRoot { root } => write!(f, "missing root exec step {}", root.get()),
+            Self::MissingReturnBinding { name } => {
+                write!(f, "return variable `{name}` has no executable binding")
+            }
             Self::MissingDependency { step, dependency } => write!(
                 f,
                 "exec step {} depends on missing step {}",

--- a/crates/planner/src/exec/error.rs
+++ b/crates/planner/src/exec/error.rs
@@ -35,6 +35,8 @@ pub enum ExecPlanError {
     DuplicateStepId { id: ExecStepId },
     /// Root step was not present.
     MissingRoot { root: ExecStepId },
+    /// Requested return variable has no executable binding.
+    MissingReturnBinding { name: ir::NonEmptyString },
     /// Dependency step was not present.
     MissingDependency {
         step: ExecStepId,
@@ -103,6 +105,9 @@ impl std::fmt::Display for ExecPlanError {
             }
             Self::DuplicateStepId { id } => write!(f, "duplicate exec step id {}", id.get()),
             Self::MissingRoot { root } => write!(f, "missing root exec step {}", root.get()),
+            Self::MissingReturnBinding { name } => {
+                write!(f, "return variable `{name}` has no executable binding")
+            }
             Self::MissingDependency { step, dependency } => write!(
                 f,
                 "exec step {} depends on missing step {}",

--- a/crates/planner/src/exec/plan/top_level.rs
+++ b/crates/planner/src/exec/plan/top_level.rs
@@ -5,7 +5,8 @@ use crate::{cost, ir, logical, physical, trace};
 use crate::exec::validation::execution_order;
 use crate::exec::{
     selected, ExecCondition, ExecExecutionOrder, ExecPlanError, ExecStep, ExecStepId,
-    PlannerMetrics, SelectedExecutableBatchPlanRequest, SelectedExecutablePlanRequest,
+    ExecutableReturns, PlannerMetrics, SelectedExecutableBatchPlanRequest,
+    SelectedExecutablePlanRequest,
 };
 
 /// Interpreter-facing executable DAG plan.
@@ -16,6 +17,9 @@ pub struct ExecutablePlan {
     kind: ir::PlanKind,
     /// Returned variables.
     returns: ir::ReturnPlan,
+    /// Returned variables with executable output shapes.
+    #[serde(skip)]
+    executable_returns: ExecutableReturns,
     /// DAG steps.
     steps: ir::AtLeast<ExecStep, 1>,
     /// Root step.
@@ -41,9 +45,11 @@ impl ExecutablePlan {
         metrics: PlannerMetrics,
     ) -> Result<Self, ExecPlanError> {
         let execution_order = execution_order(&steps, root)?;
+        let executable_returns = ExecutableReturns::resolve(&returns, &steps)?;
         Ok(Self {
             kind,
             returns,
+            executable_returns,
             steps,
             root,
             execution_order,
@@ -126,6 +132,11 @@ impl ExecutablePlan {
     /// Returned variables.
     pub const fn returns(&self) -> &ir::ReturnPlan {
         &self.returns
+    }
+
+    /// Returned variables with planner-inferred output shapes.
+    pub const fn executable_returns(&self) -> &ExecutableReturns {
+        &self.executable_returns
     }
 
     /// DAG steps in stable ID order chosen by the planner.

--- a/crates/planner/src/exec/returns.rs
+++ b/crates/planner/src/exec/returns.rs
@@ -1,0 +1,326 @@
+//! Executable return-shape contracts.
+//!
+//! Request returns remain a list of names. This module resolves each name to
+//! the semantic output shape of its binding after executable lowering. Runtime
+//! code therefore never infers shape from observed rows or cost estimates.
+
+use std::collections::BTreeSet;
+
+use crate::ir;
+
+use super::{ExecOp, ExecPlanError, ExecStep};
+
+/// Shape used only when a declared return has no value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReturnShape {
+    /// A collection return serializes an empty value as `[]`.
+    List,
+    /// An at-most-one return serializes an empty value as `null`.
+    Object,
+    /// A scalar return has no synthetic empty representation.
+    Scalar,
+}
+
+/// One executable return with its planner-inferred shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutableReturn {
+    name: ir::NonEmptyString,
+    shape: ReturnShape,
+}
+
+impl ExecutableReturn {
+    /// Build one executable return.
+    ///
+    /// ```
+    /// use helix_planner::{exec, ir};
+    ///
+    /// let returned = exec::ExecutableReturn::new(
+    ///     ir::NonEmptyString::from_static("user"),
+    ///     exec::ReturnShape::Object,
+    /// );
+    /// assert_eq!(returned.name().as_ref(), "user");
+    /// assert_eq!(returned.shape(), exec::ReturnShape::Object);
+    /// ```
+    pub fn new(name: ir::NonEmptyString, shape: ReturnShape) -> Self {
+        Self { name, shape }
+    }
+
+    /// Returned variable name.
+    pub const fn name(&self) -> &ir::NonEmptyString {
+        &self.name
+    }
+
+    /// Planner-inferred output shape.
+    pub const fn shape(&self) -> ReturnShape {
+        self.shape
+    }
+}
+
+/// Non-empty executable returns with unique names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutableReturnVariables {
+    returns: ir::AtLeast<ExecutableReturn, 1>,
+}
+
+impl ExecutableReturnVariables {
+    /// Build executable returns, rejecting duplicate names.
+    pub fn new(
+        returns: ir::AtLeast<ExecutableReturn, 1>,
+    ) -> Result<Self, ir::ReturnVariablesError> {
+        let mut names = BTreeSet::new();
+        for returned in &returns {
+            if !names.insert(returned.name.clone()) {
+                return Err(ir::ReturnVariablesError::DuplicateName {
+                    name: returned.name.clone(),
+                });
+            }
+        }
+        Ok(Self { returns })
+    }
+}
+
+impl AsRef<[ExecutableReturn]> for ExecutableReturnVariables {
+    fn as_ref(&self) -> &[ExecutableReturn] {
+        self.returns.as_ref()
+    }
+}
+
+/// Resolved executable returns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecutableReturns {
+    /// Return no variables.
+    None,
+    /// Return one or more shaped variables.
+    Variables(ExecutableReturnVariables),
+}
+
+impl ExecutableReturns {
+    pub(super) fn resolve(
+        requested: &ir::ReturnPlan,
+        steps: &[ExecStep],
+    ) -> Result<Self, ExecPlanError> {
+        let ir::ReturnPlan::Variables(variables) = requested else {
+            return Ok(Self::None);
+        };
+        let returns = variables
+            .as_ref()
+            .iter()
+            .map(|name| {
+                return_shape(steps, name)
+                    .map(|shape| ExecutableReturn::new(name.clone(), shape))
+                    .ok_or_else(|| ExecPlanError::MissingReturnBinding { name: name.clone() })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self::Variables(
+            ExecutableReturnVariables::new(
+                ir::AtLeast::try_from_vec(returns)
+                    .expect("ReturnPlan::Variables always contains at least one name"),
+            )
+            .expect("ReturnPlan::Variables already guarantees unique names"),
+        ))
+    }
+}
+
+fn return_shape(steps: &[ExecStep], name: &ir::NonEmptyString) -> Option<ReturnShape> {
+    steps.iter().rev().find_map(|step| {
+        if matches!(&step.output, ir::BatchOutputPlan::Bind(output) if output == name) {
+            return Some(step_shape(step));
+        }
+        match &step.op {
+            ExecOp::ForEach { body, .. } => return_shape(body.steps(), name),
+            _ => None,
+        }
+    })
+}
+
+fn step_shape(step: &ExecStep) -> ReturnShape {
+    match &step.op {
+        ExecOp::Project {
+            projection: ir::ProjectionPlan::Count | ir::ProjectionPlan::Exists,
+        }
+        | ExecOp::IndexDdl { .. } => ReturnShape::Scalar,
+        ExecOp::Reserved {
+            op: ir::ReservedOp::Fold,
+        } => ReturnShape::List,
+        ExecOp::Mutation { .. } => ReturnShape::List,
+        _ => match step.delivered.cardinality.upper() {
+            Some(0 | 1) => ReturnShape::Object,
+            Some(_) | None => ReturnShape::List,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::exec::{ExecCondition, ExecSchedule, ExecStepId};
+    use crate::{cost, properties};
+
+    fn name(value: &str) -> ir::NonEmptyString {
+        ir::NonEmptyString::new(value).unwrap()
+    }
+
+    fn step(op: ExecOp, cardinality: properties::CardinalityBounds) -> ExecStep {
+        ExecStep {
+            id: ExecStepId::new(1).unwrap(),
+            dependencies: Vec::new(),
+            output: ir::BatchOutputPlan::Bind(name("result")),
+            condition: ExecCondition::Always,
+            op,
+            schedule: ExecSchedule::Pipeline,
+            delivered: properties::DeliveredProperties {
+                cardinality,
+                ..properties::DeliveredProperties::default()
+            },
+            cost: cost::CostVector::ZERO,
+        }
+    }
+
+    #[test]
+    fn shape_depends_on_semantics_not_selected_operator_or_cost() {
+        let point = step(
+            ExecOp::Noop,
+            properties::CardinalityBounds::zero_to(Some(1)),
+        );
+        let mut alternative = step(
+            ExecOp::Barrier {
+                name: name("physical-alternative"),
+            },
+            properties::CardinalityBounds::zero_to(Some(1)),
+        );
+        alternative.cost = cost::CostVector {
+            object_reads: u64::MAX,
+            cpu_units: u64::MAX,
+            ..cost::CostVector::ZERO
+        };
+        let bounded_collection = step(
+            ExecOp::Noop,
+            properties::CardinalityBounds::zero_to(Some(2)),
+        );
+        let unknown_collection = step(ExecOp::Noop, properties::CardinalityBounds::unknown());
+
+        assert_eq!(step_shape(&point), ReturnShape::Object);
+        assert_eq!(step_shape(&alternative), ReturnShape::Object);
+        assert_eq!(step_shape(&bounded_collection), ReturnShape::List);
+        assert_eq!(step_shape(&unknown_collection), ReturnShape::List);
+    }
+
+    #[test]
+    fn scalar_and_collection_terminals_override_row_cardinality() {
+        let count = step(
+            ExecOp::Project {
+                projection: ir::ProjectionPlan::Count,
+            },
+            properties::CardinalityBounds::exact(1),
+        );
+        let exists = step(
+            ExecOp::Project {
+                projection: ir::ProjectionPlan::Exists,
+            },
+            properties::CardinalityBounds::exact(1),
+        );
+        let index_ddl = step(
+            ExecOp::IndexDdl {
+                plan: ir::IndexDdlPlan::GetOperation {
+                    operation_id: ir::IndexOperationId::try_new(
+                        "07070707-0707-0707-0707-070707070707",
+                    )
+                    .unwrap(),
+                },
+            },
+            properties::CardinalityBounds::exact(1),
+        );
+        let fold = step(
+            ExecOp::Reserved {
+                op: ir::ReservedOp::Fold,
+            },
+            properties::CardinalityBounds::zero_to(Some(1)),
+        );
+
+        assert_eq!(step_shape(&count), ReturnShape::Scalar);
+        assert_eq!(step_shape(&exists), ReturnShape::Scalar);
+        assert_eq!(step_shape(&index_ddl), ReturnShape::Scalar);
+        assert_eq!(step_shape(&fold), ReturnShape::List);
+    }
+
+    #[test]
+    fn mutations_keep_the_existing_list_empty_shape() {
+        let mutation = step(
+            ExecOp::Mutation {
+                plan: super::super::ExecMutationPlan::Drop,
+            },
+            properties::CardinalityBounds::zero_to(Some(1)),
+        );
+
+        assert_eq!(step_shape(&mutation), ReturnShape::List);
+    }
+
+    #[test]
+    fn executable_return_variables_reject_duplicate_names() {
+        let duplicate = ir::AtLeast::from_one_and_rest(
+            ExecutableReturn::new(name("result"), ReturnShape::List),
+            vec![ExecutableReturn::new(name("result"), ReturnShape::Object)],
+        );
+
+        assert!(matches!(
+            ExecutableReturnVariables::new(duplicate),
+            Err(ir::ReturnVariablesError::DuplicateName { .. })
+        ));
+    }
+
+    #[test]
+    fn return_resolution_rejects_names_without_executable_bindings() {
+        let requested = ir::ReturnPlan::Variables(
+            ir::ReturnVariables::new(ir::AtLeast::from_one(name("missing"))).unwrap(),
+        );
+
+        assert_eq!(
+            ExecutableReturns::resolve(
+                &requested,
+                &[step(ExecOp::Noop, properties::CardinalityBounds::unknown())],
+            ),
+            Err(ExecPlanError::MissingReturnBinding {
+                name: name("missing")
+            })
+        );
+    }
+
+    #[test]
+    fn empty_return_declaration_resolves_without_steps() {
+        assert_eq!(
+            ExecutableReturns::resolve(&ir::ReturnPlan::None, &[]),
+            Ok(ExecutableReturns::None)
+        );
+    }
+
+    #[test]
+    fn return_resolution_finds_bindings_inside_foreach_bodies() {
+        let body_step = step(
+            ExecOp::Noop,
+            properties::CardinalityBounds::zero_to(Some(1)),
+        );
+        let body = super::super::ExecutableSubplan::new(
+            ir::AtLeast::from_one(body_step),
+            ExecStepId::new(1).unwrap(),
+        )
+        .unwrap();
+        let mut foreach = step(
+            ExecOp::ForEach {
+                param: name("items"),
+                body: Box::new(body),
+            },
+            properties::CardinalityBounds::unknown(),
+        );
+        foreach.output = ir::BatchOutputPlan::Discard;
+        let requested = ir::ReturnPlan::Variables(
+            ir::ReturnVariables::new(ir::AtLeast::from_one(name("result"))).unwrap(),
+        );
+
+        let ExecutableReturns::Variables(resolved) =
+            ExecutableReturns::resolve(&requested, &[foreach]).unwrap()
+        else {
+            panic!("one requested return resolves to variables");
+        };
+        assert_eq!(resolved.as_ref()[0].shape(), ReturnShape::Object);
+    }
+}

--- a/crates/planner/src/exec/returns.rs
+++ b/crates/planner/src/exec/returns.rs
@@ -257,8 +257,10 @@ mod tests {
 
     #[test]
     fn executable_return_variables_reject_duplicate_names() {
+        let returned = ExecutableReturn::new(name("result"), ReturnShape::List);
+        assert_eq!(returned.name().as_ref(), "result");
         let duplicate = ir::AtLeast::from_one_and_rest(
-            ExecutableReturn::new(name("result"), ReturnShape::List),
+            returned,
             vec![ExecutableReturn::new(name("result"), ReturnShape::Object)],
         );
 
@@ -316,11 +318,17 @@ mod tests {
             ir::ReturnVariables::new(ir::AtLeast::from_one(name("result"))).unwrap(),
         );
 
-        let ExecutableReturns::Variables(resolved) =
-            ExecutableReturns::resolve(&requested, &[foreach]).unwrap()
-        else {
-            panic!("one requested return resolves to variables");
-        };
-        assert_eq!(resolved.as_ref()[0].shape(), ReturnShape::Object);
+        let expected = ExecutableReturns::Variables(
+            ExecutableReturnVariables::new(ir::AtLeast::from_one(ExecutableReturn::new(
+                name("result"),
+                ReturnShape::Object,
+            )))
+            .unwrap(),
+        );
+
+        assert_eq!(
+            ExecutableReturns::resolve(&requested, &[foreach]),
+            Ok(expected)
+        );
     }
 }

--- a/crates/planner/src/exec/returns.rs
+++ b/crates/planner/src/exec/returns.rs
@@ -135,8 +135,9 @@ fn return_shape(steps: &[ExecStep], name: &ir::NonEmptyString) -> Option<ReturnS
 
 fn step_shape(step: &ExecStep) -> ReturnShape {
     match &step.op {
-        ExecOp::Project {
-            projection: ir::ProjectionPlan::Count | ir::ProjectionPlan::Exists,
+        ExecOp::Count { .. }
+        | ExecOp::Project {
+            projection: ir::ProjectionPlan::Exists,
         }
         | ExecOp::IndexDdl { .. } => ReturnShape::Scalar,
         ExecOp::Reserved {
@@ -208,8 +209,8 @@ mod tests {
     #[test]
     fn scalar_and_collection_terminals_override_row_cardinality() {
         let count = step(
-            ExecOp::Project {
-                projection: ir::ProjectionPlan::Count,
+            ExecOp::Count {
+                plan: Box::new(super::super::ExecCountPlan::Constant(0)),
             },
             properties::CardinalityBounds::exact(1),
         );
@@ -259,6 +260,10 @@ mod tests {
     fn executable_return_variables_reject_duplicate_names() {
         let returned = ExecutableReturn::new(name("result"), ReturnShape::List);
         assert_eq!(returned.name().as_ref(), "result");
+        assert_eq!(returned.shape(), ReturnShape::List);
+        let single = ExecutableReturnVariables::new(ir::AtLeast::from_one(returned.clone()))
+            .expect("one return name is unique");
+        assert_eq!(single.as_ref(), &[returned.clone()]);
         let duplicate = ir::AtLeast::from_one_and_rest(
             returned,
             vec![ExecutableReturn::new(name("result"), ReturnShape::Object)],

--- a/crates/planner/src/exec/returns.rs
+++ b/crates/planner/src/exec/returns.rs
@@ -10,7 +10,7 @@ use crate::ir;
 
 use super::{ExecOp, ExecPlanError, ExecStep};
 
-/// Shape used only when a declared return has no value.
+/// Shape used to normalize an empty returned value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReturnShape {
     /// A collection return serializes an empty value as `[]`.
@@ -19,6 +19,27 @@ pub enum ReturnShape {
     Object,
     /// A scalar return has no synthetic empty representation.
     Scalar,
+}
+
+impl ExecStep {
+    /// Infer the response shape of this step's bound output.
+    pub fn inferred_return_shape(&self) -> ReturnShape {
+        match &self.op {
+            ExecOp::Count { .. }
+            | ExecOp::Project {
+                projection: ir::ProjectionPlan::Exists,
+            }
+            | ExecOp::IndexDdl { .. } => ReturnShape::Scalar,
+            ExecOp::Reserved {
+                op: ir::ReservedOp::Fold,
+            }
+            | ExecOp::Mutation { .. } => ReturnShape::List,
+            _ => match self.delivered.cardinality.upper() {
+                Some(0 | 1) => ReturnShape::Object,
+                Some(_) | None => ReturnShape::List,
+            },
+        }
+    }
 }
 
 /// One executable return with its planner-inferred shape.
@@ -124,31 +145,13 @@ impl ExecutableReturns {
 fn return_shape(steps: &[ExecStep], name: &ir::NonEmptyString) -> Option<ReturnShape> {
     steps.iter().rev().find_map(|step| {
         if matches!(&step.output, ir::BatchOutputPlan::Bind(output) if output == name) {
-            return Some(step_shape(step));
+            return Some(step.inferred_return_shape());
         }
         match &step.op {
             ExecOp::ForEach { body, .. } => return_shape(body.steps(), name),
             _ => None,
         }
     })
-}
-
-fn step_shape(step: &ExecStep) -> ReturnShape {
-    match &step.op {
-        ExecOp::Count { .. }
-        | ExecOp::Project {
-            projection: ir::ProjectionPlan::Exists,
-        }
-        | ExecOp::IndexDdl { .. } => ReturnShape::Scalar,
-        ExecOp::Reserved {
-            op: ir::ReservedOp::Fold,
-        } => ReturnShape::List,
-        ExecOp::Mutation { .. } => ReturnShape::List,
-        _ => match step.delivered.cardinality.upper() {
-            Some(0 | 1) => ReturnShape::Object,
-            Some(_) | None => ReturnShape::List,
-        },
-    }
 }
 
 #[cfg(test)]
@@ -200,10 +203,16 @@ mod tests {
         );
         let unknown_collection = step(ExecOp::Noop, properties::CardinalityBounds::unknown());
 
-        assert_eq!(step_shape(&point), ReturnShape::Object);
-        assert_eq!(step_shape(&alternative), ReturnShape::Object);
-        assert_eq!(step_shape(&bounded_collection), ReturnShape::List);
-        assert_eq!(step_shape(&unknown_collection), ReturnShape::List);
+        assert_eq!(point.inferred_return_shape(), ReturnShape::Object);
+        assert_eq!(alternative.inferred_return_shape(), ReturnShape::Object);
+        assert_eq!(
+            bounded_collection.inferred_return_shape(),
+            ReturnShape::List
+        );
+        assert_eq!(
+            unknown_collection.inferred_return_shape(),
+            ReturnShape::List
+        );
     }
 
     #[test]
@@ -238,10 +247,10 @@ mod tests {
             properties::CardinalityBounds::zero_to(Some(1)),
         );
 
-        assert_eq!(step_shape(&count), ReturnShape::Scalar);
-        assert_eq!(step_shape(&exists), ReturnShape::Scalar);
-        assert_eq!(step_shape(&index_ddl), ReturnShape::Scalar);
-        assert_eq!(step_shape(&fold), ReturnShape::List);
+        assert_eq!(count.inferred_return_shape(), ReturnShape::Scalar);
+        assert_eq!(exists.inferred_return_shape(), ReturnShape::Scalar);
+        assert_eq!(index_ddl.inferred_return_shape(), ReturnShape::Scalar);
+        assert_eq!(fold.inferred_return_shape(), ReturnShape::List);
     }
 
     #[test]
@@ -253,7 +262,7 @@ mod tests {
             properties::CardinalityBounds::zero_to(Some(1)),
         );
 
-        assert_eq!(step_shape(&mutation), ReturnShape::List);
+        assert_eq!(mutation.inferred_return_shape(), ReturnShape::List);
     }
 
     #[test]

--- a/crates/server/src/transport_contracts.rs
+++ b/crates/server/src/transport_contracts.rs
@@ -8,7 +8,7 @@ use axum::http::{Request as HttpRequest, StatusCode};
 use db::encoding::keys::tenant::{DataScope, TenantId};
 use db::encoding::property::Property as DbProperty;
 use db::execution::interpreter::{
-    ElementRef, ExecutionResult, ExecutionRow, ExecutionValue, RowPath, RowSack,
+    ElementRef, ExecutionResult, ExecutionRow, ExecutionValue, ReturnedValue, RowPath, RowSack,
     RowVirtualProperties,
 };
 use db::query_service::{
@@ -257,11 +257,19 @@ fn transport_response_preserves_ranked_public_element_metadata() {
         returns: BTreeMap::from([
             (
                 NonEmptyString::new("distance").expect("return name is non-empty"),
-                ExecutionValue::Stream(vec![row(ElementRef::Node(7), "$distance", 0.25)]),
+                ReturnedValue::Present(ExecutionValue::Stream(vec![row(
+                    ElementRef::Node(7),
+                    "$distance",
+                    0.25,
+                )])),
             ),
             (
                 NonEmptyString::new("score").expect("return name is non-empty"),
-                ExecutionValue::Stream(vec![row(ElementRef::Edge(9), "$score", 1.5)]),
+                ReturnedValue::Present(ExecutionValue::Stream(vec![row(
+                    ElementRef::Edge(9),
+                    "$score",
+                    1.5,
+                )])),
             ),
         ]),
     })

--- a/crates/server/src/transport_contracts.rs
+++ b/crates/server/src/transport_contracts.rs
@@ -238,6 +238,33 @@ fn transport_response_uses_empty_default_planner_diagnostics() {
 }
 
 #[test]
+fn transport_response_preserves_declared_empty_return_shapes() {
+    let response = QueryResponse::from_execution_result(ExecutionResult {
+        last: None,
+        variables: BTreeMap::new(),
+        returns: BTreeMap::from([
+            (
+                NonEmptyString::new("list").expect("return name is non-empty"),
+                ReturnedValue::EmptyList,
+            ),
+            (
+                NonEmptyString::new("object").expect("return name is non-empty"),
+                ReturnedValue::EmptyObject,
+            ),
+        ]),
+    })
+    .expect("shaped empty execution result converts");
+
+    assert_eq!(
+        response.returns(),
+        &BTreeMap::from([
+            ("list".to_string(), serde_json::json!([])),
+            ("object".to_string(), serde_json::Value::Null),
+        ])
+    );
+}
+
+#[test]
 fn transport_response_preserves_ranked_public_element_metadata() {
     let row = |current: ElementRef, property: &str, value: f64| ExecutionRow {
         current: Some(current.clone()),

--- a/docs/database/helix-db/core-concepts/overview.mdx
+++ b/docs/database/helix-db/core-concepts/overview.mdx
@@ -613,6 +613,20 @@ produces the shape you need — each of these replaces `valueMap` on the `friend
 | `exists()` | `true` |
 | `project(…)` | One object per row with named fields |
 
+Populated values keep these existing shapes. Only a declared return with no
+value uses an inferred empty shape:
+
+| Semantic return | Populated | Empty or skipped |
+| --- | --- | --- |
+| At most one row, such as `limit(1)` | Existing one-element array | `null` |
+| Collection, many, or unknown cardinality | Existing array | `[]` |
+| `fold` or mutation | Existing array | `[]` |
+| Scalar terminal, such as `count()` or `exists()` | Existing scalar | No synthetic empty value |
+
+The planner infers this from the semantic output type and guaranteed
+multiplicity. It does not use the observed row count or optimizer estimates. An
+empty `returns` declaration returns `{}` because it declares no response keys.
+
 ## 9. Read it back in a later request
 
 Once the write has committed, the same traversal works from a read batch — Alice is now

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2094,6 +2094,20 @@ produces the shape you need — each of these replaces `valueMap` on the `friend
 | `exists()` | `true` |
 | `project(…)` | One object per row with named fields |
 
+Populated values keep these existing shapes. Only a declared return with no
+value uses an inferred empty shape:
+
+| Semantic return | Populated | Empty or skipped |
+| --- | --- | --- |
+| At most one row, such as `limit(1)` | Existing one-element array | `null` |
+| Collection, many, or unknown cardinality | Existing array | `[]` |
+| `fold` or mutation | Existing array | `[]` |
+| Scalar terminal, such as `count()` or `exists()` | Existing scalar | No synthetic empty value |
+
+The planner infers this from the semantic output type and guaranteed
+multiplicity. It does not use the observed row count or optimizer estimates. An
+empty `returns` declaration returns `{}` because it declares no response keys.
+
 ## 9. Read it back in a later request
 
 Once the write has committed, the same traversal works from a read batch — Alice is now

--- a/scripts/db-production-coverage-baselines.json
+++ b/scripts/db-production-coverage-baselines.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "uncovered_non_vector_source_lines": {
-    "count": 9872,
-    "sha256": "ca489835b966ee40fbcc2a5a6e031e2dee8158b99880d167490396b332a22e0f",
+    "count": 9876,
+    "sha256": "1ce4cff35b508dd3bcdc249795bcb26dc69e9e959ac3c91c553261777e82e138",
     "classification": "test-required",
     "reason": "Every uncovered production source line outside vector search and its stochastic vector key/value codecs remains in the explicit production-linked test backlog. The digest makes additions, removals, and newly covered lines require a reviewed baseline update; vector code remains enforced by the whole-DB and dedicated vector thresholds plus finer named-test, architecture, invariant, and platform classifications."
   },

--- a/scripts/server-production-coverage-baselines.json
+++ b/scripts/server-production-coverage-baselines.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "uncovered_source_lines": {
     "count": 127,
-    "sha256": "a21b676a79538eb4fc878257e354863c8a2ed835998ecc064178792b3af7a19b",
+    "sha256": "03af888286220d2df59218e1e3fb81c3750405a5a4bb461bb35cd74b86eda0a0",
     "classification": "test-required",
     "reason": "Every remaining uncovered production line in the transport server and its production-compiled query-service dependency remains in the explicit launch test backlog. Three static error-code mapping lines are exhaustively covered by the database mapping tests rather than this server-only shard. The exact digest makes coverage changes require a reviewed ratchet update."
   },


### PR DESCRIPTION
## Summary

- infer an internal return shape from semantic output type and guaranteed multiplicity
- serialize empty at-most-one returns as `null`
- serialize empty collections, folds, and mutations as `[]`
- preserve populated responses, scalar terminals, the public AST, and `returns: ["name"]`
- document the response contract and regenerate the checked-in LLM documentation

## Impact

Only empty declared returns change. Populated object, list, scalar, mixed, and mutation responses keep their existing serialized bytes. A request with no declared returns still returns `{}`.

## Validation

- `cargo fmt --all --check`
- workspace tests
- Clippy with warnings denied
- targeted planner branch coverage: 100%
- DB branch-instrumented tests
- `npm run check` in `docs/`

Full DB LLVM report generation still crashes while processing the large DB coverage object; the instrumented DB tests themselves pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds planner-derived empty-return shapes and carries them through execution so absent at-most-one values serialize as `null`, while empty collections, folds, and mutations serialize as `[]`.

- Adds executable return-shape resolution without changing the public return AST.
- Normalizes empty declared returns at interpreter completion and serializes them at the query-service boundary.
- Adds planner, runtime, transport-contract, production-contract, and documentation coverage.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/planner/src/exec/returns.rs | Resolves declared return bindings to scalar, list, or at-most-one object shapes using executable semantics and guaranteed cardinality. |
| crates/planner/src/exec/plan/top_level.rs | Stores inferred return shapes as derived executable-plan state and reconstructs them through the existing checked deserialization path. |
| crates/db/src/execution/interpreter/state.rs | Converts empty or skipped declared bindings into explicit list/object return variants while preserving present scalar and populated values. |
| crates/db/src/query_service.rs | Serializes normalized empty lists as arrays and absent at-most-one objects as null without changing populated serialization. |
| docs/database/helix-db/core-concepts/overview.mdx | Documents the multiplicity-based empty-return response contract and preserved populated shapes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant C as Client
  participant P as Planner
  participant I as Interpreter
  participant Q as Query service
  C->>P: Query with declared return names
  P->>P: Resolve binding semantics and multiplicity
  P-->>I: Executable returns with List/Object/Scalar shape
  I->>I: Execute plan and collect values
  I-->>Q: Present value or shaped empty return
  Q-->>C: Existing populated JSON, [] for empty lists, null for absent objects
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Document inferred empty return shapes"](https://github.com/helixdb/helix-db/commit/ffb15dc9e376125d0214c528b6cc4384158b619f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54663957)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Query planner and executable plans](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/query-planner.md)
- Knowledge Base — [Database runtime, storage, search, and index lifecycle](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/database-runtime.md)
- Knowledge Base — [HTTP and gRPC server transports](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/server-transports.md)
</details>

<!-- /greptile_comment -->