### PR TITLE
Update SlateDB fork to v0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "fail-parallel"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f4a147ba57fcd64323c54c8f69fd4e045456a99574163010ccf5eea3168aaa"
+checksum = "c29b33a0187823f1fa88b36980227dc96c7504ede2288e7d2a77d9d6d88b260c"
 dependencies = [
  "log",
  "once_cell",
@@ -4796,8 +4796,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slatedb"
-version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
+version = "0.15.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4841,8 +4841,8 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
+version = "0.15.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
 dependencies = [
  "chrono",
  "log",
@@ -4856,8 +4856,8 @@ dependencies = [
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
+version = "0.15.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4797,7 +4797,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
 dependencies = [
  "chrono",
  "log",
@@ -4857,7 +4857,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db-testkit/fuzz/Cargo.lock
+++ b/crates/db-testkit/fuzz/Cargo.lock
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "fail-parallel"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f4a147ba57fcd64323c54c8f69fd4e045456a99574163010ccf5eea3168aaa"
+checksum = "c29b33a0187823f1fa88b36980227dc96c7504ede2288e7d2a77d9d6d88b260c"
 dependencies = [
  "log",
  "once_cell",
@@ -3145,8 +3145,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slatedb"
-version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
+version = "0.15.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3190,8 +3190,8 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
+version = "0.15.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
 dependencies = [
  "chrono",
  "log",
@@ -3205,8 +3205,8 @@ dependencies = [
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
+version = "0.15.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db-testkit/fuzz/Cargo.lock
+++ b/crates/db-testkit/fuzz/Cargo.lock
@@ -3146,7 +3146,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3191,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
 dependencies = [
  "chrono",
  "log",
@@ -3206,7 +3206,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "a60a1234f8b6a184381b0b0b2dc88c1cabd010f7" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "a60a1234f8b6a184381b0b0b2dc88c1cabd010f7" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "30d9f28cfeb93cf95652aac2b7724811c5c49630" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/db/fuzz/Cargo.lock
+++ b/crates/db/fuzz/Cargo.lock
@@ -628,6 +628,7 @@ dependencies = [
  "helix-ast",
  "helix-metrics",
  "helix-planner",
+ "helix-value-semantics",
  "insta",
  "libc",
  "object_store 0.12.5",
@@ -841,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "fail-parallel"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f4a147ba57fcd64323c54c8f69fd4e045456a99574163010ccf5eea3168aaa"
+checksum = "c29b33a0187823f1fa88b36980227dc96c7504ede2288e7d2a77d9d6d88b260c"
 dependencies = [
  "log",
  "once_cell",
@@ -1320,10 +1321,15 @@ name = "helix-planner"
 version = "0.1.0"
 dependencies = [
  "helix-ast",
+ "helix-value-semantics",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "helix-value-semantics"
+version = "0.1.0"
 
 [[package]]
 name = "hermit-abi"
@@ -3119,8 +3125,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slatedb"
-version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
+version = "0.15.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3164,8 +3170,8 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
+version = "0.15.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
 dependencies = [
  "chrono",
  "log",
@@ -3179,8 +3185,8 @@ dependencies = [
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
+version = "0.15.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db/fuzz/Cargo.lock
+++ b/crates/db/fuzz/Cargo.lock
@@ -3126,7 +3126,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3171,7 +3171,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
 dependencies = [
  "chrono",
  "log",
@@ -3186,7 +3186,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
 dependencies = [
  "async-trait",
  "bytes",

--- a/scripts/run-migration-parity.sh
+++ b/scripts/run-migration-parity.sh
@@ -88,7 +88,7 @@ fi
 TARGET_SLATEDB_REVISION="$({
     cargo metadata --locked --manifest-path "$TOOL_MANIFEST" --format-version 1
 } | jq -er '
-    [.packages[] | select(.name == "slatedb" and .version == "0.14.1")] as $packages
+    [.packages[] | select(.name == "slatedb" and .version == "0.15.0")] as $packages
     | if ($packages | length) != 1 then
         error("expected exactly one resolved target SlateDB package")
       else

--- a/tools/hyperscale-migration-parity/Cargo.lock
+++ b/tools/hyperscale-migration-parity/Cargo.lock
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
 dependencies = [
  "chrono",
  "log",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
 dependencies = [
  "async-trait",
  "bytes",

--- a/tools/hyperscale-migration-parity/Cargo.lock
+++ b/tools/hyperscale-migration-parity/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "siphasher",
- "slatedb 0.14.1",
+ "slatedb 0.15.0",
  "sonic-rs",
  "stable_deref_trait",
  "tantivy 0.26.1",
@@ -801,7 +801,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -922,7 +922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -951,6 +951,18 @@ name = "fail-parallel"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f4a147ba57fcd64323c54c8f69fd4e045456a99574163010ccf5eea3168aaa"
+dependencies = [
+ "log",
+ "once_cell",
+ "rand 0.9.5",
+ "tokio",
+]
+
+[[package]]
+name = "fail-parallel"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c29b33a0187823f1fa88b36980227dc96c7504ede2288e7d2a77d9d6d88b260c"
 dependencies = [
  "log",
  "once_cell",
@@ -1797,7 +1809,7 @@ dependencies = [
  "sha2 0.10.9",
  "siphasher",
  "slatedb 0.10.0",
- "slatedb 0.14.1",
+ "slatedb 0.15.0",
  "slatedb-common",
  "tempfile",
  "tokio",
@@ -2485,7 +2497,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2947,7 +2959,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3424,7 +3436,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3482,7 +3494,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3769,7 +3781,7 @@ dependencies = [
  "crossbeam-skiplist",
  "dotenvy",
  "duration-str",
- "fail-parallel",
+ "fail-parallel 0.5.2",
  "figment",
  "flatbuffers",
  "foyer 0.18.1",
@@ -3799,8 +3811,8 @@ dependencies = [
 
 [[package]]
 name = "slatedb"
-version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
+version = "0.15.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3813,7 +3825,7 @@ dependencies = [
  "crossbeam-skiplist",
  "dotenvy",
  "duration-str",
- "fail-parallel",
+ "fail-parallel 0.6.0",
  "figment",
  "flatbuffers",
  "foyer 0.22.3",
@@ -3844,8 +3856,8 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
+version = "0.15.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
 dependencies = [
  "chrono",
  "log",
@@ -3859,8 +3871,8 @@ dependencies = [
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.14.1"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e#dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e"
+version = "0.15.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=a60a1234f8b6a184381b0b0b2dc88c1cabd010f7#a60a1234f8b6a184381b0b0b2dc88c1cabd010f7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4360,7 +4372,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4370,7 +4382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5031,7 +5043,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/tools/hyperscale-migration-parity/Cargo.toml
+++ b/tools/hyperscale-migration-parity/Cargo.toml
@@ -16,8 +16,8 @@ futures = "0.3"
 baseline-helix-dsl = { package = "helix-db", version = "=2.0.5" }
 helix = { path = "../../../helix-hyperscale-migration-parity-source/enterprise/helix" }
 hyperscale-slatedb = { package = "slatedb", path = "../../../helix-hyperscale-migration-parity-source/enterprise/slatedb/slatedb" }
-target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "a60a1234f8b6a184381b0b0b2dc88c1cabd010f7" }
-target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "a60a1234f8b6a184381b0b0b2dc88c1cabd010f7" }
+target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "30d9f28cfeb93cf95652aac2b7724811c5c49630" }
+target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "30d9f28cfeb93cf95652aac2b7724811c5c49630" }
 object_store = { version = "0.12", features = ["aws"] }
 object_store_014 = { package = "object_store", version = "0.14", features = ["aws"] }
 roaring = { version = "0.11", features = ["serde"] }

--- a/tools/hyperscale-migration-parity/Cargo.toml
+++ b/tools/hyperscale-migration-parity/Cargo.toml
@@ -16,8 +16,8 @@ futures = "0.3"
 baseline-helix-dsl = { package = "helix-db", version = "=2.0.5" }
 helix = { path = "../../../helix-hyperscale-migration-parity-source/enterprise/helix" }
 hyperscale-slatedb = { package = "slatedb", path = "../../../helix-hyperscale-migration-parity-source/enterprise/slatedb/slatedb" }
-target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e" }
-target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "dfe4b4dc38609db8b3fe8dc6f2d3de64bfe63f0e" }
+target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "a60a1234f8b6a184381b0b0b2dc88c1cabd010f7" }
+target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "a60a1234f8b6a184381b0b0b2dc88c1cabd010f7" }
 object_store = { version = "0.12", features = ["aws"] }
 object_store_014 = { package = "object_store", version = "0.14", features = ["aws"] }
 roaring = { version = "0.11", features = ["serde"] }

--- a/tools/hyperscale-migration-parity/examples/storage_audit.rs
+++ b/tools/hyperscale-migration-parity/examples/storage_audit.rs
@@ -62,6 +62,8 @@ async fn main() -> Result<()> {
                 compactions_options: Some(directory),
                 detach_options: None,
                 metric_level: None,
+                boundary_files_enabled: true,
+                object_store_max_retries: None,
             })
             .await?;
     }

--- a/tools/hyperscale-migration-parity/src/main.rs
+++ b/tools/hyperscale-migration-parity/src/main.rs
@@ -136,7 +136,7 @@ const VECTOR_QUERY: [f32; 3] = [0.1, 0.0, 0.0];
 const EXPECTED_VECTOR_HITS: [(u64, u32); 3] =
     [(1, 1_008_981_771), (2, 1_062_165_544), (3, 1_082_151_404)];
 const SOURCE_HYPERSCALE_REVISION: &str = "e5bac15b020c9acac1649c44b58a2cf16dd1f874";
-const TARGET_SLATEDB_VERSION: &str = "0.14.1";
+const TARGET_SLATEDB_VERSION: &str = "0.15.0";
 const TARGET_SLATEDB_GIT_SOURCE: &str = "git+https://github.com/HelixDB/slatedb.git?rev=";
 const FIRST_SCALE_NODE_ID: u64 = 1_000_000;
 const SCALE_SEED_PROGRESS_INTERVAL: u64 = 100_000;
@@ -5016,6 +5016,8 @@ async fn run_target_garbage_collection(
         compactions_options: Some(directory),
         detach_options: None,
         metric_level: None,
+        boundary_files_enabled: true,
+        object_store_max_retries: None,
     };
     let clock: Arc<dyn SystemClock> = Arc::new(ShiftedSystemClock {
         advance: clock_advance,
@@ -5487,7 +5489,7 @@ mod tests {
         let lock = format!(
             r#"[[package]]
 name = "slatedb"
-version = "0.14.1"
+version = "0.15.0"
 source = "git+https://github.com/HelixDB/slatedb.git?rev={revision}#{revision}"
 "#
         );
@@ -5505,7 +5507,7 @@ source = "git+https://github.com/HelixDB/slatedb.git?rev={revision}#{revision}"
         let package = format!(
             r#"[[package]]
 name = "slatedb"
-version = "0.14.1"
+version = "0.15.0"
 source = "git+https://github.com/HelixDB/slatedb.git?rev={revision}#{revision}"
 "#
         );
@@ -5513,7 +5515,7 @@ source = "git+https://github.com/HelixDB/slatedb.git?rev={revision}#{revision}"
         assert!(target_slatedb_revision_from_lock(
             r#"[[package]]
 name = "slatedb"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 "#,
         )
@@ -5521,7 +5523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         assert!(target_slatedb_revision_from_lock(
             r#"[[package]]
 name = "slatedb"
-version = "0.14.1"
+version = "0.15.0"
 source = "git+https://github.com/HelixDB/slatedb.git?rev=main#not-a-revision"
 "#,
         )


### PR DESCRIPTION
## What changed

- update the Helix SlateDB fork revision from dfe4b4dc to merge commit 30d9f28c
- consume SlateDB v0.15.0 from the merged HelixDB/slatedb#8 port
- refresh the workspace, migration-parity, and checked-in fuzz lockfiles
- use a portable /tmp fallback for production-coverage scripts on Ubuntu runners

## Revision provenance

SlateDB commit 30d9f28cfeb93cf95652aac2b7724811c5c49630 is the merge commit for HelixDB/slatedb#8. Its second parent is a60a1234f8b6a184381b0b0b2dc88c1cabd010f7, the former codex/port-v0.15 branch tip. Pinning the merge commit validates the merged main-branch state while retaining the exact PR revision in its ancestry.

## Why

The SlateDB v0.15 fork port is now merged. Helix should validate the immutable merged revision rather than the former draft branch tip.

## Impact

No Helix source compatibility changes were required beyond the existing SlateDB v0.15 migration-parity adjustments. The production-coverage script change only replaces the macOS-specific /private/tmp fallback with portable /tmp.

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo metadata --locked resolves SlateDB v0.15.0 at 30d9f28c
- all four checked-in lockfiles resolve SlateDB packages at 30d9f28c
- shell syntax and unset-TMPDIR fallback checks pass