### PR TITLE
fix: launch cursor agent from helix chef

### DIFF
--- a/crates/cli/src/commands/chef.rs
+++ b/crates/cli/src/commands/chef.rs
@@ -1535,6 +1535,7 @@ enum AgentKind {
     ClaudeCode,
     OpenAiCodex,
     OpenCode,
+    CursorAgent,
 }
 
 impl AgentKind {
@@ -1543,6 +1544,7 @@ impl AgentKind {
             AgentKind::ClaudeCode => "claude",
             AgentKind::OpenAiCodex => "codex",
             AgentKind::OpenCode => "opencode",
+            AgentKind::CursorAgent => "agent",
         }
     }
 
@@ -1551,6 +1553,7 @@ impl AgentKind {
             AgentKind::ClaudeCode => "Claude Code",
             AgentKind::OpenAiCodex => "OpenAI Codex",
             AgentKind::OpenCode => "OpenCode",
+            AgentKind::CursorAgent => "Cursor Agent",
         }
     }
 
@@ -1559,6 +1562,7 @@ impl AgentKind {
             AgentKind::ClaudeCode => ExternalTool::ClaudeCode,
             AgentKind::OpenAiCodex => ExternalTool::OpenAiCodex,
             AgentKind::OpenCode => ExternalTool::OpenCode,
+            AgentKind::CursorAgent => ExternalTool::CursorAgent,
         }
     }
 }
@@ -1573,6 +1577,7 @@ const AGENT_PRIORITY: &[AgentKind] = &[
     AgentKind::ClaudeCode,
     AgentKind::OpenAiCodex,
     AgentKind::OpenCode,
+    AgentKind::CursorAgent,
 ];
 
 const PROMPT_FILENAME: &str = "HELIX_CHEF_PROMPT.md";
