### PR TITLE
fix(cli): model query auth schemes

### DIFF
--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    EnterpriseInstanceConfig, LocalInstanceConfig, LocalStorageMode, S3StorageConfig,
-    DEFAULT_QUERY_AUTH_ENV, DEFAULT_QUERY_AUTH_HEADER,
+    EnterpriseInstanceConfig, LocalInstanceConfig, LocalStorageMode, QueryAuthScheme,
+    S3StorageConfig, DEFAULT_QUERY_AUTH_ENV, DEFAULT_QUERY_AUTH_HEADER,
 };
 use crate::output::Operation;
 use crate::project::ProjectContext;
@@ -62,6 +62,7 @@ pub async fn run(path: Option<String>, target: Option<AddTarget>) -> Result<()> 
                     gateway_url: target.gateway_url,
                     query_auth_header: DEFAULT_QUERY_AUTH_HEADER.to_string(),
                     query_auth_env: DEFAULT_QUERY_AUTH_ENV.to_string(),
+                    query_auth_scheme: Some(QueryAuthScheme::Bearer),
                     availability_mode: None,
                     gateway_node_type: None,
                     db_node_type: None,

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    EnterpriseInstanceConfig, HelixConfig, LocalInstanceConfig, LocalStorageMode, S3StorageConfig,
-    DEFAULT_QUERY_AUTH_ENV, DEFAULT_QUERY_AUTH_HEADER,
+    EnterpriseInstanceConfig, HelixConfig, LocalInstanceConfig, LocalStorageMode, QueryAuthScheme,
+    S3StorageConfig, DEFAULT_QUERY_AUTH_ENV, DEFAULT_QUERY_AUTH_HEADER,
 };
 use crate::output::Operation;
 use crate::prompts;
@@ -104,6 +104,7 @@ pub async fn run(
                     gateway_url: target.gateway_url,
                     query_auth_header: DEFAULT_QUERY_AUTH_HEADER.to_string(),
                     query_auth_env: DEFAULT_QUERY_AUTH_ENV.to_string(),
+                    query_auth_scheme: Some(QueryAuthScheme::Bearer),
                     availability_mode: None,
                     gateway_node_type: None,
                     db_node_type: None,

--- a/crates/cli/src/commands/query.rs
+++ b/crates/cli/src/commands/query.rs
@@ -51,11 +51,26 @@ pub async fn run(
                 .into()
             })?;
             let header_name = HeaderName::from_bytes(config.query_auth_header.as_bytes())?;
+            let auth_value = config
+                .resolved_query_auth_scheme()
+                .format_header_value(&auth_value)
+                .ok_or_else(|| -> Report {
+                    CliError::new(format!(
+                        "environment variable {} must contain a valid, non-empty Enterprise query auth value",
+                        config.query_auth_env
+                    ))
+                    .into()
+                })?;
+            let header_value = HeaderValue::from_str(&auth_value).map_err(|_| -> Report {
+                CliError::new(format!(
+                    "environment variable {} contains a value that cannot be used for Enterprise query auth",
+                    config.query_auth_env
+                ))
+                .into()
+            })?;
             let endpoint = format!("{}/v2/query", gateway_url.trim_end_matches('/'));
             (
-                client
-                    .post(&endpoint)
-                    .header(header_name, HeaderValue::from_str(&auth_value)?),
+                client.post(&endpoint).header(header_name, header_value),
                 endpoint,
                 false,
             )

--- a/crates/cli/src/commands/query.rs
+++ b/crates/cli/src/commands/query.rs
@@ -1,4 +1,4 @@
-use crate::config::InstanceInfo;
+use crate::config::{InstanceInfo, QueryAuthScheme};
 use crate::errors::CliError;
 use crate::project::ProjectContext;
 use eyre::{eyre, Report, Result};
