### PR TITLE
fix(go): keep embedded adapters out of server module

### DIFF
--- a/docs/database/helix-db/start-here/release-notes.mdx
+++ b/docs/database/helix-db/start-here/release-notes.mdx
@@ -13,11 +13,11 @@ pageType: "Reference"
 <Update
   label="August 2026"
   rss={{
-    title: "Go SDK v0.3.0 and asynchronous Python SDK client",
+    title: "Go SDK v0.3.1 and asynchronous Python SDK client",
     description: "The Go server SDK and reusable asynchronous Python clients"
   }}
 >
-- **[Go SDK v0.3.0](/database/helix-db/start-here/sdk-setup/go-project-setup)** — operation-tree query construction, typed parameters, `/v2/query` execution, index lifecycle requests, and traversal-scoped vector and BM25 search. Embedded execution and native graph bindings are not distributed in this release.
+- **[Go SDK v0.3.1](/database/helix-db/start-here/sdk-setup/go-project-setup)** — operation-tree query construction, typed parameters, `/v2/query` execution, index lifecycle requests, and traversal-scoped vector and BM25 search. Upgrade from v0.3.0: this patch keeps unreleased embedded adapters out of public module discovery. Embedded execution and native graph bindings are not distributed in this release.
 - **[Python async client](/database/helix-db/start-here/sdk-setup/python-project-setup#async-execution)** — `helix-db` 0.3.3 adds reusable HTTPX connection pooling, concurrent requests, cancellation-safe response cleanup, and asynchronous embedded writer and reader clients.
 </Update>
 

--- a/docs/database/helix-db/start-here/sdk-setup/go-project-setup.mdx
+++ b/docs/database/helix-db/start-here/sdk-setup/go-project-setup.mdx
@@ -12,7 +12,7 @@ The Go SDK builds the shared operation-tree AST and executes requests through a
 typed HTTP client.
 
 <Note>
-Version `v0.3.0` ships the server query builder and HTTP client. It does not
+Version `v0.3.1` ships the server query builder and HTTP client. It does not
 distribute the native bindings required by embedded execution or native graph
 algorithms.
 </Note>
@@ -20,7 +20,7 @@ algorithms.
 ## Install
 
 ```bash
-go get github.com/helixdb/helix-db/sdks/go@v0.3.0
+go get github.com/helixdb/helix-db/sdks/go@v0.3.1
 ```
 
 ```go
@@ -69,7 +69,7 @@ options. The client does not retry conflicts automatically.
 
 ## Release scope
 
-Use `v0.3.0` with a local or remote Helix server through `/v2/query`. Embedded
+Use `v0.3.1` with a local or remote Helix server through `/v2/query`. Embedded
 constructors and `Client.Graph` return native-binding-unavailable errors in a
 standard module installation.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1091,14 +1091,14 @@ Page type: Guide
 The Go SDK builds the shared operation-tree AST and executes requests through a
 typed HTTP client.
 
-Version `v0.3.0` ships the server query builder and HTTP client. It does not
+Version `v0.3.1` ships the server query builder and HTTP client. It does not
 distribute the native bindings required by embedded execution or native graph
 algorithms.
 
 ## Install
 
 ```bash
-go get github.com/helixdb/helix-db/sdks/go@v0.3.0
+go get github.com/helixdb/helix-db/sdks/go@v0.3.1
 ```
 
 ```go
@@ -1147,7 +1147,7 @@ options. The client does not retry conflicts automatically.
 
 ## Release scope
 
-Use `v0.3.0` with a local or remote Helix server through `/v2/query`. Embedded
+Use `v0.3.1` with a local or remote Helix server through `/v2/query`. Embedded
 constructors and `Client.Graph` return native-binding-unavailable errors in a
 standard module installation.
 
@@ -1330,7 +1330,7 @@ Page type: Reference
 
 <div className="flex flex-wrap gap-2"><Badge color="gray" size="sm">Reference</Badge></div>
 
-- **[Go SDK v0.3.0](/database/helix-db/start-here/sdk-setup/go-project-setup)** — operation-tree query construction, typed parameters, `/v2/query` execution, index lifecycle requests, and traversal-scoped vector and BM25 search. Embedded execution and native graph bindings are not distributed in this release.
+- **[Go SDK v0.3.1](/database/helix-db/start-here/sdk-setup/go-project-setup)** — operation-tree query construction, typed parameters, `/v2/query` execution, index lifecycle requests, and traversal-scoped vector and BM25 search. Upgrade from v0.3.0: this patch keeps unreleased embedded adapters out of public module discovery. Embedded execution and native graph bindings are not distributed in this release.
 - **[Python async client](/database/helix-db/start-here/sdk-setup/python-project-setup#async-execution)** — `helix-db` 0.3.3 adds reusable HTTPX connection pooling, concurrent requests, cancellation-safe response cleanup, and asynchronous embedded writer and reader clients.
 
 - **Open-source database** — the engine moved out of `helix-hyperscale` into the public, modular `helix-db` workspace.

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,12 +1,12 @@
 # HelixDB Go SDK
 
-Go SDK for building and executing HelixDB server queries. Version `v0.3.0`
+Go SDK for building and executing HelixDB server queries. Version `v0.3.1`
 ships the operation-tree query builder and HTTP client.
 
 ## Install
 
 ```sh
-go get github.com/helixdb/helix-db/sdks/go@v0.3.0
+go get github.com/helixdb/helix-db/sdks/go@v0.3.1
 ```
 
 ```go
@@ -257,7 +257,7 @@ func ExecWithConflictRetry(ctx context.Context, client *helix.Client, build func
 
 ## Release scope
 
-Version `v0.3.0` does not distribute the generated native bindings required by
+Version `v0.3.1` does not distribute the generated native bindings required by
 the embedded database or native graph algorithms. A standard module install
 returns `ErrNativeBindingsUnavailable` from embedded constructors and
 `ErrNativeGraphUnavailable` from `Client.Graph`. Do not enable the

--- a/sdks/go/internal/embedded_templates/embedded_generated_test.go.tmpl
+++ b/sdks/go/internal/embedded_templates/embedded_generated_test.go.tmpl
@@ -1,5 +1,6 @@
 //go:build helixdb_uniffi
 
+// Copied into the temporary SDK only when generated native bindings are present.
 package helix
 
 import (

--- a/sdks/go/internal/embedded_templates/embedded_uniffi.go.tmpl
+++ b/sdks/go/internal/embedded_templates/embedded_uniffi.go.tmpl
@@ -1,5 +1,6 @@
 //go:build helixdb_uniffi
 
+// Copied into the temporary SDK only when generated native bindings are present.
 package helix
 
 import (

--- a/sdks/go/internal/embedded_templates/graph_generated_test.go.tmpl
+++ b/sdks/go/internal/embedded_templates/graph_generated_test.go.tmpl
@@ -1,5 +1,6 @@
 //go:build helixdb_uniffi
 
+// Copied into the temporary SDK only when generated native bindings are present.
 package helix
 
 import (

--- a/sdks/go/internal/embedded_templates/native_graph_uniffi.go.tmpl
+++ b/sdks/go/internal/embedded_templates/native_graph_uniffi.go.tmpl
@@ -1,5 +1,6 @@
 //go:build helixdb_uniffi
 
+// Copied into the temporary SDK only when generated native bindings are present.
 package helix
 
 import (

--- a/sdks/go/module_boundary_test.go
+++ b/sdks/go/module_boundary_test.go
@@ -1,0 +1,44 @@
+package helix_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestExternalConsumerCanTidyModule(t *testing.T) {
+	moduleDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	consumer := t.TempDir()
+	moduleDir = filepath.ToSlash(moduleDir)
+	goMod := fmt.Sprintf(`module example.com/helix-sdk-consumer
+
+go 1.22
+
+require github.com/helixdb/helix-db/sdks/go v0.0.0
+
+replace github.com/helixdb/helix-db/sdks/go => %s
+`, moduleDir)
+	if err := os.WriteFile(filepath.Join(consumer, "go.mod"), []byte(goMod), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(consumer, "main.go"),
+		[]byte("package main\n\nimport _ \"github.com/helixdb/helix-db/sdks/go\"\n\nfunc main() {}\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.Command("go", "mod", "tidy")
+	command.Dir = consumer
+	command.Env = append(os.Environ(), "GOWORK=off", "GOPROXY=off")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("external go mod tidy failed: %v\n%s", err, output)
+	}
+}

--- a/sdks/typescript/scripts/parity/run-embedded-parity.ts
+++ b/sdks/typescript/scripts/parity/run-embedded-parity.ts
@@ -10,6 +10,7 @@ const EXPECTED_RUNTIME = 233;
 const typescriptRoot = join(workspaceRoot, "sdks", "typescript");
 const pythonRoot = join(workspaceRoot, "sdks", "python");
 const goRoot = join(workspaceRoot, "sdks", "go");
+const goEmbeddedTemplates = join(goRoot, "internal", "embedded_templates");
 const rustManifest = join(workspaceRoot, "sdks", "rust", "Cargo.toml");
 const bindingManifest = join(workspaceRoot, "bindings", "uniffi", "Cargo.toml");
 const bindingConfig = join(workspaceRoot, "bindings", "uniffi", "uniffi.toml");
@@ -40,6 +41,11 @@ try {
     cp(goRoot, goSdk, { recursive: true }),
     ...Object.values(disks).map((root) => mkdir(root, { recursive: true })),
   ]);
+  await Promise.all(
+    ["embedded_uniffi.go", "native_graph_uniffi.go", "embedded_generated_test.go", "graph_generated_test.go"].map((file) =>
+      copyFile(join(goEmbeddedTemplates, `${file}.tmpl`), join(goSdk, file)),
+    ),
+  );
   run("cargo", ["build", "--locked", "-p", "helixdb-uniffi"], workspaceRoot, 900_000);
 
   run(


### PR DESCRIPTION
## Summary
- keep unreleased UniFFI adapters out of public Go package discovery
- restore those adapters only inside the generated-binding parity workspace
- add an external `go mod tidy` regression test
- recommend the corrective server-only release `v0.3.1`

`v0.3.0` is already indexed and cannot be changed. Its default server build works, but external `go mod tidy` sees the unreleased tagged adapters and fails.

## Validation
- `gofmt` clean
- `go test -race ./...`
- `go vet ./...`
- Go coverage: 75.5%
- clean external `go mod tidy` and `go test ./...` with networking disabled
- TypeScript `npm run check`
- docs generation and `npm run check`

After merge, publish `sdks/go/v0.3.1`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes unreleased Go UniFFI adapters from public module discovery while restoring them inside the generated-binding parity workspace and documenting the corrective v0.3.1 release.
- Moves embedded and native-graph adapters and their generated tests into internal templates.
- Injects those templates only into the temporary Go parity SDK before generated bindings are compiled.
- Adds an external offline `go mod tidy` regression test.
- Updates Go SDK installation and release documentation to v0.3.1.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdks/go/module_boundary_test.go | Adds the intended external tidy regression, but generates an invalid replace directive when the checkout path requires quoting. |
| sdks/typescript/scripts/parity/run-embedded-parity.ts | Copies the relocated adapters into the temporary SDK before generated-binding compilation without conflicting with bindgen output. |
| sdks/go/internal/embedded_templates/embedded_uniffi.go.tmpl | Preserves the tagged embedded adapter as a parity-only template rather than a publicly discoverable Go package file. |
| sdks/go/internal/embedded_templates/native_graph_uniffi.go.tmpl | Preserves native graph adaptation for the generated-binding parity workspace while excluding it from the release module. |
| sdks/go/README.md | Updates the recommended release to v0.3.1 and accurately describes the server-only distribution scope. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Repo[Go SDK source] -->|public module discovery| Public[Server-only Go module]
  Templates[Internal embedded adapter templates] -->|copy only during parity setup| Temp[Temporary Go SDK]
  Bindgen[Generated UniFFI bindings] --> Temp
  Temp -->|helixdb_uniffi build and tests| Parity[Embedded parity validation]
  Public -->|external replace| Tidy[Offline go mod tidy regression]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(go): recommend v0.3.1"](https://github.com/helixdb/helix-db/commit/74c0bad09d74d0b08241c34820079fff68c2298b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55144788)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Native graph loading, algorithms, and FFI bindings](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/native-graph-and-bindings.md)
- Knowledge Base — [Cross-SDK DSL Parity Testing](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/sdk-parity-tests.md)

<!-- /greptile_comment -->