### PR TITLE
Add idempotent write receipts

### DIFF
--- a/crates/db/src/encoding/v1/keys/metadata.rs
+++ b/crates/db/src/encoding/v1/keys/metadata.rs
@@ -12,6 +12,8 @@ pub const NEXT_NODE_ID: &[u8] = b"next_node_id";
 pub const NEXT_EDGE_ID: &[u8] = b"next_edge_id";
 const TEXT_INDEX_MANIFEST_PREFIX: &[u8] = b"text_manifest:";
 const DYNAMIC_INDEX_PREFIX: &[u8] = b"dynamic_index:";
+const WRITE_RECEIPT_PREFIX: &[u8] = b"write_receipt:";
+pub(crate) const WRITE_RECEIPT_ID_LEN: usize = 16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TextMetadataElement {
@@ -181,6 +183,20 @@ pub(crate) fn text_index_version_counter_key_scoped(scope: DataScope, index_name
     data_metadata_key_scoped(scope, format!("text_version:{index_name}").as_bytes())
 }
 
+/// Complete tenant-scoped key for one idempotent write receipt.
+///
+/// The receipt ID is fixed-width so caller-controlled bytes cannot overlap
+/// another metadata family or create ambiguous prefix encodings.
+pub(crate) fn write_receipt_key_scoped(
+    scope: DataScope,
+    request_id: &[u8; WRITE_RECEIPT_ID_LEN],
+) -> Bytes {
+    let mut name = Vec::with_capacity(WRITE_RECEIPT_PREFIX.len() + WRITE_RECEIPT_ID_LEN);
+    name.extend_from_slice(WRITE_RECEIPT_PREFIX);
+    name.extend_from_slice(request_id);
+    data_metadata_key_scoped(scope, &name)
+}
+
 fn data_metadata_key_scoped(scope: DataScope, name: &[u8]) -> Bytes {
     Key::Data {
         scope,
@@ -192,5 +208,34 @@ fn data_metadata_key_scoped(scope: DataScope, name: &[u8]) -> Bytes {
 impl<'a> From<&MetadataKey<'a>> for KeyPrefix {
     fn from(_: &MetadataKey<'a>) -> KeyPrefix {
         MetadataKey::key_prefix()
+    }
+}
+
+#[cfg(test)]
+mod write_receipt_tests {
+    use super::*;
+    use crate::encoding::keys::tenant::TenantId;
+
+    #[test]
+    fn write_receipt_key_is_fixed_width_and_tenant_scoped() {
+        let request_id = [0xA5; WRITE_RECEIPT_ID_LEN];
+        let legacy = write_receipt_key_scoped(DataScope::LegacyUnscoped, &request_id);
+        assert_eq!(
+            legacy.as_ref(),
+            [
+                &[KeyPrefix::Metadata.as_u8()][..],
+                WRITE_RECEIPT_PREFIX,
+                &request_id,
+            ]
+            .concat()
+        );
+
+        let tenant = TenantId::from_u128(7);
+        let scoped = write_receipt_key_scoped(DataScope::Tenant(tenant), &request_id);
+        assert_eq!(
+            &scoped[..DataScope::PREFIX_LEN],
+            tenant.as_u128().to_be_bytes().as_slice()
+        );
+        assert_eq!(&scoped[DataScope::PREFIX_LEN..], legacy.as_ref());
     }
 }

--- a/crates/db/src/encoding/v1/keys/metadata.rs
+++ b/crates/db/src/encoding/v1/keys/metadata.rs
@@ -235,11 +235,12 @@ mod write_receipt_tests {
         );
 
         let tenant = TenantId::from_u128(7);
-        let scoped = write_receipt_key_scoped(DataScope::Tenant(tenant), &request_id);
+        let tenant_scope = DataScope::Tenant(tenant);
+        let scoped = write_receipt_key_scoped(tenant_scope, &request_id);
+        assert_eq!(tenant_scope.strip_key(&scoped), Some(legacy.as_ref()));
         assert_eq!(
-            &scoped[..DataScope::PREFIX_LEN],
-            tenant.as_u128().to_be_bytes().as_slice()
+            DataScope::Tenant(TenantId::from_u128(8)).strip_key(&scoped),
+            None
         );
-        assert_eq!(&scoped[DataScope::PREFIX_LEN..], legacy.as_ref());
     }
 }

--- a/crates/db/src/encoding/v1/keys/metadata.rs
+++ b/crates/db/src/encoding/v1/keys/metadata.rs
@@ -197,6 +197,10 @@ pub(crate) fn write_receipt_key_scoped(
     data_metadata_key_scoped(scope, &name)
 }
 
+pub(crate) fn write_receipt_scan_prefix_scoped(scope: DataScope) -> Bytes {
+    data_metadata_key_scoped(scope, WRITE_RECEIPT_PREFIX)
+}
+
 fn data_metadata_key_scoped(scope: DataScope, name: &[u8]) -> Bytes {
     Key::Data {
         scope,

--- a/crates/db/src/encoding/v1/values/mod.rs
+++ b/crates/db/src/encoding/v1/values/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod secondary;
 pub(crate) mod text_index;
 pub(crate) mod vector_generation;
 pub mod vectors;
+pub(crate) mod write_receipt;
 
 const ENCODING_TYPE_LEN: usize = core::mem::size_of::<u8>();
 const U32_LEN: usize = core::mem::size_of::<u32>();

--- a/crates/db/src/encoding/v1/values/write_receipt.rs
+++ b/crates/db/src/encoding/v1/values/write_receipt.rs
@@ -1,0 +1,177 @@
+//! Versioned value encoding for atomic idempotent-write receipts.
+
+use bytes::{BufMut, Bytes};
+
+use crate::encoding::error::EncodingError;
+
+const VERSION: u8 = 1;
+const VERSION_LEN: usize = core::mem::size_of::<u8>();
+const EXPIRY_LEN: usize = core::mem::size_of::<u64>();
+const LEN_LEN: usize = core::mem::size_of::<u32>();
+pub(crate) const REQUEST_HASH_LEN: usize = 32;
+const HEADER_LEN: usize = VERSION_LEN + EXPIRY_LEN + REQUEST_HASH_LEN + LEN_LEN + LEN_LEN;
+
+/// One committed write response bound to its canonical request hash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WriteReceiptValue {
+    expires_at_unix_ms: u64,
+    request_hash: [u8; REQUEST_HASH_LEN],
+    response: Bytes,
+    diagnostics: Bytes,
+}
+
+impl WriteReceiptValue {
+    pub(crate) fn new(
+        expires_at_unix_ms: u64,
+        request_hash: [u8; REQUEST_HASH_LEN],
+        response: Bytes,
+        diagnostics: Bytes,
+    ) -> Result<Self, EncodingError> {
+        u32::try_from(response.len()).map_err(|_| {
+            EncodingError::Custom("write receipt response exceeds u32 length".to_string())
+        })?;
+        u32::try_from(diagnostics.len()).map_err(|_| {
+            EncodingError::Custom("write receipt diagnostics exceed u32 length".to_string())
+        })?;
+        Ok(Self {
+            expires_at_unix_ms,
+            request_hash,
+            response,
+            diagnostics,
+        })
+    }
+
+    pub(crate) const fn expires_at_unix_ms(&self) -> u64 {
+        self.expires_at_unix_ms
+    }
+
+    pub(crate) const fn request_hash(&self) -> &[u8; REQUEST_HASH_LEN] {
+        &self.request_hash
+    }
+
+    pub(crate) const fn response(&self) -> &Bytes {
+        &self.response
+    }
+
+    pub(crate) const fn diagnostics(&self) -> &Bytes {
+        &self.diagnostics
+    }
+
+    pub(crate) fn encode(&self) -> Bytes {
+        let response_len = u32::try_from(self.response.len())
+            .expect("validated write receipt response length fits u32");
+        let diagnostics_len = u32::try_from(self.diagnostics.len())
+            .expect("validated write receipt diagnostics length fits u32");
+        let mut bytes =
+            Vec::with_capacity(HEADER_LEN + self.response.len() + self.diagnostics.len());
+        bytes.put_u8(VERSION);
+        bytes.put_u64(self.expires_at_unix_ms);
+        bytes.put_slice(&self.request_hash);
+        bytes.put_u32(response_len);
+        bytes.put_u32(diagnostics_len);
+        bytes.put_slice(&self.response);
+        bytes.put_slice(&self.diagnostics);
+        Bytes::from(bytes)
+    }
+
+    pub(crate) fn decode(data: &[u8]) -> Result<Self, EncodingError> {
+        if data.len() < HEADER_LEN {
+            return Err(EncodingError::BufferTooShort {
+                expected: HEADER_LEN,
+                actual: data.len(),
+            });
+        }
+        if data[0] != VERSION {
+            return Err(EncodingError::InvalidEncodingType(data[0]));
+        }
+
+        let expires_at_unix_ms = u64::from_be_bytes(
+            data[VERSION_LEN..VERSION_LEN + EXPIRY_LEN]
+                .try_into()
+                .expect("write receipt expiry slice is 8 bytes"),
+        );
+        let request_hash = data
+            [VERSION_LEN + EXPIRY_LEN..VERSION_LEN + EXPIRY_LEN + REQUEST_HASH_LEN]
+            .try_into()
+            .expect("write receipt hash slice is 32 bytes");
+        let response_len_offset = VERSION_LEN + EXPIRY_LEN + REQUEST_HASH_LEN;
+        let response_len = u32::from_be_bytes(
+            data[response_len_offset..response_len_offset + LEN_LEN]
+                .try_into()
+                .expect("write receipt response length slice is 4 bytes"),
+        ) as usize;
+        let diagnostics_len_offset = response_len_offset + LEN_LEN;
+        let diagnostics_len = u32::from_be_bytes(
+            data[diagnostics_len_offset..diagnostics_len_offset + LEN_LEN]
+                .try_into()
+                .expect("write receipt diagnostics length slice is 4 bytes"),
+        ) as usize;
+        let response_offset = HEADER_LEN;
+        let diagnostics_offset = response_offset.checked_add(response_len).ok_or_else(|| {
+            EncodingError::Custom("write receipt response length overflows usize".to_string())
+        })?;
+        let end = diagnostics_offset
+            .checked_add(diagnostics_len)
+            .ok_or_else(|| {
+                EncodingError::Custom(
+                    "write receipt diagnostics length overflows usize".to_string(),
+                )
+            })?;
+        if data.len() != end {
+            return Err(EncodingError::Custom(format!(
+                "write receipt length mismatch: expected {end}, got {}",
+                data.len()
+            )));
+        }
+
+        Self::new(
+            expires_at_unix_ms,
+            request_hash,
+            Bytes::copy_from_slice(&data[response_offset..response_offset + response_len]),
+            Bytes::copy_from_slice(&data[diagnostics_offset..diagnostics_offset + diagnostics_len]),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_receipt_round_trips_exact_bytes() {
+        let receipt = WriteReceiptValue::new(
+            42,
+            [7; REQUEST_HASH_LEN],
+            Bytes::from_static(br#"{"created":1}"#),
+            Bytes::from_static(br#"{"statistics":{}}"#),
+        )
+        .unwrap();
+        assert_eq!(
+            WriteReceiptValue::decode(&receipt.encode()).unwrap(),
+            receipt
+        );
+    }
+
+    #[test]
+    fn write_receipt_rejects_unknown_version_and_truncated_payload() {
+        assert!(matches!(
+            WriteReceiptValue::decode(&[2; HEADER_LEN]),
+            Err(EncodingError::InvalidEncodingType(2))
+        ));
+
+        let mut encoded = WriteReceiptValue::new(
+            42,
+            [7; REQUEST_HASH_LEN],
+            Bytes::from_static(b"response"),
+            Bytes::from_static(b"diagnostics"),
+        )
+        .unwrap()
+        .encode()
+        .to_vec();
+        encoded.pop();
+        assert!(matches!(
+            WriteReceiptValue::decode(&encoded),
+            Err(EncodingError::Custom(message)) if message.contains("length mismatch")
+        ));
+    }
+}

--- a/crates/db/src/execution/interpreter/mod.rs
+++ b/crates/db/src/execution/interpreter/mod.rs
@@ -48,6 +48,8 @@ use crate::encoding::v1::values;
 use crate::error::{HelixDbError, Result};
 use crate::HelixDB;
 
+const WRITE_RECEIPT_GC_SCAN_LIMIT: usize = 64;
+
 /// Step-by-step executor for planner executable IR.
 pub struct Interpreter<'db> {
     db: &'db HelixDB,
@@ -241,6 +243,16 @@ impl<'db> Interpreter<'db> {
                 self.ctx.abort_request_write_scope();
                 return Ok(PreparedWrite::Replayed(receipt));
             }
+        }
+        let receipt_prefix =
+            keys::metadata::write_receipt_scan_prefix_scoped(self.ctx.tenant_scope);
+        if let Err(error) = self
+            .ctx
+            .prune_expired_write_receipts(&receipt_prefix, now_unix_ms, WRITE_RECEIPT_GC_SCAN_LIMIT)
+            .await
+        {
+            self.ctx.abort_request_write_scope();
+            return Err(error);
         }
 
         if let Err(error) = self.ctx.check_execution_deadline() {

--- a/crates/db/src/execution/interpreter/mod.rs
+++ b/crates/db/src/execution/interpreter/mod.rs
@@ -34,6 +34,7 @@ pub use types::{
 };
 use types::{ExecutionValueSlot, ExecutionValueStore};
 
+use bytes::Bytes;
 use helix_ast::expr::{CompareOp, Expr, Predicate};
 use helix_planner::{context, exec, ir};
 
@@ -51,6 +52,38 @@ use crate::HelixDB;
 pub struct Interpreter<'db> {
     db: &'db HelixDB,
     ctx: ExecutionContext<'db>,
+}
+
+/// Prepared idempotent write that has not crossed its durable commit boundary.
+pub(crate) struct PendingWrite<'db> {
+    ctx: ExecutionContext<'db>,
+}
+
+impl PendingWrite<'_> {
+    /// Stages the exact public response beside the graph mutation.
+    pub(crate) fn stage_receipt(
+        &mut self,
+        key: Bytes,
+        receipt: &values::write_receipt::WriteReceiptValue,
+    ) -> Result<()> {
+        self.ctx.stage_request_write_receipt(key, receipt.encode())
+    }
+
+    /// Commits the graph mutation and receipt as one serializable transaction.
+    pub(crate) async fn commit(mut self) -> Result<()> {
+        self.ctx.commit_request_write_scope().await
+    }
+}
+
+/// Result of preparing an idempotent write request.
+pub(crate) enum PreparedWrite<'db> {
+    /// A current receipt already proves this request committed.
+    Replayed(values::write_receipt::WriteReceiptValue),
+    /// The query executed inside an uncommitted request transaction.
+    Pending {
+        transaction: Box<PendingWrite<'db>>,
+        result: ExecutionResult,
+    },
 }
 
 impl<'db> Interpreter<'db> {
@@ -170,6 +203,73 @@ impl<'db> Interpreter<'db> {
             self.ctx.close_request_read_view()?;
         }
         result
+    }
+
+    /// Executes a write plan but leaves its transaction open so the caller can
+    /// serialize and stage the public response before the durable commit.
+    pub(crate) async fn prepare_idempotent_write(
+        mut self,
+        plan: &exec::ExecutablePlan,
+        receipt_key: &[u8],
+        now_unix_ms: u64,
+    ) -> Result<PreparedWrite<'db>> {
+        if plan.kind() != ir::PlanKind::Write {
+            return Err(HelixDbError::InvariantViolation(
+                "idempotent write preparation requires a write plan".to_string(),
+            ));
+        }
+        self.ctx.check_execution_deadline()?;
+        self.ensure_writer()?;
+        self.ctx.enable_request_write_scope().await?;
+
+        let existing = match self.ctx.request_write_receipt(receipt_key).await {
+            Ok(existing) => existing,
+            Err(error) => {
+                self.ctx.abort_request_write_scope();
+                return Err(error);
+            }
+        };
+        if let Some(existing) = existing {
+            let receipt = match values::write_receipt::WriteReceiptValue::decode(&existing) {
+                Ok(receipt) => receipt,
+                Err(error) => {
+                    self.ctx.abort_request_write_scope();
+                    return Err(error.into());
+                }
+            };
+            if receipt.expires_at_unix_ms() > now_unix_ms {
+                self.ctx.abort_request_write_scope();
+                return Ok(PreparedWrite::Replayed(receipt));
+            }
+        }
+
+        if let Err(error) = self.ctx.check_execution_deadline() {
+            self.ctx.abort_request_write_scope();
+            return Err(error);
+        }
+        if let Err(error) = self
+            .ctx
+            .execute_steps(plan.steps(), plan.execution_order())
+            .await
+        {
+            self.ctx.abort_request_write_scope();
+            return Err(error);
+        }
+        if let Err(error) = self.ctx.check_execution_deadline() {
+            self.ctx.abort_request_write_scope();
+            return Err(error);
+        }
+        let result = match self.ctx.finish(plan.root(), plan.returns()) {
+            Ok(result) => result,
+            Err(error) => {
+                self.ctx.abort_request_write_scope();
+                return Err(error);
+            }
+        };
+        Ok(PreparedWrite::Pending {
+            transaction: Box::new(PendingWrite { ctx: self.ctx }),
+            result,
+        })
     }
 }
 

--- a/crates/db/src/execution/interpreter/mod.rs
+++ b/crates/db/src/execution/interpreter/mod.rs
@@ -261,7 +261,7 @@ impl<'db> Interpreter<'db> {
         }
         if let Err(error) = self
             .ctx
-            .execute_steps(plan.steps(), plan.execution_order())
+            .execute_steps(plan.steps(), plan.execution_order(), plan.root())
             .await
         {
             self.ctx.abort_request_write_scope();

--- a/crates/db/src/execution/interpreter/mutation/tx.rs
+++ b/crates/db/src/execution/interpreter/mutation/tx.rs
@@ -55,6 +55,38 @@ impl<'db> ExecutionContext<'db> {
         Ok(())
     }
 
+    /// Deletes a bounded sample of expired receipt rows from the current
+    /// tenant. New unique writes therefore keep steady-state receipt storage
+    /// proportional to the live replay window.
+    pub(in crate::execution::interpreter) async fn prune_expired_write_receipts(
+        &mut self,
+        prefix: &[u8],
+        now_unix_ms: u64,
+        scan_limit: usize,
+    ) -> Result<()> {
+        let RequestWriteScopeState::Active(active) = &mut self.request_write_scope else {
+            return Err(HelixDbError::InvariantViolation(
+                "write receipt cleanup requires an active request transaction".to_string(),
+            ));
+        };
+        let mut rows = active.txn.scan_prefix(prefix, ..).await?;
+        let mut expired = Vec::new();
+        for _ in 0..scan_limit {
+            let Some(row) = rows.next().await? else {
+                break;
+            };
+            let receipt = values::write_receipt::WriteReceiptValue::decode(&row.value)?;
+            if receipt.expires_at_unix_ms() <= now_unix_ms {
+                expired.push(row.key);
+            }
+        }
+        drop(rows);
+        for key in expired {
+            active.txn.delete(key)?;
+        }
+        Ok(())
+    }
+
     /// Opens the request transaction before the first plan step.
     ///
     /// The transaction, catalog snapshot, and cache write set enter the request

--- a/crates/db/src/execution/interpreter/mutation/tx.rs
+++ b/crates/db/src/execution/interpreter/mutation/tx.rs
@@ -5,6 +5,7 @@
 //! writes. Canonical V2 generations remain in the transaction-owned family
 //! mutation sets.
 
+use bytes::Bytes;
 use slatedb::{DbTransaction, IsolationLevel};
 
 use super::super::runtime_context::{
@@ -24,6 +25,34 @@ impl<'db> ExecutionContext<'db> {
     pub(in crate::execution::interpreter) fn discard_pending_catalog_freshness(&mut self) {
         self.pending_catalog_freshness = PendingCatalogFreshness::Consumed;
         self.release_read_catalog_permit_for_ddl();
+    }
+
+    /// Reads one receipt row from the active request transaction snapshot.
+    pub(in crate::execution::interpreter) async fn request_write_receipt(
+        &self,
+        key: &[u8],
+    ) -> Result<Option<Bytes>> {
+        let RequestWriteScopeState::Active(active) = &self.request_write_scope else {
+            return Err(HelixDbError::InvariantViolation(
+                "write receipt lookup requires an active request transaction".to_string(),
+            ));
+        };
+        Ok(active.txn.get(key).await?)
+    }
+
+    /// Stages one receipt row in the active request transaction.
+    pub(in crate::execution::interpreter) fn stage_request_write_receipt(
+        &mut self,
+        key: Bytes,
+        value: Bytes,
+    ) -> Result<()> {
+        let RequestWriteScopeState::Active(active) = &mut self.request_write_scope else {
+            return Err(HelixDbError::InvariantViolation(
+                "write receipt staging requires an active request transaction".to_string(),
+            ));
+        };
+        active.txn.put(key, value)?;
+        Ok(())
     }
 
     /// Opens the request transaction before the first plan step.

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1630,27 +1630,6 @@ impl HelixDB {
         .await
     }
 
-    pub(crate) async fn prepare_idempotent_write_scoped_controlled(
-        &self,
-        plan: &exec::ExecutablePlan,
-        params: ParamBindings,
-        tenant_scope: DataScope,
-        execution_control: execution_control::ExecutionControl,
-        proof: CatalogRefreshProof,
-        receipt_key: &[u8],
-        now_unix_ms: u64,
-    ) -> Result<execution::interpreter::PreparedWrite<'_>> {
-        Interpreter::new_scoped_controlled_prepared(
-            self,
-            params,
-            tenant_scope,
-            execution_control,
-            proof,
-        )
-        .prepare_idempotent_write(plan, receipt_key, now_unix_ms)
-        .await
-    }
-
     /// Execute an SDK-built query request.
     pub async fn query(&self, request: QueryRequest) -> Result<JsonValue> {
         let query_metrics = self.embedded_query_metrics();

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1630,6 +1630,27 @@ impl HelixDB {
         .await
     }
 
+    pub(crate) async fn prepare_idempotent_write_scoped_controlled(
+        &self,
+        plan: &exec::ExecutablePlan,
+        params: ParamBindings,
+        tenant_scope: DataScope,
+        execution_control: execution_control::ExecutionControl,
+        proof: CatalogRefreshProof,
+        receipt_key: &[u8],
+        now_unix_ms: u64,
+    ) -> Result<execution::interpreter::PreparedWrite<'_>> {
+        Interpreter::new_scoped_controlled_prepared(
+            self,
+            params,
+            tenant_scope,
+            execution_control,
+            proof,
+        )
+        .prepare_idempotent_write(plan, receipt_key, now_unix_ms)
+        .await
+    }
+
     /// Execute an SDK-built query request.
     pub async fn query(&self, request: QueryRequest) -> Result<JsonValue> {
         let query_metrics = self.embedded_query_metrics();

--- a/crates/db/src/query_service.rs
+++ b/crates/db/src/query_service.rs
@@ -5,8 +5,10 @@
 //! of deserializing, planning, or serializing execution results themselves.
 
 use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use helix_ast::batch::{BatchQuery, ReadBatch, WriteBatch};
 use helix_ast::query::{QueryRequest, QueryRequestType, QueryValue};
 use helix_metrics::{query, query::transport::OssQueryMetrics};
@@ -14,9 +16,11 @@ use helix_planner::{context::ParamBindings, diagnostics::PlannerDiagnostics, ir:
 use serde::ser::Serializer;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
+use sha2::{Digest as _, Sha256};
 
 use crate::encoding::keys::tenant::DataScope;
 use crate::encoding::property::property_value::PropertyValue as DbPropertyValue;
+use crate::encoding::v1::{keys, values};
 use crate::error::HelixDbError;
 use crate::execution::interpreter::{ElementRef, ExecutionResult, ExecutionScalar, ExecutionValue};
 use crate::execution_control::ExecutionControl;
@@ -130,6 +134,102 @@ impl HelixQueryService {
         )
         .await
     }
+
+    /// Execute one tenant-scoped write with an atomic replay receipt.
+    ///
+    /// A successful graph mutation and its exact public response commit in the
+    /// same serializable SlateDB transaction. Retrying the same request ID and
+    /// payload returns the stored response without executing the mutation.
+    pub async fn execute_idempotent_write_scoped_controlled(
+        &self,
+        request: QueryRequest,
+        tenant_scope: DataScope,
+        execution_control: ExecutionControl,
+        receipt: WriteReceiptOptions,
+    ) -> std::result::Result<QueryExecution, QueryServiceError> {
+        let observation = self
+            .query_metrics
+            .as_ref()
+            .and_then(|_| QueryObservation::capture(&request, None));
+        let started_at = std::time::Instant::now();
+        let result = execute_idempotent_write_on_scoped(
+            self.db.as_ref(),
+            request,
+            tenant_scope,
+            execution_control,
+            receipt,
+        )
+        .await;
+        if let (Some(query_metrics), Some(observation)) = (self.query_metrics.as_ref(), observation)
+        {
+            let observed = result.as_ref().map(QueryExecution::response);
+            let _ = query_metrics.record(observation.event(observed, started_at.elapsed()));
+        }
+        result
+    }
+}
+
+/// Validated bounded storage policy for one idempotent write receipt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WriteReceiptOptions {
+    request_id: [u8; keys::metadata::WRITE_RECEIPT_ID_LEN],
+    expires_at_unix_ms: u64,
+    max_response_bytes: NonZeroUsize,
+}
+
+impl WriteReceiptOptions {
+    /// Build a receipt policy. Nil IDs and zero expiry are rejected because
+    /// they cannot identify a live bounded replay window.
+    pub fn try_new(
+        request_id: [u8; keys::metadata::WRITE_RECEIPT_ID_LEN],
+        expires_at_unix_ms: u64,
+        max_response_bytes: usize,
+    ) -> std::result::Result<Self, QueryServiceError> {
+        if request_id == [0; keys::metadata::WRITE_RECEIPT_ID_LEN] {
+            return Err(QueryServiceError::InvalidRequest(
+                "write receipt request ID must not be nil".to_string(),
+            ));
+        }
+        if expires_at_unix_ms == 0 {
+            return Err(QueryServiceError::InvalidRequest(
+                "write receipt expiry must not be zero".to_string(),
+            ));
+        }
+        let Some(max_response_bytes) = NonZeroUsize::new(max_response_bytes) else {
+            return Err(QueryServiceError::InvalidRequest(
+                "write receipt response limit must not be zero".to_string(),
+            ));
+        };
+        Ok(Self {
+            request_id,
+            expires_at_unix_ms,
+            max_response_bytes,
+        })
+    }
+}
+
+/// Public query response plus replay evidence for the transport.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryExecution {
+    response: QueryResponse,
+    replayed: bool,
+}
+
+impl QueryExecution {
+    /// Borrow the public query response.
+    pub const fn response(&self) -> &QueryResponse {
+        &self.response
+    }
+
+    /// Returns whether storage served a previously committed receipt.
+    pub const fn replayed(&self) -> bool {
+        self.replayed
+    }
+
+    /// Consume the execution wrapper.
+    pub fn into_response(self) -> QueryResponse {
+        self.response
+    }
 }
 
 pub(crate) async fn execute_query_on_observed(
@@ -192,7 +292,7 @@ pub(crate) async fn execute_query_on_scoped_observed(
         Err(error) => Err(error.into()),
     };
     if let (Some(query_metrics), Some(observation)) = (query_metrics, observation) {
-        let _ = query_metrics.record(observation.event(&result, started_at.elapsed()));
+        let _ = query_metrics.record(observation.event(result.as_ref(), started_at.elapsed()));
     }
     result
 }
@@ -221,7 +321,7 @@ impl QueryObservation {
 
     fn event(
         self,
-        result: &std::result::Result<QueryResponse, QueryServiceError>,
+        result: std::result::Result<&QueryResponse, &QueryServiceError>,
         latency: std::time::Duration,
     ) -> query::QueryEvent {
         let outcome = match result {
@@ -246,7 +346,6 @@ impl QueryObservation {
             }
         };
         let planner_diagnostics = result
-            .as_ref()
             .ok()
             .and_then(|response| serde_json::to_value(response.diagnostics()).ok());
         query::QueryEvent::now(
@@ -272,9 +371,13 @@ fn query_error_type(error: &QueryServiceError) -> query::QueryErrorType {
             query::QueryErrorType::InvalidRequest
         }
         QueryServiceError::Db(_) => query::QueryErrorType::Execution,
-        QueryServiceError::JsonSerialize(_) | QueryServiceError::Serialize(_) => {
-            query::QueryErrorType::Internal
+        QueryServiceError::WriteReceiptConflict => query::QueryErrorType::Conflict,
+        QueryServiceError::WriteReceiptResponseTooLarge { .. } => {
+            query::QueryErrorType::InvalidRequest
         }
+        QueryServiceError::JsonSerialize(_)
+        | QueryServiceError::Serialize(_)
+        | QueryServiceError::Deserialize(_) => query::QueryErrorType::Internal,
     }
 }
 
@@ -316,6 +419,138 @@ async fn execute_validated(
         .await?;
     let (_, diagnostics) = planning.into_parts();
     QueryResponse::from_execution_result_with_diagnostics(result, diagnostics)
+}
+
+async fn execute_idempotent_write_on_scoped(
+    db: &HelixDB,
+    request: QueryRequest,
+    tenant_scope: DataScope,
+    execution_control: ExecutionControl,
+    receipt: WriteReceiptOptions,
+) -> std::result::Result<QueryExecution, QueryServiceError> {
+    if request.request_type() != QueryRequestType::Write {
+        return Err(QueryServiceError::InvalidRequest(
+            "write receipts are valid only for write requests".to_string(),
+        ));
+    }
+    let request_bytes = request
+        .to_json_bytes()
+        .map_err(|error| QueryServiceError::InvalidRequest(error.to_string()))?;
+    let request_hash: [u8; values::write_receipt::REQUEST_HASH_LEN] =
+        Sha256::digest(&request_bytes).into();
+    let receipt_key = keys::metadata::write_receipt_key_scoped(tenant_scope, &receipt.request_id);
+
+    for attempt in 0..3 {
+        let query = ValidatedQuery::from_request(request.clone())?;
+        let result = execute_validated_idempotent(
+            db,
+            query,
+            tenant_scope,
+            execution_control,
+            &receipt_key,
+            request_hash,
+            receipt,
+        )
+        .await;
+        if attempt < 2 && matches!(&result, Err(error) if error.is_transaction_conflict()) {
+            continue;
+        }
+        return result;
+    }
+    unreachable!("bounded idempotent write attempts always return")
+}
+
+async fn execute_validated_idempotent(
+    db: &HelixDB,
+    query: ValidatedQuery,
+    tenant_scope: DataScope,
+    execution_control: ExecutionControl,
+    receipt_key: &Bytes,
+    request_hash: [u8; values::write_receipt::REQUEST_HASH_LEN],
+    receipt_options: WriteReceiptOptions,
+) -> std::result::Result<QueryExecution, QueryServiceError> {
+    execution_control.check()?;
+    let ValidatedQuery::Write { batch, parameters } = query else {
+        return Err(QueryServiceError::InvalidRequest(
+            "write receipts are valid only for write requests".to_string(),
+        ));
+    };
+    if db.is_reader_mode() {
+        return Err(HelixDbError::WriterModeRequired {
+            actual: db.mode().as_str(),
+        }
+        .into());
+    }
+    let params = query_param_bindings(parameters)?;
+    let prepared = execution_control
+        .run(db.planner_context_scoped_prepared(params.clone(), tenant_scope))
+        .await?;
+    execution_control.check()?;
+    let planning = helix_planner::planning::plan_with_diagnostics(
+        &BatchQuery::Write(batch),
+        prepared.context(),
+    )?;
+    execution_control.check()?;
+    let (plan, diagnostics) = planning.into_parts();
+    let now_unix_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| QueryServiceError::InvalidRequest(error.to_string()))?
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX);
+    match db
+        .prepare_idempotent_write_scoped_controlled(
+            &plan,
+            params,
+            tenant_scope,
+            execution_control,
+            prepared.into_catalog_proof(),
+            receipt_key,
+            now_unix_ms,
+        )
+        .await?
+    {
+        crate::execution::interpreter::PreparedWrite::Replayed(receipt) => {
+            if receipt.request_hash() != &request_hash {
+                return Err(QueryServiceError::WriteReceiptConflict);
+            }
+            let response =
+                QueryResponse::from_stored_bytes(receipt.response(), receipt.diagnostics())?;
+            Ok(QueryExecution {
+                response,
+                replayed: true,
+            })
+        }
+        crate::execution::interpreter::PreparedWrite::Pending {
+            mut transaction,
+            result,
+        } => {
+            let response =
+                QueryResponse::from_execution_result_with_diagnostics(result, diagnostics)?;
+            let response_bytes = response.to_json_bytes()?;
+            if response_bytes.len() > receipt_options.max_response_bytes.get() {
+                return Err(QueryServiceError::WriteReceiptResponseTooLarge {
+                    observed: response_bytes.len(),
+                    maximum: receipt_options.max_response_bytes.get(),
+                });
+            }
+            let diagnostics_bytes =
+                sonic_rs::to_vec(response.diagnostics()).map_err(QueryServiceError::Serialize)?;
+            let receipt = values::write_receipt::WriteReceiptValue::new(
+                receipt_options.expires_at_unix_ms,
+                request_hash,
+                Bytes::from(response_bytes),
+                Bytes::from(diagnostics_bytes),
+            )
+            .map_err(HelixDbError::from)?;
+            transaction.stage_receipt(receipt_key.clone(), &receipt)?;
+            transaction.commit().await?;
+            Ok(QueryExecution {
+                response,
+                replayed: false,
+            })
+        }
+    }
 }
 
 enum ValidatedQuery {
@@ -416,6 +651,17 @@ impl QueryResponse {
     /// Serialize the response as JSON bytes.
     pub fn to_json_bytes(&self) -> std::result::Result<Vec<u8>, QueryServiceError> {
         sonic_rs::to_vec(self).map_err(QueryServiceError::Serialize)
+    }
+
+    fn from_stored_bytes(
+        response: &[u8],
+        diagnostics: &[u8],
+    ) -> std::result::Result<Self, QueryServiceError> {
+        Ok(Self {
+            returns: sonic_rs::from_slice(response).map_err(QueryServiceError::Deserialize)?,
+            diagnostics: sonic_rs::from_slice(diagnostics)
+                .map_err(QueryServiceError::Deserialize)?,
+        })
     }
 
     /// Borrow the returned values.
@@ -592,6 +838,18 @@ pub enum QueryServiceError {
     /// Response serialization failed.
     #[error("json serialization error: {0}")]
     Serialize(sonic_rs::Error),
+
+    /// A persisted response could not be decoded.
+    #[error("json deserialization error: {0}")]
+    Deserialize(sonic_rs::Error),
+
+    /// One request ID was reused for a different canonical write.
+    #[error("write receipt request ID was already used for a different request")]
+    WriteReceiptConflict,
+
+    /// The exact response cannot fit within the configured receipt bound.
+    #[error("write receipt response is {observed} bytes, maximum is {maximum}")]
+    WriteReceiptResponseTooLarge { observed: usize, maximum: usize },
 }
 
 impl QueryServiceError {
@@ -611,7 +869,12 @@ impl QueryServiceError {
         match self {
             Self::Db(error) => error.index_error_code(),
             Self::Planner(error) => error.index_error_code(),
-            Self::InvalidRequest(_) | Self::JsonSerialize(_) | Self::Serialize(_) => None,
+            Self::InvalidRequest(_)
+            | Self::JsonSerialize(_)
+            | Self::Serialize(_)
+            | Self::Deserialize(_)
+            | Self::WriteReceiptConflict
+            | Self::WriteReceiptResponseTooLarge { .. } => None,
         }
     }
 }
@@ -628,7 +891,12 @@ impl From<QueryServiceError> for HelixDbError {
             other @ (QueryServiceError::InvalidRequest(_)
             | QueryServiceError::Planner(_)
             | QueryServiceError::JsonSerialize(_)
-            | QueryServiceError::Serialize(_)) => HelixDbError::Query(other.to_string()),
+            | QueryServiceError::Serialize(_)
+            | QueryServiceError::Deserialize(_)
+            | QueryServiceError::WriteReceiptConflict
+            | QueryServiceError::WriteReceiptResponseTooLarge { .. }) => {
+                HelixDbError::Query(other.to_string())
+            }
         }
     }
 }
