### PR TITLE
Clarify Cloud HTTP gateway contracts

### DIFF
--- a/docs/cli/workflows/helix_cloud.mdx
+++ b/docs/cli/workflows/helix_cloud.mdx
@@ -67,7 +67,7 @@ The CLI handles authentication, workspace/project/cluster selection, metadata sy
     helix sync production
     ```
 
-    `helix sync` writes the latest `gateway_url`, `query_auth_header`, `query_auth_env`, and node-type values from the cloud into `[enterprise.production]` in `helix.toml`. Re-run after any cluster change.
+    `helix sync` writes the latest `gateway_url`, `query_auth_header`, `query_auth_env`, `query_auth_scheme`, and node-type values from the cloud into `[enterprise.production]` in `helix.toml`. Re-run after any cluster change.
 
     If the cluster has not published a `gateway_url` yet, the CLI prints a warning. Set `gateway_url` manually under `[enterprise.production]` once you know it, or re-run `helix sync` later.
   </Step>

--- a/docs/database/helix-cloud/operate/error-handling.mdx
+++ b/docs/database/helix-cloud/operate/error-handling.mdx
@@ -58,6 +58,10 @@ response body separately.
 | Python     | `HelixError.status_code`    | `HelixError.code`           | `HelixError.details`           | Not exposed separately            |
 | Go         | `HelixError.StatusCode`     | `HelixError.Code`           | `HelixError.Details`           | Not exposed separately            |
 
+The current SDK error objects do not expose response headers, including
+`Retry-After`. Use direct HTTP or an application transport that retains headers
+when the exact Cloud rate-limit delay is required.
+
 Branch on the stable code while retaining the diagnostic:
 
 <CodeGroup>

--- a/docs/database/helix-cloud/operate/limits.mdx
+++ b/docs/database/helix-cloud/operate/limits.mdx
@@ -62,6 +62,11 @@ retrying, and add jitter when many workers share the same database. The response
 does not currently include `RateLimit-*` or `X-RateLimit-*` limit, remaining, or
 reset headers.
 
+Current official SDK error objects expose the HTTP status, stable code, and
+diagnostic, but not response headers. Use direct HTTP or an application
+transport that retains headers when the exact `Retry-After` value is required;
+otherwise use a configured, bounded status/code-aware delay with jitter.
+
 If the gateway cannot make a safe distributed rate-limit decision, it fails
 closed before database execution:
 

--- a/docs/database/helix-cloud/start-here/using-the-cloud.mdx
+++ b/docs/database/helix-cloud/start-here/using-the-cloud.mdx
@@ -67,7 +67,7 @@ export HELIX_API_KEY="<api-key>"
 curl --fail-with-body \
   "$HELIX_ENDPOINT/v2/query" \
   --header "Authorization: Bearer $HELIX_API_KEY" \
-  --header "x-helix-tenant-id: $HELIX_DATABASE_ID" \
+  --header "X-Helix-Database-Id: $HELIX_DATABASE_ID" \
   --header "Content-Type: application/json" \
   --data '{
     "request_type": "read",

--- a/docs/database/helix-cloud/start-here/working-with-enterprise.mdx
+++ b/docs/database/helix-cloud/start-here/working-with-enterprise.mdx
@@ -57,6 +57,13 @@ client = Client(
 
 </CodeGroup>
 
+These SDK examples target a database-specific cluster-mode gateway URL. Such an
+endpoint authenticates the API key but rejects `X-Helix-Database-Id` and
+`X-Helix-Tenant-Id`. A GA shared gateway instead requires
+`X-Helix-Database-Id`; the current public SDK request builders do not expose
+that selection header, so use the direct HTTP contract for GA shared-gateway
+requests.
+
 Each client sends the same operation-tree request body:
 
 ```json JSON

--- a/docs/database/helix-db/query-guides/http-api.mdx
+++ b/docs/database/helix-db/query-guides/http-api.mdx
@@ -47,13 +47,23 @@ client must work against both environments.
 
 ## Authentication
 
-Local servers do not require authentication by default. Helix Cloud requires a
-cluster API key and database ID:
+Local servers do not require authentication by default. A Helix Cloud GA shared
+gateway requires a cluster API key and database ID:
 
 ```http
 Authorization: Bearer <cluster-api-key>
 X-Helix-Database-Id: <database-id>
 ```
