### PR TITLE
Use commutative merges for add-only topology writes

### DIFF
--- a/crates/db/src/execution/interpreter/mutation/topology.rs
+++ b/crates/db/src/execution/interpreter/mutation/topology.rs
@@ -342,7 +342,7 @@ impl TopologyMutationRuntime {
                 .all(|mutation| *mutation == MembershipMutation::Present)
             {
                 let additions = mutations.keys().copied().collect::<RoaringTreemap>();
-                transaction.merge(
+                transaction.merge_commutative(
                     &key,
                     secondary::SecondaryEqualityValue::encode_ids(&additions),
                 )?;
@@ -388,7 +388,7 @@ impl TopologyMutationRuntime {
                         AdjacencyDirection::In => additions.add_in(neighbor),
                     }
                 }
-                transaction.merge(&key, edges::encode_edges(&additions))?;
+                transaction.merge_commutative(&key, edges::encode_edges(&additions))?;
                 self.staged_keys.insert(key);
                 continue;
             }
@@ -505,7 +505,7 @@ mod tests {
 
     use super::*;
 
-    async fn transaction(name: &str) -> DbTransaction {
+    async fn database(name: &str) -> Db {
         Db::builder(
             format!("topology-mutation-runtime/{name}"),
             Arc::new(InMemory::new()),
@@ -514,9 +514,251 @@ mod tests {
         .build()
         .await
         .expect("topology test database opens")
-        .begin(IsolationLevel::SerializableSnapshot)
-        .await
-        .expect("topology test transaction opens")
+    }
+
+    async fn transaction(name: &str) -> DbTransaction {
+        database(name)
+            .await
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .expect("topology test transaction opens")
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum RaceRow {
+        NodeLabel(&'static str),
+        OutAdjacency(u64),
+    }
+
+    impl RaceRow {
+        fn stage(
+            self,
+            runtime: &mut TopologyMutationRuntime,
+            scope: DataScope,
+            id: u64,
+            mutation: MembershipMutation,
+        ) {
+            match (self, mutation) {
+                (Self::NodeLabel(label), MembershipMutation::Present) => {
+                    runtime.add_node_label(scope, label, id).unwrap();
+                }
+                (Self::NodeLabel(label), MembershipMutation::Absent) => {
+                    runtime.remove_node_label(scope, label, id).unwrap();
+                }
+                (Self::OutAdjacency(node), MembershipMutation::Present) => {
+                    runtime
+                        .add_adjacency(scope, node, id, helix_planner::ir::ExpandDirection::Out)
+                        .unwrap();
+                }
+                (Self::OutAdjacency(node), MembershipMutation::Absent) => {
+                    runtime
+                        .remove_adjacency(scope, node, id, helix_planner::ir::ExpandDirection::Out)
+                        .unwrap();
+                }
+            }
+        }
+
+        async fn ids(self, db: &Db, scope: DataScope) -> Vec<u64> {
+            match self {
+                Self::NodeLabel(label) => secondary::SecondaryEqualityValue::decode(
+                    &db.get(node_label_key(scope, label))
+                        .await
+                        .unwrap()
+                        .expect("node label race row exists"),
+                )
+                .unwrap()
+                .into_ids()
+                .iter()
+                .collect(),
+                Self::OutAdjacency(node) => edges::decode_edges(
+                    &db.get(
+                        Key::Data {
+                            scope,
+                            kind: DataKeyKind::Adjacency(AdjacencyKey::new(node)),
+                        }
+                        .to_bytes(),
+                    )
+                    .await
+                    .unwrap()
+                    .expect("adjacency race row exists"),
+                )
+                .unwrap()
+                .iter_out()
+                .collect(),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_add_only_rows_commit_and_preserve_every_topology_membership() {
+        let db = database("concurrent-add-only").await;
+        let scope = DataScope::LegacyUnscoped;
+        let left = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .unwrap();
+        let right = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .unwrap();
+        let mut left_runtime = TopologyMutationRuntime::default();
+        let mut right_runtime = TopologyMutationRuntime::default();
+
+        left_runtime.add_node_label(scope, "User", 1).unwrap();
+        right_runtime.add_node_label(scope, "User", 2).unwrap();
+        left_runtime.add_edge_pair(scope, 10, 20, 100).unwrap();
+        right_runtime.add_edge_pair(scope, 10, 20, 101).unwrap();
+        left_runtime
+            .add_edge_label(scope, 1, 9, "FOLLOWS", 100)
+            .unwrap();
+        right_runtime
+            .add_edge_label(scope, 1, 10, "FOLLOWS", 101)
+            .unwrap();
+        left_runtime
+            .add_edge_label(scope, 11, 2, "FOLLOWS", 102)
+            .unwrap();
+        right_runtime
+            .add_edge_label(scope, 12, 2, "FOLLOWS", 103)
+            .unwrap();
+        left_runtime
+            .add_adjacency(scope, 50, 60, helix_planner::ir::ExpandDirection::Both)
+            .unwrap();
+        right_runtime
+            .add_adjacency(scope, 50, 61, helix_planner::ir::ExpandDirection::Both)
+            .unwrap();
+
+        left_runtime.prepare(&left).await.unwrap();
+        right_runtime.prepare(&right).await.unwrap();
+        left_runtime.consume_prepared().unwrap();
+        right_runtime.consume_prepared().unwrap();
+        left.commit().await.unwrap();
+        right.commit().await.unwrap();
+
+        let bitmap_ids = |key| async {
+            secondary::SecondaryEqualityValue::decode(
+                &db.get(key).await.unwrap().expect("topology bitmap exists"),
+            )
+            .unwrap()
+            .into_ids()
+            .iter()
+            .collect::<Vec<_>>()
+        };
+        assert_eq!(bitmap_ids(node_label_key(scope, "User")).await, vec![1, 2]);
+        assert_eq!(
+            bitmap_ids(edge_pair_key(scope, 10, 20)).await,
+            vec![100, 101]
+        );
+        assert_eq!(
+            bitmap_ids(edge_label_neighbor_key(
+                scope,
+                EdgeDirection::Out,
+                1,
+                "FOLLOWS",
+            ))
+            .await,
+            vec![9, 10]
+        );
+        assert_eq!(
+            bitmap_ids(edge_label_neighbor_key(
+                scope,
+                EdgeDirection::In,
+                2,
+                "FOLLOWS",
+            ))
+            .await,
+            vec![11, 12]
+        );
+        assert_eq!(
+            bitmap_ids(global_edge_label_key(scope, "FOLLOWS")).await,
+            vec![100, 101, 102, 103]
+        );
+        let adjacency = edges::decode_edges(
+            &db.get(
+                Key::Data {
+                    scope,
+                    kind: DataKeyKind::Adjacency(AdjacencyKey::new(50)),
+                }
+                .to_bytes(),
+            )
+            .await
+            .unwrap()
+            .expect("adjacency row exists"),
+        )
+        .unwrap();
+        assert_eq!(adjacency.iter_out().collect::<Vec<_>>(), vec![60, 61]);
+        assert_eq!(adjacency.iter_in().collect::<Vec<_>>(), vec![60, 61]);
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn topology_insert_remove_races_conflict_in_both_commit_orders() {
+        let db = database("insert-remove-races").await;
+        let scope = DataScope::LegacyUnscoped;
+        let cases = [
+            (RaceRow::NodeLabel("insert-first"), true),
+            (RaceRow::NodeLabel("remove-first"), false),
+            (RaceRow::OutAdjacency(100), true),
+            (RaceRow::OutAdjacency(101), false),
+        ];
+
+        for (row, insert_commits_first) in cases {
+            let seed = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut seed_runtime = TopologyMutationRuntime::default();
+            row.stage(&mut seed_runtime, scope, 1, MembershipMutation::Present);
+            seed_runtime.prepare(&seed).await.unwrap();
+            seed_runtime.consume_prepared().unwrap();
+            seed.commit().await.unwrap();
+
+            let insert = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let remove = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut insert_runtime = TopologyMutationRuntime::default();
+            row.stage(&mut insert_runtime, scope, 2, MembershipMutation::Present);
+            insert_runtime.prepare(&insert).await.unwrap();
+            insert_runtime.consume_prepared().unwrap();
+            let mut remove_runtime = TopologyMutationRuntime::default();
+            row.stage(&mut remove_runtime, scope, 1, MembershipMutation::Absent);
+            remove_runtime.prepare(&remove).await.unwrap();
+            remove_runtime.consume_prepared().unwrap();
+
+            let retry_mutation = if insert_commits_first {
+                insert.commit().await.unwrap();
+                let error = remove.commit().await.expect_err("remove must conflict");
+                assert_eq!(error.kind(), slatedb::ErrorKind::Transaction);
+                MembershipMutation::Absent
+            } else {
+                remove.commit().await.unwrap();
+                let error = insert.commit().await.expect_err("insert must conflict");
+                assert_eq!(error.kind(), slatedb::ErrorKind::Transaction);
+                MembershipMutation::Present
+            };
+
+            let retry = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut retry_runtime = TopologyMutationRuntime::default();
+            row.stage(
+                &mut retry_runtime,
+                scope,
+                if insert_commits_first { 1 } else { 2 },
+                retry_mutation,
+            );
+            retry_runtime.prepare(&retry).await.unwrap();
+            retry_runtime.consume_prepared().unwrap();
+            retry.commit().await.unwrap();
+            assert_eq!(row.ids(&db, scope).await, vec![2]);
+        }
+
+        db.close().await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- classify add-only topology bitmap unions as commutative transaction merges
- classify add-only adjacency unions as commutative transaction merges
- keep removal-bearing topology updates on exclusive read-modify-write paths
- cover concurrent additions and insert/remove races for every active topology set family

## Root cause

Add-only topology updates used ordinary transactional merges. SlateDB therefore classified independent set additions to the same physical row as exclusive writes, although the merge operands are commutative and idempotent.

The merge-site audit found that managed and legacy property bitmap additions already use `merge_commutative`. The only remaining ordinary transaction merges are blocking migration paths, so they remain exclusive.

## Validation

Passed:

- `cargo test -p db topology --lib --locked`
- `RUST_TEST_THREADS=1 cargo test --workspace --locked`
- all test binaries run by `scripts/db-production-coverage.sh`
- `cargo fmt --all -- --check`
- `git diff --check`

Repository-wide pre-existing gates:

- `scripts/db-production-coverage.sh` reports stale coverage baselines and uncovered-line classification across unrelated scopes after all tests pass
- `cargo clippy --workspace --all-targets --locked -- -D warnings` reports the existing `manual_range_patterns` warning in `crates/db/tests/production_contracts.rs:2944`

Closes #1000

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reclassifies add-only topology bitmap and adjacency unions as commutative SlateDB transaction merges while retaining exclusive read-modify-write behavior for removals.
- Uses commutative merges for add-only topology bitmap rows.
- Uses commutative merges for add-only adjacency rows.
- Adds coverage for concurrent additions, insert/remove conflicts in both commit orders, and transaction-local staged overlays.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/db/src/execution/interpreter/mutation/topology.rs | Reclassifies union-only topology writes as commutative and adds focused concurrency and staged-overlay regression coverage; no actionable defect was established. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant L as Transaction A
  participant R as Transaction B
  participant S as SlateDB
  L->>S: merge_commutative(add membership A)
  R->>S: merge_commutative(add membership B)
  L->>S: commit
  R->>S: commit
  S-->>L: success
  S-->>R: success
  Note over S: Union preserves both additions
  alt Update contains a removal
    L->>S: read current topology row
    L->>S: put/delete updated row
    R->>S: merge_commutative(add membership)
    Note over L,R: Concurrent insert/remove commits conflict
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Use commutative merges for topology addi..."](https://github.com/helixdb/helix-db/commit/471f9a6a93242ac105f40518737f4794ecc8a50f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54291331)</sub>

**Context used:**

- Knowledge Base — [Database runtime, storage, search, and index lifecycle](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/database-runtime.md)

<!-- /greptile_comment -->