### PR TITLE
feat(sdks): add managed database selection to every SDK

### DIFF
--- a/docs/database/helix-cloud/operate/security.mdx
+++ b/docs/database/helix-cloud/operate/security.mdx
@@ -17,7 +17,10 @@ Authorization: Bearer <token>
 ```
 
 The SDK clients attach this header for you—set the key once with `withApiKey`
-(TypeScript), `with_api_key` (Rust and Python), or `WithAPIKey` (Go). See the
+(TypeScript), `with_api_key` (Rust and Python), or `WithAPIKey` (Go). Managed clients
+also require the dashboard database ID and send it as `x-helix-tenant-id`; see
+`Client.managed`, `Client::managed`, `AsyncClient.managed`, or `NewManagedClient`.
+See the
 [cross-language Cloud connection example](/database/helix-cloud/start-here/working-with-enterprise#connect-and-send-a-request).
 
 Requests without a valid token are rejected at the gateway before reaching any database node.

--- a/docs/database/helix-cloud/start-here/working-with-enterprise.mdx
+++ b/docs/database/helix-cloud/start-here/working-with-enterprise.mdx
@@ -31,33 +31,39 @@ gateway
 <CodeGroup>
 
 ```rust Rust
-let client = helix_db::Client::new(Some("https://cluster.helix-db.com"))?
+let client = helix_db::Client::managed(
+    Some("https://cluster.helix-db.com"),
+    "db_your_database_id",
+)?
     .with_api_key(Some("hx_your_api_key"));
 ```
 
 ```ts TypeScript
 const client = Client
-  .server("https://cluster.helix-db.com")
+  .managed("https://cluster.helix-db.com", "db_your_database_id")
   .withApiKey("hx_your_api_key");
 ```
 
 ```go Go