@@ -696,6 +964,59 @@ mod tests {
                             == helix_planner::diagnostics::SecondaryIndexKind::Equality
             )
         })
+    }
+
+    fn write_receipt_options(id: u8, max_response_bytes: usize) -> WriteReceiptOptions {
+        let expires_at_unix_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("test clock is after the Unix epoch")
+            .as_millis()
+            .saturating_add(60_000)
+            .try_into()
+            .unwrap_or(u64::MAX);
+        WriteReceiptOptions::try_new(
+            [id; keys::metadata::WRITE_RECEIPT_ID_LEN],
+            expires_at_unix_ms,
+            max_response_bytes,
+        )
+        .expect("test receipt options are valid")
+    }
+
+    fn add_one_request(label: &str) -> QueryRequest {
+        QueryRequest::write(
+            write_batch()
+                .var_as(
+                    "created",
+                    g().add_n(label, Vec::<(&str, PropertyInput)>::new()),
+                )
+                .returning(["created"]),
+        )
+    }
+
+    async fn count_label(service: &HelixQueryService, label: &str) -> JsonValue {
+        count_label_scoped(service, label, DataScope::LegacyUnscoped).await
+    }
+
+    async fn count_label_scoped(
+        service: &HelixQueryService,
+        label: &str,
+        scope: DataScope,
+    ) -> JsonValue {
+        service
+            .execute_query_scoped(
+                QueryRequest::read(
+                    read_batch()
+                        .var_as("count", g().n_with_label(label).count())
+                        .returning(["count"]),
+                ),
+                scope,
+            )
+            .await
+            .expect("receipt postcondition read succeeds")
+            .returns()
+            .get("count")
+            .cloned()
+            .expect("count return exists")
     }
 
     #[test]
