### PR TITLE
Docs/quickstart cli drift fix

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -9,6 +9,7 @@ on:
       - "crates/cli/**"
       - "crates/metrics/**"
       - "sdks/typescript/**"
+      - "docs/database/helix-db/start-here/quickstart.mdx"
   push:
     branches: [main]
     paths:
@@ -18,6 +19,7 @@ on:
       - "crates/cli/**"
       - "crates/metrics/**"
       - "sdks/typescript/**"
+      - "docs/database/helix-db/start-here/quickstart.mdx"
   schedule:
     - cron: "0 4 * * *"
   workflow_dispatch:
@@ -101,6 +103,20 @@ jobs:
         with:
           name: cli-and-metrics-coverage
           path: target/*-coverage.lcov
+
+  docs-smoke:
+    name: Quickstart CLI smoke test
+    if: github.event_name != 'schedule'
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@1.97.1
+      - name: Run the documented init/start/query/stop journey against Docker
+        run: >-
+          cargo test --locked -p helix-cli --test docs_smoke
+          quickstart_documented_cli_journey_works
+          -- --ignored --exact --nocapture
 
   registry-smoke:
     name: Published TypeScript SDK registry smoke

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -107,7 +107,10 @@ jobs:
   docs-smoke:
     name: Quickstart CLI smoke test
     if: github.event_name != 'schedule'
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    # amd64: ghcr.io/helixdb/helixdb:v0.0.4 is pulled by tag with no --platform
+    # override, so this must run on the same architecture as the default
+    # manifest the CLI resolves in the documented (unqualified) workflow.
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/crates/cli/tests/docs_smoke.rs
+++ b/crates/cli/tests/docs_smoke.rs
@@ -1,0 +1,191 @@
+mod support;
+
+use assert_cmd::assert::Assert;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use support::{free_port, CliFixture};
+
+/// Mirrors docs/database/helix-db/start-here/quickstart.mdx's write-users example
+/// exactly (`examples/write-users.json` step). If the documented request shape or
+/// its expected response changes, update both the doc and this constant together.
+const WRITE_USERS_REQUEST: &str = r#"{
+  "request_type": "write",
+  "query_name": "write_users",
+  "query": {
+    "write": {
+      "entries": [
+        {
+          "query": {
+            "name": "alice",
+            "root": { "add_n": { "label": "User", "properties": [["name", { "value": { "string": "Alice" } }]] } }
+          }
+        },
+        {
+          "query": {
+            "name": "bob",
+            "root": { "add_n": { "label": "User", "properties": [["name", { "value": { "string": "Bob" } }]] } }
+          }
+        },
+        {
+          "query": {
+            "name": "follow",
+            "root": {
+              "add_e": {
+                "input": { "nodes": { "reference": { "var": "alice" } } },
+                "label": "FOLLOWS",
+                "to": { "var": "bob" },
+                "properties": [["since", { "value": { "string": "2026-07-24" } }]]
+              }
+            }
+          }
+        },
+        {
+          "query": {
+            "name": "friends",
+            "root": {
+              "value_map": {
+                "input": { "out": { "input": { "nodes": { "reference": { "var": "alice" } } }, "label": "FOLLOWS" } },
+                "properties": ["$id", "name"]
+              }
+            }
+          }
+        }
+      ],
+      "returns": ["alice", "bob", "friends"]
+    }
+  }
+}
+"#;
+
+fn stdout(assert: Assert) -> String {
+    String::from_utf8(assert.get_output().stdout.clone()).expect("stdout should be utf8")
+}
+
+struct RuntimeCleanup<'a> {
+    fixture: &'a CliFixture,
+    project: PathBuf,
+}
+
+impl Drop for RuntimeCleanup<'_> {
+    fn drop(&mut self) {
+        cleanup_runtime(self.fixture, &self.project);
+    }
+}
+
+fn cleanup_runtime(fixture: &CliFixture, project: &Path) {
+    let _ = fixture
+        .command()
+        .current_dir(project)
+        .args(["stop", "dev"])
+        .output();
+    let _ = fixture
+        .command()
+        .current_dir(project)
+        .args(["prune", "dev", "--yes"])
+        .output();
+}
+
+/// Runs the exact `helix init` / `helix start` / `helix query` / `helix stop`
+/// journey documented in the database quickstart
+/// (docs/database/helix-db/start-here/quickstart.mdx), against an isolated
+/// fixture project, so a docs edit that drifts from real CLI behavior fails CI
+/// instead of silently shipping.
+#[test]
+#[ignore = "requires Docker and pulls ghcr.io/helixdb/helixdb:v0.0.4"]
+fn quickstart_documented_cli_journey_works() {
+    let fixture = CliFixture::new();
+    let port = free_port();
+    let project = fixture
+        .root()
+        .join(format!("quickstart-smoke-{}-{port}", std::process::id()));
+
+    // Step: "Create a project" — `helix init local` (docs use the bare form; the
+    // fixture pins name/port so the test can run concurrently with other suites).
+    fixture
+        .command()
+        .args(["init", "--path"])
+        .arg(&project)
+        .args(["local", "--name", "dev", "--port"])
+        .arg(port.to_string())
+        .arg("--no-skills")
+        .assert()
+        .success();
+
+    assert!(
+        project.join("helix.toml").exists(),
+        "helix init local must create helix.toml as documented"
+    );
+    assert!(
+        project.join(".helix").is_dir(),
+        "helix init local must create the .helix/ workspace directory as documented"
+    );
+    assert!(
+        project.join("examples/request.json").exists(),
+        "helix init local must create examples/request.json as documented"
+    );
+
+    cleanup_runtime(&fixture, &project);
+    let _cleanup = RuntimeCleanup {
+        fixture: &fixture,
+        project: project.clone(),
+    };
+
+    // Step: "Start the local database" — `helix start dev`.
+    fixture
+        .command()
+        .current_dir(&project)
+        .args(["start", "dev"])
+        .assert()
+        .success();
+
+    // Step: "Write the graph" — save examples/write-users.json, then
+    // `helix query dev --file examples/write-users.json --compact`.
+    let write_request = project.join("examples/write-users.json");
+    fs::write(&write_request, WRITE_USERS_REQUEST).unwrap();
+
+    let query_output = stdout(
+        fixture
+            .command()
+            .current_dir(&project)
+            .args(["query", "dev", "--file"])
+            .arg(&write_request)
+            .arg("--compact")
+            .assert()
+            .success(),
+    );
+
+    // Step: "Read the result" — the response documented in the quickstart.
+    assert!(
+        query_output.contains("\"alice\""),
+        "expected alice in response: {query_output}"
+    );
+    assert!(
+        query_output.contains("\"bob\""),
+        "expected bob in response: {query_output}"
+    );
+    assert!(
+        query_output.contains("\"friends\""),
+        "expected friends in response: {query_output}"
+    );
+    assert!(
+        query_output.contains("\"name\":\"Bob\"") || query_output.contains("\"name\": \"Bob\""),
+        "expected friends to resolve Bob's name across the FOLLOWS edge: {query_output}"
+    );
+
+    // Step: "Clean up" — `helix stop dev`.
+    fixture
+        .command()
+        .current_dir(&project)
+        .args(["stop", "dev"])
+        .assert()
+        .success();
+
+    // `helix stop` is documented as idempotent.
+    fixture
+        .command()
+        .current_dir(&project)
+        .args(["stop", "dev"])
+        .assert()
+        .success();
+}

--- a/docs/database/helix-db/start-here/quickstart.mdx
+++ b/docs/database/helix-db/start-here/quickstart.mdx
@@ -9,12 +9,12 @@ pageType: "Tutorial"
 <div className="flex flex-wrap gap-2"><Badge color="green" size="sm">Tutorial</Badge></div>
 
 You will start a local HelixDB server, create two `User` nodes connected by a
-`FOLLOWS` edge, and read them back with one of the forthcoming v3 SDKs.
+`FOLLOWS` edge, and read them back using the `helix` CLI.
 
 ## Prerequisites
 
 - Docker or Podman
-- Rust, Node.js 20+, Go, Python 3.11+, or the `helix` CLI for raw JSON
+- The `helix` CLI
 
 <Steps>
   <Step title="Install the CLI">
@@ -24,186 +24,40 @@ curl -sSL "https://install.helix-db.com" | bash
 ```
 
   </Step>
-  <Step title="Setup a local project">
+  <Step title="Create a project">
 
 ```bash
-helix init local # --lang {rs,ts,go,py}
+mkdir my-helix-app
+cd my-helix-app
+helix init local
 ```
 
-This creates the project structure, example query files, and installs dependencies.
+`helix init local` creates:
+
+- `helix.toml` with a single `[local.dev]` instance.
+- `.helix/` workspace state (added to `.gitignore`).
+- `examples/request.json` — a runnable read request.
 
 <Note>
-  you can choose a language to use with the `--lang` flag. The default is TypeScript.
+  `helix init` does not scaffold a language-specific project. To use a language SDK
+  instead of raw JSON requests, see [SDK setup](/database/helix-db/start-here/sdk-setup/typescript-project-setup).
 </Note>
 
   </Step>
   <Step title="Start the local database">
 
 ```bash
-helix start local
+helix start dev
 ```
 
-This starts the local database at `http://localhost:6969/`.
+This starts the `dev` instance at `http://localhost:6969/`.
 
   </Step>
-  <Step title="Create and query the graph">
+  <Step title="Write the graph">
 
-In the generated after running `helix init local`, you will find a file called `queries.rs` (the file suffix will be different depending on the language you chose).
-For the language you chose, paste the following code into the file:
+Save the following request as `examples/write-users.json`:
 
-<CodeGroup>
-
-```rust Rust [expandable]
-use helix_db::dsl::prelude::*;
-use helix_db::Client;
-
-#[query]
-fn write_users() -> WriteBatch {
-    write_batch()
-        .var_as("alice", g().add_n("User", vec![("name", "Alice")]))
-        .var_as("bob", g().add_n("User", vec![("name", "Bob")]))
-        .var_as(
-            "follow",
-            g()
-                .n(NodeRef::var("alice"))
-                .add_e(
-                    "FOLLOWS",
-                    NodeRef::var("bob"),
-                    vec![("since", "2026-07-24")],
-                ),
-        )
-        .var_as(
-            "friends",
-            g()
-                .n(NodeRef::var("alice"))
-                .out(Some("FOLLOWS"))
-                .value_map(Some(vec!["$id", "name"])),
-        )
-        .returning(["alice", "bob", "friends"])
-}
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let result: serde_json::Value = Client::new(None)?
-        .query(write_users())
-        .send()
-        .await?;
-    println!("{result:?}");
-    Ok(())
-}
-```
-
-```ts TypeScript [expandable]
-import { Client, NodeRef, g, writeBatch } from "@helix-db/helix-db";
-
-const query = writeBatch()
-  .varAs("alice", g().addN("User", { name: "Alice" }))
-  .varAs("bob", g().addN("User", { name: "Bob" }))
-  .varAs(
-    "follow",
-    g()
-      .n(NodeRef.var("alice"))
-      .addE("FOLLOWS", NodeRef.var("bob"), { since: "2026-07-24" }),
-  )
-  .varAs(
-    "friends",
-    g().n(NodeRef.var("alice")).out("FOLLOWS").valueMap(["$id", "name"]),
-  )
-  .returning(["alice", "bob", "friends"]);
-
-const client = Client.server("http://localhost:6969");
-const result = await client
-  .query(query.toQueryRequest({ queryName: "write_users" }))
-  .send();
-console.log(result);
-```
-
-```go Go [expandable]
-package main
-
-import (
-	"context"
-	"fmt"
-	"log"
-
-	helix "github.com/helixdb/helix-db/sdks/go"
-)
-
-func main() {
-	request := helix.WriteQuery("write_users").
-		VarAs("alice", helix.G().AddN(
-			"User",
-			helix.Props{helix.Prop("name", "Alice")},
-		)).
-		VarAs("bob", helix.G().AddN(
-			"User",
-			helix.Props{helix.Prop("name", "Bob")},
-		)).
-		VarAs(
-			"follow",
-			helix.G().
-				N(helix.NodeVar("alice")).
-				AddE(
-					"FOLLOWS",
-					helix.NodeVar("bob"),
-					helix.Props{helix.Prop("since", "2026-07-24")},
-				),
-		).
-		VarAs(
-			"friends",
-			helix.G().
-				N(helix.NodeVar("alice")).
-				Out("FOLLOWS").
-				ValueMap("$id", "name"),
-		).
-		Returning("alice", "bob", "friends")
-
-	client, err := helix.NewClient("http://localhost:6969")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	var result map[string]any
-	if err := client.Exec(context.Background(), request, &result); err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(result)
-}
-```
-
-```python Python [expandable]
-from helixdb import Client, NodeRef, g, write_batch
-
-request = (
-    write_batch()
-    .var_as("alice", g().add_n("User", {"name": "Alice"}))
-    .var_as("bob", g().add_n("User", {"name": "Bob"}))
-    .var_as(
-        "follow",
-        g()
-        .n(NodeRef.var("alice"))
-        .add_e(
-            "FOLLOWS",
-            NodeRef.var("bob"),
-            {"since": "2026-07-24"},
-        ),
-    )
-    .var_as(
-        "friends",
-        g()
-        .n(NodeRef.var("alice"))
-        .out("FOLLOWS")
-        .value_map(["$id", "name"]),
-    )
-    .returning(["alice", "bob", "friends"])
-    .to_query_request(query_name="write_users")
-)
-
-result = Client("http://localhost:6969").query(request)
-print(result)
-```
-
-```json JSON [expandable]
+```json examples/write-users.json
 {
   "request_type": "write",
   "query_name": "write_users",
@@ -213,27 +67,13 @@ print(result)
         {
           "query": {
             "name": "alice",
-            "root": {
-              "add_n": {
-                "label": "User",
-                "properties": [
-                  ["name", { "value": { "string": "Alice" } }]
-                ]
-              }
-            }
+            "root": { "add_n": { "label": "User", "properties": [["name", { "value": { "string": "Alice" } }]] } }
           }
         },
         {
           "query": {
             "name": "bob",
-            "root": {
-              "add_n": {
-                "label": "User",
-                "properties": [
-                  ["name", { "value": { "string": "Bob" } }]
-                ]
-              }
-            }
+            "root": { "add_n": { "label": "User", "properties": [["name", { "value": { "string": "Bob" } }]] } }
           }
         },
         {
@@ -241,14 +81,10 @@ print(result)
             "name": "follow",
             "root": {
               "add_e": {
-                "input": {
-                  "nodes": { "reference": { "var": "alice" } }
-                },
+                "input": { "nodes": { "reference": { "var": "alice" } } },
                 "label": "FOLLOWS",
                 "to": { "var": "bob" },
-                "properties": [
-                  ["since", { "value": { "string": "2026-07-24" } }]
-                ]
+                "properties": [["since", { "value": { "string": "2026-07-24" } }]]
               }
             }
           }
@@ -258,14 +94,7 @@ print(result)
             "name": "friends",
             "root": {
               "value_map": {
-                "input": {
-                  "out": {
-                    "input": {
-                      "nodes": { "reference": { "var": "alice" } }
-                    },
-                    "label": "FOLLOWS"
-                  }
-                },
+                "input": { "out": { "input": { "nodes": { "reference": { "var": "alice" } } }, "label": "FOLLOWS" } },
                 "properties": ["$id", "name"]
               }
             }
@@ -278,36 +107,17 @@ print(result)
 }
 ```
 
-</CodeGroup>
+Then send it:
 
-</Step>
-
-<Step title="Run the query">
-
-{/* sdk-commands: no JSON representation */}
-<CodeGroup>
-```bash Rust
-cargo run --bin queries
+```bash
+helix query dev --file examples/write-users.json --compact
 ```
 
-```bash TypeScript
-npm run queries
-```
+  </Step>
 
-```bash Go
-go run queries.go
-```
+  <Step title="Read the result">
 
-```bash Python
-python queries.py
-```
-</CodeGroup>
-<Note>
-  you need to run this in the directory created by `helix init local`.
-</Note>
-
-Each SDK decodes the same JSON response. Your terminal's object formatting differs by
-language, but the response body is:
+`helix query` prints the response body. For this request it looks like:
 
 ```json
 {
@@ -319,35 +129,27 @@ language, but the response body is:
 
   </Step>
 
-  <Step title="Open the dashboard">
-
-```bash
-helix dashboard
-```
-
-This opens the dashboard at `http://localhost:3000/`. You can explore the graph and query it with the UI.
-
-  </Step>
-
 </Steps>
 
 ## What just happened
 
-- `writeBatch()` made invalid read-only mutation states unrepresentable.
-- Each `varAs` added one named query entry.
-- `NodeRef.var("alice")` referred to the result of the first entry.
-- Each chained operation wrapped the preceding operation as `input`.
-- `returning(...)` selected the named values in the response.
-- The `follow` entry still ran even though it was not returned.
+- Each entry under `write.entries` ran as one named step in the batch (`alice`, `bob`, `follow`, `friends`).
+- `{"reference": {"var": "alice"}}` referred to the result of the `alice` entry.
+- `add_e` chained `FOLLOWS` from `alice` to `bob`, then `friends` traversed that edge with `out` and read `$id`/`name` back with `value_map`.
+- `returns` selected which named entries appear in the response — `follow` still ran even though it was not returned.
 
 The [query walkthrough](/database/helix-db/core-concepts/overview) takes this same query
-apart operation by operation and explains the request and response JSON.
+apart operation by operation and explains the request and response JSON. If you would
+rather write queries as code than raw JSON, see the [TypeScript DSL input](/cli/command-reference/query#typescript-dsl-input)
+for `helix query -e`, or a [language SDK](/database/helix-db/start-here/sdk-setup/typescript-project-setup).
 
 ## Clean up
 
 ```bash
-helix stop local
+helix stop dev
 ```
+
+`helix stop` is idempotent — it reports cleanly if the instance was not running.
 
 ## Next steps
 
@@ -361,7 +163,7 @@ helix stop local
   <Card title="Reading data" icon="book-open" href="/database/helix-db/query-guides/reading-data">
     Select data by ID, label, or indexed property.
   </Card>
-  <Card title="Use another SDK" icon="code" href="/database/helix-db/start-here/sdk-setup/typescript-project-setup">
-    Switch to Rust, Go, or Python with the same query model.
+  <Card title="CLI getting started" icon="terminal" href="/cli/getting-started">
+    The full CLI tour: `helix chef`, local and Helix Cloud quickstarts, and troubleshooting.
   </Card>
 </CardGroup>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -99,12 +99,12 @@ Page type: Tutorial
 <div className="flex flex-wrap gap-2"><Badge color="green" size="sm">Tutorial</Badge></div>
 
 You will start a local HelixDB server, create two `User` nodes connected by a
-`FOLLOWS` edge, and read them back with one of the forthcoming v3 SDKs.
+`FOLLOWS` edge, and read them back using the `helix` CLI.
 
 ## Prerequisites
 
 - Docker or Podman
-- Rust, Node.js 20+, Go, Python 3.11+, or the `helix` CLI for raw JSON
+- The `helix` CLI
 
   <Step title="Install the CLI">
 
@@ -113,182 +113,38 @@ curl -sSL "https://install.helix-db.com" | bash
 ```
 
   </Step>
-  <Step title="Setup a local project">
+  <Step title="Create a project">
 
 ```bash
-helix init local # --lang {rs,ts,go,py}
+mkdir my-helix-app
+cd my-helix-app
+helix init local
 ```
 
-This creates the project structure, example query files, and installs dependencies.
+`helix init local` creates:
 
-  you can choose a language to use with the `--lang` flag. The default is TypeScript.
+- `helix.toml` with a single `[local.dev]` instance.
+- `.helix/` workspace state (added to `.gitignore`).
+- `examples/request.json` — a runnable read request.
+
+  `helix init` does not scaffold a language-specific project. To use a language SDK
+  instead of raw JSON requests, see [SDK setup](/database/helix-db/start-here/sdk-setup/typescript-project-setup).
 
   </Step>
   <Step title="Start the local database">
 
 ```bash
-helix start local
+helix start dev
 ```
 
-This starts the local database at `http://localhost:6969/`.
+This starts the `dev` instance at `http://localhost:6969/`.
 
   </Step>
-  <Step title="Create and query the graph">
+  <Step title="Write the graph">
 
-In the generated after running `helix init local`, you will find a file called `queries.rs` (the file suffix will be different depending on the language you chose).
-For the language you chose, paste the following code into the file:
+Save the following request as `examples/write-users.json`:
 
-```rust Rust [expandable]
-use helix_db::dsl::prelude::*;
-use helix_db::Client;
-
-#[query]
-fn write_users() -> WriteBatch {
-    write_batch()
-        .var_as("alice", g().add_n("User", vec![("name", "Alice")]))
-        .var_as("bob", g().add_n("User", vec![("name", "Bob")]))
-        .var_as(
-            "follow",
-            g()
-                .n(NodeRef::var("alice"))
-                .add_e(
-                    "FOLLOWS",
-                    NodeRef::var("bob"),
-                    vec![("since", "2026-07-24")],
-                ),
-        )
-        .var_as(
-            "friends",
-            g()
-                .n(NodeRef::var("alice"))
-                .out(Some("FOLLOWS"))
-                .value_map(Some(vec!["$id", "name"])),
-        )
-        .returning(["alice", "bob", "friends"])
-}
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let result: serde_json::Value = Client::new(None)?
-        .query(write_users())
-        .send()
-        .await?;
-    println!("{result:?}");
-    Ok(())
-}
-```
-
-```ts TypeScript [expandable]
-import { Client, NodeRef, g, writeBatch } from "@helix-db/helix-db";
-
-const query = writeBatch()
-  .varAs("alice", g().addN("User", { name: "Alice" }))
-  .varAs("bob", g().addN("User", { name: "Bob" }))
-  .varAs(
-    "follow",
-    g()
-      .n(NodeRef.var("alice"))
-      .addE("FOLLOWS", NodeRef.var("bob"), { since: "2026-07-24" }),
-  )
-  .varAs(
-    "friends",
-    g().n(NodeRef.var("alice")).out("FOLLOWS").valueMap(["$id", "name"]),
-  )
-  .returning(["alice", "bob", "friends"]);
-
-const client = Client.server("http://localhost:6969");
-const result = await client
-  .query(query.toQueryRequest({ queryName: "write_users" }))
-  .send();
-console.log(result);
-```
-
-```go Go [expandable]
-package main
-
-import (
-	"context"
-	"fmt"
-	"log"
-
-	helix "github.com/helixdb/helix-db/sdks/go"
-)
-
-func main() {
-	request := helix.WriteQuery("write_users").
-		VarAs("alice", helix.G().AddN(
-			"User",
-			helix.Props{helix.Prop("name", "Alice")},
-		)).
-		VarAs("bob", helix.G().AddN(
-			"User",
-			helix.Props{helix.Prop("name", "Bob")},
-		)).
-		VarAs(
-			"follow",
-			helix.G().
-				N(helix.NodeVar("alice")).
-				AddE(
-					"FOLLOWS",
-					helix.NodeVar("bob"),
-					helix.Props{helix.Prop("since", "2026-07-24")},
-				),
-		).
-		VarAs(
-			"friends",
-			helix.G().
-				N(helix.NodeVar("alice")).
-				Out("FOLLOWS").
-				ValueMap("$id", "name"),
-		).
-		Returning("alice", "bob", "friends")
-
-	client, err := helix.NewClient("http://localhost:6969")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	var result map[string]any
-	if err := client.Exec(context.Background(), request, &result); err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(result)
-}
-```
-
-```python Python [expandable]
-from helixdb import Client, NodeRef, g, write_batch
-
-request = (
-    write_batch()
-    .var_as("alice", g().add_n("User", {"name": "Alice"}))
-    .var_as("bob", g().add_n("User", {"name": "Bob"}))
-    .var_as(
-        "follow",
-        g()
-        .n(NodeRef.var("alice"))
-        .add_e(
-            "FOLLOWS",
-            NodeRef.var("bob"),
-            {"since": "2026-07-24"},
-        ),
-    )
-    .var_as(
-        "friends",
-        g()
-        .n(NodeRef.var("alice"))
-        .out("FOLLOWS")
-        .value_map(["$id", "name"]),
-    )
-    .returning(["alice", "bob", "friends"])
-    .to_query_request(query_name="write_users")
-)
-
-result = Client("http://localhost:6969").query(request)
-print(result)
-```
-
-```json JSON [expandable]
+```json examples/write-users.json
 {
   "request_type": "write",
   "query_name": "write_users",
@@ -298,27 +154,13 @@ print(result)
         {
           "query": {
             "name": "alice",
-            "root": {
-              "add_n": {
-                "label": "User",
-                "properties": [
-                  ["name", { "value": { "string": "Alice" } }]
-                ]
-              }
-            }
+            "root": { "add_n": { "label": "User", "properties": [["name", { "value": { "string": "Alice" } }]] } }
           }
         },
         {
           "query": {
             "name": "bob",
-            "root": {
-              "add_n": {
-                "label": "User",
-                "properties": [
-                  ["name", { "value": { "string": "Bob" } }]
-                ]
-              }
-            }
+            "root": { "add_n": { "label": "User", "properties": [["name", { "value": { "string": "Bob" } }]] } }
           }
         },
         {
@@ -326,14 +168,10 @@ print(result)
             "name": "follow",
             "root": {
               "add_e": {
-                "input": {
-                  "nodes": { "reference": { "var": "alice" } }
-                },
+                "input": { "nodes": { "reference": { "var": "alice" } } },
                 "label": "FOLLOWS",
                 "to": { "var": "bob" },
-                "properties": [
-                  ["since", { "value": { "string": "2026-07-24" } }]
-                ]
+                "properties": [["since", { "value": { "string": "2026-07-24" } }]]
               }
             }
           }
@@ -343,14 +181,7 @@ print(result)
             "name": "friends",
             "root": {
               "value_map": {
-                "input": {
-                  "out": {
-                    "input": {
-                      "nodes": { "reference": { "var": "alice" } }
-                    },
-                    "label": "FOLLOWS"
-                  }
-                },
+                "input": { "out": { "input": { "nodes": { "reference": { "var": "alice" } } }, "label": "FOLLOWS" } },
                 "properties": ["$id", "name"]
               }
             }
@@ -363,27 +194,17 @@ print(result)
 }
 ```
 
-{/* sdk-commands: no JSON representation */}
-```bash Rust
-cargo run --bin queries
+Then send it:
+
+```bash
+helix query dev --file examples/write-users.json --compact
 ```
 
-```bash TypeScript
-npm run queries
-```
+  </Step>
 
-```bash Go
-go run queries.go
-```
+  <Step title="Read the result">
 
-```bash Python
-python queries.py
-```
-
-  you need to run this in the directory created by `helix init local`.
-
-Each SDK decodes the same JSON response. Your terminal's object formatting differs by
-language, but the response body is:
+`helix query` prints the response body. For this request it looks like:
 
 ```json
 {
@@ -395,33 +216,25 @@ language, but the response body is:
 
   </Step>
 
-  <Step title="Open the dashboard">
-
-```bash
-helix dashboard
-```
-
-This opens the dashboard at `http://localhost:3000/`. You can explore the graph and query it with the UI.
-
-  </Step>
-
 ## What just happened
 
-- `writeBatch()` made invalid read-only mutation states unrepresentable.
-- Each `varAs` added one named query entry.
-- `NodeRef.var("alice")` referred to the result of the first entry.
-- Each chained operation wrapped the preceding operation as `input`.
-- `returning(...)` selected the named values in the response.
-- The `follow` entry still ran even though it was not returned.
+- Each entry under `write.entries` ran as one named step in the batch (`alice`, `bob`, `follow`, `friends`).
+- `{"reference": {"var": "alice"}}` referred to the result of the `alice` entry.
+- `add_e` chained `FOLLOWS` from `alice` to `bob`, then `friends` traversed that edge with `out` and read `$id`/`name` back with `value_map`.
+- `returns` selected which named entries appear in the response — `follow` still ran even though it was not returned.
 
 The [query walkthrough](/database/helix-db/core-concepts/overview) takes this same query
-apart operation by operation and explains the request and response JSON.
+apart operation by operation and explains the request and response JSON. If you would
+rather write queries as code than raw JSON, see the [TypeScript DSL input](/cli/command-reference/query#typescript-dsl-input)
+for `helix query -e`, or a [language SDK](/database/helix-db/start-here/sdk-setup/typescript-project-setup).
 
 ## Clean up
 
 ```bash
-helix stop local
+helix stop dev
 ```
+
+`helix stop` is idempotent — it reports cleanly if the instance was not running.
 
 ## Next steps
 
@@ -434,8 +247,8 @@ helix stop local
   <Card title="Reading data" icon="book-open" href="/database/helix-db/query-guides/reading-data">
     Select data by ID, label, or indexed property.
   </Card>
-  <Card title="Use another SDK" icon="code" href="/database/helix-db/start-here/sdk-setup/typescript-project-setup">
-    Switch to Rust, Go, or Python with the same query model.
+  <Card title="CLI getting started" icon="terminal" href="/cli/getting-started">
+    The full CLI tour: `helix chef`, local and Helix Cloud quickstarts, and troubleshooting.
   </Card>
 
 # Deployment options


### PR DESCRIPTION
* Update the quickstart to use the real CLI flow: `helix init local → helix start dev → helix query dev --file ... → helix stop dev`
* Remove outdated/nonexistent items: `--lang`, `queries.rs`, and `helix dashboard`
* Use the actual generated names: `dev` and `examples/request.json`
* Link to SDK setup instead of saying `helix init` creates language projects
* Keep the existing User/FOLLOWS example
* Add a `docs_smoke.rs` integration test to run the documented commands
* Add a `docs-smoke` CI job in `cli-tests.yml`
* Regenerate `docs/llms-full.txt`
* No changes needed to `introduction.mdx` or `core-concepts/overview.mdx`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the database quickstart to match the current CLI workflow and adds a Docker-backed integration test and CI job intended to keep that journey valid.

- Replaces obsolete SDK scaffolding and dashboard instructions with `init`, `start`, raw JSON `query`, and `stop` commands.
- Adds an ignored end-to-end CLI test and a nonscheduled CI job that executes it.
- Regenerates the consolidated LLM documentation from the revised quickstart.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/database/helix-db/start-here/quickstart.mdx | Rewrites the tutorial around the current raw-JSON CLI journey and removes obsolete SDK scaffolding and dashboard instructions. |
| crates/cli/tests/docs_smoke.rs | Adds a real Docker integration journey, but its copied payload and explicit init overrides do not fully enforce synchronization with the documented commands. |
| .github/workflows/cli-tests.yml | Adds quickstart changes to workflow path filters and runs the ignored Docker smoke test on nonscheduled events. |
| docs/llms-full.txt | Regenerates the consolidated documentation to reflect the updated quickstart. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as Quickstart user
  participant C as helix CLI
  participant D as Local Docker runtime
  U->>C: helix init local
  C-->>U: helix.toml, .helix/, examples/request.json
  U->>C: helix start dev
  C->>D: Start local HelixDB container
  U->>C: helix query dev --file examples/write-users.json
  C->>D: POST /v2/query
  D-->>C: Graph mutation response
  C-->>U: alice, bob, friends
  U->>C: helix stop dev
  C->>D: Remove local container
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: pin quickstart smoke test to amd64 r..."](https://github.com/helixdb/helix-db/commit/e1ec6e85b432fb3ce9782447d634f900a5e1e600) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54407491)</sub>

**Context used:**

- Knowledge Base — [Helix CLI core: parsing, config, and shared plumbing](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/helix-cli-core.md)
- Knowledge Base — [Project scaffolding and the query development loop](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/helix-cli-project-commands.md)

<!-- /greptile_comment -->