@@ -1705,6 +1710,22 @@ fn build_agent_argv(
             ];
             if matches!(mode, PermissionMode::FullAuto) {
                 args.push("--dangerously-skip-permissions".to_string());
+            }
+            args.push(format!(
+                "Follow the spec in ./{prompt_file}. {AGENT_USER_PROMPT}"
+            ));
+            args
+        }
+        AgentKind::CursorAgent => {
+            let mut args = vec![
+                "-p".to_string(),
+                "--trust".to_string(),
+                "--workspace".to_string(),
+                project_dir.display().to_string(),
+            ];
+            if matches!(mode, PermissionMode::FullAuto) {
+                args.push("--force".to_string());
+                args.push("--approve-mcps".to_string());
             }
             args.push(format!(
                 "Follow the spec in ./{prompt_file}. {AGENT_USER_PROMPT}"
@@ -1894,7 +1915,7 @@ async fn launch_agent(kind: AgentKind, mode: PermissionMode, project_dir: &Path)
 
     let run_result = match kind {
         AgentKind::ClaudeCode => launch_claude_streaming(mode, project_dir, &mut step).await,
-        AgentKind::OpenAiCodex | AgentKind::OpenCode => {
+        AgentKind::OpenAiCodex | AgentKind::OpenCode | AgentKind::CursorAgent => {
             launch_other_captured(kind, mode, project_dir)
         }
     };
@@ -2102,12 +2123,12 @@ async fn launch_claude_streaming(
 }
 
 fn print_no_agent_fallback(project_dir: &Path) {
-    let lead = format!(
-        "No supported coding-agent CLI was found in PATH ({}, {}, {}).",
-        AgentKind::ClaudeCode.binary(),
-        AgentKind::OpenAiCodex.binary(),
-        AgentKind::OpenCode.binary(),
-    );
+    let binaries = AGENT_PRIORITY
+        .iter()
+        .map(|agent| agent.binary())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let lead = format!("No supported coding-agent CLI was found in PATH ({binaries}).");
     print_paste_prompt_hint(project_dir, &lead);
 }
 
@@ -2936,18 +2957,21 @@ mod tests {
     }
 
     #[test]
-    fn agent_priority_is_claude_codex_opencode() {
+    fn agent_priority_is_claude_codex_opencode_cursor() {
         assert_eq!(
             AGENT_PRIORITY,
             &[
                 AgentKind::ClaudeCode,
                 AgentKind::OpenAiCodex,
                 AgentKind::OpenCode,
+                AgentKind::CursorAgent,
             ],
         );
         assert_eq!(AgentKind::ClaudeCode.binary(), "claude");
         assert_eq!(AgentKind::OpenAiCodex.binary(), "codex");
         assert_eq!(AgentKind::OpenCode.binary(), "opencode");
+        assert_eq!(AgentKind::CursorAgent.binary(), "agent");
+        assert_eq!(AgentKind::CursorAgent.display(), "Cursor Agent");
     }
 
     #[test]
@@ -3051,6 +3075,44 @@ mod tests {
         assert_eq!(argv[0], "run");
         assert_eq!(argv[1], "--dir");
         assert!(!argv.iter().any(|a| a == "--dangerously-skip-permissions"));
+    }
+
+    #[test]
+    fn build_agent_argv_cursor_full_auto() {
+        let argv = build_agent_argv(
+            AgentKind::CursorAgent,
+            PermissionMode::FullAuto,
+            "HELIX_CHEF_PROMPT.md",
+            Path::new("/tmp/proj"),
+        );
+        assert_eq!(argv[0], "-p");
+        assert!(argv.iter().any(|a| a == "--trust"));
+        assert!(argv.iter().any(|a| a == "--force"));
+        assert!(argv.iter().any(|a| a == "--approve-mcps"));
+        let workspace = argv
+            .iter()
+            .position(|a| a == "--workspace")
+            .expect("--workspace present");
+        assert_eq!(argv[workspace + 1], "/tmp/proj");
+        assert!(argv.last().unwrap().contains("HELIX_CHEF_PROMPT.md"));
+        assert!(argv.last().unwrap().contains(AGENT_USER_PROMPT));
+    }
+
+    #[test]
+    fn build_agent_argv_cursor_scoped() {
+        let argv = build_agent_argv(
+            AgentKind::CursorAgent,
+            PermissionMode::Scoped,
+            "HELIX_CHEF_PROMPT.md",
+            Path::new("/tmp/proj"),
+        );
+        assert_eq!(argv[0], "-p");
+        assert!(argv.iter().any(|a| a == "--trust"));
+        assert!(argv.iter().any(|a| a == "--workspace"));
+        assert!(!argv.iter().any(|a| a == "--force"));
+        assert!(!argv.iter().any(|a| a == "--yolo"));
+        assert!(!argv.iter().any(|a| a == "--approve-mcps"));
+        assert!(argv.last().unwrap().contains("HELIX_CHEF_PROMPT.md"));
     }
 
     // ---------- Claude stream-json event parsing ----------

--- a/crates/cli/src/commands/chef.rs
+++ b/crates/cli/src/commands/chef.rs
@@ -1544,7 +1544,7 @@ impl AgentKind {
             AgentKind::ClaudeCode => "claude",
             AgentKind::OpenAiCodex => "codex",
             AgentKind::OpenCode => "opencode",
-            AgentKind::CursorAgent => "agent",
+            AgentKind::CursorAgent => "cursor-agent",
         }
     }
 
@@ -1717,12 +1717,17 @@ fn build_agent_argv(
             args
         }
         AgentKind::CursorAgent => {
-            let mut args = vec![
-                "-p".to_string(),
+            let mut args = Vec::new();
+            if matches!(mode, PermissionMode::FullAuto) {
+                args.push("-p".to_string());
+                args.push("--output-format".to_string());
+                args.push("text".to_string());
+            }
+            args.extend([
                 "--trust".to_string(),
                 "--workspace".to_string(),
                 project_dir.display().to_string(),
-            ];
+            ]);
             if matches!(mode, PermissionMode::FullAuto) {
                 args.push("--force".to_string());
                 args.push("--approve-mcps".to_string());
@@ -1911,10 +1916,19 @@ async fn launch_agent(kind: AgentKind, mode: PermissionMode, project_dir: &Path)
     let progress = format!("Cheffing in {}", project_dir.display());
     let completion = format!("Cheffed in {}", project_dir.display());
     let mut step = Step::with_messages(&progress, &completion);
-    step.start();
+    let interactive = matches!(
+        (kind, mode),
+        (AgentKind::CursorAgent, PermissionMode::Scoped)
+    );
+    if !interactive {
+        step.start();
+    }
 
     let run_result = match kind {
         AgentKind::ClaudeCode => launch_claude_streaming(mode, project_dir, &mut step).await,
+        AgentKind::CursorAgent if mode == PermissionMode::Scoped => {
+            launch_other_interactive(kind, mode, project_dir)
+        }
         AgentKind::OpenAiCodex | AgentKind::OpenCode | AgentKind::CursorAgent => {
             launch_other_captured(kind, mode, project_dir)
         }
@@ -1951,6 +1965,31 @@ async fn launch_agent(kind: AgentKind, mode: PermissionMode, project_dir: &Path)
         final_stats: None,
         final_summary: None,
         transcript: vec![format!("agent launch error: {error}")],
+    })
+}
+
+fn launch_other_interactive(
+    kind: AgentKind,
+    mode: PermissionMode,
+    project_dir: &Path,
+) -> Result<AgentRunReport> {
+    let argv = build_agent_argv(kind, mode, PROMPT_FILENAME, project_dir);
+    let status = external_tools::command(kind.external_tool())
+        .args(&argv)
+        .current_dir(project_dir)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()?;
+
+    Ok(AgentRunReport {
+        agent: kind,
+        permission_mode: mode,
+        success: status.success(),
+        exit_code: status.code(),
+        final_stats: None,
+        final_summary: None,
+        transcript: Vec::new(),
     })
 }
 
@@ -2970,7 +3009,7 @@ mod tests {
         assert_eq!(AgentKind::ClaudeCode.binary(), "claude");
         assert_eq!(AgentKind::OpenAiCodex.binary(), "codex");
         assert_eq!(AgentKind::OpenCode.binary(), "opencode");
-        assert_eq!(AgentKind::CursorAgent.binary(), "agent");
+        assert_eq!(AgentKind::CursorAgent.binary(), "cursor-agent");
         assert_eq!(AgentKind::CursorAgent.display(), "Cursor Agent");
     }
 
@@ -3086,6 +3125,11 @@ mod tests {
             Path::new("/tmp/proj"),
         );
         assert_eq!(argv[0], "-p");
+        let output_format = argv
+            .iter()
+            .position(|a| a == "--output-format")
+            .expect("--output-format present");
+        assert_eq!(argv[output_format + 1], "text");
         assert!(argv.iter().any(|a| a == "--trust"));
         assert!(argv.iter().any(|a| a == "--force"));
         assert!(argv.iter().any(|a| a == "--approve-mcps"));
@@ -3106,7 +3150,8 @@ mod tests {
             "HELIX_CHEF_PROMPT.md",
             Path::new("/tmp/proj"),
         );
-        assert_eq!(argv[0], "-p");
+        assert!(!argv.iter().any(|a| a == "-p"));
+        assert!(!argv.iter().any(|a| a == "--output-format"));
         assert!(argv.iter().any(|a| a == "--trust"));
         assert!(argv.iter().any(|a| a == "--workspace"));
         assert!(!argv.iter().any(|a| a == "--force"));

--- a/crates/cli/src/external_tools.rs
+++ b/crates/cli/src/external_tools.rs
@@ -35,7 +35,7 @@ impl ExternalTool {
             Self::ClaudeCode => "claude",
             Self::OpenAiCodex => "codex",
             Self::OpenCode => "opencode",
-            Self::CursorAgent => "agent",
+            Self::CursorAgent => "cursor-agent",
         }
     }
 
@@ -122,7 +122,7 @@ mod tests {
         assert_eq!(ExternalTool::ClaudeCode.binary(), "claude");
         assert_eq!(ExternalTool::OpenAiCodex.binary(), "codex");
         assert_eq!(ExternalTool::OpenCode.binary(), "opencode");
-        assert_eq!(ExternalTool::CursorAgent.binary(), "agent");
+        assert_eq!(ExternalTool::CursorAgent.binary(), "cursor-agent");
     }
 
     #[cfg(windows)]

--- a/crates/cli/src/external_tools.rs
+++ b/crates/cli/src/external_tools.rs
@@ -21,6 +21,7 @@ pub(crate) enum ExternalTool {
     ClaudeCode,
     OpenAiCodex,
     OpenCode,
+    CursorAgent,
 }
 
 impl ExternalTool {
@@ -34,6 +35,7 @@ impl ExternalTool {
             Self::ClaudeCode => "claude",
             Self::OpenAiCodex => "codex",
             Self::OpenCode => "opencode",
+            Self::CursorAgent => "agent",
         }
     }
 
@@ -120,6 +122,7 @@ mod tests {
         assert_eq!(ExternalTool::ClaudeCode.binary(), "claude");
         assert_eq!(ExternalTool::OpenAiCodex.binary(), "codex");
         assert_eq!(ExternalTool::OpenCode.binary(), "opencode");
+        assert_eq!(ExternalTool::CursorAgent.binary(), "agent");
     }
 
     #[cfg(windows)]

--- a/crates/cli/tests/chef_command.rs
+++ b/crates/cli/tests/chef_command.rs
@@ -93,3 +93,58 @@ async fn headless_chef_runs_setup_and_surfaces_external_tool_errors() {
     assert!(prompt.contains("# HelixDB MVP Builder"));
     assert!(prompt.contains("Personal CRM"));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn headless_chef_launches_cursor_agent() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/healthz"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v2/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok":true})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let fixture = CliFixture::new_with_fake_runtime()
+        .with_fake_tools_named(&["cargo", "node", "npm", "npx", "curl", "agent"]);
+    let project = fixture.home().join("my-first-helix-project");
+    fixture
+        .command()
+        .args(["init", "--path"])
+        .arg(&project)
+        .args(["local", "--port"])
+        .arg(server.address().port().to_string())
+        .arg("--no-skills")
+        .assert()
+        .success();
+    fs::create_dir_all(project.join("web")).unwrap();
+    fs::write(project.join("web/package.json"), "{}").unwrap();
+
+    let chef = stdout(
+        fixture
+            .command()
+            .current_dir(fixture.root())
+            .arg("chef")
+            .env("HELIX_SKIP_CLOUD_AUTH", "1")
+            .env("HELIX_TEST_CHEF_PERMISSION_MODE", "full_auto")
+            .env("HELIX_TEST_TOOL_STDOUT", "Built successfully")
+            .assert()
+            .success(),
+    );
+    assert!(chef.contains("Built successfully"));
+    let tools = fixture.tool_log();
+    assert!(tools.contains("agent -p"));
+    assert!(tools.contains("--force"));
+    assert!(tools.contains("--trust"));
+    assert!(tools.contains("--approve-mcps"));
+    assert!(tools.contains("--workspace"));
+    assert!(tools.contains("HELIX_CHEF_PROMPT.md"));
+    assert!(!tools.contains("claude --append-system-prompt-file"));
+    assert!(!tools.contains("codex exec"));
+    assert!(!tools.contains("opencode run"));
+}

--- a/crates/cli/tests/chef_command.rs
+++ b/crates/cli/tests/chef_command.rs
@@ -110,8 +110,14 @@ async fn headless_chef_launches_cursor_agent() {
         .mount(&server)
         .await;
 
-    let fixture = CliFixture::new_with_fake_runtime()
-        .with_fake_tools_named(&["cargo", "node", "npm", "npx", "curl", "agent"]);
+    let fixture = CliFixture::new_with_fake_runtime().with_fake_tools_named(&[
+        "cargo",
+        "node",
+        "npm",
+        "npx",
+        "curl",
+        "cursor-agent",
+    ]);
     let project = fixture.home().join("my-first-helix-project");
     fixture
         .command()
@@ -138,7 +144,8 @@ async fn headless_chef_launches_cursor_agent() {
     );
     assert!(chef.contains("Built successfully"));
     let tools = fixture.tool_log();
-    assert!(tools.contains("agent -p"));
+    assert!(tools.contains("cursor-agent -p"));
+    assert!(tools.contains("--output-format text"));
     assert!(tools.contains("--force"));
     assert!(tools.contains("--trust"));
     assert!(tools.contains("--approve-mcps"));
@@ -147,4 +154,60 @@ async fn headless_chef_launches_cursor_agent() {
     assert!(!tools.contains("claude --append-system-prompt-file"));
     assert!(!tools.contains("codex exec"));
     assert!(!tools.contains("opencode run"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scoped_chef_launches_cursor_agent_interactively() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/healthz"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v2/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok":true})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let fixture = CliFixture::new_with_fake_runtime().with_fake_tools_named(&[
+        "cargo",
+        "node",
+        "npm",
+        "npx",
+        "curl",
+        "cursor-agent",
+    ]);
+    let project = fixture.home().join("my-first-helix-project");
+    fixture
+        .command()
+        .args(["init", "--path"])
+        .arg(&project)
+        .args(["local", "--port"])
+        .arg(server.address().port().to_string())
+        .arg("--no-skills")
+        .assert()
+        .success();
+    fs::create_dir_all(project.join("web")).unwrap();
+    fs::write(project.join("web/package.json"), "{}").unwrap();
+
+    fixture
+        .command()
+        .current_dir(fixture.root())
+        .arg("chef")
+        .env("HELIX_SKIP_CLOUD_AUTH", "1")
+        .env("HELIX_TEST_CHEF_PERMISSION_MODE", "scoped")
+        .env("HELIX_TEST_TOOL_STDOUT", "Built successfully")
+        .assert()
+        .success();
+
+    let tools = fixture.tool_log();
+    assert!(tools.contains("cursor-agent --trust"));
+    assert!(tools.contains("--workspace"));
+    assert!(tools.contains("HELIX_CHEF_PROMPT.md"));
+    assert!(!tools.contains("cursor-agent -p"));
+    assert!(!tools.contains("--force"));
+    assert!(!tools.contains("--output-format"));
 }

--- a/crates/cli/tests/support/mod.rs
+++ b/crates/cli/tests/support/mod.rs
@@ -92,6 +92,17 @@ impl CliFixture {
     }
 
     #[allow(dead_code)]
+    pub fn with_fake_tools_named(mut self, tools: &[&str]) -> Self {
+        let directory = self.root.join("tools");
+        fs::create_dir_all(&directory).expect("create fake tool directory");
+        for tool in tools {
+            install_fake_tool(&directory, tool);
+        }
+        self.test_tool_dir = Some(directory);
+        self
+    }
+
+    #[allow(dead_code)]
     pub fn write_credentials(&self, user_id: &str, api_key: &str) {
         let directory = &self.helix_home;
         fs::create_dir_all(directory).expect("create credentials directory");


### PR DESCRIPTION
chef already installs the helix docs mcp for cursor, but detect_agent only looks for claude, codex, and opencode. if only `agent` is on path, chef says no supported coding-agent cli and never launches.

repro:
1. agent on path, no claude/codex/opencode
2. helix chef
3. No supported coding-agent CLI was found in PATH (claude, codex, opencode)

same captured launch path as codex/opencode.

tested with the existing cli fixture.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Cursor Agent detection and launch support to `helix chef`, including permission-mode arguments and integration coverage.

- Adds `agent` as the lowest-priority supported coding-agent executable.
- Routes Cursor through the captured-output launch path.
- Adds unit and end-to-end coverage for Cursor argument construction and selection.
- Leaves the README's supported-agent list out of date.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/cli/src/commands/chef.rs | Adds Cursor detection, argv construction, captured launch routing, fallback output, and unit tests; the corresponding README support list remains stale. |
| crates/cli/src/external_tools.rs | Adds the Cursor Agent external-tool variant and maps it to the `agent` executable. |
| crates/cli/tests/chef_command.rs | Adds an integration test proving Cursor-only detection and full-auto argument forwarding through the fake-tool fixture. |
| crates/cli/tests/support/mod.rs | Adds a selective fake-tool installer used to isolate agent detection in integration tests. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(cli): cover chef launching agent"](https://github.com/helixdb/helix-db/commit/82d84586d3a6eea17822e2797e7880612753d20e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53606263)</sub>

**Context used:**

- Context used - readme for helixdb ([source](https://github.com/helixdb/helix-db/blob/main/README.md))
- Knowledge Base — [`helix chef`, Skills, and Feedback](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/helix-cli-chef-skills.md)

<!-- /greptile_comment -->