### PR TITLE
Treat Cloud warm 204 responses as SDK success

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -308,7 +308,7 @@ func (c *Client) Exec(ctx context.Context, req Request, out any, opts ...ExecOpt
 	if err != nil {
 		return &HelixError{Kind: ErrorNetwork, Err: err, Details: err.Error()}
 	}
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		remoteErr := decodeRemoteError(respBody, resp.Status, resp.StatusCode)
 		if resp.StatusCode == http.StatusConflict {
 			remoteErr.Err = ErrConflict

--- a/sdks/go/dsl_test.go
+++ b/sdks/go/dsl_test.go
@@ -707,6 +707,27 @@ func TestClientExecConflictError(t *testing.T) {
 	}
 }
 
+func TestClientExecWarmNoContentIsSuccess(t *testing.T) {
+	var warmHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		warmHeader = r.Header.Get("x-helix-warm")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out findUsersResponse
+	if err := client.Exec(context.Background(), findUsers("acme", 25), &out, WarmOnly()); err != nil {
+		t.Fatal(err)
+	}
+	if warmHeader != "true" {
+		t.Fatalf("expected warm header, got %q", warmHeader)
+	}
+}
+
 func TestClientExecParsesNewLegacyFutureMissingAndMalformedErrors(t *testing.T) {
 	cases := []struct {
 		body    string

--- a/sdks/python/src/helixdb/async_client.py
+++ b/sdks/python/src/helixdb/async_client.py
@@ -365,7 +365,7 @@ class AsyncQueryExecutionRequest:
         except httpx.RequestError as exc:
             raise HelixError.network(str(exc), cause=exc) from exc
 
-        if status != 200:
+        if status not in {200, 204}:
             raise remote_error(response_body, reason, status_code=status)
         return response_body
 

--- a/sdks/python/src/helixdb/client.py
+++ b/sdks/python/src/helixdb/client.py
@@ -270,7 +270,7 @@ class QueryExecutionRequest:
         except OSError as exc:
             raise HelixError.network(str(exc), cause=exc) from exc
 
-        if status != 200:
+        if status not in {200, 204}:
             raise remote_error(response_body, reason, status_code=status)
         return response_body
 

--- a/sdks/python/tests/test_async_client.py
+++ b/sdks/python/tests/test_async_client.py
@@ -256,6 +256,19 @@ class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(remote.exception.status_code, 503)
         self.assertTrue(error_stream.closed)
 
+    async def test_warm_no_content_is_success(self) -> None:
+        calls: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request)
+            return httpx.Response(204)
+
+        async with AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            result = await client.execute(read_request(), warm_only=True)
+
+        self.assertIsNone(result)
+        self.assertEqual(calls[0].headers["x-helix-warm"], "true")
+
     async def test_cancellation_closes_response_and_client_is_reusable(self) -> None:
         stream = ControlledStream(b'{"blocked":true}', block=True)
         transport = SequencedTransport(stream)

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -278,6 +278,20 @@ class ClientTests(unittest.TestCase):
         self.assertEqual(ctx.exception.details, "conflict")
         self.assertIsNone(ctx.exception.code)
 
+    def test_warm_no_content_is_success(self) -> None:
+        request = QueryRequest.read(read_batch())
+        calls = []
+
+        def fake_urlopen(req):
+            calls.append(req)
+            return FakeResponse(body=b"", status=204, reason="No Content")
+
+        with patch("helixdb.client.urlopen", fake_urlopen):
+            result = Client("http://127.0.0.1:6969").execute(request, warm_only=True)
+
+        self.assertIsNone(result)
+        self.assertEqual(calls[0].headers["X-helix-warm"], "true")
+
     def test_remote_error_parses_new_legacy_future_missing_and_malformed_bodies(self) -> None:
         request = QueryRequest.read(read_batch())
         cases = [

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -626,9 +626,13 @@ pub struct QueryExecutionRequest<'hlx, 'a, R> {
     _phantom: PhantomData<R>,
 }
 
+struct QueryResponse {
+    status: StatusCode,
+    body: Vec<u8>,
+}
+
 impl<'hlx, 'a, R> QueryExecutionRequest<'hlx, 'a, R> {
-    /// Send the request and return the successful response body unchanged.
-    pub async fn send_bytes(self) -> Result<Vec<u8>, HelixError> {
+    async fn execute(self) -> Result<QueryResponse, HelixError> {
         match &self.client.backend {
             ClientBackend::Server(server) => {
                 let mut request = server.client.post(server.url.clone());
@@ -640,11 +644,10 @@ impl<'hlx, 'a, R> QueryExecutionRequest<'hlx, 'a, R> {
                 }
                 let response = request.body(sonic_rs::to_vec(&self.query)?).send().await?;
                 match response.status() {
-                    StatusCode::OK | StatusCode::NO_CONTENT => response
-                        .bytes()
-                        .await
-                        .map(|bytes| bytes.to_vec())
-                        .map_err(Into::into),
+                    status @ (StatusCode::OK | StatusCode::NO_CONTENT) => {
+                        let body = response.bytes().await?.to_vec();
+                        Ok(QueryResponse { status, body })
+                    }
                     code => Err(remote_error(
                         code,
                         response.text().await.unwrap_or_default(),
@@ -659,9 +662,20 @@ impl<'hlx, 'a, R> QueryExecutionRequest<'hlx, 'a, R> {
                     });
                 }
                 let request = sonic_rs::to_vec(&self.query)?;
-                db.query_json(&request).await.map_err(embedded_error)
+                db.query_json(&request)
+                    .await
+                    .map(|body| QueryResponse {
+                        status: StatusCode::OK,
+                        body,
+                    })
+                    .map_err(embedded_error)
             }
         }
+    }
+
+    /// Send the request and return the successful response body unchanged.
+    pub async fn send_bytes(self) -> Result<Vec<u8>, HelixError> {
+        self.execute().await.map(|response| response.body)
     }
 }
 
@@ -698,11 +712,11 @@ impl<'hlx, 'a, R: for<'de> Deserialize<'de>> QueryExecutionRequest<'hlx, 'a, R> 
     /// # }
     /// ```
     pub async fn send(self) -> Result<R, HelixError> {
-        let response = self.send_bytes().await?;
-        if response.is_empty() {
+        let response = self.execute().await?;
+        if response.status == StatusCode::NO_CONTENT {
             sonic_rs::from_slice::<R>(b"null").map_err(Into::into)
         } else {
-            sonic_rs::from_slice::<R>(&response).map_err(Into::into)
+            sonic_rs::from_slice::<R>(&response.body).map_err(Into::into)
         }
     }
 }
@@ -1456,6 +1470,19 @@ mod client_tests {
             .send()
             .await
             .unwrap();
+        assert_eq!(handle.await.unwrap(), "/v2/query");
+    }
+
+    #[tokio::test]
+    async fn empty_ok_response_is_a_serialization_error() {
+        let (base, handle) = spawn_capture_server(200, "").await;
+        let client = Client::new(Some(&base)).unwrap();
+        let error = client
+            .query::<()>(sample_request())
+            .send()
+            .await
+            .expect_err("an empty 200 response must not decode as JSON null");
+        assert!(matches!(error, HelixError::SerializationError(_)));
         assert_eq!(handle.await.unwrap(), "/v2/query");
     }
 

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -170,7 +170,8 @@ impl fmt::Debug for Client {
 /// Backwards-compatible alias for [`Client`].
 pub type HelixDBClient = Client;
 
-/// Metadata returned when the server responds with a non-`200` HTTP status.
+/// Metadata returned when the server responds with a status other than `200`
+/// or the Cloud warm-success status `204`.
 #[derive(Debug)]
 pub struct RemoteError {
     status_code: u16,
@@ -230,7 +231,7 @@ pub enum HelixError {
     /// timeout, TLS error, …), surfaced from [`reqwest`].
     #[error("Error communicating with server: {0}")]
     ReqwestError(#[from] reqwest::Error),
-    /// The server responded with a non-`200` status.
+    /// The server responded with a status other than `200` or `204`.
     #[error("Got Error from server: {0}")]
     RemoteError(Box<RemoteError>),
     /// Failed to (de)serialize a request body or response payload.
@@ -639,7 +640,7 @@ impl<'hlx, 'a, R> QueryExecutionRequest<'hlx, 'a, R> {
                 }
                 let response = request.body(sonic_rs::to_vec(&self.query)?).send().await?;
                 match response.status() {
-                    StatusCode::OK => response
+                    StatusCode::OK | StatusCode::NO_CONTENT => response
                         .bytes()
                         .await
                         .map(|bytes| bytes.to_vec())
@@ -673,8 +674,9 @@ impl<'hlx, 'a, R: for<'de> Deserialize<'de>> QueryExecutionRequest<'hlx, 'a, R> 
     /// # Errors
     ///
     /// - [`HelixError::ReqwestError`] for transport failures.
-    /// - [`HelixError::RemoteError`] for any non-`200` response (carrying the
-    ///   server's body or status reason).
+    /// - [`HelixError::RemoteError`] for any response other than `200` or the
+    ///   Cloud warm-success status `204` (carrying the server's body or status
+    ///   reason).
     /// - [`HelixError::SerializationError`] if the request payload cannot be
     ///   serialized or the response body cannot be deserialized into `R`.
     ///
@@ -697,7 +699,11 @@ impl<'hlx, 'a, R: for<'de> Deserialize<'de>> QueryExecutionRequest<'hlx, 'a, R> 
     /// ```
     pub async fn send(self) -> Result<R, HelixError> {
         let response = self.send_bytes().await?;
-        sonic_rs::from_slice::<R>(&response).map_err(Into::into)
+        if response.is_empty() {
+            sonic_rs::from_slice::<R>(b"null").map_err(Into::into)
+        } else {
+            sonic_rs::from_slice::<R>(&response).map_err(Into::into)
+        }
     }
 }
 
@@ -1436,6 +1442,20 @@ mod client_tests {
         let (base, handle) = spawn_capture_server(200, "{}").await;
         let client = Client::new(Some(&base)).unwrap();
         let _: EmptyResp = client.query(sample_request()).send().await.unwrap();
+        assert_eq!(handle.await.unwrap(), "/v2/query");
+    }
+
+    #[tokio::test]
+    async fn warm_no_content_is_success() {
+        let (base, handle) = spawn_capture_server(204, "").await;
+        let client = Client::new(Some(&base)).unwrap();
+        client
+            .request_builder::<()>()
+            .warm_only()
+            .query(sample_request())
+            .send()
+            .await
+            .unwrap();
         assert_eq!(handle.await.unwrap(), "/v2/query");
     }
 

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -19,7 +19,8 @@ const QUERY_PATH = "/v2/query";
  *
  * Strict port of the Rust `HelixError` enum:
  * - `Network` ↔ `ReqwestError` (the request failed to reach the server)
- * - `Remote` ↔ `RemoteError` (the server returned a non-200 response)
+ * - `Remote` ↔ `RemoteError` (the server returned neither query success `200`
+ *   nor Cloud warm success `204`)
  * - `Serialization` ↔ `SerializationError` (request/response (de)serialization failed)
  * - `InvalidUrl` ↔ `InvalidURL` (the client URL could not be parsed)
  * - `InvalidRequest` ↔ `InvalidRequest` (server-only options were used in embedded mode)
@@ -403,8 +404,7 @@ export class QueryExecutionRequest<R = unknown> {
       throw HelixError.network(error instanceof Error ? error.message : String(error), url);
     }
 
-    // Mirror the Rust client: only HTTP 200 is treated as success.
-    if (response.status === 200) {
+    if (response.status === 200 || response.status === 204) {
       return new Uint8Array(await response.arrayBuffer());
     }
 
@@ -419,6 +419,7 @@ export class QueryExecutionRequest<R = unknown> {
 
   async send(): Promise<R> {
     const response = await this.sendBytes();
+    if (response.byteLength === 0) return undefined as R;
     try {
       return parseJson(new TextDecoder().decode(response)) as R;
     } catch (error) {

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -160,6 +160,11 @@ interface RequestParts {
   query: QueryRequest;
 }
 
+interface QueryResponse {
+  status: number;
+  body: Uint8Array;
+}
+
 export type HelixDbSource =
   | { kind: "inMemory"; database: string }
   | { kind: "disk"; root: string; database: string }
@@ -370,7 +375,7 @@ export class QueryBuilder<R = unknown> {
 export class QueryExecutionRequest<R = unknown> {
   constructor(private readonly parts: RequestParts) {}
 
-  async sendBytes(): Promise<Uint8Array> {
+  private async execute(): Promise<QueryResponse> {
     const { backend, headers, query } = this.parts;
 
     if (backend.kind === "embedded") {
@@ -384,7 +389,7 @@ export class QueryExecutionRequest<R = unknown> {
       } catch (error) {
         throw embeddedError(error);
       }
-      return response;
+      return { status: 200, body: response };
     }
 
     let url: string;
@@ -405,7 +410,7 @@ export class QueryExecutionRequest<R = unknown> {
     }
 
     if (response.status === 200 || response.status === 204) {
-      return new Uint8Array(await response.arrayBuffer());
+      return { status: response.status, body: new Uint8Array(await response.arrayBuffer()) };
     }
 
     let body: string;
@@ -417,11 +422,15 @@ export class QueryExecutionRequest<R = unknown> {
     throw remoteError(body, response.statusText || `unknown error with code: ${response.status}`, response.status);
   }
 
+  async sendBytes(): Promise<Uint8Array> {
+    return (await this.execute()).body;
+  }
+
   async send(): Promise<R> {
-    const response = await this.sendBytes();
-    if (response.byteLength === 0) return undefined as R;
+    const response = await this.execute();
+    if (response.status === 204) return undefined as R;
     try {
-      return parseJson(new TextDecoder().decode(response)) as R;
+      return parseJson(new TextDecoder().decode(response.body)) as R;
     } catch (error) {
       throw HelixError.serialization(error instanceof Error ? error.message : String(error));
     }

--- a/sdks/typescript/test/client.test.ts
+++ b/sdks/typescript/test/client.test.ts
@@ -237,6 +237,19 @@ assert.throws(
   assert.equal(result, undefined);
 }
 
+// ---- Empty HTTP 200 still fails response deserialization -------------------
+
+{
+  const server = await spawnCaptureServer({ status: 200, body: "" });
+  const client = new Client(server.base);
+
+  await assert.rejects(
+    client.query(sampleRequest()).send(),
+    (error: unknown) => error instanceof HelixError && error.kind === "Serialization",
+  );
+  await server.close();
+}
+
 // ---- Other non-success responses surface a remote error --------------------
 
 {

--- a/sdks/typescript/test/client.test.ts
+++ b/sdks/typescript/test/client.test.ts
@@ -223,7 +223,21 @@ assert.throws(
   assert.deepEqual(result, { ok: true });
 }
 
-// ---- Non-200 response surfaces a remote error -------------------------------
+// ---- Cloud warm 204 is a successful empty response -------------------------
+
+{
+  const server = await spawnCaptureServer({ status: 204, body: "" });
+  const client = new Client(server.base);
+  const result = await client.requestBuilder<void>().warmOnly().query(sampleRequest()).send();
+
+  const req = await server.captured;
+  await server.close();
+
+  assert.equal(req.headers["x-helix-warm"], "true");
+  assert.equal(result, undefined);
+}
+
+// ---- Other non-success responses surface a remote error --------------------
 
 {
   const body = '{"error":"write conflict","code":"write_conflict","details":{"retryable":true}}';


### PR DESCRIPTION
## Summary

- accept HTTP 204 No Content as a successful query response in the Rust, TypeScript, Python sync/async, and Go SDK transports
- map the empty response to unit/undefined/None/no decode as appropriate
- preserve the existing structured remote-error behavior for every other non-success status
- add focused warm-request coverage in all four SDKs

## Validation

- cargo test --manifest-path sdks/rust/Cargo.toml --lib
- cargo fmt --manifest-path sdks/rust/Cargo.toml -- --check
- cargo clippy --manifest-path sdks/rust/Cargo.toml --lib --tests -- -D warnings
- npm run check in sdks/typescript
- Python unittest suite: 48 passed
- targeted Ruff check and format check for changed Python files
- go test ./... and go vet ./... in sdks/go



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Rust, TypeScript, Python, and Go SDK transports to accept Cloud warm HTTP 204 responses as successful empty results. The TypeScript fix preserves response status correctly, but the Rust implementation also converts malformed empty HTTP 200 responses into successful null-like values.
- Accepts HTTP 204 across all four SDK transports while retaining remote errors for other statuses.
- Adds focused warm-request tests for each SDK.
- Preserves the 200-versus-204 distinction in TypeScript, but loses it before Rust response deserialization.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdks/rust/src/lib.rs | Accepts HTTP 204, but body-only status handling causes empty HTTP 200 responses to deserialize successfully for null-accepting result types. |
| sdks/typescript/src/index.ts | Preserves status through execution and skips JSON parsing only for HTTP 204, correcting the previously reported empty-200 regression. |
| sdks/python/src/helixdb/client.py | Adds synchronous HTTP 204 acceptance and maps the empty response through the SDK's established `None` behavior. |
| sdks/python/src/helixdb/async_client.py | Mirrors the synchronous transport's HTTP 204 handling for asynchronous requests. |
| sdks/go/client.go | Accepts HTTP 204 while the existing empty-body guard safely skips output decoding. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Preserve validation for empty query resp..."](https://github.com/helixdb/helix-db/commit/0494f804cd7dd6492bbe3af3f6500a8173bba04c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56247345)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->