+
+`X-Helix-Tenant-Id` remains a legacy alias in GA mode. Database-specific
+cluster-mode gateway URLs require the API key but reject both database and
+tenant selection headers. Use the endpoint mode shown in the dashboard or
+written by `helix sync`; do not copy headers between the two modes.
+
+The current public SDK request builders set bearer authentication and execution
+headers but do not expose the GA database-selection header. Use them with a
+database-specific cluster gateway URL, or use direct HTTP for a GA shared
+gateway.
 
 Create or rotate the cluster key in the Helix Cloud dashboard. Do not put keys
 in source control, agent instructions, `llms.txt`, or catalog manifests.
@@ -130,7 +140,8 @@ durability waits on reads are rejected with `400 Bad Request`.
   exhausted.
 - `403` reports that the Helix Cloud API key lacks permission for the query.
 - `408` reports that a Helix Cloud query exceeded its wall-clock limit.
-- `409` reports a transaction conflict that can be retried.
+- `409` reports a transaction conflict. Retry the whole transaction only when
+  it is idempotent or protected by an application idempotency key.
 - `413` reports that a Helix Cloud request body exceeded 2 MiB. The gateway
   rejects it before query parsing.
 - `429` reports a Helix Cloud rate limit and can include `Retry-After`.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3955,13 +3955,23 @@ client must work against both environments.
 
 ## Authentication
 
-Local servers do not require authentication by default. Helix Cloud requires a
-cluster API key and database ID:
+Local servers do not require authentication by default. A Helix Cloud GA shared
+gateway requires a cluster API key and database ID:
 
 ```http
 Authorization: Bearer <cluster-api-key>
 X-Helix-Database-Id: <database-id>
 ```
+
+`X-Helix-Tenant-Id` remains a legacy alias in GA mode. Database-specific
+cluster-mode gateway URLs require the API key but reject both database and
+tenant selection headers. Use the endpoint mode shown in the dashboard or
+written by `helix sync`; do not copy headers between the two modes.
+
+The current public SDK request builders set bearer authentication and execution
+headers but do not expose the GA database-selection header. Use them with a
+database-specific cluster gateway URL, or use direct HTTP for a GA shared
+gateway.
 
 Create or rotate the cluster key in the Helix Cloud dashboard. Do not put keys
 in source control, agent instructions, `llms.txt`, or catalog manifests.
@@ -4038,7 +4048,8 @@ durability waits on reads are rejected with `400 Bad Request`.
   exhausted.
 - `403` reports that the Helix Cloud API key lacks permission for the query.
 - `408` reports that a Helix Cloud query exceeded its wall-clock limit.
-- `409` reports a transaction conflict that can be retried.
+- `409` reports a transaction conflict. Retry the whole transaction only when
+  it is idempotent or protected by an application idempotency key.
 - `413` reports that a Helix Cloud request body exceeded 2 MiB. The gateway
   rejects it before query parsing.
 - `429` reports a Helix Cloud rate limit and can include `Retry-After`.
@@ -4373,6 +4384,13 @@ client = Client(
 )
 ```
 
+These SDK examples target a database-specific cluster-mode gateway URL. Such an
+endpoint authenticates the API key but rejects `X-Helix-Database-Id` and
+`X-Helix-Tenant-Id`. A GA shared gateway instead requires
+`X-Helix-Database-Id`; the current public SDK request builders do not expose
+that selection header, so use the direct HTTP contract for GA shared-gateway
+requests.
+
 Each client sends the same operation-tree request body:
 
 ```json JSON
@@ -4509,7 +4527,7 @@ export HELIX_API_KEY="<api-key>"
 curl --fail-with-body \
   "$HELIX_ENDPOINT/v2/query" \
   --header "Authorization: Bearer $HELIX_API_KEY" \
-  --header "x-helix-tenant-id: $HELIX_DATABASE_ID" \
+  --header "X-Helix-Database-Id: $HELIX_DATABASE_ID" \
   --header "Content-Type: application/json" \
   --data '{
     "request_type": "read",
@@ -5382,6 +5400,11 @@ retrying, and add jitter when many workers share the same database. The response
 does not currently include `RateLimit-*` or `X-RateLimit-*` limit, remaining, or
 reset headers.
 
+Current official SDK error objects expose the HTTP status, stable code, and
+diagnostic, but not response headers. Use direct HTTP or an application
+transport that retains headers when the exact `Retry-After` value is required;
+otherwise use a configured, bounded status/code-aware delay with jitter.
+
 If the gateway cannot make a safe distributed rate-limit decision, it fails
 closed before database execution:
 
