### PR TITLE
docs: correct contributor guide license

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -365,6 +365,6 @@ Format and lint before opening a PR: `cargo fmt` and `./clippy_check.sh`.
 5. Send a query: `helix query dev --file examples/request.json`
 
 ## License
-AGPL (Affero General Public License)
+[Apache License 2.0](LICENSE)
 
 For commercial support: founders@helix-db.com


### PR DESCRIPTION
## Summary
- replace the stale AGPL reference in the contributor guide
- link to the repository Apache License 2.0 text

## Validation
- `git diff --check`
- confirmed the `LICENSE` link target exists

Documentation-only change; no Rust tests were required.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects the contributor guide’s stale AGPL license reference.
- Identifies the repository license as Apache License 2.0.
- Links the license label to the repository’s `LICENSE` file.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CONTRIBUTORS.md | Replaces the incorrect AGPL statement with an accurate link to the Apache License 2.0 text. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: correct contributor guide license"](https://github.com/helixdb/helix-db/commit/07ab700f4d22ef5609d5be8fe31bbc94cbd4a0e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56213175)</sub>

<!-- /greptile_comment -->