### PR TITLE
Move heavy CI to free GitHub runners

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -36,13 +36,14 @@ env:
 jobs:
   test:
     name: Test (${{ matrix.os }})
+    if: github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os:
           - blacksmith-2vcpu-ubuntu-2404-arm
-          - blacksmith-6vcpu-macos-latest
+          - macos-latest
           - blacksmith-2vcpu-windows-2025
     steps:
       - uses: actions/checkout@v6
@@ -61,8 +62,10 @@ jobs:
       - name: Unit and binary integration tests
         run: cargo test --locked -p helix-metrics -p helix-cli --all-targets
       - name: Doc tests
+        if: runner.os == 'Linux'
         run: cargo test --locked -p helix-metrics -p helix-cli --doc
       - name: Clippy
+        if: runner.os == 'Linux'
         run: cargo clippy --locked -p helix-metrics -p helix-cli --all-targets -- -D warnings
       - name: Formatting
         if: runner.os == 'Linux'
@@ -70,6 +73,7 @@ jobs:
 
   coverage:
     name: Coverage (Ubuntu)
+    if: github.event_name != 'schedule'
     runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cloud-launch-nightly.yml
+++ b/.github/workflows/cloud-launch-nightly.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   planner-matrix:
     name: Planner matrix shard ${{ matrix.shard }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -38,7 +38,7 @@ jobs:
 
   fuzz:
     name: Fuzz ${{ matrix.target }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -77,7 +77,7 @@ jobs:
 
   workload-matrix:
     name: Deterministic workload seeds
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -100,7 +100,7 @@ jobs:
 
   vector-lifecycle:
     name: Bounded 8k vector lifecycle
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -114,7 +114,7 @@ jobs:
 
   coverage:
     name: ${{ matrix.name }}
-    runs-on: blacksmith-6vcpu-macos-15
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/cloud-launch-vector-100k.yml
+++ b/.github/workflows/cloud-launch-vector-100k.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build-vector-100k:
     name: Build vector 100k contract
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -52,7 +52,7 @@ jobs:
   vector-100k:
     name: Vector 100k create, search, drop, and residue
     needs: build-vector-100k
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 360
     steps:
       - uses: actions/download-artifact@v5

--- a/.github/workflows/db-vector-production-coverage.yml
+++ b/.github/workflows/db-vector-production-coverage.yml
@@ -2,6 +2,12 @@ name: Production coverage
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
     paths:
       - ".github/workflows/cloud-launch-vector-100k.yml"
       - ".github/workflows/db-vector-production-coverage.yml"
@@ -26,11 +32,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: production-coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   production-coverage:
     name: DB production thresholds
-    if: github.event_name != 'workflow_dispatch' || inputs.profile == 'coverage'
-    runs-on: blacksmith-6vcpu-macos-15
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'workflow_dispatch' || inputs.profile == 'coverage')
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 75
     steps:
       - uses: actions/checkout@v6
@@ -47,8 +59,10 @@ jobs:
 
   server-production-coverage:
     name: Transport and query-service thresholds
-    if: github.event_name != 'workflow_dispatch' || inputs.profile == 'coverage'
-    runs-on: blacksmith-6vcpu-macos-15
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'workflow_dispatch' || inputs.profile == 'coverage')
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -63,29 +77,31 @@ jobs:
 
   architecture-kernels:
     name: ${{ matrix.kernel }}
-    if: github.event_name != 'workflow_dispatch' || inputs.profile == 'coverage'
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'workflow_dispatch' || inputs.profile == 'coverage')
     strategy:
       fail-fast: false
       matrix:
         include:
           - kernel: x86_64 scalar reference
-            runner: blacksmith-2vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             rustflags: -C target-cpu=x86-64
             features: production-coverage,force-vector-scalar-kernel
           - kernel: x86_64 SSE4.1
-            runner: blacksmith-2vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             rustflags: -C target-cpu=x86-64 -C target-feature=+sse4.1,-avx,-avx2,-fma
             features: production-coverage
           - kernel: x86_64 AVX FMA
-            runner: blacksmith-2vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             rustflags: -C target-cpu=x86-64 -C target-feature=+sse4.1,+avx,+avx2,+fma
             features: production-coverage
           - kernel: aarch64 scalar reference
-            runner: blacksmith-6vcpu-macos-15
+            runner: ubuntu-24.04-arm
             rustflags: ""
             features: production-coverage,force-vector-scalar-kernel
           - kernel: aarch64 NEON
