### PR TITLE
Update MCP setup guide for production

### DIFF
--- a/docs/database/helix-cloud/connect/mcp.mdx
+++ b/docs/database/helix-cloud/connect/mcp.mdx
@@ -3,10 +3,9 @@ title: "HelixDB Model Context Protocol (MCP)"
 description: "Connect Codex, Cursor, VS Code, Claude Code, and other agents to Helix Cloud insights"
 sidebarTitle: "Model Context Protocol (MCP)"
 pageType: "Tutorial"
-status: "Preview"
 ---
 
-<div className="flex flex-wrap gap-2"><Badge color="green" size="sm">Tutorial</Badge><Badge color="orange" size="sm">Preview</Badge></div>
+<div className="flex flex-wrap gap-2"><Badge color="green" size="sm">Tutorial</Badge></div>
 
 > For the complete documentation index optimized for AI agents, see [llms.txt](/llms.txt).
 
@@ -43,18 +42,13 @@ active indexes, usage, and dedicated-cluster health.
 - It works with MCP clients that support remote Streamable HTTP servers and OAuth.
 - It cannot execute queries or change database or Cloud resources.
 
-<Warning>
-  The preview endpoint uses the Helix development environment. Use test
-  resources only until the production endpoint is announced.
-</Warning>
-
 ## Quick start
 
 <CardGroup cols={2}>
-  <Card title="Cursor" icon={<CursorLogo />} href="https://cursor.com/en-US/install-mcp?name=HelixDB&config=eyJ1cmwiOiJodHRwczovL21jcC5kZXYuaGVsaXgtZGIuY29tL21jcCJ9">
+  <Card title="Cursor" icon={<CursorLogo />} href="https://cursor.com/en-US/install-mcp?name=HelixDB&config=eyJ1cmwiOiJodHRwczovL21jcC5oZWxpeC1kYi5jb20vbWNwIn0=">
     One-click install
   </Card>
-  <Card title="VS Code" icon={<VSCodeLogo />} href="vscode:mcp/install?%7B%22url%22%3A%22https%3A%2F%2Fmcp.dev.helix-db.com%2Fmcp%22%2C%22name%22%3A%22HelixDB%22%2C%22type%22%3A%22http%22%7D">
+  <Card title="VS Code" icon={<VSCodeLogo />} href="vscode:mcp/install?%7B%22url%22%3A%22https%3A%2F%2Fmcp.helix-db.com%2Fmcp%22%2C%22name%22%3A%22HelixDB%22%2C%22type%22%3A%22http%22%7D">
     One-click install
   </Card>
   <Card title="Codex" icon={<CodexLogo />} href="#codex-cli">
@@ -75,10 +69,14 @@ current workspace, project, cluster, and tenant membership on every tool call.
 Removing a user's Helix access removes the corresponding MCP access without a
 separate resource grant.
 
+If your browser already has an active Helix session, WorkOS can reuse that
+account during authorization. Confirm the email address on the consent screen
+before you approve access.
+
 **Server URL:**
 
 ```text
-https://mcp.dev.helix-db.com/mcp
+https://mcp.helix-db.com/mcp
 ```
 
 ## Security boundary
@@ -102,7 +100,7 @@ names, and recommendation bodies are not written to logs.
 
 ### Cursor
 
-<Card title="Install HelixDB in Cursor" icon={<CursorLogo />} horizontal href="https://cursor.com/en-US/install-mcp?name=HelixDB&config=eyJ1cmwiOiJodHRwczovL21jcC5kZXYuaGVsaXgtZGIuY29tL21jcCJ9">
+<Card title="Install HelixDB in Cursor" icon={<CursorLogo />} horizontal href="https://cursor.com/en-US/install-mcp?name=HelixDB&config=eyJ1cmwiOiJodHRwczovL21jcC5oZWxpeC1kYi5jb20vbWNwIn0=">
   Add the hosted MCP server, then complete OAuth in your browser.
 </Card>
 
@@ -112,7 +110,7 @@ For manual installation, add this configuration to `.cursor/mcp.json`:
 {
   "mcpServers": {
     "helix-db": {
-      "url": "https://mcp.dev.helix-db.com/mcp"
+      "url": "https://mcp.helix-db.com/mcp"
     }
   }
 }
@@ -123,7 +121,7 @@ Helix sign-in flow. Restart Cursor if the server does not appear.
 
 ### VS Code
 