@@ -5532,6 +5555,10 @@ response body separately.
 | TypeScript | `HelixError.statusCode`     | `HelixError.code`           | `HelixError.serverMessage`     | `HelixError.rawBody`              |
 | Python     | `HelixError.status_code`    | `HelixError.code`           | `HelixError.details`           | Not exposed separately            |
 | Go         | `HelixError.StatusCode`     | `HelixError.Code`           | `HelixError.Details`           | Not exposed separately            |
+
+The current SDK error objects do not expose response headers, including
+`Retry-After`. Use direct HTTP or an application transport that retains headers
+when the exact Cloud rate-limit delay is required.
 
 Branch on the stable code while retaining the diagnostic:
 
@@ -6047,7 +6074,7 @@ The CLI handles authentication, workspace/project/cluster selection, metadata sy
     helix sync production
     ```
 
-    `helix sync` writes the latest `gateway_url`, `query_auth_header`, `query_auth_env`, and node-type values from the cloud into `[enterprise.production]` in `helix.toml`. Re-run after any cluster change.
+    `helix sync` writes the latest `gateway_url`, `query_auth_header`, `query_auth_env`, `query_auth_scheme`, and node-type values from the cloud into `[enterprise.production]` in `helix.toml`. Re-run after any cluster change.
 
     If the cluster has not published a `gateway_url` yet, the CLI prints a warning. Set `gateway_url` manually under `[enterprise.production]` once you know it, or re-run `helix sync` later.
   </Step>

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -291,7 +291,7 @@
         "name": "X-Helix-Database-Id",
         "in": "header",
         "required": false,
-        "description": "Database identifier shown in Helix Cloud connection details. It is not needed by a standalone local server.",
+        "description": "Database identifier shown in Helix Cloud connection details. Required by the GA shared gateway, not needed by a standalone local server, and not allowed by a database-specific cluster-mode gateway. The legacy X-Helix-Tenant-Id alias is also accepted in GA mode.",
         "schema": {
           "type": "string",
           "minLength": 1


### PR DESCRIPTION
## Summary

- use X-Helix-Database-Id consistently as the preferred GA database-selection header while documenting the legacy alias
- distinguish GA shared gateways from database-specific cluster-mode gateways
- document the current public SDK database-header and Retry-After limitations
- qualify transaction-conflict retries as whole idempotent transactions
- include query_auth_scheme in the helix sync workflow field list
- update the OpenAPI description and regenerate llms-full.txt

## Validation

- npm run check in docs
  - validated 63 navigable pages, 49 redirects, 11 cross-SDK guides, and all JSON examples
  - generated llms files are current
  - openapi.json matches the local operations and Cloud query assertions

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR clarifies the HTTP contracts for GA shared gateways and database-specific cluster gateways and aligns generated reference material with those distinctions.
- Standardizes examples on `X-Helix-Database-Id` while documenting the legacy tenant-header alias.
- Documents public SDK limitations around database selection and response headers.
- Refines transaction-conflict retry guidance and the `helix sync` field list.
- Updates OpenAPI prose and regenerates `llms-full.txt`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/database/helix-db/query-guides/http-api.mdx | Accurately distinguishes shared- and cluster-gateway authentication contracts and qualifies conflict retries. |
| docs/database/helix-cloud/start-here/using-the-cloud.mdx | Replaces the legacy tenant-selection header with the preferred GA database-selection header. |
| docs/database/helix-cloud/start-here/working-with-enterprise.mdx | Correctly limits current SDK examples to database-specific cluster gateways. |
| docs/database/helix-cloud/operate/error-handling.mdx | Correctly documents that current SDK error objects do not retain response headers. |
| docs/database/helix-cloud/operate/limits.mdx | Adds accurate fallback guidance for clients unable to inspect `Retry-After`. |
| docs/cli/workflows/helix_cloud.mdx | Adds `query_auth_scheme` to the synchronized metadata list consistently with CLI behavior and tests. |
| docs/openapi.json | Clarifies the database-header requirements for each Cloud gateway mode. |
| docs/llms-full.txt | Regenerates the consolidated documentation to mirror the source-page changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Clarify Cloud HTTP gateway contracts"](https://github.com/helixdb/helix-db/commit/717a651cbe6882c87a28aefeed428cc3ff6fe78f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56247939)</sub>

<!-- /greptile_comment -->