### PR TITLE
release(go): publish server SDK v0.3.0

### DIFF
--- a/docs/database/helix-db/start-here/release-notes.mdx
+++ b/docs/database/helix-db/start-here/release-notes.mdx
@@ -13,10 +13,11 @@ pageType: "Reference"
 <Update
   label="August 2026"
   rss={{
-    title: "Asynchronous Python SDK client",
-    description: "Reusable asynchronous server and embedded clients in helix-db 0.3.3"
+    title: "Go SDK v0.3.0 and asynchronous Python SDK client",
+    description: "The Go server SDK and reusable asynchronous Python clients"
   }}
 >
+- **[Go SDK v0.3.0](/database/helix-db/start-here/sdk-setup/go-project-setup)** — operation-tree query construction, typed parameters, `/v2/query` execution, index lifecycle requests, and traversal-scoped vector and BM25 search. Embedded execution and native graph bindings are not distributed in this release.
 - **[Python async client](/database/helix-db/start-here/sdk-setup/python-project-setup#async-execution)** — `helix-db` 0.3.3 adds reusable HTTPX connection pooling, concurrent requests, cancellation-safe response cleanup, and asynchronous embedded writer and reader clients.
 </Update>
 

--- a/docs/database/helix-db/start-here/sdk-setup/go-project-setup.mdx
+++ b/docs/database/helix-db/start-here/sdk-setup/go-project-setup.mdx
@@ -8,18 +8,19 @@ pageType: "Guide"
 
 <div className="flex flex-wrap gap-2"><Badge color="blue" size="sm">Guide</Badge></div>
 
-The forthcoming v3 Go SDK builds the shared operation-tree AST and executes it through
-a typed client.
+The Go SDK builds the shared operation-tree AST and executes requests through a
+typed HTTP client.
 
 <Note>
-The v3 SDK packages have not been published yet. The Go SDK keeps the module path
-`github.com/helixdb/helix-db/sdks/go`; it does not add a `/v3` suffix.
+Version `v0.3.0` ships the server query builder and HTTP client. It does not
+distribute the native bindings required by embedded execution or native graph
+algorithms.
 </Note>
 
 ## Install
 
 ```bash
-go get github.com/helixdb/helix-db/sdks/go
+go get github.com/helixdb/helix-db/sdks/go@v0.3.0
 ```
 
 ```go
@@ -66,11 +67,11 @@ if err := client.Exec(ctx, FindUsers("acme", 25), &response); err != nil {
 Write requests can pass `helix.WriterOnly()` and `helix.AwaitDurability(true)` execution
 options. The client does not retry conflicts automatically.
 
-## Embedded runtime
+## Release scope
 
-Install the SDK with `go get github.com/helixdb/helix-db/sdks/go`. See
-[Embedded database](/database/helix-db/start-here/local-development/embedded-database)
-for storage, cache, and handle configuration.
+Use `v0.3.0` with a local or remote Helix server through `/v2/query`. Embedded
+constructors and `Client.Graph` return native-binding-unavailable errors in a
+standard module installation.
 
 ## Verify
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1088,16 +1088,17 @@ Page type: Guide
 
 <div className="flex flex-wrap gap-2"><Badge color="blue" size="sm">Guide</Badge></div>
 
-The forthcoming v3 Go SDK builds the shared operation-tree AST and executes it through
-a typed client.
+The Go SDK builds the shared operation-tree AST and executes requests through a
+typed HTTP client.
 
-The v3 SDK packages have not been published yet. The Go SDK keeps the module path
-`github.com/helixdb/helix-db/sdks/go`; it does not add a `/v3` suffix.
+Version `v0.3.0` ships the server query builder and HTTP client. It does not
+distribute the native bindings required by embedded execution or native graph
+algorithms.
 
 ## Install
 
 ```bash
-go get github.com/helixdb/helix-db/sdks/go
+go get github.com/helixdb/helix-db/sdks/go@v0.3.0
 ```
 
 ```go
@@ -1144,11 +1145,11 @@ if err := client.Exec(ctx, FindUsers("acme", 25), &response); err != nil {
 Write requests can pass `helix.WriterOnly()` and `helix.AwaitDurability(true)` execution
 options. The client does not retry conflicts automatically.
 
-## Embedded runtime
+## Release scope
 
-Install the SDK with `go get github.com/helixdb/helix-db/sdks/go`. See
-[Embedded database](/database/helix-db/start-here/local-development/embedded-database)
-for storage, cache, and handle configuration.
+Use `v0.3.0` with a local or remote Helix server through `/v2/query`. Embedded
+constructors and `Client.Graph` return native-binding-unavailable errors in a
+standard module installation.
 
 ## Verify
 
@@ -1329,6 +1330,7 @@ Page type: Reference
 
 <div className="flex flex-wrap gap-2"><Badge color="gray" size="sm">Reference</Badge></div>
 
+- **[Go SDK v0.3.0](/database/helix-db/start-here/sdk-setup/go-project-setup)** — operation-tree query construction, typed parameters, `/v2/query` execution, index lifecycle requests, and traversal-scoped vector and BM25 search. Embedded execution and native graph bindings are not distributed in this release.
 - **[Python async client](/database/helix-db/start-here/sdk-setup/python-project-setup#async-execution)** — `helix-db` 0.3.3 adds reusable HTTPX connection pooling, concurrent requests, cancellation-safe response cleanup, and asynchronous embedded writer and reader clients.
 
 - **Open-source database** — the engine moved out of `helix-hyperscale` into the public, modular `helix-db` workspace.

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,11 +1,12 @@
 # HelixDB Go SDK
 
-Go SDK for building and executing HelixDB queries.
+Go SDK for building and executing HelixDB server queries. Version `v0.3.0`
+ships the operation-tree query builder and HTTP client.
 
 ## Install
 
 ```sh
-go get github.com/helixdb/helix-db/sdks/go
+go get github.com/helixdb/helix-db/sdks/go@v0.3.0
 ```
 
 ```go
@@ -234,8 +235,9 @@ create a binding.
 
 `Client.Exec` does not retry HTTP 409 conflicts automatically. Callers should
 retry only when the operation is safe to replay. Remote errors are returned as
-`*helix.HelixError` with `StatusCode` and the static `Code` populated, and `helix.IsConflict(err)`
-or `errors.Is(err, helix.ErrConflict)` checks for HTTP 409:
+`*helix.HelixError` with `StatusCode` and the static `Code` populated. Use
+`helix.IsConflict(err)` or `errors.Is(err, helix.ErrConflict)` to detect HTTP
+409:
 
 The canonical [query error-code reference](../../docs/database/helix-db/query-guides/error-handling.mdx)
 documents the complete catalog and migration contract.
@@ -253,42 +255,14 @@ func ExecWithConflictRetry(ctx context.Context, client *helix.Client, build func
 }
 ```
 
-## Embedded cache profiles
+## Release scope
 
-Configured embedded constructors accept vector-memory-only, memory, or hybrid
-cache profiles. Vector-memory-only disables SlateDB and object-store caches;
-canonical data still uses the selected storage source.
-
-```go
-client, err := helix.NewEmbeddedClientWithConfig(
-	helix.DiskSource{Root: "/data/helix", Database: "app"},
-	helix.EmbeddedCacheConfig{
-		VectorMemoryBytes: 256 * 1024 * 1024,
-		Mode:              helix.VectorMemoryOnlyCache{},
-	},
-)
-```
-
-## Native graph algorithms
-
-Native graph support is included when the generated UniFFI tree is linked with
-the `helixdb_uniffi` build tag:
-
-```go
-selection := helix.GraphSelection{
-	NodeTraversal: helix.G().NWhere(helix.SourceHasKey("$id")),
-	EdgeTraversal: helix.G().EWhere(helix.SourceHasKey("$id")),
-	Direction: helix.GraphDirected,
-	AllowFullScan: true,
-}
-graph, err := client.Graph(ctx, selection)
-if err != nil { return err }
-scores, err := graph.BetweennessCentrality(helix.GraphifyBetweennessOptions())
-```
-
-The load performs one ordinary query and all later algorithms run locally.
-Without generated native bindings, `Client.Graph` returns
-`ErrNativeGraphUnavailable` before issuing the query.
+Version `v0.3.0` does not distribute the generated native bindings required by
+the embedded database or native graph algorithms. A standard module install
+returns `ErrNativeBindingsUnavailable` from embedded constructors and
+`ErrNativeGraphUnavailable` from `Client.Graph`. Do not enable the
+`helixdb_uniffi` build tag unless you separately generate and link compatible
+bindings and native libraries.
 
 ## Notes
 

--- a/sdks/go/dsl.go
+++ b/sdks/go/dsl.go
@@ -1002,32 +1002,32 @@ func (IndexDdlAlreadyActive) indexDdlReceipt() {}
 type IndexErrorCode string
 
 const (
-	IndexLifecycleUnavailable              IndexErrorCode = "index_lifecycle_unavailable"
-	IndexAlreadyExists                     IndexErrorCode = "index_already_exists"
-	IndexDefinitionConflict                IndexErrorCode = "index_definition_conflict"
-	IndexBusy                              IndexErrorCode = "index_busy"
-	IndexNotFound                          IndexErrorCode = "index_not_found"
-	IndexOperationNotFound                 IndexErrorCode = "index_operation_not_found"
-	IndexOperationNotAbortable             IndexErrorCode = "index_operation_not_abortable"
-	IndexIDExhausted                       IndexErrorCode = "index_id_exhausted"
-	VectorPhysicalIDExhausted              IndexErrorCode = "vector_physical_id_exhausted"
-	IndexGenerationExhausted               IndexErrorCode = "index_generation_exhausted"
-	IndexRevisionExhausted                 IndexErrorCode = "index_revision_exhausted"
-	IndexOperationRevisionExhausted        IndexErrorCode = "index_operation_revision_exhausted"
-	StaleIndexGeneration                   IndexErrorCode = "stale_index_generation"
-	WriterFencedCommitOutcomeUnknown       IndexErrorCode = "writer_fenced_commit_outcome_unknown"
+	IndexLifecycleUnavailable        IndexErrorCode = "index_lifecycle_unavailable"
+	IndexAlreadyExists               IndexErrorCode = "index_already_exists"
+	IndexDefinitionConflict          IndexErrorCode = "index_definition_conflict"
+	IndexBusy                        IndexErrorCode = "index_busy"
+	IndexNotFound                    IndexErrorCode = "index_not_found"
+	IndexOperationNotFound           IndexErrorCode = "index_operation_not_found"
+	IndexOperationNotAbortable       IndexErrorCode = "index_operation_not_abortable"
+	IndexIDExhausted                 IndexErrorCode = "index_id_exhausted"
+	VectorPhysicalIDExhausted        IndexErrorCode = "vector_physical_id_exhausted"
+	IndexGenerationExhausted         IndexErrorCode = "index_generation_exhausted"
+	IndexRevisionExhausted           IndexErrorCode = "index_revision_exhausted"
+	IndexOperationRevisionExhausted  IndexErrorCode = "index_operation_revision_exhausted"
+	StaleIndexGeneration             IndexErrorCode = "stale_index_generation"
+	WriterFencedCommitOutcomeUnknown IndexErrorCode = "writer_fenced_commit_outcome_unknown"
 )
 
 // IndexOperationBlockerCode is a stable reason explicit control is required.
 type IndexOperationBlockerCode string
 
 const (
-	IndexBlockerInvalidSourceData                      IndexOperationBlockerCode = "invalid_source_data"
-	IndexBlockerUniquenessViolation                    IndexOperationBlockerCode = "uniqueness_violation"
-	IndexBlockerOversizedEntity                        IndexOperationBlockerCode = "oversized_entity"
-	IndexBlockerManifestLimit                          IndexOperationBlockerCode = "manifest_limit"
-	IndexBlockerObjectStoreConfigurationUnavailable    IndexOperationBlockerCode = "object_store_configuration_unavailable"
-	IndexBlockerInvariantViolation                     IndexOperationBlockerCode = "invariant_violation"
+	IndexBlockerInvalidSourceData                   IndexOperationBlockerCode = "invalid_source_data"
+	IndexBlockerUniquenessViolation                 IndexOperationBlockerCode = "uniqueness_violation"
+	IndexBlockerOversizedEntity                     IndexOperationBlockerCode = "oversized_entity"
+	IndexBlockerManifestLimit                       IndexOperationBlockerCode = "manifest_limit"
+	IndexBlockerObjectStoreConfigurationUnavailable IndexOperationBlockerCode = "object_store_configuration_unavailable"
+	IndexBlockerInvariantViolation                  IndexOperationBlockerCode = "invariant_violation"
 )
 
 // IndexOperationProgress contains decimal-string bounded-work counters.


### PR DESCRIPTION
## Summary
- prepare the Go server/query SDK for the `sdks/go/v0.3.0` module tag
- document that embedded execution and native graph bindings are not distributed in this release
- publish the installation guide and release notes, including generated LLM docs

## Validation
- `go test -race ./...`
- `go vet ./...`
- `gofmt` clean
- Go statement coverage: 75.5%
- 248-request cross-SDK JSON parity
- 233-request server-disk runtime parity with restart coverage
- `npm run check` in `docs/`
- clean external-module server SDK smoke test

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prepares documentation for the Go server SDK v0.3.0 release while clearly excluding embedded execution and native graph bindings from the distributed module.
- Pins installation instructions to `github.com/helixdb/helix-db/sdks/go@v0.3.0`.
- Updates the setup guide, SDK README, release notes, and generated LLM documentation with the supported server-query scope.
- Applies formatting-only alignment changes to existing Go error-code constants.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/database/helix-db/start-here/release-notes.mdx | Adds the Go SDK v0.3.0 announcement and accurately summarizes its server-only feature scope. |
| docs/database/helix-db/start-here/sdk-setup/go-project-setup.mdx | Publishes version-pinned installation guidance and documents the unavailable embedded and native graph functionality. |
| docs/llms-full.txt | Mirrors the setup-guide and release-note changes in the generated LLM documentation. |
| sdks/go/README.md | Updates installation and release-scope guidance, including precise unavailable-binding sentinel errors and build-tag precautions. |
| sdks/go/dsl.go | Contains formatting-only alignment changes with no behavioral or wire-contract impact. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(go): publish v0.3.0 release scope"](https://github.com/helixdb/helix-db/commit/1997d3c6851c9afad00ee64012989a75fe50ee38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55128838)</sub>

<!-- /greptile_comment -->