-client, err := helix.NewClient(
+client, err := helix.NewManagedClient(
 	"https://cluster.helix-db.com",
+	"db_your_database_id",
 	helix.WithAPIKey("hx_your_api_key"),
 )
 ```
 
 ```python Python
-client = Client(
+client = Client.managed(
     "https://cluster.helix-db.com",
+    database_id="db_your_database_id",
     api_key="hx_your_api_key",
 )
 ```
 
 </CodeGroup>
 
-Each client sends the same operation-tree request body:
+Each client sends the database ID in the canonical `x-helix-tenant-id` header and the
+same operation-tree request body:
 
 ```json JSON
 {

--- a/docs/database/helix-db/start-here/sdk-setup/rust-project-setup.mdx
+++ b/docs/database/helix-db/start-here/sdk-setup/rust-project-setup.mdx
@@ -59,7 +59,8 @@ let request = find_users("acme".to_string(), 25);
 let response: serde_json::Value = client.query(request).send().await?;
 ```
 
-Use `.with_api_key(Some("hx_..."))` for Helix Cloud. Request-builder options can
+Use `Client::managed(Some("https://..."), "db_...")?.with_api_key(Some("hx_..."))`
+for Helix Cloud. Request-builder options can
 require the writer, require a warm read, or control durability waiting.
 
 ## Build without the macro

--- a/docs/database/helix-db/start-here/sdk-setup/typescript-project-setup.mdx
+++ b/docs/database/helix-db/start-here/sdk-setup/typescript-project-setup.mdx
@@ -70,7 +70,7 @@ const result = await Client.server("http://localhost:6969")
   .send();
 ```
 
-Use `withApiKey("hx_...")` for Helix Cloud.
+Use `Client.managed("https://...", "db_...").withApiKey("hx_...")` for Helix Cloud.
 
 ## Integer safety
 

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -57,6 +57,17 @@ var out FindUsersResponse
 err = client.Exec(ctx, FindUsers("acme", 25), &out)
 ```
 
+For Helix Cloud, use the managed constructor with the dashboard database ID. It
+sends that ID in the `x-helix-tenant-id` header on query and warm requests:
+
+```go
+client, err := helix.NewManagedClient(
+	"https://cluster.helix-db.com",
+	"db_your_database_id",
+	helix.WithAPIKey("hx_your_api_key"),
+)
+```
+
 Pass `helix.WarmOnly()` to mark a read for cache warming. Helix Cloud fans the
 request out to every eligible backend and returns `204 No Content` after at
 least one succeeds, so do not expect a query payload. Combine it with

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 )
 
@@ -16,6 +17,7 @@ type ErrorKind string
 type QueryErrorCode string
 
 const (
+	DatabaseIDHeader                   = "x-helix-tenant-id"
 	ErrorNetwork             ErrorKind = "Network"
 	ErrorRemote              ErrorKind = "Remote"
 	ErrorSerialization       ErrorKind = "Serialization"
@@ -54,11 +56,14 @@ func IsConflict(err error) bool {
 }
 
 type Client struct {
-	baseURL    *url.URL
-	httpClient *http.Client
-	embedded   nativeDB
-	apiKeyMu   sync.RWMutex
-	apiKey     string
+	baseURL           *url.URL
+	httpClient        *http.Client
+	embedded          nativeDB
+	apiKeyMu          sync.RWMutex
+	apiKey            string
+	databaseIDMu      sync.RWMutex
+	databaseID        *string
+	requireDatabaseID bool
 }
 
 type nativeDB interface {
@@ -148,6 +153,12 @@ func WithAPIKey(apiKey string) ClientOption {
 	return func(c *Client) { c.setAPIKey(apiKey) }
 }
 
+// WithDatabaseID configures the managed database sent in the
+// x-helix-tenant-id header for server requests.
+func WithDatabaseID(databaseID string) ClientOption {
+	return func(c *Client) { c.setDatabaseID(databaseID) }
+}
+
 func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 	if baseURL == "" {
 		baseURL = "http://localhost:6969"
@@ -162,6 +173,24 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 	client := &Client{baseURL: parsed, httpClient: http.DefaultClient}
 	for _, opt := range opts {
 		opt(client)
+	}
+	if databaseID, required := client.getDatabaseConfig(); databaseID != nil {
+		if err := validateDatabaseID(databaseID, required); err != nil {
+			return nil, err
+		}
+	}
+	return client, nil
+}
+
+// NewManagedClient creates a server client that requires a database ID and
+// sends it using the canonical x-helix-tenant-id header.
+func NewManagedClient(baseURL, databaseID string, opts ...ClientOption) (*Client, error) {
+	client, err := NewClient(baseURL, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err := client.setManagedDatabaseID(databaseID); err != nil {
+		return nil, err
 	}
 	return client, nil
 }
@@ -203,6 +232,14 @@ func NewEmbeddedReaderClientWithConfig(source HelixDbSource, cache EmbeddedCache
 
 func (c *Client) WithAPIKey(apiKey string) *Client { c.setAPIKey(apiKey); return c }
 func (c *Client) ClearAPIKey() *Client             { c.setAPIKey(""); return c }
+func (c *Client) WithDatabaseID(databaseID string) *Client {
+	c.setDatabaseID(databaseID)
+	return c
+}
+func (c *Client) ClearDatabaseID() *Client {
+	c.clearDatabaseID()
+	return c
+}
 func (c *Client) BaseURL() string {
 	if c == nil || c.baseURL == nil {
 		return ""
@@ -224,6 +261,63 @@ func (c *Client) getAPIKey() string {
 	apiKey := c.apiKey
 	c.apiKeyMu.RUnlock()
 	return apiKey
+}
+
+func (c *Client) setDatabaseID(databaseID string) {
+	if c == nil {
+		return
+	}
+	c.databaseIDMu.Lock()
+	c.databaseID = &databaseID
+	c.databaseIDMu.Unlock()
+}
+
+func (c *Client) clearDatabaseID() {
+	if c == nil {
+		return
+	}
+	c.databaseIDMu.Lock()
+	c.databaseID = nil
+	c.databaseIDMu.Unlock()
+}
+
+func (c *Client) setManagedDatabaseID(databaseID string) error {
+	if err := validateDatabaseID(&databaseID, true); err != nil {
+		return err
+	}
+	c.databaseIDMu.Lock()
+	c.databaseID = &databaseID
+	c.requireDatabaseID = true
+	c.databaseIDMu.Unlock()
+	return nil
+}
+
+func (c *Client) getDatabaseConfig() (*string, bool) {
+	c.databaseIDMu.RLock()
+	defer c.databaseIDMu.RUnlock()
+	if c.databaseID == nil {
+		return nil, c.requireDatabaseID
+	}
+	databaseID := *c.databaseID
+	return &databaseID, c.requireDatabaseID
+}
+
+func validateDatabaseID(databaseID *string, required bool) error {
+	if required && databaseID == nil {
+		return &HelixError{
+			Kind:    ErrorInvalidRequest,
+			Code:    QueryErrorCode("invalid_request"),
+			Details: "managed clients require a database ID",
+		}
+	}
+	if databaseID != nil && strings.TrimSpace(*databaseID) == "" {
+		return &HelixError{
+			Kind:    ErrorInvalidRequest,
+			Code:    QueryErrorCode("invalid_request"),
+			Details: "database ID must not be empty",
+		}
+	}
+	return nil
 }
 
 type execOptions struct {
@@ -277,6 +371,10 @@ func (c *Client) Exec(ctx context.Context, req Request, out any, opts ...ExecOpt
 	if c.baseURL == nil {
 		return &HelixError{Kind: ErrorInvalidURL, Details: "nil server client"}
 	}
+	databaseID, requireDatabaseID := c.getDatabaseConfig()
+	if err := validateDatabaseID(databaseID, requireDatabaseID); err != nil {
+		return err
+	}
 	endpoint := c.baseURL.ResolveReference(&url.URL{Path: "/v2/query"})
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), bytes.NewReader(body))
 	if err != nil {
@@ -285,6 +383,9 @@ func (c *Client) Exec(ctx context.Context, req Request, out any, opts ...ExecOpt
 	httpReq.Header.Set("Content-Type", "application/json")
 	if apiKey := c.getAPIKey(); apiKey != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	if databaseID != nil {
+		httpReq.Header.Set(DatabaseIDHeader, *databaseID)
 	}
 	if options.writerOnly {
 		httpReq.Header.Set("x-helix-require-writer", "true")

--- a/sdks/go/dsl_test.go
+++ b/sdks/go/dsl_test.go
@@ -646,16 +646,18 @@ func TestBatchDecodersCoverClosedVariantsAndMalformedShapes(t *testing.T) {
 func TestClientExec(t *testing.T) {
 	var capturedPath string
 	var capturedAuth string
+	var capturedDatabaseID string
 	var capturedWriter string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedPath = r.URL.Path
 		capturedAuth = r.Header.Get("Authorization")
+		capturedDatabaseID = r.Header.Get("x-helix-tenant-id")
 		capturedWriter = r.Header.Get("x-helix-require-writer")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"users":[{"$id":9223372036854775807,"name":"Alice"}]}`))
 	}))
 	defer server.Close()