-            runner: blacksmith-6vcpu-macos-15
+            runner: ubuntu-24.04-arm
             rustflags: -C target-feature=+neon
             features: production-coverage
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/db-vector-production-coverage.yml
+++ b/.github/workflows/db-vector-production-coverage.yml
@@ -34,7 +34,7 @@ permissions:
 
 concurrency:
   group: production-coverage-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   production-coverage:

--- a/.github/workflows/sdk-query-parity-macos.yml
+++ b/.github/workflows/sdk-query-parity-macos.yml
@@ -1,0 +1,70 @@
+name: SDK query parity macOS
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/sdk-query-parity-macos.yml"
+      - "bindings/uniffi/**"
+      - "bindings/uniffi-bindgen/**"
+      - "sdks/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/sdk-query-parity-macos.yml"
+      - "bindings/uniffi/**"
+      - "bindings/uniffi-bindgen/**"
+      - "sdks/**"
+  schedule:
+    - cron: "23 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-query-parity-macos-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  embedded:
+    name: Generated embedded bindings (macOS)
+    runs-on: macos-latest
+    env:
+      CARGO_BUILD_JOBS: "1"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: sdks/typescript/package-lock.json
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24.x"
+          cache: false
+      - uses: dtolnay/rust-toolchain@1.97.1
+      - name: Fetch locked Rust dependencies
+        run: |
+          cargo fetch --locked
+          cargo fetch --locked --manifest-path bindings/uniffi-bindgen/Cargo.toml
+      - name: Build Go embedded binding generator
+        run: >-
+          cargo build --locked
+          --manifest-path bindings/uniffi-bindgen/Cargo.toml
+          --no-default-features --features go
+          --bin helixdb-uniffi-bindgen-go
+      - name: Prebuild embedded binding generators
+        run: |
+          cargo build --locked -p helixdb-uniffi --features bindgen --bin helixdb-uniffi-bindgen
+          cargo build --locked --manifest-path bindings/uniffi-bindgen/Cargo.toml --no-default-features --features node --bin helixdb-uniffi-bindgen-node
+      - run: npm ci
+        working-directory: sdks/typescript
+      - run: python -m pip install -e './sdks/python[dev]'
+      - run: npm run parity:embedded
+        working-directory: sdks/typescript
+        env:
+          HELIXDB_UNIFFI_GO_BINDGEN: ${{ github.workspace }}/bindings/uniffi-bindgen/target/debug/helixdb-uniffi-bindgen-go