@@ -1287,6 +1608,249 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn idempotent_write_replays_exact_response_without_duplicate_mutation() {
+        let db = Arc::new(
+            HelixDB::open(HelixDbSource::InMemory {
+                database: "query-service-write-receipt-replay".to_string(),
+            })
+            .await
+            .expect("writer should open"),
+        );
+        let service = HelixQueryService::new(db);
+        let request = add_one_request("ReceiptReplay");
+        let options = write_receipt_options(1, 8 * 1024 * 1024);
+
+        let first = service
+            .execute_idempotent_write_scoped_controlled(
+                request.clone(),
+                DataScope::LegacyUnscoped,
+                ExecutionControl::unlimited(),
+                options,
+            )
+            .await
+            .expect("first write commits");
+        let second = service
+            .execute_idempotent_write_scoped_controlled(
+                request,
+                DataScope::LegacyUnscoped,
+                ExecutionControl::unlimited(),
+                options,
+            )
+            .await
+            .expect("duplicate write replays");
+
+        assert!(!first.replayed());
+        assert!(second.replayed());
+        assert_eq!(first.response(), second.response());
+        assert_eq!(
+            count_label(&service, "ReceiptReplay").await,
+            JsonValue::from(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn idempotent_write_rejects_request_id_payload_mismatch() {
+        let db = Arc::new(
+            HelixDB::open(HelixDbSource::InMemory {
+                database: "query-service-write-receipt-conflict".to_string(),
+            })
+            .await
+            .expect("writer should open"),
+        );
+        let service = HelixQueryService::new(db);
+        let options = write_receipt_options(2, 8 * 1024 * 1024);
+        service
+            .execute_idempotent_write_scoped_controlled(
+                add_one_request("ReceiptOriginal"),
+                DataScope::LegacyUnscoped,
+                ExecutionControl::unlimited(),
+                options,
+            )
+            .await
+            .expect("original write commits");
+
+        let error = service
+            .execute_idempotent_write_scoped_controlled(
+                add_one_request("ReceiptDifferent"),
+                DataScope::LegacyUnscoped,
+                ExecutionControl::unlimited(),
+                options,
+            )
+            .await
+            .expect_err("different payload must not reuse a receipt ID");
+        assert!(matches!(error, QueryServiceError::WriteReceiptConflict));
+        assert_eq!(
+            count_label(&service, "ReceiptDifferent").await,
+            JsonValue::from(0)
+        );
+    }
+
+    #[tokio::test]
+    async fn idempotent_write_aborts_before_commit_when_response_exceeds_limit() {
+        let db = Arc::new(
+            HelixDB::open(HelixDbSource::InMemory {
+                database: "query-service-write-receipt-limit".to_string(),
+            })
+            .await
+            .expect("writer should open"),
+        );
+        let service = HelixQueryService::new(db);
+        let error = service
+            .execute_idempotent_write_scoped_controlled(
+                add_one_request("ReceiptOversized"),
+                DataScope::LegacyUnscoped,
+                ExecutionControl::unlimited(),
+                write_receipt_options(3, 1),
+            )
+            .await
+            .expect_err("oversized receipt response must abort");
+        assert!(matches!(
+            error,
+            QueryServiceError::WriteReceiptResponseTooLarge { maximum: 1, .. }
+        ));
+        assert_eq!(
+            count_label(&service, "ReceiptOversized").await,
+            JsonValue::from(0)
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_idempotent_writes_converge_to_one_receipt() {
+        let db = Arc::new(
+            HelixDB::open(HelixDbSource::InMemory {
+                database: "query-service-write-receipt-concurrent".to_string(),
+            })
+            .await
+            .expect("writer should open"),
+        );
+        let service = HelixQueryService::new(db);
+        let request = add_one_request("ReceiptConcurrent");
+        let options = write_receipt_options(4, 8 * 1024 * 1024);
+        let left = service.execute_idempotent_write_scoped_controlled(
+            request.clone(),
+            DataScope::LegacyUnscoped,
+            ExecutionControl::unlimited(),
+            options,
+        );
+        let right = service.execute_idempotent_write_scoped_controlled(
+            request,
+            DataScope::LegacyUnscoped,
+            ExecutionControl::unlimited(),
+            options,
+        );
+        let (left, right) = tokio::join!(left, right);
+        let left = left.expect("left duplicate succeeds");
+        let right = right.expect("right duplicate succeeds");
+
+        assert_eq!(
+            usize::from(left.replayed()) + usize::from(right.replayed()),
+            1
+        );
+        assert_eq!(left.response(), right.response());
+        assert_eq!(
+            count_label(&service, "ReceiptConcurrent").await,
+            JsonValue::from(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_receipt_executes_again_and_replaces_the_response() {
+        let db = Arc::new(
+            HelixDB::open(HelixDbSource::InMemory {
+                database: "query-service-write-receipt-expired".to_string(),
+            })
+            .await
+            .expect("writer should open"),
+        );
+        let service = HelixQueryService::new(db);
+        let request = add_one_request("ReceiptExpired");
+        let expired = WriteReceiptOptions::try_new(
+            [5; keys::metadata::WRITE_RECEIPT_ID_LEN],
+            1,
+            8 * 1024 * 1024,
+        )
+        .expect("expired receipt options remain structurally valid");
+
+        let first = service
+            .execute_idempotent_write_scoped_controlled(
+                request.clone(),
+                DataScope::LegacyUnscoped,
+                ExecutionControl::unlimited(),
+                expired,
+            )
+            .await
+            .expect("first write commits");
+        let replacement = service
+            .execute_idempotent_write_scoped_controlled(
+                request,
+                DataScope::LegacyUnscoped,
+                ExecutionControl::unlimited(),
+                write_receipt_options(5, 8 * 1024 * 1024),
+            )
+            .await
+            .expect("expired receipt is replaced");
+
+        assert!(!first.replayed());
+        assert!(!replacement.replayed());
+        assert_eq!(
+            count_label(&service, "ReceiptExpired").await,
+            JsonValue::from(2)
+        );
+    }
+
+    #[tokio::test]
+    async fn receipt_ids_are_isolated_by_tenant_scope() {
+        let db = Arc::new(
+            HelixDB::open(HelixDbSource::InMemory {
+                database: "query-service-write-receipt-tenants".to_string(),
+            })
+            .await
+            .expect("writer should open"),
+        );
+        let service = HelixQueryService::new(db);
+        let request = add_one_request("TenantReceipt");
+        let options = write_receipt_options(6, 8 * 1024 * 1024);
+        let tenant_a = DataScope::Tenant(
+            crate::encoding::keys::tenant::TenantId::from_ulid_str("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+                .expect("tenant A ULID"),
+        );
+        let tenant_b = DataScope::Tenant(
+            crate::encoding::keys::tenant::TenantId::from_ulid_str("01ARZ3NDEKTSV4RRFFQ69G5FAW")
+                .expect("tenant B ULID"),
+        );
+
+        let first_a = service
+            .execute_idempotent_write_scoped_controlled(
+                request.clone(),
+                tenant_a,
+                ExecutionControl::unlimited(),
+                options,
+            )
+            .await
+            .expect("tenant A write commits");
+        let first_b = service
+            .execute_idempotent_write_scoped_controlled(
+                request,
+                tenant_b,
+                ExecutionControl::unlimited(),
+                options,
+            )
+            .await
+            .expect("tenant B write commits");
+
+        assert!(!first_a.replayed());
+        assert!(!first_b.replayed());
+        assert_eq!(
+            count_label_scoped(&service, "TenantReceipt", tenant_a).await,
+            JsonValue::from(1)
+        );
+        assert_eq!(
+            count_label_scoped(&service, "TenantReceipt", tenant_b).await,
+            JsonValue::from(1)
+        );
+    }
+
+    #[tokio::test]
     async fn query_response_carries_executed_plan_diagnostics_outside_result_json() {
         const SECRET_LITERAL: &str = "secret-query-value";
 
@@ -1365,7 +1929,7 @@ mod tests {
         assert!(!public_json.contains("diagnostics"));
 
         let telemetry_event = observation
-            .event(&Ok(response), std::time::Duration::from_micros(42))
+            .event(Ok(&response), std::time::Duration::from_micros(42))
             .into_telemetry()
             .expect("telemetry event");
         assert!(telemetry_event
@@ -2108,18 +2672,14 @@ mod tests {
             query::QueryErrorType::Execution
         );
 
-        let failed = observation.event(
-            &Err(QueryServiceError::Db(
-                HelixDbError::UniqueConstraintViolation {
-                    label: "User".to_owned(),
-                    property: "email".to_owned(),
-                    value: "\"secret@example.com\"".to_owned(),
-                    existing_node_id: 1,
-                    attempted_node_id: 2,
-                },
-            )),
-            std::time::Duration::from_micros(1),
-        );
+        let error = QueryServiceError::Db(HelixDbError::UniqueConstraintViolation {
+            label: "User".to_owned(),
+            property: "email".to_owned(),
+            value: "\"secret@example.com\"".to_owned(),
+            existing_node_id: 1,
+            attempted_node_id: 2,
+        });
+        let failed = observation.event(Err(&error), std::time::Duration::from_micros(1));
         let encoded = serde_json::to_string(
             &failed
                 .into_telemetry()

--- a/crates/db/src/query_service.rs
+++ b/crates/db/src/query_service.rs
@@ -863,6 +863,15 @@ impl QueryServiceError {
         matches!(self, Self::Db(HelixDbError::QueryDeadlineExceeded))
     }
 
+    /// Returns true when a writer fence made the durable commit outcome
+    /// ambiguous. Receipt-aware transports may safely retry this exact write.
+    pub fn is_commit_outcome_unknown(&self) -> bool {
+        matches!(
+            self,
+            Self::Db(HelixDbError::WriterFencedCommitOutcomeUnknown)
+        )
+    }
+
     /// Stable index lifecycle error code, when this failure belongs to that
     /// public compatibility surface.
     pub fn index_error_code(&self) -> Option<&'static str> {
@@ -2580,8 +2589,13 @@ mod tests {
             HelixDbError::TransactionConflict(_)
         ));
 
+        let unknown = QueryServiceError::Db(HelixDbError::WriterFencedCommitOutcomeUnknown);
+        assert!(unknown.is_transaction_conflict());
+        assert!(unknown.is_commit_outcome_unknown());
+
         let invalid = QueryServiceError::InvalidRequest("bad request".to_string());
         assert!(!invalid.is_transaction_conflict());
+        assert!(!invalid.is_commit_outcome_unknown());
         assert!(matches!(
             HelixDbError::from(invalid),
             HelixDbError::Query(message) if message.contains("invalid request")

--- a/crates/db/src/query_service.rs
+++ b/crates/db/src/query_service.rs
@@ -1808,6 +1808,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_new_write_prunes_an_expired_receipt_in_the_same_transaction() {
+        let db = Arc::new(
+            HelixDB::open(HelixDbSource::InMemory {
+                database: "query-service-write-receipt-prune".to_string(),
+            })
+            .await
+            .expect("writer should open"),
+        );
+        let service = HelixQueryService::new(Arc::clone(&db));
+        let expired_id = [7; keys::metadata::WRITE_RECEIPT_ID_LEN];
+        let expired = WriteReceiptOptions::try_new(expired_id, 1, 8 * 1024 * 1024)
+            .expect("expired receipt options remain structurally valid");
+        service
+            .execute_idempotent_write_scoped_controlled(
+                add_one_request("ReceiptPruned"),
+                DataScope::LegacyUnscoped,
+                ExecutionControl::unlimited(),
+                expired,
+            )
+            .await
+            .expect("expired receipt write commits");
+        let expired_key =
+            keys::metadata::write_receipt_key_scoped(DataScope::LegacyUnscoped, &expired_id);
+        assert!(db.inner_db().get(&expired_key).await.unwrap().is_some());
+
+        service
+            .execute_idempotent_write_scoped_controlled(
+                add_one_request("ReceiptPruneTrigger"),
+                DataScope::LegacyUnscoped,
+                ExecutionControl::unlimited(),
+                write_receipt_options(8, 8 * 1024 * 1024),
+            )
+            .await
+            .expect("new write commits and prunes expired receipt");
+
+        assert!(db.inner_db().get(&expired_key).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
     async fn receipt_ids_are_isolated_by_tenant_scope() {
         let db = Arc::new(
             HelixDB::open(HelixDbSource::InMemory {

--- a/crates/db/src/query_service.rs
+++ b/crates/db/src/query_service.rs
@@ -498,17 +498,15 @@ async fn execute_validated_idempotent(
         .as_millis()
         .try_into()
         .unwrap_or(u64::MAX);
-    match db
-        .prepare_idempotent_write_scoped_controlled(
-            &plan,
-            params,
-            tenant_scope,
-            execution_control,
-            prepared.into_catalog_proof(),
-            receipt_key,
-            now_unix_ms,
-        )
-        .await?
+    match crate::execution::interpreter::Interpreter::new_scoped_controlled_prepared(
+        db,
+        params,
+        tenant_scope,
+        execution_control,
+        prepared.into_catalog_proof(),
+    )
+    .prepare_idempotent_write(&plan, receipt_key, now_unix_ms)
+    .await?
     {
         crate::execution::interpreter::PreparedWrite::Replayed(receipt) => {
             if receipt.request_hash() != &request_hash {

--- a/crates/server/src/grpc.rs
+++ b/crates/server/src/grpc.rs
@@ -164,8 +164,13 @@ pub(super) fn status_from_service_error(error: QueryServiceError) -> Status {
         QueryServiceError::Db(db::error::HelixDbError::WriterModeRequired { .. }) => {
             Status::failed_precondition(message)
         }
+        QueryServiceError::WriteReceiptConflict => Status::already_exists(message),
+        QueryServiceError::WriteReceiptResponseTooLarge { .. } => {
+            Status::resource_exhausted(message)
+        }
         QueryServiceError::Db(_)
         | QueryServiceError::JsonSerialize(_)
-        | QueryServiceError::Serialize(_) => Status::internal(message),
+        | QueryServiceError::Serialize(_)
+        | QueryServiceError::Deserialize(_) => Status::internal(message),
     }
 }

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -149,10 +149,12 @@ pub(super) fn service_error_response(error: QueryServiceError) -> Response {
             QueryServiceError::Db(db::error::HelixDbError::WriterModeRequired { .. }) => {
                 StatusCode::SERVICE_UNAVAILABLE
             }
+            QueryServiceError::WriteReceiptConflict => StatusCode::CONFLICT,
+            QueryServiceError::WriteReceiptResponseTooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
             QueryServiceError::Db(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            QueryServiceError::JsonSerialize(_) | QueryServiceError::Serialize(_) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
+            QueryServiceError::JsonSerialize(_)
+            | QueryServiceError::Serialize(_)
+            | QueryServiceError::Deserialize(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     };
     let message = error.to_string();


### PR DESCRIPTION
## Summary

- persist idempotent write receipts in the same transaction as graph mutations
- replay committed results after ambiguous transport failures without applying writes twice
- reject request-ID reuse with different write content and prune expired receipts
- expose typed ambiguous-write outcomes through HTTP and gRPC

## Validation

- `cargo test -p db query_service --quiet` (36 passed)
- `cargo test -p server --quiet` (32 unit tests, transport tests, and doctests passed)
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`

## Dependency

This is required by the Helix Hyperscale zero-downtime failover PR. Keep this PR draft until the paired integration branch has completed its post-rebase cluster validation.
