### PR TITLE
ci: notify Discord about new issues

### DIFF
--- a/.github/workflows/discord-new-issue.yml
+++ b/.github/workflows/discord-new-issue.yml
@@ -1,0 +1,45 @@
+name: Notify Discord of new issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    name: Notify Discord
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Send issue notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_ISSUES_WEBHOOK_URL }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          test -n "$DISCORD_WEBHOOK_URL"
+
+          jq -n \
+            --arg author "$ISSUE_AUTHOR" \
+            --arg number "$ISSUE_NUMBER" \
+            --arg title "$ISSUE_TITLE" \
+            --arg url "$ISSUE_URL" \
+            '{
+              username: "HelixDB Issues",
+              allowed_mentions: {parse: []},
+              embeds: [{
+                title: $title,
+                url: $url,
+                description: ("Opened by `" + $author + "`"),
+                color: 5814783,
+                footer: {text: ("HelixDB/helix-db issue #" + $number)}
+              }]
+            }' |
+            curl --silent --show-error --fail-with-body \
+              --retry 3 --retry-all-errors \
+              --header "Content-Type: application/json" \
+              --data-binary @- \
+              "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## Summary

- notify Discord when a GitHub issue is opened
- format the notification as an embed with the issue title, author, number, and URL
- disable mention parsing and retry transient webhook failures
- read the webhook only from the `DISCORD_ISSUES_WEBHOOK_URL` Actions secret

## Why

New open-source issues should be visible in Discord without running or maintaining a separate bot.

## Validation

- `actionlint .github/workflows/discord-new-issue.yml`
- `git diff --check origin/main...HEAD`
- confirmed the repository Actions secret exists
- confirmed the webhook URL is absent from the committed tree

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a GitHub Actions workflow that posts newly opened issues to Discord using a secret-backed webhook.
- Builds a structured Discord embed from the issue title, author, number, and URL.
- Disables mention parsing and configures webhook retries.
- Grants the workflow no GitHub token permissions.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/discord-new-issue.yml | Adds a least-privilege issue-opened workflow that safely serializes event fields into a Discord webhook payload; no actionable defect was established. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as GitHub user
  participant A as GitHub Actions
  participant J as jq
  participant D as Discord webhook
  U->>A: Open issue
  A->>J: Issue metadata
  J-->>A: JSON embed payload
  A->>D: POST webhook payload
  alt Transient request failure
    A->>D: Retry webhook request
  end
  D-->>A: HTTP response
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: notify Discord about new issues"](https://github.com/helixdb/helix-db/commit/5c4e866808c9f609ccfbc89fd66a72241bd157dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53960557)</sub>

<!-- /greptile_comment -->