-	client, err := NewClient(server.URL, WithAPIKey("hx_secret"))
+	client, err := NewClient(server.URL, WithAPIKey("hx_secret"), WithDatabaseID("db_123"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -666,11 +668,35 @@ func TestClientExec(t *testing.T) {
 	if capturedPath != "/v2/query" {
 		t.Fatalf("unexpected path %s", capturedPath)
 	}
-	if capturedAuth != "Bearer hx_secret" || capturedWriter != "true" {
-		t.Fatalf("headers not set: auth=%q writer=%q", capturedAuth, capturedWriter)
+	if capturedAuth != "Bearer hx_secret" || capturedDatabaseID != "db_123" || capturedWriter != "true" {
+		t.Fatalf("headers not set: auth=%q database=%q writer=%q", capturedAuth, capturedDatabaseID, capturedWriter)
 	}
 	if got := out.Users[0].ID.String(); got != "9223372036854775807" {
 		t.Fatalf("large id lost precision: %s", got)
+	}
+}
+
+func TestManagedClientRequiresDatabaseID(t *testing.T) {
+	for _, databaseID := range []string{"", "  "} {
+		t.Run(databaseID, func(t *testing.T) {
+			if _, err := NewManagedClient("http://localhost:6969", databaseID); err == nil {
+				t.Fatal("expected empty database ID to be rejected")
+			}
+		})
+	}
+
+	client, err := NewManagedClient("http://localhost:6969", "db_123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client == nil {
+		t.Fatal("expected managed client")
+	}
+	client.WithDatabaseID(" ")
+	err = client.Exec(context.Background(), findUsers("acme", 1), nil)
+	var helixErr *HelixError
+	if !errors.As(err, &helixErr) || helixErr.Kind != ErrorInvalidRequest {
+		t.Fatalf("expected invalid database ID error, got %v", err)
 	}
 }
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -30,6 +30,18 @@ request = query.to_query_request()
 result = Client("http://localhost:6969").query(request)
 ```
 
+For Helix Cloud, provide the dashboard database ID with the API key. The client
+sends it in the canonical `x-helix-tenant-id` header:
+
+```python
+client = Client.managed(
+    "https://cluster.helix-db.com",
+    database_id="db_your_database_id",
+    api_key="hx_your_api_key",
+)
+result = client.query(request)
+```
+
 ## Async Client
 
 Reuse one `AsyncClient` so its HTTPX connection pool can serve many requests.

--- a/sdks/python/src/helixdb/_client_common.py
+++ b/sdks/python/src/helixdb/_client_common.py
@@ -11,6 +11,7 @@ from .dsl import QueryRequest
 
 DEFAULT_URL = "http://localhost:6969"
 QUERY_PATH = "/v2/query"
+DATABASE_ID_HEADER = "x-helix-tenant-id"
 
 
 class HelixError(Exception):
@@ -177,11 +178,14 @@ def validate_base_url(url: str | None) -> str:
 def prepare_request(
     base_url: str,
     api_key: str | None,
+    database_id: str | None,
+    require_database_id: bool,
     headers: Mapping[str, str],
     query: QueryRequest,
 ) -> PreparedRequest:
     """Serialize a query and resolve the common HelixDB HTTP request."""
 
+    validate_database_id(database_id, required=require_database_id)
     body = serialize_query(query)
     try:
         url = urljoin(base_url.rstrip("/") + "/", QUERY_PATH)
@@ -191,7 +195,18 @@ def prepare_request(
     prepared_headers = dict(headers)
     if api_key is not None:
         prepared_headers["Authorization"] = f"Bearer {api_key}"
+    if database_id is not None:
+        prepared_headers[DATABASE_ID_HEADER] = database_id
     return PreparedRequest(url, tuple(prepared_headers.items()), body)
+
+
+def validate_database_id(database_id: str | None, *, required: bool = False) -> None:
+    """Validate a managed database ID before a request is sent."""
+
+    if required and database_id is None:
+        raise HelixError.invalid_request("managed clients require a database ID")
+    if database_id is not None and not database_id.strip():
+        raise HelixError.invalid_request("database ID must not be empty")
 
 
 def serialize_query(query: QueryRequest) -> bytes:

--- a/sdks/python/src/helixdb/async_client.py
+++ b/sdks/python/src/helixdb/async_client.py
@@ -16,6 +16,7 @@ from ._client_common import (
     remote_error,
     serialize_query,
     validate_base_url,
+    validate_database_id,
 )
 from .client import (
     EmbeddedCacheConfig,
@@ -33,6 +34,8 @@ Timeout = float | httpx.Timeout | None
 class _ServerBackend:
     base_url: str
     api_key: str | None
+    database_id: str | None
+    require_database_id: bool
     http_client: httpx.AsyncClient
     timeout: Timeout
 
@@ -60,6 +63,8 @@ class _ServerRequestBackend:
     state: _ClientState
     base_url: str
     api_key: str | None
+    database_id: str | None
+    require_database_id: bool
     http_client: httpx.AsyncClient
     timeout: Timeout
 
@@ -97,6 +102,7 @@ class AsyncClient:
         url: str | None = None,
         *,
         api_key: str | None = None,
+        database_id: str | None = None,
         timeout: Timeout = None,
         limits: httpx.Limits | None = None,
         transport: httpx.AsyncBaseTransport | None = None,
@@ -113,6 +119,8 @@ class AsyncClient:
             _ServerBackend(
                 validate_base_url(url),
                 api_key,
+                database_id,
+                False,
                 httpx.AsyncClient(**client_options),
                 timeout,
             )
@@ -130,6 +138,7 @@ class AsyncClient:
         url: str | None = None,
         *,
         api_key: str | None = None,
+        database_id: str | None = None,
         timeout: Timeout = None,
         limits: httpx.Limits | None = None,
         transport: httpx.AsyncBaseTransport | None = None,
@@ -139,10 +148,36 @@ class AsyncClient:
         return cls(
             url,
             api_key=api_key,
+            database_id=database_id,
             timeout=timeout,
             limits=limits,
             transport=transport,
         )
+
+    @classmethod
+    def managed(
+        cls,
+        url: str | None,
+        *,
+        api_key: str | None = None,
+        database_id: str,
+        timeout: Timeout = None,
+        limits: httpx.Limits | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> "AsyncClient":
+        validate_database_id(database_id, required=True)
+        client = cls(
+            url,
+            api_key=api_key,
+            database_id=database_id,
+            timeout=timeout,
+            limits=limits,
+            transport=transport,
+        )
+        backend = client._state.backend
+        if isinstance(backend, _ServerBackend):
+            client._state.backend = replace(backend, require_database_id=True)
+        return client
 
     @classmethod
     async def embedded(
@@ -204,6 +239,16 @@ class AsyncClient:
             raise HelixError.invalid_request("client is closed")
         return self
 
+    def with_database_id(self, database_id: str | None = None) -> "AsyncClient":
+        """Set or clear the managed database ID sent as ``x-helix-tenant-id``."""
+
+        backend = self._state.backend
+        if isinstance(backend, _ServerBackend):
+            self._state.backend = replace(backend, database_id=database_id)
+        elif backend is _ClosedBackend.CLOSED:
+            raise HelixError.invalid_request("client is closed")
+        return self
+
     def _request_backend(self) -> _RequestBackend:
         backend = self._state.backend
         if isinstance(backend, _ServerBackend):
@@ -211,6 +256,8 @@ class AsyncClient:
                 self._state,
                 backend.base_url,
                 backend.api_key,
+                backend.database_id,
+                backend.require_database_id,
                 backend.http_client,
                 backend.timeout,
             )
@@ -347,6 +394,8 @@ class AsyncQueryExecutionRequest:
         prepared = prepare_request(
             self._backend.base_url,
             self._backend.api_key,
+            self._backend.database_id,
+            self._backend.require_database_id,
             dict(self._headers),
             self._query,
         )

--- a/sdks/python/src/helixdb/client.py
+++ b/sdks/python/src/helixdb/client.py
@@ -17,6 +17,7 @@ from ._client_common import (
     remote_error,
     serialize_query,
     validate_base_url,
+    validate_database_id,
 )
 from .dsl import QueryRequest
 
@@ -27,15 +28,36 @@ QUERY_PATH = _client_common.QUERY_PATH
 class Client:
     """Synchronous client for running queries against HelixDB."""
 
-    def __init__(self, url: str | None = None, *, api_key: str | None = None) -> None:
+    def __init__(
+        self,
+        url: str | None = None,
+        *,
+        api_key: str | None = None,
+        database_id: str | None = None,
+    ) -> None:
         self._mode: Literal["server", "embedded"] = "server"
         self._base_url = validate_base_url(url)
         self._api_key = api_key
+        self._database_id = database_id
+        self._require_database_id = False
         self._native: Any | None = None
 
     @classmethod
-    def server(cls, url: str | None = None, *, api_key: str | None = None) -> "Client":
-        return cls(url, api_key=api_key)
+    def server(
+        cls,
+        url: str | None = None,
+        *,
+        api_key: str | None = None,
+        database_id: str | None = None,
+    ) -> "Client":
+        return cls(url, api_key=api_key, database_id=database_id)
+
+    @classmethod
+    def managed(cls, url: str | None, *, api_key: str | None = None, database_id: str) -> "Client":
+        validate_database_id(database_id, required=True)
+        client = cls(url, api_key=api_key, database_id=database_id)
+        client._require_database_id = True
+        return client
 
     @classmethod
     def embedded(
@@ -88,8 +110,20 @@ class Client:
             self._api_key = api_key
         return self
 
+    def with_database_id(self, database_id: str | None = None) -> "Client":
+        """Set or clear the managed database ID sent as ``x-helix-tenant-id``."""
+
+        if self._mode == "server":
+            self._database_id = database_id
+        return self
+
     def request_builder(self) -> "QueryBuilder":
-        return QueryBuilder(self._base_url, self._api_key)
+        return QueryBuilder(
+            self._base_url,
+            self._api_key,
+            self._database_id,
+            self._require_database_id,
+        )
 
     def query(self, request: QueryRequest | None = None) -> Any:
         if request is None:
@@ -212,6 +246,8 @@ class EmbeddedCacheConfig:
 class QueryBuilder:
     _base_url: str
     _api_key: str | None = None
+    _database_id: str | None = None
+    _require_database_id: bool = False
     _headers: dict[str, str] | None = None
 
     def __post_init__(self) -> None:
@@ -234,6 +270,8 @@ class QueryBuilder:
         return QueryExecutionRequest(
             base_url=self._base_url,
             api_key=self._api_key,
+            database_id=self._database_id,
+            require_database_id=self._require_database_id,
             headers=dict(self._headers or {}),
             query=query,
         )
@@ -243,11 +281,20 @@ class QueryBuilder:
 class QueryExecutionRequest:
     base_url: str
     api_key: str | None
+    database_id: str | None
+    require_database_id: bool
     headers: dict[str, str]
     query: QueryRequest
 
     def send_bytes(self) -> bytes:
-        prepared = prepare_request(self.base_url, self.api_key, self.headers, self.query)
+        prepared = prepare_request(
+            self.base_url,
+            self.api_key,
+            self.database_id,
+            self.require_database_id,
+            self.headers,
+            self.query,
+        )
         request = Request(
             prepared.url,
             data=prepared.body,

--- a/sdks/python/tests/test_async_client.py
+++ b/sdks/python/tests/test_async_client.py
@@ -78,7 +78,9 @@ class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
                 "server",
                 "embedded",
                 "embedded_reader",
+                "managed",
                 "with_api_key",
+                "with_database_id",
                 "request_builder",
                 "query",
                 "execute",
@@ -122,9 +124,10 @@ class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
             calls.append(request)
             return httpx.Response(200, json={"ok": True})
 
-        async with AsyncClient(
+        async with AsyncClient.managed(
             "http://127.0.0.1:6969/base",
             api_key="hx_secret",
+            database_id="db_123",
             timeout=5.0,
             limits=httpx.Limits(max_connections=4, max_keepalive_connections=2),
             transport=httpx.MockTransport(handler),
@@ -142,11 +145,30 @@ class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
         request = calls[0]
         self.assertEqual(str(request.url), "http://127.0.0.1:6969/v2/query")
         self.assertEqual(request.headers["authorization"], "Bearer hx_secret")
+        self.assertEqual(request.headers["x-helix-tenant-id"], "db_123")
         self.assertEqual(request.headers["x-helix-require-writer"], "true")
         self.assertEqual(request.headers["x-helix-warm"], "true")
         self.assertEqual(request.headers["x-helix-await-durable"], "false")
         self.assertEqual(request.extensions["timeout"]["read"], 0.25)
         self.assertEqual(json.loads(request.content)["request_type"], "read")
+
+    async def test_managed_client_rejects_missing_or_empty_database_id(self) -> None:
+        for database_id in ("", "   "):
+            with self.subTest(database_id=database_id):
+                with self.assertRaisesRegex(HelixError, "database ID"):
+                    AsyncClient.managed("http://127.0.0.1:6969", database_id=database_id)
+
+        calls: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request)
+            return httpx.Response(200, json={"ok": True})
+
+        async with AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            client.with_database_id(" ")
+            with self.assertRaisesRegex(HelixError, "database ID"):
+                await client.query(read_request())
+        self.assertEqual(calls, [])
 
     async def test_default_timeout_is_disabled(self) -> None:
         calls: list[httpx.Request] = []

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -174,7 +174,9 @@ class ClientTests(unittest.TestCase):
                 "server",
                 "embedded",
                 "embedded_reader",
+                "managed",
                 "with_api_key",
+                "with_database_id",
                 "request_builder",
                 "query",
                 "base_url",
@@ -245,7 +247,9 @@ class ClientTests(unittest.TestCase):
 
         with patch("helixdb.client.urlopen", fake_urlopen):
             result = (
-                Client("http://127.0.0.1:6969", api_key="hx_secret")
+                Client.managed(
+                    "http://127.0.0.1:6969", api_key="hx_secret", database_id="db_123"
+                )
                 .request_builder()
                 .writer_only()
                 .warm_only()
@@ -258,10 +262,30 @@ class ClientTests(unittest.TestCase):
         req = calls[0]
         self.assertEqual(req.full_url, "http://127.0.0.1:6969/v2/query")
         self.assertEqual(req.headers["Authorization"], "Bearer hx_secret")
+        self.assertEqual(req.headers["X-helix-tenant-id"], "db_123")
         self.assertEqual(req.headers["X-helix-require-writer"], "true")
         self.assertEqual(req.headers["X-helix-warm"], "true")
         self.assertEqual(req.headers["X-helix-await-durable"], "false")
         self.assertEqual(json.loads(req.data.decode("utf-8"))["request_type"], "read")
+
+    def test_managed_client_rejects_missing_or_empty_database_id(self) -> None:
+        for database_id in ("", "   "):
+            with self.subTest(database_id=database_id):
+                with self.assertRaisesRegex(HelixError, "database ID"):
+                    Client.managed("http://127.0.0.1:6969", database_id=database_id)
+
+        calls = []
+
+        def fake_urlopen(req):
+            calls.append(req)
+            return FakeResponse()
+
+        with patch("helixdb.client.urlopen", fake_urlopen):
+            with self.assertRaisesRegex(HelixError, "database ID"):
+                Client("http://127.0.0.1:6969").with_database_id(" ").query(
+                    QueryRequest.read(read_batch())
+                )
+        self.assertEqual(calls, [])
 
     def test_remote_error_includes_status_and_details(self) -> None:
         request = QueryRequest.read(read_batch())

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -158,8 +158,11 @@ use helix_db::Client;
 // Defaults to http://localhost:6969 when `url` is None.
 let client = Client::new(None)?;
 
-// Or point at a remote cluster and attach an API key:
-let client = Client::new(Some("https://11e2fc88c410fa5eb13e.cluster.helix-db.com"))?
+// Or point at Helix Cloud with an API key and dashboard database ID:
+let client = Client::managed(
+    Some("https://11e2fc88c410fa5eb13e.cluster.helix-db.com"),
+    "db_your_database_id",
+)?
     .with_api_key(Some("hx_your_api_key"));
 ```
 
@@ -219,7 +222,10 @@ struct AddUserResponse {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = Client::new(Some("https://11e2fc88c410fa5eb13e.cluster.helix-db.com"))?
+    let client = Client::managed(
+        Some("https://11e2fc88c410fa5eb13e.cluster.helix-db.com"),
+        "db_your_database_id",
+    )?
         .with_api_key(Some("hx_your_api_key"));
 
     // Building the request is infallible — no `?` needed here.

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -60,7 +60,8 @@
 //!
 //! # async fn run(request: QueryRequest) -> Result<(), helix_db::HelixError> {
 //! let client = Client::new(Some("https://cluster.helix-db.com"))?
-//!     .with_api_key(Some("hx_your_api_key"));
+//!     .with_api_key(Some("hx_your_api_key"))
+//!     .with_database_id(Some("db_your_database_id"));
 //!
 //! let response: Friends = client.query(request).send().await?;
 //! # let _ = response.friends;
@@ -102,12 +103,15 @@ use reqwest::{Client as ReqwestClient, StatusCode};
 use serde::Deserialize;
 use thiserror::Error;
 
+const DATABASE_ID_HEADER: &str = "x-helix-tenant-id";
+
 /// Async HTTP client for running queries against a Helix instance.
 ///
 /// A thin async wrapper over [`reqwest`] that knows how to reach a Helix
-/// gateway's query routes. Construct it with [`Client::new`], optionally attach
-/// a bearer API key via [`Client::with_api_key`], then build and send requests
-/// through [`Client::query`].
+/// gateway's query routes. Construct it with [`Client::new`] or
+/// [`Client::managed`], optionally attach a bearer API key via
+/// [`Client::with_api_key`], then build and send requests through
+/// [`Client::query`].
 ///
 /// The client is cheap to [`Clone`] — the underlying `reqwest::Client` shares
 /// its connection pool — so a single instance can be reused across tasks.
@@ -124,8 +128,11 @@ use thiserror::Error;
 /// let local = Client::new(None)?;
 ///
 /// // Or point at a remote cluster and attach an API key.
-/// let remote = Client::new(Some("https://cluster.helix-db.com"))?
-///     .with_api_key(Some("hx_your_api_key"));
+/// let remote = Client::managed(
+///     Some("https://cluster.helix-db.com"),
+///     "db_your_database_id",
+/// )?
+/// .with_api_key(Some("hx_your_api_key"));
 /// # let _ = (local, remote);
 /// # Ok(())
 /// # }
@@ -147,6 +154,8 @@ struct ServerClient {
     client: ReqwestClient,
     url: reqwest::Url,
     api_key: Option<String>,
+    database_id: Option<String>,
+    require_database_id: bool,
 }
 
 impl fmt::Debug for Client {
@@ -157,6 +166,7 @@ impl fmt::Debug for Client {
                 .field("mode", &"server")
                 .field("url", &server.url)
                 .field("api_key", &server.api_key.as_ref().map(|_| "<redacted>"))
+                .field("database_id", &server.database_id)
                 .finish(),
             #[cfg(feature = "embedded")]
             ClientBackend::Embedded(_) => formatter
@@ -252,8 +262,29 @@ impl Client {
                 client: ReqwestClient::new(),
                 url,
                 api_key: None,
+                database_id: None,
+                require_database_id: false,
             }),
         })
+    }
+
+    /// Create a managed Helix Cloud client with a required database ID.
+    ///
+    /// The database ID is sent as `x-helix-tenant-id` with every server request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HelixError::InvalidRequest`] when `database_id` is empty or
+    /// contains only whitespace, or [`HelixError::InvalidURL`] for an invalid
+    /// endpoint URL.
+    pub fn managed(url: Option<&str>, database_id: &str) -> Result<Self, HelixError> {
+        let mut client = Self::server(url)?;
+        validate_database_id(Some(database_id), true)?;
+        if let ClientBackend::Server(server) = &mut client.backend {
+            server.database_id = Some(database_id.to_string());
+            server.require_database_id = true;
+        }
+        Ok(client)
     }
 
     /// Create an embedded-mode writer client backed by the DB crate.
@@ -320,6 +351,17 @@ impl Client {
             }
             #[cfg(feature = "embedded")]
             ClientBackend::Embedded(_) => {}
+        }
+        self
+    }
+
+    /// Attach (or clear) the managed database ID sent as `x-helix-tenant-id`.
+    ///
+    /// An empty value is rejected when the first server request is sent. Use
+    /// [`Client::managed`] when the endpoint must always have a database ID.
+    pub fn with_database_id(mut self, database_id: Option<&str>) -> Self {
+        if let ClientBackend::Server(server) = &mut self.backend {
+            server.database_id = database_id.map(str::to_string);
         }
         self
     }
