### PR TITLE
Publish HelixDB agent-ready HTTP API documentation

### DIFF
--- a/crates/ast/src/query.rs
+++ b/crates/ast/src/query.rs
@@ -709,6 +709,26 @@ mod tests {
     }
 
     #[test]
+    fn published_openapi_examples_are_valid_query_requests() {
+        let specification =
+            sonic_rs::from_str::<sonic_rs::Value>(include_str!("../../../docs/openapi.json"))
+                .expect("published OpenAPI document is valid JSON");
+        let examples = &specification["paths"]["/v2/query"]["post"]["requestBody"]["content"]
+            ["application/json"]["examples"];
+
+        for (name, expected_type) in [
+            ("read", QueryRequestType::Read),
+            ("write", QueryRequestType::Write),
+        ] {
+            let example = sonic_rs::to_string(&examples[name]["value"])
+                .expect("OpenAPI query example is serializable");
+            let request = sonic_rs::from_str::<QueryRequest>(&example)
+                .unwrap_or_else(|error| panic!("OpenAPI {name} example is invalid: {error}"));
+            assert_eq!(request.request_type(), expected_type);
+        }
+    }
+
+    #[test]
     fn typed_parameter_schema_matrix_accepts_only_valid_shapes() {
         assert!(typed(QueryParamType::Bool, QueryValue::Bool(true)).is_ok());
         assert!(typed(QueryParamType::Bool, QueryValue::I64(1)).is_err());

--- a/docs/database/helix-db/query-guides/http-api.mdx
+++ b/docs/database/helix-db/query-guides/http-api.mdx
@@ -1,0 +1,122 @@
+---
+title: "HelixDB HTTP API and OpenAPI specification"
+description: "Call the HelixDB v2 query endpoint and discover its machine-readable OpenAPI 3.1 contract"
+sidebarTitle: "HTTP API and OpenAPI"
+pageType: "Reference"
+---
+
+<div className="flex flex-wrap gap-2"><Badge color="gray" size="sm">Reference</Badge></div>
+
+> For the complete documentation index optimized for AI agents, see [llms.txt](/llms.txt).
+
+The HelixDB HTTP API accepts operation-tree queries at `POST /v2/query`. The
+same contract is available from a local server and a Helix Cloud gateway.
+
+## Machine-readable specification
+
+The canonical OpenAPI 3.1 document is published at both predictable URLs:
+
+- [https://www.helix-db.com/openapi.json](https://www.helix-db.com/openapi.json)
+- [https://docs.helix-db.com/openapi.json](https://docs.helix-db.com/openapi.json)
+
+Use the specification to discover request headers, response codes, health
+endpoints, query-envelope variants, and example read and write requests. Use the
+typed SDKs or `helix query` to build the nested operation tree.
+
+## Endpoint
+
+```http
+POST /v2/query
+Content-Type: application/json
+```
+
+Local development uses `http://localhost:6969/v2/query` by default. For Helix
+Cloud, use the gateway URL and database ID shown in the dashboard.
+
+## Authentication
+
+Local servers do not require authentication by default. Helix Cloud requires a
+cluster API key and database ID:
+
+```http
+Authorization: Bearer <cluster-api-key>
+X-Helix-Database-Id: <database-id>
+```
+
+Create or rotate the cluster key in the Helix Cloud dashboard. Do not put keys
+in source control, agent instructions, `llms.txt`, or catalog manifests.
+
+The hosted HelixDB MCP server has a separate browser OAuth flow. See the
+[HelixDB MCP guide](/database/helix-cloud/connect/mcp) and the public
+[HelixDB authentication guide](https://www.helix-db.com/auth.md).
+
+## Request envelope
+
+`request_type` and the single `query` variant must agree: `read` with `read`, or
+`write` with `write`. `query_name` is optional diagnostic metadata. Parameters
+can be untyped, or every parameter can have a matching entry in
+`parameter_types`.
+
+```json
+{
+  "request_type": "read",
+  "query_name": "node_count",
+  "query": {
+    "read": {
+      "entries": [
+        {
+          "query": {
+            "name": "node_count",
+            "root": {
+              "count": {
+                "input": {
+                  "nodes_where": {
+                    "predicate": {
+                      "eq": {
+                        "left": { "property": "$label" },
+                        "right": { "constant": { "string": "User" } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returns": ["node_count"]
+    }
+  }
+}
+```
+
+## Execution headers
+
+| Header | Applies to | Purpose |
+| --- | --- | --- |
+| `X-Helix-Warm` | Reads | Warm eligible execution state before normal traffic. |
+| `X-Helix-Require-Writer` | Reads and writes | Reject execution when the selected server is not a writer. |
+| `X-Helix-Await-Durable` | Writes | Flush the writer before returning success. |
+| `X-Helix-Database-Id` | Helix Cloud | Select the managed database behind a gateway. |
+
+Boolean execution headers accept `true`, `false`, `1`, or `0`. Warm writes and
+durability waits on reads are rejected with `400 Bad Request`.
+
+## Responses
+
+- `200` returns a JSON object keyed by the requested return variables.
+- `400` reports invalid JSON, invalid query plans, or invalid request options.
+- `401` reports a missing or invalid Helix Cloud API key.
+- `409` reports a transaction conflict that can be retried.
+- `500` reports an internal query or storage failure.
+- `503` reports that a required writer or ready database is unavailable.
+
+All query errors use the stable `{ "error": "<code>", "msg": "<message>" }`
+envelope. See [Error handling](/database/helix-db/query-guides/error-handling)
+for the full code catalog and retry guidance.
+
+## Related resources
+
+- [`helix query`](/cli/command-reference/query) builds and sends requests from JSON or the TypeScript DSL.
+- [Build and run a query](/database/helix-db/core-concepts/overview) explains the operation tree.
+- [Parameters](/database/helix-db/query-guides/parameters) defines typed and untyped runtime values.

--- a/docs/database/helix-db/query-guides/http-api.mdx
+++ b/docs/database/helix-db/query-guides/http-api.mdx
@@ -36,6 +36,11 @@ Cloud, use the gateway URL and database ID shown in the dashboard or written to
 `cluster.helix-db.com` hostname in the OpenAPI document is a placeholder, not a
 shared query endpoint.
 
+The root OpenAPI server and the `/healthz` and `/readyz` operations describe a
+local HelixDB server. The Helix Cloud gateway is advertised only for
+`POST /v2/query`; its separate `/health` and `/readyz` contracts are not part of
+this specification.
+
 ## Authentication
 
 Local servers do not require authentication by default. Helix Cloud requires a
@@ -108,15 +113,24 @@ durability waits on reads are rejected with `400 Bad Request`.
 ## Responses
 
 - `200` returns a JSON object keyed by the requested return variables.
-- `400` reports invalid JSON, invalid query plans, or invalid request options.
-- `401` reports a missing or invalid Helix Cloud API key.
+- `204` means Helix Cloud completed a cache-warming read without a body.
+- `400` reports invalid input or request options. On Helix Cloud, it also
+  reports a missing or malformed authentication header.
+- `401` reports an invalid Helix Cloud API key.
+- `402` reports that Helix Cloud query processing is disabled because credit is
+  exhausted.
+- `403` reports that the Helix Cloud API key lacks permission for the query.
+- `408` reports that a Helix Cloud query exceeded its wall-clock limit.
 - `409` reports a transaction conflict that can be retried.
+- `429` reports a Helix Cloud rate limit and can include `Retry-After`.
 - `500` reports an internal query or storage failure.
 - `503` reports that a required writer or ready database is unavailable.
 
-All query errors use the stable `{ "error": "<code>", "msg": "<message>" }`
-envelope. See [Error handling](/database/helix-db/query-guides/error-handling)
-for the full code catalog and retry guidance.
+Local servers return `{ "error": "<code>", "msg": "<message>" }`. Helix
+Cloud gateways return `{ "error": "<message>", "code": "<code>" }`, with
+`code` omitted when no stable gateway code is available. See
+[Error handling](/database/helix-db/query-guides/error-handling) for local
+error codes and retry guidance.
 
 ## Related resources
 

--- a/docs/database/helix-db/query-guides/http-api.mdx
+++ b/docs/database/helix-db/query-guides/http-api.mdx
@@ -69,6 +69,11 @@ The hosted HelixDB MCP server has a separate browser OAuth flow. See the
 can be untyped, or every parameter can have a matching entry in
 `parameter_types`.
 
+For raw HTTP JSON, send floating-point values without `parameter_types`.
+The HTTP schema does not advertise typed `f32` or `f64` declarations because
+JSON Schema cannot distinguish an integral number token such as `5` from the
+integer representation that exact typed decoding rejects.
+
 ```json
 {
   "request_type": "read",

--- a/docs/database/helix-db/query-guides/http-api.mdx
+++ b/docs/database/helix-db/query-guides/http-api.mdx
@@ -41,6 +41,10 @@ local HelixDB server. The Helix Cloud gateway is advertised only for
 `POST /v2/query`; its separate `/health` and `/readyz` contracts are not part of
 this specification.
 
+Local HelixDB accepts encoded request bodies up to 16 MiB. The Helix Cloud
+gateway accepts up to 2 MiB. Keep requests at or below 2 MiB when the same
+client must work against both environments.
+
 ## Authentication
 
 Local servers do not require authentication by default. Helix Cloud requires a
@@ -122,13 +126,16 @@ durability waits on reads are rejected with `400 Bad Request`.
 - `403` reports that the Helix Cloud API key lacks permission for the query.
 - `408` reports that a Helix Cloud query exceeded its wall-clock limit.
 - `409` reports a transaction conflict that can be retried.
+- `413` reports that a Helix Cloud request body exceeded 2 MiB. The gateway
+  rejects it before the query handler runs.
 - `429` reports a Helix Cloud rate limit and can include `Retry-After`.
 - `500` reports an internal query or storage failure.
 - `503` reports that a required writer or ready database is unavailable.
 
 Local servers return `{ "error": "<code>", "msg": "<message>" }`. Helix
 Cloud gateways return `{ "error": "<message>", "code": "<code>" }`, with
-`code` omitted when no stable gateway code is available. See
+`code` omitted when no stable gateway code is available. The pre-handler Cloud
+`413` response is plain text instead of either JSON envelope. See
 [Error handling](/database/helix-db/query-guides/error-handling) for local
 error codes and retry guidance.
 

--- a/docs/database/helix-db/query-guides/http-api.mdx
+++ b/docs/database/helix-db/query-guides/http-api.mdx
@@ -31,7 +31,10 @@ Content-Type: application/json
 ```
 
 Local development uses `http://localhost:6969/v2/query` by default. For Helix
-Cloud, use the gateway URL and database ID shown in the dashboard.
+Cloud, use the gateway URL and database ID shown in the dashboard or written to
+`helix.toml` by [`helix sync`](/cli/command-reference/sync). The
+`cluster.helix-db.com` hostname in the OpenAPI document is a placeholder, not a
+shared query endpoint.
 
 ## Authentication
 

--- a/docs/database/helix-db/query-guides/http-api.mdx
+++ b/docs/database/helix-db/query-guides/http-api.mdx
@@ -132,17 +132,17 @@ durability waits on reads are rejected with `400 Bad Request`.
 - `408` reports that a Helix Cloud query exceeded its wall-clock limit.
 - `409` reports a transaction conflict that can be retried.
 - `413` reports that a Helix Cloud request body exceeded 2 MiB. The gateway
-  rejects it before the query handler runs.
+  rejects it before query parsing.
 - `429` reports a Helix Cloud rate limit and can include `Retry-After`.
 - `500` reports an internal query or storage failure.
 - `503` reports that a required writer or ready database is unavailable.
 
-Local servers return `{ "error": "<code>", "msg": "<message>" }`. Helix
-Cloud gateways return `{ "error": "<message>", "code": "<code>" }`, with
-`code` omitted when no stable gateway code is available. The pre-handler Cloud
-`413` response is plain text instead of either JSON envelope. See
-[Error handling](/database/helix-db/query-guides/error-handling) for local
-error codes and retry guidance.
+Local servers and Helix Cloud gateways return
+`{ "error": "<code>", "msg": "<message>" }`. Clients should branch on
+`error` and treat `msg` as diagnostic text. An oversized Cloud request uses
+`payload_too_large` as its stable error code. See
+[Error handling](/database/helix-db/query-guides/error-handling) for local error
+codes and retry guidance.
 
 ## Related resources
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -176,6 +176,7 @@
               "database/helix-db/query-guides/projections",
               "database/helix-db/query-guides/advanced",
               "database/helix-db/query-guides/parameters",
+              "database/helix-db/query-guides/http-api",
               "database/helix-db/query-guides/error-handling"
             ]
           }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3944,6 +3944,11 @@ Cloud, use the gateway URL and database ID shown in the dashboard or written to
 `cluster.helix-db.com` hostname in the OpenAPI document is a placeholder, not a
 shared query endpoint.
 
+The root OpenAPI server and the `/healthz` and `/readyz` operations describe a
+local HelixDB server. The Helix Cloud gateway is advertised only for
+`POST /v2/query`; its separate `/health` and `/readyz` contracts are not part of
+this specification.
+
 ## Authentication
 
 Local servers do not require authentication by default. Helix Cloud requires a
@@ -4016,15 +4021,24 @@ durability waits on reads are rejected with `400 Bad Request`.
 ## Responses
 
 - `200` returns a JSON object keyed by the requested return variables.
-- `400` reports invalid JSON, invalid query plans, or invalid request options.
-- `401` reports a missing or invalid Helix Cloud API key.
+- `204` means Helix Cloud completed a cache-warming read without a body.
+- `400` reports invalid input or request options. On Helix Cloud, it also
+  reports a missing or malformed authentication header.
+- `401` reports an invalid Helix Cloud API key.
+- `402` reports that Helix Cloud query processing is disabled because credit is
+  exhausted.
+- `403` reports that the Helix Cloud API key lacks permission for the query.
+- `408` reports that a Helix Cloud query exceeded its wall-clock limit.
 - `409` reports a transaction conflict that can be retried.
+- `429` reports a Helix Cloud rate limit and can include `Retry-After`.
 - `500` reports an internal query or storage failure.
 - `503` reports that a required writer or ready database is unavailable.
 
-All query errors use the stable `{ "error": "<code>", "msg": "<message>" }`
-envelope. See [Error handling](/database/helix-db/query-guides/error-handling)
-for the full code catalog and retry guidance.
+Local servers return `{ "error": "<code>", "msg": "<message>" }`. Helix
+Cloud gateways return `{ "error": "<message>", "code": "<code>" }`, with
+`code` omitted when no stable gateway code is available. See
+[Error handling](/database/helix-db/query-guides/error-handling) for local
+error codes and retry guidance.
 
 ## Related resources
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3977,6 +3977,11 @@ The hosted HelixDB MCP server has a separate browser OAuth flow. See the
 can be untyped, or every parameter can have a matching entry in
 `parameter_types`.
 
+For raw HTTP JSON, send floating-point values without `parameter_types`.
+The HTTP schema does not advertise typed `f32` or `f64` declarations because
+JSON Schema cannot distinguish an integral number token such as `5` from the
+integer representation that exact typed decoding rejects.
+
 ```json
 {
   "request_type": "read",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3949,6 +3949,10 @@ local HelixDB server. The Helix Cloud gateway is advertised only for
 `POST /v2/query`; its separate `/health` and `/readyz` contracts are not part of
 this specification.
 
+Local HelixDB accepts encoded request bodies up to 16 MiB. The Helix Cloud
+gateway accepts up to 2 MiB. Keep requests at or below 2 MiB when the same
+client must work against both environments.
+
 ## Authentication
 
 Local servers do not require authentication by default. Helix Cloud requires a
@@ -4030,13 +4034,16 @@ durability waits on reads are rejected with `400 Bad Request`.
 - `403` reports that the Helix Cloud API key lacks permission for the query.
 - `408` reports that a Helix Cloud query exceeded its wall-clock limit.
 - `409` reports a transaction conflict that can be retried.
+- `413` reports that a Helix Cloud request body exceeded 2 MiB. The gateway
+  rejects it before the query handler runs.
 - `429` reports a Helix Cloud rate limit and can include `Retry-After`.
 - `500` reports an internal query or storage failure.
 - `503` reports that a required writer or ready database is unavailable.
 
 Local servers return `{ "error": "<code>", "msg": "<message>" }`. Helix
 Cloud gateways return `{ "error": "<message>", "code": "<code>" }`, with
-`code` omitted when no stable gateway code is available. See
+`code` omitted when no stable gateway code is available. The pre-handler Cloud
+`413` response is plain text instead of either JSON envelope. See
 [Error handling](/database/helix-db/query-guides/error-handling) for local
 error codes and retry guidance.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3939,7 +3939,10 @@ Content-Type: application/json
 ```
 
 Local development uses `http://localhost:6969/v2/query` by default. For Helix
-Cloud, use the gateway URL and database ID shown in the dashboard.
+Cloud, use the gateway URL and database ID shown in the dashboard or written to
+`helix.toml` by [`helix sync`](/cli/command-reference/sync). The
+`cluster.helix-db.com` hostname in the OpenAPI document is a placeholder, not a
+shared query endpoint.
 
 ## Authentication
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4040,17 +4040,17 @@ durability waits on reads are rejected with `400 Bad Request`.
 - `408` reports that a Helix Cloud query exceeded its wall-clock limit.
 - `409` reports a transaction conflict that can be retried.
 - `413` reports that a Helix Cloud request body exceeded 2 MiB. The gateway
-  rejects it before the query handler runs.
+  rejects it before query parsing.
 - `429` reports a Helix Cloud rate limit and can include `Retry-After`.
 - `500` reports an internal query or storage failure.
 - `503` reports that a required writer or ready database is unavailable.
 
-Local servers return `{ "error": "<code>", "msg": "<message>" }`. Helix
-Cloud gateways return `{ "error": "<message>", "code": "<code>" }`, with
-`code` omitted when no stable gateway code is available. The pre-handler Cloud
-`413` response is plain text instead of either JSON envelope. See
-[Error handling](/database/helix-db/query-guides/error-handling) for local
-error codes and retry guidance.
+Local servers and Helix Cloud gateways return
+`{ "error": "<code>", "msg": "<message>" }`. Clients should branch on
+`error` and treat `msg` as diagnostic text. An oversized Cloud request uses
+`payload_too_large` as its stable error code. See
+[Error handling](/database/helix-db/query-guides/error-handling) for local error
+codes and retry guidance.
 
 ## Related resources
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3911,6 +3911,124 @@ the request at runtime and send it to `POST /v2/query`.
     Apply parameters to indexed sources and filters.
   </Card>
 
+# HelixDB HTTP API and OpenAPI specification
+
+Page type: Reference
+
+<div className="flex flex-wrap gap-2"><Badge color="gray" size="sm">Reference</Badge></div>
+
+The HelixDB HTTP API accepts operation-tree queries at `POST /v2/query`. The
+same contract is available from a local server and a Helix Cloud gateway.
+
+## Machine-readable specification
+
+The canonical OpenAPI 3.1 document is published at both predictable URLs:
+
+- [https://www.helix-db.com/openapi.json](https://www.helix-db.com/openapi.json)
+- [https://docs.helix-db.com/openapi.json](https://docs.helix-db.com/openapi.json)
+
+Use the specification to discover request headers, response codes, health
+endpoints, query-envelope variants, and example read and write requests. Use the
+typed SDKs or `helix query` to build the nested operation tree.
+
+## Endpoint
+
+```http
+POST /v2/query
+Content-Type: application/json
+```
+
+Local development uses `http://localhost:6969/v2/query` by default. For Helix
+Cloud, use the gateway URL and database ID shown in the dashboard.
+
+## Authentication
+
+Local servers do not require authentication by default. Helix Cloud requires a
+cluster API key and database ID:
+
+```http
+Authorization: Bearer <cluster-api-key>
+X-Helix-Database-Id: <database-id>
+```
+
+Create or rotate the cluster key in the Helix Cloud dashboard. Do not put keys
+in source control, agent instructions, `llms.txt`, or catalog manifests.
+
+The hosted HelixDB MCP server has a separate browser OAuth flow. See the
+[HelixDB MCP guide](/database/helix-cloud/connect/mcp) and the public
+[HelixDB authentication guide](https://www.helix-db.com/auth.md).
+
+## Request envelope
+
+`request_type` and the single `query` variant must agree: `read` with `read`, or
+`write` with `write`. `query_name` is optional diagnostic metadata. Parameters
+can be untyped, or every parameter can have a matching entry in
+`parameter_types`.
+
+```json
+{
+  "request_type": "read",
+  "query_name": "node_count",
+  "query": {
+    "read": {
+      "entries": [
+        {
+          "query": {
+            "name": "node_count",
+            "root": {
+              "count": {
+                "input": {
+                  "nodes_where": {
+                    "predicate": {
+                      "eq": {
+                        "left": { "property": "$label" },
+                        "right": { "constant": { "string": "User" } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "returns": ["node_count"]
+    }
+  }
+}
+```
+
+## Execution headers
+
+| Header | Applies to | Purpose |
+| --- | --- | --- |
+| `X-Helix-Warm` | Reads | Warm eligible execution state before normal traffic. |
+| `X-Helix-Require-Writer` | Reads and writes | Reject execution when the selected server is not a writer. |
+| `X-Helix-Await-Durable` | Writes | Flush the writer before returning success. |
+| `X-Helix-Database-Id` | Helix Cloud | Select the managed database behind a gateway. |
+
+Boolean execution headers accept `true`, `false`, `1`, or `0`. Warm writes and
+durability waits on reads are rejected with `400 Bad Request`.
+
+## Responses
+
+- `200` returns a JSON object keyed by the requested return variables.
+- `400` reports invalid JSON, invalid query plans, or invalid request options.
+- `401` reports a missing or invalid Helix Cloud API key.
+- `409` reports a transaction conflict that can be retried.
+- `500` reports an internal query or storage failure.
+- `503` reports that a required writer or ready database is unavailable.
+
+All query errors use the stable `{ "error": "<code>", "msg": "<message>" }`
+envelope. See [Error handling](/database/helix-db/query-guides/error-handling)
+for the full code catalog and retry guidance.
+
+## Related resources
+
+- [`helix query`](/cli/command-reference/query) builds and sends requests from JSON or the TypeScript DSL.
+- [Build and run a query](/database/helix-db/core-concepts/overview) explains the operation tree.
+- [Parameters](/database/helix-db/query-guides/parameters) defines typed and untyped runtime values.
+
 # Handle query errors
 
 Page type: Reference

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -24,6 +24,13 @@ helix query dev -e 'readBatch().varAs("users", g().nWithLabel("User")).returning
 
 Full walkthrough: https://docs.helix-db.com/database/helix-db/start-here/quickstart
 
+## HelixDB developer resources
+- [HelixDB HTTP API documentation](https://docs.helix-db.com/database/helix-db/query-guides/http-api): Request contract, authentication, headers, responses, and examples for `POST /v2/query`.
+- [HelixDB OpenAPI specification](https://www.helix-db.com/openapi.json): OpenAPI 3.1 JSON for the public HelixDB HTTP API.
+- [HelixDB authentication guide for agents](https://www.helix-db.com/auth.md): Supported API-key and OAuth surfaces, with links to machine-readable discovery metadata.
+- [HelixDB hosted MCP server](https://docs.helix-db.com/database/helix-cloud/connect/mcp): Connect agents to read-only Helix Cloud insights over OAuth.
+- [HelixDB AI Catalog](https://www.helix-db.com/.well-known/ai-catalog.json): ARD catalog of HelixDB agent resources.
+
 ## HelixDB — Start Here
 - [Introduction](https://docs.helix-db.com/database/helix-db/start-here/introduction) — Page type: Concept
 - [Get Started](https://docs.helix-db.com/database/helix-db/start-here/quickstart): Initialize HelixDB, start a local instance, run the generated query, and stop it — Page type: Tutorial
@@ -52,6 +59,7 @@ Full walkthrough: https://docs.helix-db.com/database/helix-db/start-here/quickst
 - [Shape query results](https://docs.helix-db.com/database/helix-db/query-guides/projections): Return properties, computed values, aggregates, and correlated binding rows — Page type: Guide
 - [Branch, repeat, and condition queries](https://docs.helix-db.com/database/helix-db/query-guides/advanced): Compose sub-traversals and gate named entries without leaving one transaction — Page type: Guide
 - [Bind typed query parameters](https://docs.helix-db.com/database/helix-db/query-guides/parameters): Keep the operation tree stable while request values change — Page type: Guide
+- [HelixDB HTTP API and OpenAPI specification](https://docs.helix-db.com/database/helix-db/query-guides/http-api): Call the HelixDB v2 query endpoint and discover its machine-readable OpenAPI 3.1 contract — Page type: Reference
 - [Handle query errors](https://docs.helix-db.com/database/helix-db/query-guides/error-handling): Branch on stable error codes while retaining diagnostic messages — Page type: Reference
 
 ## Helix Cloud — Start Here

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -26,11 +26,11 @@
     },
     {
       "url": "https://{gatewayHost}",
-      "description": "Helix Cloud gateway shown in the database connection details",
+      "description": "Helix Cloud query gateway from the database connection details or helix sync output",
       "variables": {
         "gatewayHost": {
-          "default": "api.helix-db.com",
-          "description": "Managed gateway hostname"
+          "default": "cluster.helix-db.com",
+          "description": "Placeholder only. Replace it with the managed gateway hostname shown in the Helix Cloud dashboard or written to helix.toml by helix sync."
         }
       }
     }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,799 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "HelixDB HTTP API",
+    "version": "2.0.0",
+    "summary": "Execute operation-tree queries against HelixDB",
+    "description": "The HelixDB HTTP API exposes the same v2 query contract on local servers and Helix Cloud gateways. Typed SDKs build the nested operation tree; clients send the serialized QueryRequest to POST /v2/query.",
+    "termsOfService": "https://www.helix-db.com/terms",
+    "contact": {
+      "name": "HelixDB",
+      "url": "https://www.helix-db.com/developers"
+    },
+    "license": {
+      "name": "Apache-2.0",
+      "identifier": "Apache-2.0"
+    }
+  },
+  "externalDocs": {
+    "description": "HelixDB HTTP API documentation",
+    "url": "https://docs.helix-db.com/database/helix-db/query-guides/http-api"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:6969",
+      "description": "Default local HelixDB server"
+    },
+    {
+      "url": "https://{gatewayHost}",
+      "description": "Helix Cloud gateway shown in the database connection details",
+      "variables": {
+        "gatewayHost": {
+          "default": "api.helix-db.com",
+          "description": "Managed gateway hostname"
+        }
+      }
+    }
+  ],
+  "tags": [
+    {
+      "name": "Queries",
+      "description": "Execute serialized HelixDB operation trees."
+    },
+    {
+      "name": "Health",
+      "description": "Inspect process liveness and database readiness."
+    }
+  ],
+  "paths": {
+    "/v2/query": {
+      "post": {
+        "operationId": "executeQuery",
+        "summary": "Execute a HelixDB query",
+        "description": "Executes one read or write batch. request_type must match the closed read or write variant under query. Request bodies are limited to 16 MiB.",
+        "tags": [
+          "Queries"
+        ],
+        "security": [
+          {},
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DatabaseId"
+          },
+          {
+            "$ref": "#/components/parameters/WarmOnly"
+          },
+          {
+            "$ref": "#/components/parameters/RequireWriter"
+          },
+          {
+            "$ref": "#/components/parameters/AwaitDurable"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryRequest"
+              },
+              "examples": {
+                "read": {
+                  "summary": "Count User nodes",
+                  "value": {
+                    "request_type": "read",
+                    "query_name": "node_count",
+                    "query": {
+                      "read": {
+                        "entries": [
+                          {
+                            "query": {
+                              "name": "node_count",
+                              "root": {
+                                "count": {
+                                  "input": {
+                                    "nodes_where": {
+                                      "predicate": {
+                                        "eq": {
+                                          "left": {
+                                            "property": "$label"
+                                          },
+                                          "right": {
+                                            "constant": {
+                                              "string": "User"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "returns": [
+                          "node_count"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "write": {
+                  "summary": "Create one User node",
+                  "value": {
+                    "request_type": "write",
+                    "query_name": "create_user",
+                    "query": {
+                      "write": {
+                        "entries": [
+                          {
+                            "query": {
+                              "name": "user",
+                              "root": {
+                                "add_n": {
+                                  "label": "User",
+                                  "properties": [
+                                    [
+                                      "name",
+                                      {
+                                        "value": {
+                                          "string": "Alice"
+                                        }
+                                      }
+                                    ]
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "returns": [
+                          "user"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Query executed successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryResponse"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "Helix Cloud completed a cache-warming read and intentionally omitted the response body."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "$ref": "#/components/responses/Unavailable"
+          }
+        }
+      }
+    },
+    "/healthz": {
+      "get": {
+        "operationId": "getHealth",
+        "summary": "Get process health",
+        "description": "Reports process liveness and the current database and index-runtime state. Liveness returns 200 even when ready is false.",
+        "tags": [
+          "Health"
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "The server process is alive.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/readyz": {
+      "get": {
+        "operationId": "getReadiness",
+        "summary": "Get database readiness",
+        "description": "Returns 200 only when the configured database handle and index runtime are ready to serve queries.",
+        "tags": [
+          "Health"
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "The database is ready.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The process is alive, but the database is not ready.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Helix Cloud cluster API key. Local servers do not require this credential by default."
+      }
+    },
+    "parameters": {
+      "DatabaseId": {
+        "name": "X-Helix-Database-Id",
+        "in": "header",
+        "required": false,
+        "description": "Database identifier shown in Helix Cloud connection details. It is not needed by a standalone local server.",
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "WarmOnly": {
+        "name": "X-Helix-Warm",
+        "in": "header",
+        "required": false,
+        "description": "Warm read execution state. Valid only for read requests.",
+        "schema": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "RequireWriter": {
+        "name": "X-Helix-Require-Writer",
+        "in": "header",
+        "required": false,
+        "description": "Reject the request unless it reaches a writer-capable server.",
+        "schema": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "AwaitDurable": {
+        "name": "X-Helix-Await-Durable",
+        "in": "header",
+        "required": false,
+        "description": "Flush the writer before acknowledging success. Valid only for write requests.",
+        "schema": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Invalid JSON, query plan, vector input, or request option.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/QueryError"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Helix Cloud authentication is missing or invalid.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/QueryError"
+            }
+          }
+        }
+      },
+      "Conflict": {
+        "description": "The transaction conflicted with concurrent work and can be retried.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/QueryError"
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "The Helix Cloud gateway rate limit was exceeded.",
+        "headers": {
+          "Retry-After": {
+            "description": "Delay before retrying, when supplied by the gateway.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/QueryError"
+            }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "An internal query, storage, or serialization failure occurred.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/QueryError"
+            }
+          }
+        }
+      },
+      "Unavailable": {
+        "description": "A required writer or ready database is unavailable.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/QueryError"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "QueryRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ReadQueryRequest"
+          },
+          {
+            "$ref": "#/components/schemas/WriteQueryRequest"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "request_type",
+          "mapping": {
+            "read": "#/components/schemas/ReadQueryRequest",
+            "write": "#/components/schemas/WriteQueryRequest"
+          }
+        }
+      },
+      "ReadQueryRequest": {
+        "type": "object",
+        "required": [
+          "request_type",
+          "query"
+        ],
+        "properties": {
+          "request_type": {
+            "const": "read"
+          },
+          "query_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional diagnostic name. It does not create a stored endpoint."
+          },
+          "query": {
+            "$ref": "#/components/schemas/ReadBatchQuery"
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/QueryParameters"
+          },
+          "parameter_types": {
+            "$ref": "#/components/schemas/QueryParameterTypes"
+          }
+        },
+        "dependentRequired": {
+          "parameter_types": [
+            "parameters"
+          ]
+        },
+        "additionalProperties": false
+      },
+      "WriteQueryRequest": {
+        "type": "object",
+        "required": [
+          "request_type",
+          "query"
+        ],
+        "properties": {
+          "request_type": {
+            "const": "write"
+          },
+          "query_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional diagnostic name. It does not create a stored endpoint."
+          },
+          "query": {
+            "$ref": "#/components/schemas/WriteBatchQuery"
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/QueryParameters"
+          },
+          "parameter_types": {
+            "$ref": "#/components/schemas/QueryParameterTypes"
+          }
+        },
+        "dependentRequired": {
+          "parameter_types": [
+            "parameters"
+          ]
+        },
+        "additionalProperties": false
+      },
+      "ReadBatchQuery": {
+        "type": "object",
+        "required": [
+          "read"
+        ],
+        "properties": {
+          "read": {
+            "$ref": "#/components/schemas/Batch"
+          }
+        },
+        "additionalProperties": false
+      },
+      "WriteBatchQuery": {
+        "type": "object",
+        "required": [
+          "write"
+        ],
+        "properties": {
+          "write": {
+            "$ref": "#/components/schemas/Batch"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Batch": {
+        "type": "object",
+        "required": [
+          "entries"
+        ],
+        "properties": {
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BatchEntry"
+            }
+          },
+          "returns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          }
+        },
+        "additionalProperties": false
+      },
+      "BatchEntry": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "query"
+            ],
+            "properties": {
+              "query": {
+                "$ref": "#/components/schemas/NamedQuery"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "for_each"
+            ],
+            "properties": {
+              "for_each": {
+                "type": "object",
+                "required": [
+                  "param",
+                  "body"
+                ],
+                "properties": {
+                  "param": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/BatchEntry"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "NamedQuery": {
+        "type": "object",
+        "required": [
+          "root"
+        ],
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "root": {
+            "$ref": "#/components/schemas/OperationTree"
+          },
+          "condition": {
+            "$ref": "#/components/schemas/BatchCondition"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BatchCondition": {
+        "description": "Externally tagged condition for a conditional batch entry.",
+        "oneOf": [
+          {
+            "type": "string",
+            "const": "prev_not_empty"
+          },
+          {
+            "type": "object",
+            "required": [
+              "var_not_empty"
+            ],
+            "properties": {
+              "var_not_empty": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "var_empty"
+            ],
+            "properties": {
+              "var_empty": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "var_min_size"
+            ],
+            "properties": {
+              "var_min_size": {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                ],
+                "minItems": 2,
+                "maxItems": 2
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "OperationTree": {
+        "type": "object",
+        "minProperties": 1,
+        "maxProperties": 1,
+        "description": "One externally tagged, snake_case HelixDB AstNode operation. Source operations start a traversal; subsequent operations contain their predecessor under input. Use a typed HelixDB SDK or the query documentation to construct this recursive tree.",
+        "additionalProperties": true,
+        "examples": [
+          {
+            "nodes": {
+              "reference": "all"
+            }
+          },
+          {
+            "count": {
+              "input": {
+                "nodes": {
+                  "reference": "all"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "QueryParameters": {
+        "type": "object",
+        "propertyNames": {
+          "minLength": 1
+        },
+        "additionalProperties": {
+          "$ref": "#/components/schemas/QueryParameterValue"
+        }
+      },
+      "QueryParameterValue": {
+        "description": "JSON-compatible runtime parameter. Datetimes are RFC 3339 strings when declared as date_time. Raw bytes cannot be represented on the JSON route.",
+        "anyOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueryParameterValue"
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/QueryParameterValue"
+            }
+          }
+        ]
+      },
+      "QueryParameterTypes": {
+        "type": "object",
+        "description": "When present, keys must exactly match parameters. Typed and untyped parameters cannot be mixed.",
+        "propertyNames": {
+          "minLength": 1
+        },
+        "additionalProperties": {
+          "$ref": "#/components/schemas/QueryParameterType"
+        }
+      },
+      "QueryParameterType": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "bool",
+              "i64",
+              "f64",
+              "f32",
+              "string",
+              "date_time",
+              "bytes",
+              "value",
+              "object"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "array"
+            ],
+            "properties": {
+              "array": {
+                "$ref": "#/components/schemas/QueryParameterType"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "QueryResponse": {
+        "type": "object",
+        "description": "Returned variables keyed by the names listed in the batch returns array.",
+        "additionalProperties": true,
+        "example": {
+          "node_count": [
+            42
+          ]
+        }
+      },
+      "QueryError": {
+        "type": "object",
+        "required": [
+          "error",
+          "msg"
+        ],
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Stable snake_case error code."
+          },
+          "msg": {
+            "type": "string",
+            "description": "Human-readable diagnostic message."
+          }
+        },
+        "additionalProperties": false,
+        "example": {
+          "error": "invalid_query_json",
+          "msg": "invalid query JSON: expected value"
+        }
+      },
+      "HealthResponse": {
+        "type": "object",
+        "required": [
+          "ready",
+          "mode",
+          "index_runtime"
+        ],
+        "properties": {
+          "ready": {
+            "type": "boolean"
+          },
+          "mode": {
+            "type": "string",
+            "description": "Configured database mode."
+          },
+          "index_runtime": {
+            "type": "string",
+            "description": "Stable index-runtime readiness code."
+          }
+        },
+        "additionalProperties": false,
+        "example": {
+          "ready": true,
+          "mode": "writer",
+          "index_runtime": "ready"
+        }
+      }
+    }
+  }
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -726,7 +726,7 @@
         }
       },
       "QueryParameterValue": {
-        "description": "JSON-compatible runtime parameter. Datetimes are RFC 3339 strings when declared as date_time. Raw bytes cannot be represented on the JSON route.",
+        "description": "JSON-compatible runtime parameter. Datetimes are RFC 3339 strings when declared as date_time. Raw bytes cannot be represented on the JSON route. Send floating-point JSON numbers without parameter_types because JSON Schema cannot distinguish an integral number token from the integer representation used by the exact typed decoder.",
         "anyOf": [
           {
             "type": "null"
@@ -761,7 +761,7 @@
       },
       "QueryParameterTypes": {
         "type": "object",
-        "description": "When present, keys must exactly match parameters. Typed and untyped parameters cannot be mixed.",
+        "description": "When present, keys must exactly match parameters. Typed and untyped parameters cannot be mixed. The HTTP contract deliberately omits f32 and f64 declarations because JSON Schema cannot express the lexical distinction required by exact typed decoding; send floating-point JSON numbers without parameter_types.",
         "propertyNames": {
           "minLength": 1
         },
@@ -776,8 +776,6 @@
             "enum": [
               "bool",
               "i64",
-              "f64",
-              "f32",
               "string",
               "date_time",
               "value",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -344,7 +344,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/GatewayQueryError"
+              "$ref": "#/components/schemas/QueryError"
             }
           }
         }
@@ -354,7 +354,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/GatewayQueryError"
+              "$ref": "#/components/schemas/QueryError"
             }
           }
         }
@@ -364,7 +364,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/GatewayQueryError"
+              "$ref": "#/components/schemas/QueryError"
             }
           }
         }
@@ -374,7 +374,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/GatewayQueryError"
+              "$ref": "#/components/schemas/QueryError"
             }
           }
         }
@@ -390,13 +390,16 @@
         }
       },
       "PayloadTooLarge": {
-        "description": "The Helix Cloud gateway rejected a request body larger than 2 MiB before the query handler ran.",
+        "description": "The Helix Cloud gateway rejected a request body larger than 2 MiB before query parsing.",
         "content": {
-          "text/plain": {
+          "application/json": {
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/QueryError"
             },
-            "example": "Failed to buffer the request body: length limit exceeded"
+            "example": {
+              "error": "payload_too_large",
+              "msg": "request body exceeds the maximum allowed size"
+            }
           }
         }
       },
@@ -413,7 +416,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/GatewayQueryError"
+              "$ref": "#/components/schemas/QueryError"
             }
           }
         }
@@ -806,8 +809,9 @@
           ]
         }
       },
-      "LocalQueryError": {
+      "QueryError": {
         "type": "object",
+        "description": "Stable error envelope returned by local servers and Helix Cloud gateways.",
         "required": [
           "error",
           "msg"
@@ -827,38 +831,6 @@
           "error": "invalid_query_json",
           "msg": "invalid query JSON: expected value"
         }
-      },
-      "GatewayQueryError": {
-        "type": "object",
-        "required": [
-          "error"
-        ],
-        "properties": {
-          "error": {
-            "type": "string",
-            "description": "Human-readable gateway error message."
-          },
-          "code": {
-            "type": "string",
-            "description": "Stable gateway error code when one is available."
-          }
-        },
-        "additionalProperties": false,
-        "example": {
-          "code": "QUERY_TIMEOUT",
-          "error": "query exceeded its wall-clock limit"
-        }
-      },
-      "QueryError": {
-        "description": "Local servers return LocalQueryError. Helix Cloud gateways return GatewayQueryError.",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/LocalQueryError"
-          },
-          {
-            "$ref": "#/components/schemas/GatewayQueryError"
-          }
-        ]
       },
       "HealthResponse": {
         "type": "object",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -40,7 +40,11 @@
       "post": {
         "operationId": "executeQuery",
         "summary": "Execute a HelixDB query",
-        "description": "Executes one read or write batch. request_type must match the closed read or write variant under query. Request bodies are limited to 16 MiB.",
+        "description": "Executes one read or write batch. request_type must match the closed read or write variant under query. Local servers accept request bodies up to 16 MiB. Helix Cloud gateways accept request bodies up to 2 MiB.",
+        "x-helix-request-body-limits": {
+          "localBytes": 16777216,
+          "helixCloudBytes": 2097152
+        },
         "servers": [
           {
             "url": "http://localhost:6969",
@@ -82,6 +86,7 @@
         ],
         "requestBody": {
           "required": true,
+          "description": "Maximum encoded body size: 16 MiB on a local HelixDB server and 2 MiB on a Helix Cloud gateway.",
           "content": {
             "application/json": {
               "schema": {
@@ -200,6 +205,9 @@
           },
           "409": {
             "$ref": "#/components/responses/Conflict"
+          },
+          "413": {
+            "$ref": "#/components/responses/PayloadTooLarge"
           },
           "429": {
             "$ref": "#/components/responses/RateLimited"
@@ -378,6 +386,17 @@
             "schema": {
               "$ref": "#/components/schemas/QueryError"
             }
+          }
+        }
+      },
+      "PayloadTooLarge": {
+        "description": "The Helix Cloud gateway rejected a request body larger than 2 MiB before the query handler ran.",
+        "content": {
+          "text/plain": {
+            "schema": {
+              "type": "string"
+            },
+            "example": "Failed to buffer the request body: length limit exceeded"
           }
         }
       },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -23,16 +23,6 @@
     {
       "url": "http://localhost:6969",
       "description": "Default local HelixDB server"
-    },
-    {
-      "url": "https://{gatewayHost}",
-      "description": "Helix Cloud query gateway from the database connection details or helix sync output",
-      "variables": {
-        "gatewayHost": {
-          "default": "cluster.helix-db.com",
-          "description": "Placeholder only. Replace it with the managed gateway hostname shown in the Helix Cloud dashboard or written to helix.toml by helix sync."
-        }
-      }
     }
   ],
   "tags": [
@@ -51,6 +41,22 @@
         "operationId": "executeQuery",
         "summary": "Execute a HelixDB query",
         "description": "Executes one read or write batch. request_type must match the closed read or write variant under query. Request bodies are limited to 16 MiB.",
+        "servers": [
+          {
+            "url": "http://localhost:6969",
+            "description": "Default local HelixDB server"
+          },
+          {
+            "url": "https://{gatewayHost}",
+            "description": "Helix Cloud query gateway from the database connection details or helix sync output",
+            "variables": {
+              "gatewayHost": {
+                "default": "cluster.helix-db.com",
+                "description": "Placeholder only. Replace it with the managed gateway hostname shown in the Helix Cloud dashboard or written to helix.toml by helix sync."
+              }
+            }
+          }
+        ],
         "tags": [
           "Queries"
         ],
@@ -183,6 +189,15 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "408": {
+            "$ref": "#/components/responses/RequestTimeout"
+          },
           "409": {
             "$ref": "#/components/responses/Conflict"
           },
@@ -307,7 +322,7 @@
     },
     "responses": {
       "BadRequest": {
-        "description": "Invalid JSON, query plan, vector input, or request option.",
+        "description": "Invalid JSON, query plan, vector input, request option, or Helix Cloud authentication header.",
         "content": {
           "application/json": {
             "schema": {
@@ -317,11 +332,41 @@
         }
       },
       "Unauthorized": {
-        "description": "Helix Cloud authentication is missing or invalid.",
+        "description": "The Helix Cloud API key is invalid.",
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/QueryError"
+              "$ref": "#/components/schemas/GatewayQueryError"
+            }
+          }
+        }
+      },
+      "PaymentRequired": {
+        "description": "Helix Cloud query processing is disabled because the tenant has exhausted its credit.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/GatewayQueryError"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "The Helix Cloud API key does not have permission to execute the query.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/GatewayQueryError"
+            }
+          }
+        }
+      },
+      "RequestTimeout": {
+        "description": "The Helix Cloud query exceeded its wall-clock limit.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/GatewayQueryError"
             }
           }
         }
@@ -349,7 +394,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/QueryError"
+              "$ref": "#/components/schemas/GatewayQueryError"
             }
           }
         }
@@ -716,7 +761,6 @@
               "f32",
               "string",
               "date_time",
-              "bytes",
               "value",
               "object"
             ]
@@ -745,7 +789,7 @@
           ]
         }
       },
-      "QueryError": {
+      "LocalQueryError": {
         "type": "object",
         "required": [
           "error",
@@ -766,6 +810,38 @@
           "error": "invalid_query_json",
           "msg": "invalid query JSON: expected value"
         }
+      },
+      "GatewayQueryError": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Human-readable gateway error message."
+          },
+          "code": {
+            "type": "string",
+            "description": "Stable gateway error code when one is available."
+          }
+        },
+        "additionalProperties": false,
+        "example": {
+          "code": "QUERY_TIMEOUT",
+          "error": "query exceeded its wall-clock limit"
+        }
+      },
+      "QueryError": {
+        "description": "Local servers return LocalQueryError. Helix Cloud gateways return GatewayQueryError.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/LocalQueryError"
+          },
+          {
+            "$ref": "#/components/schemas/GatewayQueryError"
+          }
+        ]
       },
       "HealthResponse": {
         "type": "object",

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,8 +3,9 @@
     "dev": "mintlify dev",
     "generate-llms": "node scripts/generate-llms.mjs && node scripts/generate-llms-full.mjs",
     "check-llms": "node scripts/generate-llms.mjs --check && node scripts/generate-llms-full.mjs --check",
+    "check-openapi": "node scripts/check-openapi.mjs",
     "check-docs": "node scripts/check-docs.mjs",
-    "check": "npm run check-docs && npm run check-llms",
+    "check": "npm run check-docs && npm run check-llms && npm run check-openapi",
     "add-llms-directive": "node scripts/add-llms-directive.mjs"
   },
   "dependencies": {

--- a/docs/scripts/check-openapi.mjs
+++ b/docs/scripts/check-openapi.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DOCS_ROOT = path.resolve(__dirname, '..');
+const SPEC_PATH = path.join(DOCS_ROOT, 'openapi.json');
+const ROUTER_PATH = path.resolve(DOCS_ROOT, '../crates/server/src/http.rs');
+
+const errors = [];
+let spec;
+
+try {
+  spec = JSON.parse(fs.readFileSync(SPEC_PATH, 'utf8'));
+} catch (error) {
+  console.error(`openapi.json is not valid JSON: ${error.message}`);
+  process.exit(1);
+}
+
+if (spec.openapi !== '3.1.0') {
+  errors.push('openapi.json: openapi must be exactly 3.1.0');
+}
+if (!spec.info?.title?.includes('HelixDB')) {
+  errors.push('openapi.json: info.title must include HelixDB');
+}
+
+const router = fs.readFileSync(ROUTER_PATH, 'utf8');
+const routerOperations = new Set(
+  [...router.matchAll(/\.route\("([^"]+)",\s*(get|post)\(/g)].map(
+    ([, route, method]) => `${method} ${route}`,
+  ),
+);
+const documentedOperations = new Set(
+  Object.entries(spec.paths ?? {}).flatMap(([route, pathItem]) =>
+    ['get', 'post', 'put', 'patch', 'delete'].flatMap((method) =>
+      pathItem[method] ? [`${method} ${route}`] : [],
+    ),
+  ),
+);
+
+for (const operation of routerOperations) {
+  if (!documentedOperations.has(operation)) {
+    errors.push(`openapi.json: missing server operation ${operation}`);
+  }
+}
+for (const operation of documentedOperations) {
+  if (!routerOperations.has(operation)) {
+    errors.push(`openapi.json: documents nonexistent server operation ${operation}`);
+  }
+}
+
+const operationIds = [];
+for (const [route, pathItem] of Object.entries(spec.paths ?? {})) {
+  for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
+    const operation = pathItem[method];
+    if (!operation) continue;
+    if (!operation.operationId) {
+      errors.push(`openapi.json: ${method.toUpperCase()} ${route} needs operationId`);
+    } else {
+      operationIds.push(operation.operationId);
+    }
+    if (!operation.responses || Object.keys(operation.responses).length === 0) {
+      errors.push(`openapi.json: ${method.toUpperCase()} ${route} needs responses`);
+    }
+  }
+}
+if (new Set(operationIds).size !== operationIds.length) {
+  errors.push('openapi.json: operationId values must be unique');
+}
+
+const querySchema = spec.components?.schemas?.QueryRequest;
+if (!querySchema?.oneOf || querySchema.oneOf.length !== 2) {
+  errors.push('openapi.json: QueryRequest must close over read and write variants');
+}
+const examples = spec.paths?.['/v2/query']?.post?.requestBody?.content?.[
+  'application/json'
+]?.examples;
+if (!examples?.read?.value || !examples?.write?.value) {
+  errors.push('openapi.json: /v2/query needs read and write request examples');
+}
+
+if (errors.length > 0) {
+  for (const error of errors) console.error(error);
+  process.exit(1);
+}
+
+console.log(
+  `openapi.json matches ${routerOperations.size} HelixDB HTTP server operations.`,
+);

--- a/docs/scripts/check-openapi.mjs
+++ b/docs/scripts/check-openapi.mjs
@@ -217,8 +217,21 @@ if (
 const scalarParameterTypes = spec.components?.schemas?.QueryParameterType?.oneOf?.find(
   (variant) => Array.isArray(variant.enum),
 )?.enum;
-if (!scalarParameterTypes || scalarParameterTypes.includes('bytes')) {
-  errors.push('openapi.json: the JSON query route must not advertise bytes parameters');
+const expectedScalarParameterTypes = [
+  'bool',
+  'date_time',
+  'i64',
+  'object',
+  'string',
+  'value',
+];
+if (
+  !scalarParameterTypes ||
+  scalarParameterTypes.toSorted().join(',') !== expectedScalarParameterTypes.join(',')
+) {
+  errors.push(
+    'openapi.json: typed JSON parameters must omit bytes, f32, and f64',
+  );
 }
 
 if (errors.length > 0) {

--- a/docs/scripts/check-openapi.mjs
+++ b/docs/scripts/check-openapi.mjs
@@ -24,6 +24,12 @@ if (spec.openapi !== '3.1.0') {
 if (!spec.info?.title?.includes('HelixDB')) {
   errors.push('openapi.json: info.title must include HelixDB');
 }
+if (
+  spec.servers?.length !== 1 ||
+  spec.servers[0]?.url !== 'http://localhost:6969'
+) {
+  errors.push('openapi.json: root servers must describe only the local server');
+}
 
 const router = fs.readFileSync(ROUTER_PATH, 'utf8');
 const routerOperations = new Set(
@@ -80,11 +86,126 @@ if (!examples?.read?.value || !examples?.write?.value) {
   errors.push('openapi.json: /v2/query needs read and write request examples');
 }
 
+const queryOperation = spec.paths?.['/v2/query']?.post;
+const queryServerUrls = queryOperation?.servers?.map(({ url }) => url) ?? [];
+if (
+  queryServerUrls.length !== 2 ||
+  !queryServerUrls.includes('http://localhost:6969') ||
+  !queryServerUrls.includes('https://{gatewayHost}')
+) {
+  errors.push(
+    'openapi.json: /v2/query must advertise the local server and Helix Cloud gateway',
+  );
+}
+for (const route of ['/healthz', '/readyz']) {
+  if (spec.paths?.[route]?.get?.servers) {
+    errors.push(`openapi.json: ${route} must inherit the local root server`);
+  }
+}
+
+const documentedQueryStatuses = Object.keys(queryOperation?.responses ?? {}).sort();
+const expectedQueryStatuses = [
+  '200',
+  '204',
+  '400',
+  '401',
+  '402',
+  '403',
+  '408',
+  '409',
+  '429',
+  '500',
+  '503',
+];
+if (documentedQueryStatuses.join(',') !== expectedQueryStatuses.join(',')) {
+  errors.push(
+    `openapi.json: /v2/query response codes must be ${expectedQueryStatuses.join(', ')}`,
+  );
+}
+const expectedQueryResponseRefs = {
+  400: 'BadRequest',
+  401: 'Unauthorized',
+  402: 'PaymentRequired',
+  403: 'Forbidden',
+  408: 'RequestTimeout',
+  409: 'Conflict',
+  429: 'RateLimited',
+  500: 'InternalError',
+  503: 'Unavailable',
+};
+for (const [status, name] of Object.entries(expectedQueryResponseRefs)) {
+  if (
+    queryOperation.responses?.[status]?.$ref !==
+    `#/components/responses/${name}`
+  ) {
+    errors.push(`openapi.json: ${status} must reference ${name}`);
+  }
+}
+
+const responseSchemaRef = (name) =>
+  spec.components?.responses?.[name]?.content?.['application/json']?.schema?.$ref;
+for (const name of [
+  'Unauthorized',
+  'PaymentRequired',
+  'Forbidden',
+  'RequestTimeout',
+  'RateLimited',
+]) {
+  if (responseSchemaRef(name) !== '#/components/schemas/GatewayQueryError') {
+    errors.push(`openapi.json: ${name} must use GatewayQueryError`);
+  }
+}
+for (const name of ['BadRequest', 'Conflict', 'InternalError', 'Unavailable']) {
+  if (responseSchemaRef(name) !== '#/components/schemas/QueryError') {
+    errors.push(`openapi.json: ${name} must allow local and gateway errors`);
+  }
+}
+
+const localError = spec.components?.schemas?.LocalQueryError;
+if (
+  localError?.additionalProperties !== false ||
+  localError.required?.join(',') !== 'error,msg' ||
+  !localError.properties?.error ||
+  !localError.properties?.msg
+) {
+  errors.push('openapi.json: LocalQueryError must require only error and msg');
+}
+const gatewayError = spec.components?.schemas?.GatewayQueryError;
+if (
+  gatewayError?.additionalProperties !== false ||
+  gatewayError.required?.join(',') !== 'error' ||
+  !gatewayError.properties?.error ||
+  !gatewayError.properties?.code ||
+  gatewayError.properties?.msg
+) {
+  errors.push(
+    'openapi.json: GatewayQueryError must require error and allow optional code',
+  );
+}
+const errorVariants =
+  spec.components?.schemas?.QueryError?.oneOf?.map((variant) => variant.$ref).sort() ?? [];
+if (
+  errorVariants.join(',') !==
+  [
+    '#/components/schemas/GatewayQueryError',
+    '#/components/schemas/LocalQueryError',
+  ].join(',')
+) {
+  errors.push('openapi.json: QueryError must close over local and gateway errors');
+}
+
+const scalarParameterTypes = spec.components?.schemas?.QueryParameterType?.oneOf?.find(
+  (variant) => Array.isArray(variant.enum),
+)?.enum;
+if (!scalarParameterTypes || scalarParameterTypes.includes('bytes')) {
+  errors.push('openapi.json: the JSON query route must not advertise bytes parameters');
+}
+
 if (errors.length > 0) {
   for (const error of errors) console.error(error);
   process.exit(1);
 }
 
 console.log(
-  `openapi.json matches ${routerOperations.size} HelixDB HTTP server operations.`,
+  `openapi.json matches ${routerOperations.size} local operations and validates the Helix Cloud query contract.`,
 );

--- a/docs/scripts/check-openapi.mjs
+++ b/docs/scripts/check-openapi.mjs
@@ -147,19 +147,19 @@ for (const [status, name] of Object.entries(expectedQueryResponseRefs)) {
 const responseSchemaRef = (name) =>
   spec.components?.responses?.[name]?.content?.['application/json']?.schema?.$ref;
 for (const name of [
+  'BadRequest',
   'Unauthorized',
   'PaymentRequired',
   'Forbidden',
   'RequestTimeout',
+  'Conflict',
+  'PayloadTooLarge',
   'RateLimited',
+  'InternalError',
+  'Unavailable',
 ]) {
-  if (responseSchemaRef(name) !== '#/components/schemas/GatewayQueryError') {
-    errors.push(`openapi.json: ${name} must use GatewayQueryError`);
-  }
-}
-for (const name of ['BadRequest', 'Conflict', 'InternalError', 'Unavailable']) {
   if (responseSchemaRef(name) !== '#/components/schemas/QueryError') {
-    errors.push(`openapi.json: ${name} must allow local and gateway errors`);
+    errors.push(`openapi.json: ${name} must use QueryError`);
   }
 }
 const bodyLimits = queryOperation?.['x-helix-request-body-limits'];
@@ -172,46 +172,24 @@ if (
   );
 }
 const payloadTooLarge = spec.components?.responses?.PayloadTooLarge;
+const payloadTooLargeJson = payloadTooLarge?.content?.['application/json'];
 if (
-  payloadTooLarge?.content?.['text/plain']?.schema?.type !== 'string' ||
-  payloadTooLarge.content['text/plain'].example !==
-    'Failed to buffer the request body: length limit exceeded' ||
-  payloadTooLarge.content?.['application/json']
+  payloadTooLargeJson?.schema?.$ref !== '#/components/schemas/QueryError' ||
+  payloadTooLargeJson?.example?.error !== 'payload_too_large' ||
+  payloadTooLargeJson?.example?.msg !== 'request body exceeds the maximum allowed size' ||
+  payloadTooLarge?.content?.['text/plain']
 ) {
-  errors.push('openapi.json: PayloadTooLarge must match the Axum text response');
+  errors.push('openapi.json: PayloadTooLarge must match the gateway JSON envelope');
 }
 
-const localError = spec.components?.schemas?.LocalQueryError;
+const queryError = spec.components?.schemas?.QueryError;
 if (
-  localError?.additionalProperties !== false ||
-  localError.required?.join(',') !== 'error,msg' ||
-  !localError.properties?.error ||
-  !localError.properties?.msg
+  queryError?.additionalProperties !== false ||
+  queryError.required?.join(',') !== 'error,msg' ||
+  !queryError.properties?.error ||
+  !queryError.properties?.msg
 ) {
-  errors.push('openapi.json: LocalQueryError must require only error and msg');
-}
-const gatewayError = spec.components?.schemas?.GatewayQueryError;
-if (
-  gatewayError?.additionalProperties !== false ||
-  gatewayError.required?.join(',') !== 'error' ||
-  !gatewayError.properties?.error ||
-  !gatewayError.properties?.code ||
-  gatewayError.properties?.msg
-) {
-  errors.push(
-    'openapi.json: GatewayQueryError must require error and allow optional code',
-  );
-}
-const errorVariants =
-  spec.components?.schemas?.QueryError?.oneOf?.map((variant) => variant.$ref).sort() ?? [];
-if (
-  errorVariants.join(',') !==
-  [
-    '#/components/schemas/GatewayQueryError',
-    '#/components/schemas/LocalQueryError',
-  ].join(',')
-) {
-  errors.push('openapi.json: QueryError must close over local and gateway errors');
+  errors.push('openapi.json: QueryError must require only error and msg');
 }
 
 const scalarParameterTypes = spec.components?.schemas?.QueryParameterType?.oneOf?.find(

--- a/docs/scripts/check-openapi.mjs
+++ b/docs/scripts/check-openapi.mjs
@@ -113,6 +113,7 @@ const expectedQueryStatuses = [
   '403',
   '408',
   '409',
+  '413',
   '429',
   '500',
   '503',
@@ -129,6 +130,7 @@ const expectedQueryResponseRefs = {
   403: 'Forbidden',
   408: 'RequestTimeout',
   409: 'Conflict',
+  413: 'PayloadTooLarge',
   429: 'RateLimited',
   500: 'InternalError',
   503: 'Unavailable',
@@ -159,6 +161,24 @@ for (const name of ['BadRequest', 'Conflict', 'InternalError', 'Unavailable']) {
   if (responseSchemaRef(name) !== '#/components/schemas/QueryError') {
     errors.push(`openapi.json: ${name} must allow local and gateway errors`);
   }
+}
+const bodyLimits = queryOperation?.['x-helix-request-body-limits'];
+if (
+  bodyLimits?.localBytes !== 16 * 1024 * 1024 ||
+  bodyLimits?.helixCloudBytes !== 2 * 1024 * 1024
+) {
+  errors.push(
+    'openapi.json: /v2/query must distinguish the 16 MiB local and 2 MiB Cloud body limits',
+  );
+}
+const payloadTooLarge = spec.components?.responses?.PayloadTooLarge;
+if (
+  payloadTooLarge?.content?.['text/plain']?.schema?.type !== 'string' ||
+  payloadTooLarge.content['text/plain'].example !==
+    'Failed to buffer the request body: length limit exceeded' ||
+  payloadTooLarge.content?.['application/json']
+) {
+  errors.push('openapi.json: PayloadTooLarge must match the Axum text response');
 }
 
 const localError = spec.components?.schemas?.LocalQueryError;

--- a/docs/scripts/generate-llms.mjs
+++ b/docs/scripts/generate-llms.mjs
@@ -40,6 +40,15 @@ const QUICKSTART = [
   "Full walkthrough: https://docs.helix-db.com/database/helix-db/start-here/quickstart",
 ].join("\n");
 
+const DEVELOPER_RESOURCES = [
+  "## HelixDB developer resources",
+  "- [HelixDB HTTP API documentation](https://docs.helix-db.com/database/helix-db/query-guides/http-api): Request contract, authentication, headers, responses, and examples for `POST /v2/query`.",
+  "- [HelixDB OpenAPI specification](https://www.helix-db.com/openapi.json): OpenAPI 3.1 JSON for the public HelixDB HTTP API.",
+  "- [HelixDB authentication guide for agents](https://www.helix-db.com/auth.md): Supported API-key and OAuth surfaces, with links to machine-readable discovery metadata.",
+  "- [HelixDB hosted MCP server](https://docs.helix-db.com/database/helix-cloud/connect/mcp): Connect agents to read-only Helix Cloud insights over OAuth.",
+  "- [HelixDB AI Catalog](https://www.helix-db.com/.well-known/ai-catalog.json): ARD catalog of HelixDB agent resources.",
+].join("\n");
+
 const OPTIONAL_PREFIXES = ["change-log/", "benchmarks/"];
 
 function readFrontmatter(slug) {
@@ -148,7 +157,7 @@ function build() {
     if (optSection) sections.push(optSection);
   }
 
-  const lines = [TITLE, "", SUMMARY, "", QUICKSTART, ""];
+  const lines = [TITLE, "", SUMMARY, "", QUICKSTART, "", DEVELOPER_RESOURCES, ""];
   for (const s of sections) {
     lines.push(s, "");
   }


### PR DESCRIPTION
## Summary

- publish an OpenAPI 3.1 contract for the local HelixDB HTTP API and managed Cloud query gateway
- add the HTTP API guide, generated llms resources, and source-parity validation
- model local and Cloud servers, authentication failures, and their shared error/msg envelope
- document the 16 MiB local limit, 2 MiB Cloud limit, and stable JSON payload_too_large response
- remove the unsupported bytes HTTP parameter type

This is documentation and discovery only. It does not change authentication or runtime behavior.

Related website discovery: https://github.com/HelixDB/helix-website/pull/159

## Validation

- npm run generate-llms
- npm run check
- Redocly OpenAPI validation
- Mint broken-link validation
- cargo test -p helix-ast
- cargo clippy --workspace --quiet -- -D warnings
- cargo fmt --all -- --check
- rustfmt --edition 2024 --check crates/ast/src/query.rs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Publishes an OpenAPI 3.1 contract and HTTP API guide for local HelixDB and the managed Cloud gateway, adds generated agent-discovery resources, and introduces source-parity checks.
- Adds request, response, authentication, health, execution-header, and body-limit documentation.
- Adds generated llms indexes and navigation for the new API reference.
- Removes the unsupported bytes parameter type from the JSON API contract.
- Adds a Rust test for published request examples and a Node-based OpenAPI consistency checker.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/openapi.json | Adds the complete public API contract, but its typed numeric parameter schema accepts requests that runtime normalization rejects. |
| docs/scripts/check-openapi.mjs | Adds useful route and contract assertions; it captures the current router but is not enforced by repository CI. |
| docs/package.json | Integrates OpenAPI validation into the local docs check command without adding workflow enforcement. |
| docs/database/helix-db/query-guides/http-api.mdx | Adds the human-readable local and Cloud HTTP API guide, including authentication, limits, headers, and response behavior. |
| crates/ast/src/query.rs | Adds a test proving the two published OpenAPI examples deserialize correctly, but not full schema/runtime parity. |
| docs/scripts/generate-llms.mjs | Adds stable developer-resource links to generated agent documentation. |
| docs/llms.txt | Publishes the generated concise discovery entries for the new HTTP API resources. |
| docs/llms-full.txt | Publishes the generated full-text version of the new API guide. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Source[HelixDB router and AST contracts] --> Check[OpenAPI consistency checks]
  Spec[docs/openapi.json] --> Check
  Spec --> Guide[HTTP API guide]
  Guide --> LLMS[llms.txt and llms-full.txt]
  Spec --> Client[Agents and generated clients]
  Client --> API[POST /v2/query]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Document the Cloud query body limit"](https://github.com/helixdb/helix-db/commit/2998a24e29376bdac63b3cd8d842f74ecf82a922) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56035556)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->