--- a/.github/workflows/sdk-query-parity.yml
+++ b/.github/workflows/sdk-query-parity.yml
@@ -24,16 +24,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: sdk-query-parity-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   contracts:
-    name: Contracts (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - blacksmith-2vcpu-ubuntu-2404-arm
-          - blacksmith-6vcpu-macos-latest
+    name: Contracts (Linux ARM)
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -91,17 +89,11 @@ jobs:
       - run: cargo test --locked -p helixdb-uniffi
 
   embedded-go-generator:
-    name: Go embedded binding generator (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Go embedded binding generator (Linux ARM)
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     env:
       CARGO_BUILD_JOBS: "1"
       CARGO_PROFILE_DEV_DEBUG: "0"
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - blacksmith-2vcpu-ubuntu-2404-arm
-          - blacksmith-6vcpu-macos-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.97.1
@@ -139,22 +131,16 @@ jobs:
           tar -czf embedded-go-generator.tar.gz -C embedded-go-generator-artifact .
       - uses: actions/upload-artifact@v4
         with:
-          name: embedded-go-generator-${{ matrix.os }}
+          name: embedded-go-generator-linux-arm
           path: embedded-go-generator.tar.gz
           retention-days: 1
 
   embedded:
-    name: Generated embedded bindings (${{ matrix.os }})
+    name: Generated embedded bindings (Linux ARM)
     needs: embedded-go-generator
-    runs-on: ${{ matrix.os }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     env:
       CARGO_PROFILE_DEV_DEBUG: "0"
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - blacksmith-2vcpu-ubuntu-2404-arm
-          - blacksmith-6vcpu-macos-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -172,7 +158,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.97.1
       - uses: actions/download-artifact@v5
         with:
-          name: embedded-go-generator-${{ matrix.os }}
+          name: embedded-go-generator-linux-arm
           path: embedded-go-generator-download
       - name: Extract Go embedded binding generator
         run: |


### PR DESCRIPTION
## Summary

- Move production coverage, nightly coverage, and the manual vector-100k workflow to free GitHub-hosted ARM/x64 runners.
- Skip production coverage on draft pull requests and cancel stale pull-request coverage runs.
- Keep recurring Linux SDK parity and coverage on 2-vCPU Blacksmith ARM runners.
- Run macOS SDK validation only for binding/SDK changes, weekly, or manually.
- Replace the three paid SDK macOS legs with one `macos-latest` embedded-binding job that builds and validates its generators in one runner.
- Restore the CLI macOS leg to `macos-latest`; daily CLI schedules now run only the registry smoke job.
- Keep CLI docs, Clippy, formatting, and coverage on Blacksmith Linux.
- Leave pre-launch CI unchanged because it has no current run volume.

## Why

Architecture-independent production and nightly coverage used paid 6-vCPU Blacksmith macOS runners. Production coverage also ran for draft pull requests, and SDK parity repeated full contracts plus generator and embedded validation on macOS.

Standard GitHub-hosted runners are free and unlimited for this public repository. This change keeps fast, frequent pull-request checks on Blacksmith while moving long or infrequent work to free runners.

## Expected impact

Based on completed jobs since August 6, this should remove about 80–90% of current Blacksmith macOS spend without deleting meaningful platform coverage. Hosted run time and the 14 GB GitHub runner disk limit still need verification on this PR and the next scheduled nightly.

## Validation

- Actionlint passes for all six changed workflows after allowing the existing Blacksmith custom labels.
- YAML parsing and exact runner-mapping assertions pass.
- `cargo fmt --all -- --check` passes.
- `cargo clippy --workspace -- -D warnings` passes.
- The combined macOS Go binding generator builds successfully and produces the executable at the path used by the new workflow.
- Cargo targets were cleaned after validation.

## References

- [GitHub-hosted runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)
- [Blacksmith runner pricing](https://docs.blacksmith.sh/blacksmith-runners/overview)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reallocates expensive CI workloads from paid Blacksmith macOS/Linux runners to GitHub-hosted runners and splits recurring macOS SDK validation into a dedicated workflow.
- Skips scheduled CLI test and coverage jobs while retaining the registry smoke check.
- Moves nightly, production-coverage, architecture-kernel, and vector-100k workloads to hosted ARM or x64 runners.
- Consolidates macOS embedded-binding generation and validation into one weekly/path-filtered job.
- Adds cancellation and draft-PR controls to reduce unnecessary coverage runs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/cli-tests.yml | Restores hosted macOS CLI testing and limits scheduled execution to the registry smoke job without an identified defect. |
| .github/workflows/cloud-launch-nightly.yml | Moves nightly workloads to hosted ARM; the unchanged ten-minute timeout is poorly aligned with cold production coverage compilation. |
| .github/workflows/cloud-launch-vector-100k.yml | Moves both vector-100k phases to hosted ARM while preserving architecture compatibility and generous timeouts. |
| .github/workflows/db-vector-production-coverage.yml | Adds draft filtering and PR-only cancellation while moving coverage and architecture matrices to hosted runners. |
| .github/workflows/sdk-query-parity-macos.yml | Adds consolidated macOS embedded parity, but unrelated non-PR event types can cancel one another through the shared main-ref concurrency group. |
| .github/workflows/sdk-query-parity.yml | Removes duplicated macOS matrix legs and retains Linux ARM contracts, embedded-generation, and coverage validation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  PR[Pull request] --> Linux[Linux SDK parity]
  PR -->|SDK or binding paths| Mac[macOS embedded parity]
  Push[Push to main] --> Linux
  Push --> Mac
  Weekly[Weekly schedule] --> Mac
  Manual[Manual dispatch] --> Mac
  Push -. shared main concurrency group .-> Cancel{Cancel in-progress}
  Weekly -. shared main concurrency group .-> Cancel
  Manual -. shared main concurrency group .-> Cancel
  Cancel --> Mac
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Limit coverage cancellation to pull requ..."](https://github.com/helixdb/helix-db/commit/0baf58affc5acbb24fe0f6f5266b013cc1ba8fd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53951534)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Cross-SDK DSL Parity Testing](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/sdk-parity-tests.md)

<!-- /greptile_comment -->