@@ -25,15 +25,18 @@ pub async fn run(
     let request_json = parse_query_request(file, json, ts, ts_file)?;
 
     validate_dynamic_request(&request_json, warm)?;
-    let client = reqwest::Client::new();
     let (mut request, endpoint, is_local) = match project.config.get_instance(&instance)? {
         InstanceInfo::Local(config) => {
+            let client = reqwest::Client::new();
             let host = host.unwrap_or_else(|| "localhost".to_string());
             let port = port.unwrap_or(config.port);
             let endpoint = format!("http://{host}:{port}/v2/query");
             (client.post(&endpoint), endpoint, true)
         }
         InstanceInfo::Enterprise(config) => {
+            let client = reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()?;
             let gateway_url = config.gateway_url.as_deref().ok_or_else(|| {
                 eyre!(
                     "Enterprise gateway URL is not configured for '{instance}'. Run 'helix sync {instance}' or set gateway_url in helix.toml."
@@ -51,23 +54,11 @@ pub async fn run(
                 .into()
             })?;
             let header_name = HeaderName::from_bytes(config.query_auth_header.as_bytes())?;
-            let auth_value = config
-                .resolved_query_auth_scheme()
-                .format_header_value(&auth_value)
-                .ok_or_else(|| -> Report {
-                    CliError::new(format!(
-                        "environment variable {} must contain a valid, non-empty Enterprise query auth value",
-                        config.query_auth_env
-                    ))
-                    .into()
-                })?;
-            let header_value = HeaderValue::from_str(&auth_value).map_err(|_| -> Report {
-                CliError::new(format!(
-                    "environment variable {} contains a value that cannot be used for Enterprise query auth",
-                    config.query_auth_env
-                ))
-                .into()
-            })?;
+            let header_value = query_auth_header_value(
+                config.resolved_query_auth_scheme(),
+                &auth_value,
+                &config.query_auth_env,
+            )?;
             let endpoint = format!("{}/v2/query", gateway_url.trim_end_matches('/'));
             (
                 client.post(&endpoint).header(header_name, header_value),
@@ -114,6 +105,29 @@ pub async fn run(
         }
     }
     Ok(())
+}
+
+fn query_auth_header_value(
+    scheme: QueryAuthScheme,
+    value: &str,
+    env_name: &str,
+) -> Result<HeaderValue> {
+    let value = scheme
+        .format_header_value(value)
+        .ok_or_else(|| -> Report {
+            CliError::new(format!(
+                "environment variable {env_name} must contain a valid, non-empty Enterprise query auth value"
+            ))
+            .into()
+        })?;
+    let mut value = HeaderValue::from_str(&value).map_err(|_| -> Report {
+        CliError::new(format!(
+            "environment variable {env_name} contains a value that cannot be used for Enterprise query auth"
+        ))
+        .into()
+    })?;
+    value.set_sensitive(true);
+    Ok(value)
 }
 
 /// Error for a query that never reached a Helix instance (connection refused,
@@ -204,6 +218,16 @@ fn validate_dynamic_request(request: &Value, warm: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::QueryAuthScheme;
+
+    #[test]
+    fn query_auth_header_values_are_sensitive() {
+        let value =
+            query_auth_header_value(QueryAuthScheme::Bearer, "secret", "HELIX_API_KEY").unwrap();
+
+        assert_eq!(value, "Bearer secret");
+        assert!(value.is_sensitive());
+    }
 
     #[test]
     fn parse_query_request_accepts_inline_json() {

--- a/crates/cli/src/commands/sync.rs
+++ b/crates/cli/src/commands/sync.rs
@@ -3,7 +3,9 @@ use crate::commands::enterprise_deploy::{
     compile_enterprise_queries, deploy_enterprise_by_cluster_id, enterprise_queries_dir,
     should_descend_enterprise_source_dir, should_include_enterprise_source_file,
 };
-use crate::config::{HelixConfig, InstanceInfo, DEFAULT_QUERY_AUTH_ENV, DEFAULT_QUERY_AUTH_HEADER};
+use crate::config::{
+    HelixConfig, InstanceInfo, QueryAuthScheme, DEFAULT_QUERY_AUTH_ENV, DEFAULT_QUERY_AUTH_HEADER,
+};
 use crate::enterprise_cloud::{
     cloud_base_url, resolve_enterprise_cluster, ResolvedEnterpriseCluster,
 };
@@ -304,6 +306,12 @@ fn refresh_enterprise_metadata(
         .query_auth_env
         .clone()
         .unwrap_or_else(|| DEFAULT_QUERY_AUTH_ENV.to_string());
+    instance.query_auth_scheme = Some(
+        remote
+            .cluster
+            .query_auth_scheme
+            .unwrap_or_else(|| QueryAuthScheme::inferred_from_header(&instance.query_auth_header)),
+    );
     instance.availability_mode = remote
         .cluster
         .availability_mode

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -399,6 +399,46 @@ impl LocalInstanceConfig {
     }
 }
 
+/// How the CLI turns an environment value into a query authentication header.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum QueryAuthScheme {
+    /// Add the `Bearer` authorization scheme to the configured key.
+    Bearer,
+    /// Send the configured value without adding a scheme.
+    Raw,
+}
+
+impl QueryAuthScheme {
+    pub(crate) fn inferred_from_header(header: &str) -> Self {
+        if header.eq_ignore_ascii_case(DEFAULT_QUERY_AUTH_HEADER) {
+            Self::Bearer
+        } else {
+            Self::Raw
+        }
+    }
+
+    pub(crate) fn format_header_value(self, value: &str) -> Option<String> {
+        if value.trim().is_empty() || value.chars().any(char::is_control) {
+            return None;
+        }
+        match self {
+            Self::Raw => Some(value.to_string()),
+            Self::Bearer => {
+                let trimmed = value.trim();
+                let mut parts = trimmed.splitn(2, char::is_whitespace);
+                let prefix = parts.next().unwrap_or_default();
+                if prefix.eq_ignore_ascii_case("bearer") {
+                    let token = parts.next().unwrap_or_default().trim();
+                    (!token.is_empty()).then(|| format!("Bearer {token}"))
+                } else {
+                    Some(format!("Bearer {trimmed}"))
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnterpriseInstanceConfig {
     pub cluster_id: String,
@@ -412,6 +452,9 @@ pub struct EnterpriseInstanceConfig {
     pub query_auth_header: String,
     #[serde(default = "default_query_auth_env")]
     pub query_auth_env: String,
+    /// Explicit query authentication scheme. Legacy configs infer it from the header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query_auth_scheme: Option<QueryAuthScheme>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub availability_mode: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -424,6 +467,13 @@ pub struct EnterpriseInstanceConfig {
     pub max_instances: u64,
     #[serde(flatten)]
     pub db_config: DbConfig,
+}
+
+impl EnterpriseInstanceConfig {
+    pub(crate) fn resolved_query_auth_scheme(&self) -> QueryAuthScheme {
+        self.query_auth_scheme
+            .unwrap_or_else(|| QueryAuthScheme::inferred_from_header(&self.query_auth_header))
+    }
 }
 
 fn default_min_instances() -> u64 {
@@ -663,6 +713,87 @@ max_instances = 4
         assert_eq!(enterprise.min_instances, 2);
         assert_eq!(enterprise.max_instances, 4);
         assert_eq!(enterprise.db_config.vector_config.db_max_size_gb, 20);
+        assert_eq!(
+            enterprise.resolved_query_auth_scheme(),
+            QueryAuthScheme::Bearer
+        );
+    }
+
+    #[test]
+    fn query_auth_scheme_supports_legacy_and_explicit_configs() {
+        let legacy_raw: HelixConfig = toml::from_str(
+            r#"
+[project]
+name = "demo"
+
+[enterprise.production]
+cluster_id = "cluster-123"
+query_auth_header = "x-api-key"
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            legacy_raw
+                .enterprise
+                .get("production")
+                .unwrap()
+                .resolved_query_auth_scheme(),
+            QueryAuthScheme::Raw
+        );
+
+        let explicit: HelixConfig = toml::from_str(
+            r#"
+[project]
+name = "demo"
+
+[enterprise.production]
+cluster_id = "cluster-123"
+query_auth_header = "Authorization"
+query_auth_scheme = "bearer"
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            explicit
+                .enterprise
+                .get("production")
+                .unwrap()
+                .query_auth_scheme,
+            Some(QueryAuthScheme::Bearer)
+        );
+
+        let invalid = toml::from_str::<HelixConfig>(
+            r#"
+[project]
+name = "demo"
+
+[enterprise.production]
+cluster_id = "cluster-123"
+query_auth_scheme = "token"
+"#,
+        );
+        assert!(invalid.is_err());
+    }
+
+    #[test]
+    fn query_auth_scheme_formats_header_values() {
+        assert_eq!(
+            QueryAuthScheme::Bearer.format_header_value("secret"),
+            Some("Bearer secret".to_string())
+        );
+        assert_eq!(
+            QueryAuthScheme::Bearer.format_header_value("bearer secret"),
+            Some("Bearer secret".to_string())
+        );
+        assert_eq!(
+            QueryAuthScheme::Raw.format_header_value("secret"),
+            Some("secret".to_string())
+        );
+        assert_eq!(QueryAuthScheme::Bearer.format_header_value("  "), None);
+        assert_eq!(
+            QueryAuthScheme::Bearer.format_header_value("Bearer\r\nsecret"),
+            None
+        );
     }
 
     #[test]

--- a/crates/cli/src/enterprise_cloud.rs
+++ b/crates/cli/src/enterprise_cloud.rs
@@ -149,6 +149,8 @@ pub struct CliEnterpriseCluster {
     #[serde(default)]
     pub query_auth_env: Option<String>,
     #[serde(default)]
+    pub query_auth_scheme: Option<crate::config::QueryAuthScheme>,
+    #[serde(default)]
     pub min_gateway_count: Option<u64>,
     #[serde(default)]
     pub max_gateway_count: Option<u64>,

--- a/crates/cli/tests/api_contracts.rs
+++ b/crates/cli/tests/api_contracts.rs
@@ -325,6 +325,124 @@ async fn query_command_sends_body_headers_and_surfaces_http_errors() {
     assert!(error.contains("invalid traversal"));
 }
 
+fn write_enterprise_query_project(
+    project: &std::path::Path,
+    gateway_url: &str,
+    auth_header: &str,
+    auth_scheme: Option<&str>,
+) {
+    let auth_scheme = auth_scheme.map_or_else(String::new, |scheme| {
+        format!("query_auth_scheme = \"{scheme}\"\n")
+    });
+    fs::create_dir_all(project).unwrap();
+    fs::write(
+        project.join("helix.toml"),
+        format!(
+            r#"[project]
+name = "query-auth-project"
+
+[enterprise.production]
+cluster_id = "cluster-1"
+gateway_url = "{gateway_url}"
+query_auth_header = "{auth_header}"
+query_auth_env = "HELIX_API_KEY"
+{auth_scheme}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn enterprise_query_auth_formats_bearer_and_raw_headers_without_leaking_secrets() {
+    let server = MockServer::start().await;
+    let fixture = CliFixture::new();
+    let project = fixture.root().join("enterprise-query-auth-project");
+    let request = serde_json::json!({
+        "request_type": "read",
+        "query": {"queries": [], "returns": []},
+        "parameters": {}
+    });
+
+    write_enterprise_query_project(&project, &server.uri(), "Authorization", Some("bearer"));
+    Mock::given(method("POST"))
+        .and(path("/v2/query"))
+        .and(header("authorization", "Bearer cluster-key"))
+        .and(body_json(&request))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok":true})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    fixture
+        .command()
+        .current_dir(&project)
+        .args(["query", "production", "--json"])
+        .arg(request.to_string())
+        .env("HELIX_API_KEY", "cluster-key")
+        .assert()
+        .success();
+
+    server.reset().await;
+    write_enterprise_query_project(&project, &server.uri(), "x-api-key", None);
+    Mock::given(method("POST"))
+        .and(path("/v2/query"))
+        .and(header("x-api-key", "cluster-key"))
+        .and(body_json(&request))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok":true})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    fixture
+        .command()
+        .current_dir(&project)
+        .args(["query", "production", "--json"])
+        .arg(request.to_string())
+        .env("HELIX_API_KEY", "cluster-key")
+        .assert()
+        .success();
+
+    let missing = stderr(
+        fixture
+            .command()
+            .current_dir(&project)
+            .args(["query", "production", "--json"])
+            .arg(request.to_string())
+            .env_remove("HELIX_API_KEY")
+            .assert()
+            .failure(),
+    );
+    assert!(missing.contains("HELIX_API_KEY"));
+
+    server.reset().await;
+    write_enterprise_query_project(&project, &server.uri(), "Authorization", Some("bearer"));
+    let secret = "Bearer\r\nsecret-value";
+    let invalid_value = stderr(
+        fixture
+            .command()
+            .current_dir(&project)
+            .args(["query", "production", "--json"])
+            .arg(request.to_string())
+            .env("HELIX_API_KEY", secret)
+            .assert()
+            .failure(),
+    );
+    assert!(!invalid_value.contains("secret-value"));
+    assert!(server.received_requests().await.unwrap().is_empty());
+
+    write_enterprise_query_project(&project, &server.uri(), "Authorization", Some("token"));
+    let invalid_config = stderr(
+        fixture
+            .command()
+            .current_dir(&project)
+            .args(["query", "production", "--json"])
+            .arg(request.to_string())
+            .env("HELIX_API_KEY", "cluster-key")
+            .assert()
+            .failure(),
+    );
+    assert!(invalid_config.contains("token"));
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn query_command_preserves_the_shared_transport_corpus() {
     let server = MockServer::start().await;

--- a/crates/cli/tests/api_contracts.rs
+++ b/crates/cli/tests/api_contracts.rs
@@ -401,6 +401,33 @@ async fn enterprise_query_auth_formats_bearer_and_raw_headers_without_leaking_se
         .assert()
         .success();
 
+    server.reset().await;
+    let redirect_target = MockServer::start().await;
+    write_enterprise_query_project(&project, &server.uri(), "x-api-key", None);
+    Mock::given(method("POST"))
+        .and(path("/v2/query"))
+        .and(header("x-api-key", "cluster-key"))
+        .respond_with(
+            ResponseTemplate::new(302)
+                .insert_header("location", format!("{}/redirected", redirect_target.uri())),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    fixture
+        .command()
+        .current_dir(&project)
+        .args(["query", "production", "--json"])
+        .arg(request.to_string())
+        .env("HELIX_API_KEY", "cluster-key")
+        .assert()
+        .failure();
+    assert!(redirect_target
+        .received_requests()
+        .await
+        .unwrap()
+        .is_empty());
+
     let missing = stderr(
         fixture
             .command()

--- a/crates/cli/tests/sync_reconciliation.rs
+++ b/crates/cli/tests/sync_reconciliation.rs
@@ -66,7 +66,9 @@ async fn mount_cluster(server: &MockServer) {
                 "cluster_id":"cluster-1",
                 "name":"production",
                 "project_id":"project-1",
-                "gateway_url":server.uri()
+                "gateway_url":server.uri(),
+                "query_auth_header":"x-api-key",
+                "query_auth_env":"HELIX_API_KEY"
             }]
         })))
         .expect(1)
@@ -120,6 +122,9 @@ async fn sync_reconciliation_covers_push_pull_divergence_fallback_and_errors() {
     );
     assert!(local_only.contains("Cloud files to be created"));
     assert!(local_only.contains("Enterprise sync reconciliation applied"));
+    assert!(fs::read_to_string(project.join("helix.toml"))
+        .unwrap()
+        .contains("query_auth_scheme = \"raw\""));
 
     server.reset().await;
     mount_cluster(&server).await;

--- a/docs/cli/command-reference/auth.mdx
+++ b/docs/cli/command-reference/auth.mdx
@@ -30,7 +30,7 @@ helix auth <SUBCOMMAND>
 |----------|-------------|
 | `CLUSTER` | Cluster ID to rotate. Find one with [`helix cluster list`](/cli/command-reference/cluster). |
 
-`helix auth create-key` requires you to already be logged in. The new key replaces any previous keys for that cluster — update `HELIX_API_KEY` (or whatever `query_auth_env` resolves to for the instance) before running [`helix query`](/cli/command-reference/query) again.
+`helix auth create-key` requires you to already be logged in. The new key replaces any previous keys for that cluster. Update `HELIX_API_KEY` (or whatever `query_auth_env` resolves to for the instance) with the raw key before running [`helix query`](/cli/command-reference/query) again. Bearer mode adds the prefix automatically.
 
 ## Examples
 

--- a/docs/cli/command-reference/query.mdx
+++ b/docs/cli/command-reference/query.mdx
@@ -147,7 +147,7 @@ If Node is missing, the CLI tells you to install Node 20+ or fall back to `--jso
 For a Helix Cloud instance, `helix query` reads `[enterprise.<instance>]` in `helix.toml` and:
 
 - Posts to `<gateway_url>/v2/query`.
-- Sends an auth header named by `query_auth_header` (default `Authorization`) with the value read from the environment variable `query_auth_env` (default `HELIX_API_KEY`). The value is read from your shell environment or from a `.env` file in the project root (whichever is set), so you can keep the key out of your shell history.
+- Sends an auth header named by `query_auth_header` (default `Authorization`) using `query_auth_scheme` (`bearer` or `raw`). Bearer mode adds `Bearer` to the raw key read from `query_auth_env` (default `HELIX_API_KEY`); raw mode sends the value unchanged. The value is read from your shell environment or from a `.env` file in the project root.
 
 If `gateway_url` is missing, the CLI returns:
 
@@ -189,7 +189,8 @@ helix query dev --json '{"request_type":"read","query_name":"ad_hoc_read","query
 # Build the request from a TypeScript DSL expression instead of JSON
 helix query dev -e 'readBatch().varAs("c", g().nWithLabel("User").count()).returning(["c"])'
 
-# Target a Helix Cloud instance (requires HELIX_API_KEY in env and gateway_url in helix.toml)
+# Target Helix Cloud. Export the raw key; bearer mode adds the prefix.
+export HELIX_API_KEY="..."
 helix query production --file examples/request.json
 ```
 

--- a/docs/cli/command-reference/sync.mdx
+++ b/docs/cli/command-reference/sync.mdx
@@ -38,6 +38,7 @@ For each matched Helix Cloud instance, `helix sync` overwrites these fields in `
 - `gateway_url`
 - `query_auth_header` (defaults to `Authorization`)
 - `query_auth_env` (defaults to `HELIX_API_KEY`)
+- `query_auth_scheme` (`bearer` or `raw`, inferred from the header when omitted)
 - `availability_mode`
 - `gateway_node_type`
 - `db_node_type`

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -83,6 +83,7 @@ One block per Helix Cloud instance. Most fields here are populated automatically
 | `gateway_url` | URL | No (required at query time) | — | Runtime gateway base URL. Populated by `helix sync` when available. |
 | `query_auth_header` | String | No | `Authorization` | HTTP header name used for query auth. |
 | `query_auth_env` | String | No | `HELIX_API_KEY` | Environment variable read by [`helix query`](/cli/command-reference/query) for the auth header value. |
+| `query_auth_scheme` | `bearer` or `raw` | No | Inferred from the header | `bearer` adds the `Bearer` prefix; `raw` sends the environment value unchanged. Missing values infer `bearer` for `Authorization` and `raw` for other headers. |
 | `availability_mode` | String | No | — | Cluster availability mode, returned by `helix sync`. |
 | `gateway_node_type` | String | No | — | Gateway node type, returned by `helix sync`. |
 | `db_node_type` | String | No | — | DB node type, returned by `helix sync`. |
@@ -119,7 +120,7 @@ Remove with `helix auth logout`. Never commit this file.
 
 | Variable | Used by | Description |
 |----------|---------|-------------|
-| `HELIX_API_KEY` (default) | [`helix query`](/cli/command-reference/query) | Per-cluster Helix Cloud API key sent in the configured auth header. The variable name is configurable per-instance via `query_auth_env`. |
+| `HELIX_API_KEY` (default) | [`helix query`](/cli/command-reference/query) | Raw per-cluster Helix Cloud API key. With `query_auth_scheme = "bearer"`, the CLI adds the `Bearer` prefix. The variable name is configurable per-instance via `query_auth_env`. |
 
 ## Troubleshooting
 

--- a/docs/cli/getting-started.mdx
+++ b/docs/cli/getting-started.mdx
@@ -135,7 +135,7 @@ helix add cloud --name production --cluster-id <cluster-id>
 <Step title="Sync metadata and query">
 ```bash
 helix sync production
-export HELIX_API_KEY="..."   # or whatever query_auth_env resolves to
+export HELIX_API_KEY="..."   # raw key; bearer mode adds the prefix
 helix query production --file examples/request.json
 ```
 

--- a/docs/cli/troubleshooting.mdx
+++ b/docs/cli/troubleshooting.mdx
@@ -197,6 +197,10 @@ The auth env var named by `query_auth_env` is unset.
 export HELIX_API_KEY="..."
 ```
 
+Set the raw key only. With the default `Authorization` header, an omitted
+`query_auth_scheme` infers `bearer` and adds the `Bearer` prefix. Headers such
+as `x-api-key` infer `raw`.
+
 ### `--warm is only valid for read requests`
 
 `helix query --warm` is rejected for write requests before any backend executes.

--- a/docs/cli/workflows/helix_cloud.mdx
+++ b/docs/cli/workflows/helix_cloud.mdx
@@ -74,11 +74,11 @@ The CLI handles authentication, workspace/project/cluster selection, metadata sy
 
   <Step title="Send dynamic queries">
     ```bash
-    export HELIX_API_KEY="..."   # value for the configured query_auth_env
+    export HELIX_API_KEY="..."   # raw key; bearer mode adds the prefix
     helix query production --file examples/request.json
     ```
 
-    `helix query` posts to `<gateway_url>/v2/query` with the header named by `query_auth_header` (default `Authorization`).
+    `helix query` posts to `<gateway_url>/v2/query` with the header named by `query_auth_header` (default `Authorization`). `query_auth_scheme = "bearer"` adds the `Bearer` prefix; `"raw"` sends the environment value unchanged.
   </Step>
 
   <Step title="Pull historical logs">
@@ -101,6 +101,7 @@ Each `[enterprise.<instance>]` block stores the auth contract used by `helix que
 |-------|---------|---------|
 | `query_auth_header` | `Authorization` | HTTP header name set on every query request. |
 | `query_auth_env` | `HELIX_API_KEY` | Environment variable the CLI reads to populate the header value. |
+| `query_auth_scheme` | inferred | `bearer` for `Authorization`; `raw` for other headers. |
 
 Override the variable name per-instance by setting `query_auth_env` under `[enterprise.<instance>]` and exporting whatever name you choose.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5625,7 +5625,7 @@ helix add cloud --name production --cluster-id <cluster-id>
 
 ```bash
 helix sync production
-export HELIX_API_KEY="..."   # or whatever query_auth_env resolves to
+export HELIX_API_KEY="..."   # raw key; bearer mode adds the prefix
 helix query production --file examples/request.json
 ```
 
@@ -5885,11 +5885,11 @@ The CLI handles authentication, workspace/project/cluster selection, metadata sy
 
   <Step title="Send dynamic queries">
     ```bash
-    export HELIX_API_KEY="..."   # value for the configured query_auth_env
+    export HELIX_API_KEY="..."   # raw key; bearer mode adds the prefix
     helix query production --file examples/request.json
     ```
 
-    `helix query` posts to `<gateway_url>/v2/query` with the header named by `query_auth_header` (default `Authorization`).
+    `helix query` posts to `<gateway_url>/v2/query` with the header named by `query_auth_header` (default `Authorization`). `query_auth_scheme = "bearer"` adds the `Bearer` prefix; `"raw"` sends the environment value unchanged.
   </Step>
 
   <Step title="Pull historical logs">
@@ -5911,6 +5911,7 @@ Each `[enterprise.<instance>]` block stores the auth contract used by `helix que
 |-------|---------|---------|
 | `query_auth_header` | `Authorization` | HTTP header name set on every query request. |
 | `query_auth_env` | `HELIX_API_KEY` | Environment variable the CLI reads to populate the header value. |
+| `query_auth_scheme` | inferred | `bearer` for `Authorization`; `raw` for other headers. |
 
 Override the variable name per-instance by setting `query_auth_env` under `[enterprise.<instance>]` and exporting whatever name you choose.
 
@@ -6006,6 +6007,7 @@ One block per Helix Cloud instance. Most fields here are populated automatically
 | `gateway_url` | URL | No (required at query time) | — | Runtime gateway base URL. Populated by `helix sync` when available. |
 | `query_auth_header` | String | No | `Authorization` | HTTP header name used for query auth. |
 | `query_auth_env` | String | No | `HELIX_API_KEY` | Environment variable read by [`helix query`](/cli/command-reference/query) for the auth header value. |
+| `query_auth_scheme` | `bearer` or `raw` | No | Inferred from the header | `bearer` adds the `Bearer` prefix; `raw` sends the environment value unchanged. Missing values infer `bearer` for `Authorization` and `raw` for other headers. |
 | `availability_mode` | String | No | — | Cluster availability mode, returned by `helix sync`. |
 | `gateway_node_type` | String | No | — | Gateway node type, returned by `helix sync`. |
 | `db_node_type` | String | No | — | DB node type, returned by `helix sync`. |
@@ -6042,7 +6044,7 @@ Remove with `helix auth logout`. Never commit this file.
 
 | Variable | Used by | Description |
 |----------|---------|-------------|
-| `HELIX_API_KEY` (default) | [`helix query`](/cli/command-reference/query) | Per-cluster Helix Cloud API key sent in the configured auth header. The variable name is configurable per-instance via `query_auth_env`. |
+| `HELIX_API_KEY` (default) | [`helix query`](/cli/command-reference/query) | Raw per-cluster Helix Cloud API key. With `query_auth_scheme = "bearer"`, the CLI adds the `Bearer` prefix. The variable name is configurable per-instance via `query_auth_env`. |
 
 ## Troubleshooting
 
@@ -6251,6 +6253,10 @@ The auth env var named by `query_auth_env` is unset.
 ```bash
 export HELIX_API_KEY="..."
 ```
+
+Set the raw key only. With the default `Authorization` header, an omitted
+`query_auth_scheme` infers `bearer` and adds the `Bearer` prefix. Headers such
+as `x-api-key` infer `raw`.
 
 ### `--warm is only valid for read requests`
 
@@ -6485,7 +6491,7 @@ helix auth <SUBCOMMAND>
 |----------|-------------|
 | `CLUSTER` | Cluster ID to rotate. Find one with [`helix cluster list`](/cli/command-reference/cluster). |
 
-`helix auth create-key` requires you to already be logged in. The new key replaces any previous keys for that cluster — update `HELIX_API_KEY` (or whatever `query_auth_env` resolves to for the instance) before running [`helix query`](/cli/command-reference/query) again.
+`helix auth create-key` requires you to already be logged in. The new key replaces any previous keys for that cluster. Update `HELIX_API_KEY` (or whatever `query_auth_env` resolves to for the instance) with the raw key before running [`helix query`](/cli/command-reference/query) again. Bearer mode adds the prefix automatically.
 
 ## Examples
 
@@ -7288,7 +7294,7 @@ If Node is missing, the CLI tells you to install Node 20+ or fall back to `--jso
 For a Helix Cloud instance, `helix query` reads `[enterprise.<instance>]` in `helix.toml` and:
 
 - Posts to `<gateway_url>/v2/query`.
-- Sends an auth header named by `query_auth_header` (default `Authorization`) with the value read from the environment variable `query_auth_env` (default `HELIX_API_KEY`). The value is read from your shell environment or from a `.env` file in the project root (whichever is set), so you can keep the key out of your shell history.
+- Sends an auth header named by `query_auth_header` (default `Authorization`) using `query_auth_scheme` (`bearer` or `raw`). Bearer mode adds `Bearer` to the raw key read from `query_auth_env` (default `HELIX_API_KEY`); raw mode sends the value unchanged. The value is read from your shell environment or from a `.env` file in the project root.
 
 If `gateway_url` is missing, the CLI returns:
 
@@ -7330,7 +7336,8 @@ helix query dev --json '{"request_type":"read","query_name":"ad_hoc_read","query
 # Build the request from a TypeScript DSL expression instead of JSON
 helix query dev -e 'readBatch().varAs("c", g().nWithLabel("User").count()).returning(["c"])'
 
-# Target a Helix Cloud instance (requires HELIX_API_KEY in env and gateway_url in helix.toml)
+# Target Helix Cloud. Export the raw key; bearer mode adds the prefix.
+export HELIX_API_KEY="..."
 helix query production --file examples/request.json
 ```
 
@@ -7618,6 +7625,7 @@ For each matched Helix Cloud instance, `helix sync` overwrites these fields in `
 - `gateway_url`
 - `query_auth_header` (defaults to `Authorization`)
 - `query_auth_env` (defaults to `HELIX_API_KEY`)
+- `query_auth_scheme` (`bearer` or `raw`, inferred from the header when omitted)
 - `availability_mode`
 - `gateway_node_type`
 - `db_node_type`


### PR DESCRIPTION
closes #985

enterprise query auth currently sends environment values unchanged, so default Authorization targets send raw keys instead of bearer tokens.

this adds typed bearer/raw schemes, infers old configs from the header, formats outgoing values without exposing secrets, and carries the scheme through init/add/sync.

tested with the full cli suite, clippy, doctests, docs validation, and request-level auth checks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR models Enterprise query authentication as explicit `bearer` or `raw` schemes and applies the selected scheme when constructing query headers.

- Adds backward-compatible scheme inference for existing `helix.toml` files.
- Carries auth schemes through Enterprise initialization, addition, cloud metadata parsing, and synchronization.
- Adds request-level and reconciliation coverage for bearer/raw behavior and secret-safe failures.
- Updates CLI documentation and generated full-text documentation for the new configuration contract.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/cli/src/config.rs | Introduces the serialized auth-scheme model, legacy header-based inference, and validated bearer/raw header formatting. |
| crates/cli/src/commands/query.rs | Applies the resolved scheme to Enterprise credentials before constructing the outbound query request without exposing invalid secret values. |
| crates/cli/src/commands/sync.rs | Persists cloud-provided auth schemes and infers legacy schemes from synchronized headers when the field is absent. |
| crates/cli/src/enterprise_cloud.rs | Extends the typed Enterprise cluster response with optional query-auth scheme metadata. |
| crates/cli/tests/api_contracts.rs | Adds request-level coverage for bearer formatting, raw compatibility, legacy inference, invalid values, and secret-safe errors. |
| crates/cli/tests/sync_reconciliation.rs | Verifies that synchronization persists an inferred raw scheme for legacy non-Authorization headers. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User environment
    participant C as helix.toml
    participant CLI as helix query
    participant G as Enterprise gateway
    U->>CLI: Raw credential from query_auth_env
    C->>CLI: Header and optional auth scheme
    CLI->>CLI: Resolve explicit scheme or infer from header
    alt bearer
        CLI->>G: Authorization header with Bearer prefix
    else raw
        CLI->>G: Configured header with unchanged value
    end
    G-->>CLI: Query response
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(cli): document query auth schemes"](https://github.com/helixdb/helix-db/commit/095b7569a9dbed5ee45ec7aa1d935a30a69716f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55188324)</sub>

<!-- /greptile_comment -->