-<Card title="Install HelixDB in VS Code" icon={<VSCodeLogo />} horizontal href="vscode:mcp/install?%7B%22url%22%3A%22https%3A%2F%2Fmcp.dev.helix-db.com%2Fmcp%22%2C%22name%22%3A%22HelixDB%22%2C%22type%22%3A%22http%22%7D">
+<Card title="Install HelixDB in VS Code" icon={<VSCodeLogo />} horizontal href="vscode:mcp/install?%7B%22url%22%3A%22https%3A%2F%2Fmcp.helix-db.com%2Fmcp%22%2C%22name%22%3A%22HelixDB%22%2C%22type%22%3A%22http%22%7D">
   Add the hosted MCP server, then complete OAuth in your browser.
 </Card>
 
@@ -132,7 +130,7 @@ For manual installation:
 1. Open the Command Palette.
 2. Run **MCP: Add Server**.
 3. Choose **HTTP**.
-4. Enter `https://mcp.dev.helix-db.com/mcp` and name it `HelixDB`.
+4. Enter `https://mcp.helix-db.com/mcp` and name it `HelixDB`.
 5. Start the server and approve the browser authentication prompt.
 
 ### Codex CLI
@@ -141,7 +139,7 @@ Add the server, then authenticate if Codex does not open the browser flow
 automatically:
 
 ```bash
-codex mcp add helix-db --url https://mcp.dev.helix-db.com/mcp
+codex mcp add helix-db --url https://mcp.helix-db.com/mcp
 codex mcp login helix-db
 codex mcp list
 ```
@@ -162,7 +160,7 @@ is enabled and authenticated.
 Add the remote HTTP server:
 
 ```bash
-claude mcp add --transport http helix-db https://mcp.dev.helix-db.com/mcp
+claude mcp add --transport http helix-db https://mcp.helix-db.com/mcp
 ```
 
 Start Claude Code, run `/mcp`, select `helix-db`, and complete authentication in
@@ -178,7 +176,7 @@ Add the server to `~/.config/opencode/opencode.json`:
   "mcp": {
     "helix-db": {
       "type": "remote",
-      "url": "https://mcp.dev.helix-db.com/mcp"
+      "url": "https://mcp.helix-db.com/mcp"
     }
   }
 }
@@ -199,7 +197,7 @@ Create a custom remote MCP connection with this URL and choose OAuth when the
 client asks for an authentication method:
 
 ```text
-https://mcp.dev.helix-db.com/mcp
+https://mcp.helix-db.com/mcp
 ```
 
 The client must support Streamable HTTP, OAuth protected-resource discovery,
@@ -286,13 +284,28 @@ Remove any manually configured OAuth resource, remove and re-add the MCP
 server, then authenticate again. For Codex, use only:
 
 ```bash
-codex mcp add helix-db --url https://mcp.dev.helix-db.com/mcp
+codex mcp add helix-db --url https://mcp.helix-db.com/mcp
+codex mcp login helix-db
+```
+
+### WorkOS used the wrong account
+
+WorkOS can reuse the Helix account that is already active in your browser. If
+the consent screen shows the wrong email address, do not approve access. Sign
+out of Helix Cloud in that browser, then start authentication again and sign in
+with the account that has access to the required workspace. Use a separate
+browser profile or private window if you need to keep both accounts signed in.
+
+For Codex, clear the existing MCP authorization before you authenticate again:
+
+```bash
+codex mcp logout helix-db
 codex mcp login helix-db
 ```
 
 ### The server cannot connect
 
-Confirm the URL ends in exactly `/mcp`. Older preview paths are not supported.
+Confirm the URL ends in exactly `/mcp`. Older paths are not supported.
 Restart the client after changing its MCP configuration.
 
 ### A database is missing

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4676,9 +4676,8 @@ regardless of cache state; caching affects latency, not correctness.
 # HelixDB Model Context Protocol (MCP)
 
 Page type: Tutorial
-Status: Preview
 