@@ -416,6 +458,20 @@ fn remote_error(response_body: String, fallback: String) -> HelixError {
     HelixError::RemoteError { code, details }
 }
 
+fn validate_database_id(database_id: Option<&str>, required: bool) -> Result<(), HelixError> {
+    if required && database_id.is_none() {
+        return Err(HelixError::InvalidRequest {
+            details: "managed clients require a database ID".to_string(),
+        });
+    }
+    if database_id.is_some_and(|value| value.trim().is_empty()) {
+        return Err(HelixError::InvalidRequest {
+            details: "database ID must not be empty".to_string(),
+        });
+    }
+    Ok(())
+}
+
 /// Fluent builder for a single request, produced by [`Client::query`].
 ///
 /// Optional server header toggles ([`writer_only`](Self::writer_only),
@@ -507,12 +563,16 @@ impl<'hlx, 'a, R> QueryExecutionRequest<'hlx, 'a, R> {
     pub async fn send_bytes(self) -> Result<Vec<u8>, HelixError> {
         match &self.client.backend {
             ClientBackend::Server(server) => {
+                validate_database_id(server.database_id.as_deref(), server.require_database_id)?;
                 let mut request = server.client.post(server.url.clone());
                 for (key, value) in self.headers.into_iter().flatten() {
                     request = request.header(key, value);
                 }
                 if let Some(api_key) = &server.api_key {
                     request = request.bearer_auth(api_key);
+                }
+                if let Some(database_id) = &server.database_id {
+                    request = request.header(DATABASE_ID_HEADER, database_id);
                 }
                 let response = request.body(sonic_rs::to_vec(&self.query)?).send().await?;
                 match response.status() {
@@ -1151,6 +1211,7 @@ mod client_tests {
         let server = server_backend(&client);
         assert_eq!(server.url.as_str(), "http://localhost:6969/v2/query");
         assert!(server.api_key.is_none());
+        assert!(server.database_id.is_none());
     }
 
     #[test]
@@ -1178,6 +1239,33 @@ mod client_tests {
 
         let cleared = client.with_api_key(None);
         assert!(server_backend(&cleared).api_key.is_none());
+    }
+
+    #[test]
+    fn managed_requires_a_non_empty_database_id() {
+        for database_id in ["", "   "] {
+            let error = Client::managed(Some("https://cluster.helix-db.com"), database_id)
+                .unwrap_err();
+            assert!(matches!(error, HelixError::InvalidRequest { .. }));
+        }
+
+        let client = Client::managed(
+            Some("https://cluster.helix-db.com"),
+            "db_123",
+        )
+        .unwrap();
+        let server = server_backend(&client);
+        assert_eq!(server.database_id.as_deref(), Some("db_123"));
+        assert!(server.require_database_id);
+    }
+
+    #[test]
+    fn with_database_id_sets_and_clears() {
+        let client = Client::new(None).unwrap().with_database_id(Some("db_123"));
+        assert_eq!(server_backend(&client).database_id.as_deref(), Some("db_123"));
+
+        let cleared = client.with_database_id(None);
+        assert!(server_backend(&cleared).database_id.is_none());
     }
 
     #[test]
@@ -1268,7 +1356,7 @@ mod client_tests {
     struct EmptyResp {}
 
     /// Spawn a one-shot HTTP server on a random port. Returns its base URL and a
-    /// handle that resolves to the request-target (path) of the first request.
+    /// handle that resolves to the first request received.
     async fn spawn_capture_server() -> (String, tokio::task::JoinHandle<String>) {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1277,16 +1365,9 @@ mod client_tests {
             let (mut socket, _) = listener.accept().await.unwrap();
             let mut buf = [0u8; 4096];
             let n = socket.read(&mut buf).await.unwrap();
-            let request_line = String::from_utf8_lossy(&buf[..n])
-                .lines()
-                .next()
-                .unwrap()
-                .to_string();
-            // `METHOD <target> HTTP/1.1` -> the target.
-            let target = request_line.split_whitespace().nth(1).unwrap().to_string();
             let resp = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}";
             socket.write_all(resp.as_bytes()).await.unwrap();
-            target
+            String::from_utf8_lossy(&buf[..n]).into_owned()
         });
         (base, handle)
     }
@@ -1296,7 +1377,26 @@ mod client_tests {
         let (base, handle) = spawn_capture_server().await;
         let client = Client::new(Some(&base)).unwrap();
         let _: EmptyResp = client.query(sample_request()).send().await.unwrap();
-        assert_eq!(handle.await.unwrap(), "/v2/query");
+        assert!(handle.await.unwrap().contains("POST /v2/query HTTP/1.1"));
+    }
+
+    #[tokio::test]
+    async fn managed_query_sends_database_id_header() {
+        let (base, handle) = spawn_capture_server().await;
+        let client = Client::managed(Some(&base), "db_123")
+            .unwrap()
+            .with_api_key(Some("hx_secret"));
+        let _: EmptyResp = client.query(sample_request()).send().await.unwrap();
+        let captured = handle.await.unwrap();
+        assert!(captured.contains("x-helix-tenant-id: db_123"));
+        assert!(captured.contains("authorization: Bearer hx_secret"));
+    }
+
+    #[tokio::test]
+    async fn empty_database_id_is_rejected_before_sending() {
+        let client = Client::new(Some("http://127.0.0.1:1")).unwrap().with_database_id(Some(" "));
+        let error = client.query::<EmptyResp>(sample_request()).send().await.unwrap_err();
+        assert!(matches!(error, HelixError::InvalidRequest { .. }));
     }
 
     // ---- Embedded execution -------------------------------------------------

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -44,7 +44,7 @@ routes, registration, or query-bundle APIs.
 Server mode uses the built-in global `fetch`:
 
 ```ts
-const client = Client.server("https://cluster.helix-db.com").withApiKey("hx_secret");
+const client = Client.managed("https://cluster.helix-db.com", "db_your_database_id").withApiKey("hx_secret");
 const result = await client.query<MyResponse>(request).send();
 ```
 

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -326,11 +326,15 @@ export class QueryBuilder<R = unknown> {
   /** Attach a query and target `POST /v2/query`. */
   query(query: QueryRequest): QueryExecutionRequest<R> {
     return new QueryExecutionRequest<R>({
-      backend: this.backend,
+      backend: snapshotBackend(this.backend),
       headers: { ...this.headers },
       query,
     });
   }
+}
+
+function snapshotBackend(backend: ClientBackend): ClientBackend {
+  return backend.kind === "server" ? { ...backend } : backend;
 }
 
 export class QueryExecutionRequest<R = unknown> {

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -13,6 +13,7 @@ import { GraphSelection, NativeGraph, loadGraph } from "./graph.js";
 
 const DEFAULT_URL = "http://localhost:6969";
 const QUERY_PATH = "/v2/query";
+const DATABASE_ID_HEADER = "x-helix-tenant-id";
 
 /**
  * Error raised by the network {@link Client}.
@@ -97,7 +98,9 @@ function remoteError(body: string, fallback: string): HelixError {
   return HelixError.remote(body.length === 0 ? fallback : body);
 }
 
-type ClientBackend = { kind: "server"; url: URL; apiKey?: string } | { kind: "embedded"; native: NativeHelixDB };
+type ClientBackend =
+  | { kind: "server"; url: URL; apiKey?: string; databaseId?: string; requireDatabaseId: boolean }
+  | { kind: "embedded"; native: NativeHelixDB };
 
 /** Complete query request handed from {@link QueryBuilder} to {@link QueryExecutionRequest}. */
 interface RequestParts {
@@ -183,7 +186,7 @@ export class Client {
 
   constructor(url?: string | null) {
     try {
-      this.backend = { kind: "server", url: new URL(url ?? DEFAULT_URL) };
+      this.backend = { kind: "server", url: new URL(url ?? DEFAULT_URL), requireDatabaseId: false };
     } catch (error) {
       throw HelixError.invalidUrl(error instanceof Error ? error.message : String(error));
     }
@@ -197,6 +200,17 @@ export class Client {
 
   static server(url?: string | null): Client {
     return new Client(url);
+  }
+
+  /** Create a managed Helix Cloud client with a required database ID. */
+  static managed(url: string | null | undefined, databaseId: string): Client {
+    validateDatabaseId(databaseId, true);
+    const client = new Client(url);
+    if (client.backend.kind === "server") {
+      client.backend.databaseId = databaseId;
+      client.backend.requireDatabaseId = true;
+    }
+    return client;
   }
 
   static async embedded(source: HelixDbSource, cache?: EmbeddedCacheConfig): Promise<Client> {
@@ -234,6 +248,12 @@ export class Client {
   /** Set (or, with `null`/`undefined`, clear) the bearer API key sent on every request. */
   withApiKey(apiKey?: string | null): Client {
     if (this.backend.kind === "server") this.backend.apiKey = apiKey ?? undefined;
+    return this;
+  }
+
+  /** Set (or clear) the managed database ID sent as `x-helix-tenant-id`. */
+  withDatabaseId(databaseId?: string | null): Client {
+    if (this.backend.kind === "server") this.backend.databaseId = databaseId ?? undefined;
     return this;
   }
 
@@ -340,8 +360,10 @@ export class QueryExecutionRequest<R = unknown> {
       throw HelixError.invalidUrl(error instanceof Error ? error.message : String(error));
     }
 
+    validateDatabaseId(backend.databaseId, backend.requireDatabaseId);
     const requestHeaders: Record<string, string> = { ...headers };
     if (backend.apiKey !== undefined) requestHeaders["Authorization"] = `Bearer ${backend.apiKey}`;
+    if (backend.databaseId !== undefined) requestHeaders[DATABASE_ID_HEADER] = backend.databaseId;
 
     let response: Response;
     try {
@@ -371,6 +393,15 @@ export class QueryExecutionRequest<R = unknown> {
     } catch (error) {
       throw HelixError.serialization(error instanceof Error ? error.message : String(error));
     }
+  }
+}
+
+function validateDatabaseId(databaseId: string | undefined, required: boolean): void {
+  if (required && databaseId === undefined) {
+    throw HelixError.invalidRequest("managed clients require a database ID");
+  }
+  if (databaseId !== undefined && databaseId.trim().length === 0) {
+    throw HelixError.invalidRequest("database ID must not be empty");
   }
 }
 

--- a/sdks/typescript/test/client.test.ts
+++ b/sdks/typescript/test/client.test.ts
@@ -211,6 +211,17 @@ for (const databaseId of ["", "   "]) {
 
 {
   const server = await spawnCaptureServer();
+  const client = Client.managed(server.base, "db_initial");
+  const request = client.query(sampleRequest());
+  client.withDatabaseId("db_later");
+  await request.send();
+  const req = await server.captured;
+  await server.close();
+  assert.equal(req.headers["x-helix-tenant-id"], "db_initial");
+}
+
+{
+  const server = await spawnCaptureServer();
   const client = new Client(server.base).withDatabaseId(" ");
   await assert.rejects(
     client.query(sampleRequest()).send(),

--- a/sdks/typescript/test/client.test.ts
+++ b/sdks/typescript/test/client.test.ts
@@ -172,11 +172,18 @@ assert.throws(
   (error: unknown) => error instanceof HelixError && error.kind === "InvalidUrl",
 );
 
+for (const databaseId of ["", "   "]) {
+  assert.throws(
+    () => Client.managed("https://cluster.helix-db.com", databaseId),
+    (error: unknown) => error instanceof HelixError && error.kind === "InvalidRequest",
+  );
+}
+
 // ---- Request routing + headers ----------------------------------------------
 
 {
   const server = await spawnCaptureServer();
-  const client = new Client(server.base).withApiKey("hx_secret");
+  const client = Client.managed(server.base, "db_123").withApiKey("hx_secret");
   const result = await client.requestBuilder<Record<string, unknown>>().warmOnly().writerOnly().query(sampleRequest()).send();
 
   const req = await server.captured;
@@ -186,10 +193,30 @@ assert.throws(
   assert.equal(req.path, "/v2/query");
   assert.equal(req.headers["content-type"], "application/json");
   assert.equal(req.headers["authorization"], "Bearer hx_secret");
+  assert.equal(req.headers["x-helix-tenant-id"], "db_123");
   assert.equal(req.headers["x-helix-warm"], "true");
   assert.equal(req.headers["x-helix-require-writer"], "true");
   assert.equal(req.body, sampleRequest().toJsonString());
   assert.deepEqual(result, {});
+}
+
+{
+  const server = await spawnCaptureServer();
+  const client = new Client(server.base).withDatabaseId("db_123");
+  await client.query(sampleRequest()).send();
+  const req = await server.captured;
+  await server.close();
+  assert.equal(req.headers["x-helix-tenant-id"], "db_123");
+}
+
+{
+  const server = await spawnCaptureServer();
+  const client = new Client(server.base).withDatabaseId(" ");
+  await assert.rejects(
+    client.query(sampleRequest()).send(),
+    (error: unknown) => error instanceof HelixError && error.kind === "InvalidRequest",
+  );
+  await server.close();
 }
 
 // ---- Durability header -------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #984.

- Add the canonical `x-helix-tenant-id` database ID option to the Rust, TypeScript, Python (sync/async), and Go clients.
- Add managed-client constructors that validate required database IDs before sending requests.
- Emit the database header on query, warm, writer, and durability-controlled Cloud requests.
- Add request-capture and validation coverage across all four SDKs.
- Update Cloud security, setup, README, and cross-language connection examples.

## Verification

- `go test ./...`
- `ruff check src tests`
- `python -m unittest discover -s tests -v` (48 tests)
- `npm test`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

Rust checks could not be run locally because Cargo is not installed in the environment; the Rust changes are included for CI verification.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds managed Cloud database selection to the Rust, TypeScript, Python, and Go SDKs, validates required database IDs, and emits the canonical tenant header on query requests. It also updates cross-language documentation and request-capture tests.
- Adds managed-client constructors and database-ID mutators across all four SDKs.
- Propagates `x-helix-tenant-id` through query, warm, writer, and durability-controlled requests.
- Adds validation and header-capture coverage, though the TypeScript request lifecycle currently permits later client mutation to retarget an already-built request.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdks/typescript/src/index.ts | Adds managed database selection, but request objects read mutable shared database state at send time and can be retargeted after construction. |
| sdks/python/src/helixdb/client.py | Adds synchronous managed-client state and snapshots its database selection into request builders. |
| sdks/python/src/helixdb/async_client.py | Adds asynchronous managed-client state while preserving per-request backend snapshots. |
| sdks/go/client.go | Adds synchronized database-ID configuration, managed construction, validation, and header emission during Exec. |
| sdks/rust/src/lib.rs | Adds managed construction, validation, and tenant-header emission to the Rust server client without a confirmed blocking defect. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant App
  participant Client
  participant Request
  participant Gateway
  App->>Client: managed(url, databaseId)
  App->>Client: query(payload)
  Client-->>App: Request sharing backend
  App->>Client: withDatabaseId(otherId)
  App->>Request: send()
  Request->>Client: read current databaseId
  Request->>Gateway: POST /v2/query + x-helix-tenant-id
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(sdks): support managed database sel..."](https://github.com/helixdb/helix-db/commit/3609502dcc2b04c3bf45f2d395eb9001695332da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54849529)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Rust SDK (`helix-db` crate)](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/sdk-rust.md)

<!-- /greptile_comment -->