### PR TITLE
fix: align Python SDK license packaging with Apache-2.0

### DIFF
--- a/.github/workflows/python-js-packages.yml
+++ b/.github/workflows/python-js-packages.yml
@@ -10,6 +10,7 @@ on:
       - "crates/**"
       - "sdks/python/**"
       - "sdks/typescript/**"
+      - "LICENSE"
       - "Cargo.toml"
       - "Cargo.lock"
   push:
@@ -21,6 +22,7 @@ on:
       - "crates/**"
       - "sdks/python/**"
       - "sdks/typescript/**"
+      - "LICENSE"
       - "Cargo.toml"
       - "Cargo.lock"
 
@@ -41,6 +43,7 @@ jobs:
           python -m pip install --upgrade build twine
           python -m build --sdist --wheel --outdir dist sdks/python
           python -m twine check dist/*
+          python sdks/python/scripts/validate_package_license.py dist/*
           python -m pip install --force-reinstall dist/*.whl
           python -m unittest discover -s sdks/python/tests -v
       - uses: actions/upload-artifact@v4

--- a/sdks/python/LICENSE
+++ b/sdks/python/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -5,6 +5,11 @@ asynchronous clients for sending HelixDB queries to `POST /v2/query` or
 executing them against an embedded database. The async client uses HTTPX; the
 sync API remains unchanged.
 
+## License
+
+The HelixDB Python SDK is licensed under the Apache License 2.0. See
+[`LICENSE`](LICENSE) for the complete terms.
+
 ```python
 from helixdb import Client, Predicate, g, read_batch
 

--- a/sdks/python/publish.sh
+++ b/sdks/python/publish.sh
@@ -37,6 +37,7 @@ echo ">> Building sdist + wheel"
 
 echo ">> Validating artifacts"
 twine check dist/*
+"${PYTHON}" scripts/validate_package_license.py dist/*
 
 echo ">> Uploading to ${INDEX_NAME}"
 TWINE_USERNAME=__token__ TWINE_PASSWORD="${PYPI_TOKEN}" \

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,13 +8,13 @@ version = "0.3.4"
 description = "Python SDK for the HelixDB query DSL and client"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [{ name = "HelixDB" }]
 keywords = ["helixdb", "graph", "vector", "database", "dsl"]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/sdks/python/scripts/validate_package_license.py
+++ b/sdks/python/scripts/validate_package_license.py
@@ -1,0 +1,125 @@
+"""Validate license metadata and files in Python distribution archives."""
+
+from __future__ import annotations
+
+import argparse
+import tarfile
+import zipfile
+from email.parser import BytesParser
+from email.policy import default
+from pathlib import Path, PurePosixPath
+from typing import Callable
+
+EXPECTED_EXPRESSION = "Apache-2.0"
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = PACKAGE_ROOT.parents[1]
+EXPECTED_LICENSE = (REPOSITORY_ROOT / "LICENSE").read_bytes()
+
+
+def require_one(names: list[str], description: str, predicate: Callable[[str], bool]) -> str:
+    matches = [name for name in names if predicate(name)]
+    if len(matches) != 1:
+        raise ValueError(f"expected one {description}, found {len(matches)}")
+    return matches[0]
+
+
+def validate_metadata(contents: bytes) -> None:
+    """Validate the PEP 639 license contract in core package metadata."""
+
+    metadata = BytesParser(policy=default).parsebytes(contents)
+    expression = metadata.get("License-Expression")
+    if expression != EXPECTED_EXPRESSION:
+        raise ValueError(
+            f"expected License-Expression {EXPECTED_EXPRESSION!r}, found {expression!r}"
+        )
+
+    classifiers = metadata.get_all("Classifier", [])
+    license_classifiers = [value for value in classifiers if value.startswith("License ::")]
+    if license_classifiers:
+        raise ValueError(f"deprecated license classifiers found: {license_classifiers!r}")
+
+    license_files = metadata.get_all("License-File", [])
+    if "LICENSE" not in license_files:
+        raise ValueError(f"expected License-File 'LICENSE', found {license_files!r}")
+
+
+def validate_wheel(path: Path) -> None:
+    """Validate one built wheel without extracting it to disk."""
+
+    with zipfile.ZipFile(path) as archive:
+        names = archive.namelist()
+        metadata_name = require_one(
+            names,
+            "wheel METADATA file",
+            lambda name: name.endswith(".dist-info/METADATA"),
+        )
+        license_name = require_one(
+            names,
+            "wheel LICENSE file",
+            lambda name: name.endswith(".dist-info/licenses/LICENSE"),
+        )
+        validate_metadata(archive.read(metadata_name))
+        if archive.read(license_name) != EXPECTED_LICENSE:
+            raise ValueError("packaged wheel LICENSE does not match sdks/python/LICENSE")
+
+
+def validate_sdist(path: Path) -> None:
+    """Validate one built source distribution without extracting it to disk."""
+
+    with tarfile.open(path, mode="r:gz") as archive:
+        names = archive.getnames()
+        metadata_name = require_one(
+            names,
+            "source distribution PKG-INFO file",
+            lambda name: len(PurePosixPath(name).parts) == 2 and name.endswith("/PKG-INFO"),
+        )
+        license_name = require_one(
+            names,
+            "source distribution LICENSE file",
+            lambda name: len(PurePosixPath(name).parts) == 2 and name.endswith("/LICENSE"),
+        )
+
+        metadata_file = archive.extractfile(metadata_name)
+        license_file = archive.extractfile(license_name)
+        if metadata_file is None or license_file is None:
+            raise ValueError("package metadata or license is not a regular file")
+
+        validate_metadata(metadata_file.read())
+        if license_file.read() != EXPECTED_LICENSE:
+            raise ValueError("packaged source LICENSE does not match sdks/python/LICENSE")
+
+
+def validate_artifact(path: Path) -> None:
+    if path.suffix == ".whl":
+        validate_wheel(path)
+    elif path.name.endswith(".tar.gz"):
+        validate_sdist(path)
+    else:
+        raise ValueError("expected a .whl or .tar.gz package")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate the Python SDK license metadata and packaged license files."
+    )
+    parser.add_argument("artifacts", nargs="+", type=Path)
+    args = parser.parse_args()
+
+    if (PACKAGE_ROOT / "LICENSE").read_bytes() != EXPECTED_LICENSE:
+        print("sdks/python/LICENSE does not match the repository LICENSE")
+        return 1
+
+    failed = False
+    for artifact in args.artifacts:
+        try:
+            validate_artifact(artifact)
+        except (OSError, ValueError, tarfile.TarError, zipfile.BadZipFile) as error:
+            failed = True
+            print(f"{artifact}: {error}")
+        else:
+            print(f"{artifact}: license metadata and files are valid")
+    return int(failed)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- declare the Python SDK license as Apache-2.0 with PEP 639 metadata
- include the repository license in wheel and sdist artifacts
- validate built license metadata and files in CI and before publishing
- document the SDK license

## Root cause

The Python package declared MIT metadata while the repository uses Apache-2.0, and the built artifacts did not include the license file.

## Impact

Python package consumers receive consistent license metadata and an exact copy of the repository license in both distribution formats.

## Validation

- built the wheel and sdist
- `twine check dist/*`
- package license artifact validator
- 44 Python SDK tests
- `cargo test --workspace --locked`
- `cargo clippy --workspace -- -D warnings`
- Cargo formatting check
- Ruff format and lint checks
- Actionlint

Closes #991

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns the Python SDK’s package metadata and bundled license with the repository’s Apache-2.0 license.
- Adopts PEP 639 license metadata and requires a compatible setuptools version.
- Adds an exact SDK-local copy of the repository license to wheel and sdist artifacts.
- Validates license metadata and archive contents in CI and before publishing.
- Documents the Python SDK license and reruns package CI when the root license changes.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdks/python/pyproject.toml | Replaces obsolete MIT metadata with PEP 639 Apache-2.0 metadata and includes the license file. |
| sdks/python/scripts/validate_package_license.py | Validates wheel and sdist metadata, archive layout, and byte-for-byte license contents without extracting archives. |
| .github/workflows/python-js-packages.yml | Runs package-license validation in Python SDK CI and adds the repository license to workflow path triggers. |
| sdks/python/publish.sh | Prevents publication unless freshly built distributions pass the license validator. |
| sdks/python/LICENSE | Adds a byte-identical copy of the repository Apache-2.0 license for package inclusion. |
| sdks/python/README.md | Documents the SDK’s Apache-2.0 licensing and links to the bundled terms. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Validate Python package license artifact..."](https://github.com/helixdb/helix-db/commit/95035c1950e7da624d1a26342a1dd2defe66d87f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54319721)</sub>

<!-- /greptile_comment -->