-<div className="flex flex-wrap gap-2"><Badge color="green" size="sm">Tutorial</Badge><Badge color="orange" size="sm">Preview</Badge></div>
+<div className="flex flex-wrap gap-2"><Badge color="green" size="sm">Tutorial</Badge></div>
 
 export const CursorLogo = () => (
   <svg viewBox="0 0 452 516" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -4713,15 +4712,12 @@ active indexes, usage, and dedicated-cluster health.
 - It works with MCP clients that support remote Streamable HTTP servers and OAuth.
 - It cannot execute queries or change database or Cloud resources.
 
-  The preview endpoint uses the Helix development environment. Use test
-  resources only until the production endpoint is announced.
-
 ## Quick start
 
-  <Card title="Cursor" icon={<CursorLogo />} href="https://cursor.com/en-US/install-mcp?name=HelixDB&config=eyJ1cmwiOiJodHRwczovL21jcC5kZXYuaGVsaXgtZGIuY29tL21jcCJ9">
+  <Card title="Cursor" icon={<CursorLogo />} href="https://cursor.com/en-US/install-mcp?name=HelixDB&config=eyJ1cmwiOiJodHRwczovL21jcC5oZWxpeC1kYi5jb20vbWNwIn0=">
     One-click install
   </Card>
-  <Card title="VS Code" icon={<VSCodeLogo />} href="vscode:mcp/install?%7B%22url%22%3A%22https%3A%2F%2Fmcp.dev.helix-db.com%2Fmcp%22%2C%22name%22%3A%22HelixDB%22%2C%22type%22%3A%22http%22%7D">
+  <Card title="VS Code" icon={<VSCodeLogo />} href="vscode:mcp/install?%7B%22url%22%3A%22https%3A%2F%2Fmcp.helix-db.com%2Fmcp%22%2C%22name%22%3A%22HelixDB%22%2C%22type%22%3A%22http%22%7D">
     One-click install
   </Card>
   <Card title="Codex" icon={<CodexLogo />} href="#codex-cli">
@@ -4741,10 +4737,14 @@ current workspace, project, cluster, and tenant membership on every tool call.
 Removing a user's Helix access removes the corresponding MCP access without a
 separate resource grant.
 
+If your browser already has an active Helix session, WorkOS can reuse that
+account during authorization. Confirm the email address on the consent screen
+before you approve access.
+
 **Server URL:**
 
 ```text
-https://mcp.dev.helix-db.com/mcp
+https://mcp.helix-db.com/mcp
 ```
 
 ## Security boundary
@@ -4768,7 +4768,7 @@ names, and recommendation bodies are not written to logs.
 
 ### Cursor
 
-<Card title="Install HelixDB in Cursor" icon={<CursorLogo />} horizontal href="https://cursor.com/en-US/install-mcp?name=HelixDB&config=eyJ1cmwiOiJodHRwczovL21jcC5kZXYuaGVsaXgtZGIuY29tL21jcCJ9">
+<Card title="Install HelixDB in Cursor" icon={<CursorLogo />} horizontal href="https://cursor.com/en-US/install-mcp?name=HelixDB&config=eyJ1cmwiOiJodHRwczovL21jcC5oZWxpeC1kYi5jb20vbWNwIn0=">
   Add the hosted MCP server, then complete OAuth in your browser.
 
 For manual installation, add this configuration to `.cursor/mcp.json`:
@@ -4777,7 +4777,7 @@ For manual installation, add this configuration to `.cursor/mcp.json`:
 {
   "mcpServers": {
     "helix-db": {
-      "url": "https://mcp.dev.helix-db.com/mcp"
+      "url": "https://mcp.helix-db.com/mcp"
     }
   }
 }
@@ -4788,7 +4788,7 @@ Helix sign-in flow. Restart Cursor if the server does not appear.
 
 ### VS Code
 
-<Card title="Install HelixDB in VS Code" icon={<VSCodeLogo />} horizontal href="vscode:mcp/install?%7B%22url%22%3A%22https%3A%2F%2Fmcp.dev.helix-db.com%2Fmcp%22%2C%22name%22%3A%22HelixDB%22%2C%22type%22%3A%22http%22%7D">
+<Card title="Install HelixDB in VS Code" icon={<VSCodeLogo />} horizontal href="vscode:mcp/install?%7B%22url%22%3A%22https%3A%2F%2Fmcp.helix-db.com%2Fmcp%22%2C%22name%22%3A%22HelixDB%22%2C%22type%22%3A%22http%22%7D">
   Add the hosted MCP server, then complete OAuth in your browser.
 
 For manual installation:
@@ -4796,7 +4796,7 @@ For manual installation:
 1. Open the Command Palette.
 2. Run **MCP: Add Server**.
 3. Choose **HTTP**.
-4. Enter `https://mcp.dev.helix-db.com/mcp` and name it `HelixDB`.
+4. Enter `https://mcp.helix-db.com/mcp` and name it `HelixDB`.
 5. Start the server and approve the browser authentication prompt.
 
 ### Codex CLI
@@ -4805,7 +4805,7 @@ Add the server, then authenticate if Codex does not open the browser flow
 automatically:
 
 ```bash
-codex mcp add helix-db --url https://mcp.dev.helix-db.com/mcp
+codex mcp add helix-db --url https://mcp.helix-db.com/mcp
 codex mcp login helix-db
 codex mcp list
 ```
@@ -4824,7 +4824,7 @@ is enabled and authenticated.
 Add the remote HTTP server:
 
 ```bash
-claude mcp add --transport http helix-db https://mcp.dev.helix-db.com/mcp
+claude mcp add --transport http helix-db https://mcp.helix-db.com/mcp
 ```
 
 Start Claude Code, run `/mcp`, select `helix-db`, and complete authentication in
@@ -4840,7 +4840,7 @@ Add the server to `~/.config/opencode/opencode.json`:
   "mcp": {
     "helix-db": {
       "type": "remote",
-      "url": "https://mcp.dev.helix-db.com/mcp"
+      "url": "https://mcp.helix-db.com/mcp"
     }
   }
 }
@@ -4861,7 +4861,7 @@ Create a custom remote MCP connection with this URL and choose OAuth when the
 client asks for an authentication method:
 
 ```text
-https://mcp.dev.helix-db.com/mcp
+https://mcp.helix-db.com/mcp
 ```
 
 The client must support Streamable HTTP, OAuth protected-resource discovery,
@@ -4948,13 +4948,28 @@ Remove any manually configured OAuth resource, remove and re-add the MCP
 server, then authenticate again. For Codex, use only:
 
 ```bash
-codex mcp add helix-db --url https://mcp.dev.helix-db.com/mcp
+codex mcp add helix-db --url https://mcp.helix-db.com/mcp
+codex mcp login helix-db
+```
+
+### WorkOS used the wrong account
+
+WorkOS can reuse the Helix account that is already active in your browser. If
+the consent screen shows the wrong email address, do not approve access. Sign
+out of Helix Cloud in that browser, then start authentication again and sign in
+with the account that has access to the required workspace. Use a separate
+browser profile or private window if you need to keep both accounts signed in.
+
+For Codex, clear the existing MCP authorization before you authenticate again:
+
+```bash
+codex mcp logout helix-db
 codex mcp login helix-db
 ```
 
 ### The server cannot connect
 
-Confirm the URL ends in exactly `/mcp`. Older preview paths are not supported.
+Confirm the URL ends in exactly `/mcp`. Older paths are not supported.
 Restart the client after changing its MCP configuration.
 
 ### A database is missing

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -50,7 +50,7 @@ Full walkthrough: https://docs.helix-db.com/cli/getting-started
 - [Architecture](https://docs.helix-db.com/database/helix-cloud/start-here/architecture) — Page type: Concept
 
 ## Connect and automate
-- [HelixDB Model Context Protocol (MCP)](https://docs.helix-db.com/database/helix-cloud/connect/mcp): Connect Codex, Cursor, VS Code, Claude Code, and other agents to Helix Cloud insights — Page type: Tutorial; Status: Preview
+- [HelixDB Model Context Protocol (MCP)](https://docs.helix-db.com/database/helix-cloud/connect/mcp): Connect Codex, Cursor, VS Code, Claude Code, and other agents to Helix Cloud insights — Page type: Tutorial
 
 ## Operate
 - [Multi-Tenancy](https://docs.helix-db.com/database/helix-cloud/operate/multi-tenancy) — Page type: Guide


### PR DESCRIPTION
## Summary

- change every MCP setup path from the development endpoint to `https://mcp.helix-db.com/mcp`
- update the Cursor and VS Code one-click installers
- remove the preview status and development-environment warning
- explain WorkOS session reuse and how to reauthenticate with the correct account
- regenerate `llms.txt` and `llms-full.txt`

## Root cause

The public guide hard-coded the development MCP endpoint. Users following it authenticated successfully but could only see development memberships, so existing production workspaces appeared to be missing. WorkOS can also reuse the Helix account already active in the browser, while the consent screen does not act as an account picker.

## User impact

New installations target the production MCP service and return production resources authorized for the signed-in Helix user. The troubleshooting section now tells users how to stop and reauthenticate when WorkOS selects the wrong browser session.

## Validation

- `npm run check`
- `npx mint broken-links --check-anchors --check-redirects --check-snippets`
- decoded the Cursor one-click configuration and verified the exact production URL
- verified the production MCP returns the expected unauthenticated `401` and publishes matching OAuth protected-resource metadata
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the MCP setup guide from the development service to the production endpoint and removes its preview designation.
- Updates manual and one-click installation configurations for supported MCP clients.
- Documents WorkOS session reuse and account-switching recovery.
- Regenerates the AI-facing documentation indexes to match the source guide.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/database/helix-cloud/connect/mcp.mdx | Consistently switches MCP setup instructions to the production endpoint and adds coherent wrong-account recovery guidance. |
| docs/llms-full.txt | Regenerated full documentation content faithfully reflects the MCP source-page changes. |
| docs/llms.txt | Removes the MCP preview status from the generated documentation index. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Update MCP setup guide for production"](https://github.com/helixdb/helix-db/commit/5bffa2ba2b15f0b87a7b084c5f6f2d5659395282) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54663258)</sub>

<!-- /greptile_comment -->