### PR TITLE
fix(rust-sdk): align #[query] examples with Result contract

### DIFF
--- a/.github/workflows/sdk-query-parity.yml
+++ b/.github/workflows/sdk-query-parity.yml
@@ -93,9 +93,13 @@ jobs:
           raise SystemExit(doctest.testmod(module).failed)'
       - run: go test ./...
         working-directory: sdks/go
-      - run: cargo test --locked --manifest-path sdks/rust/Cargo.toml --lib --doc
-      - name: Compile-test #[query] end-to-end example
-        run: cargo check --locked --manifest-path sdks/rust/Cargo.toml --example basic_query
+      - run: cargo test --locked --manifest-path sdks/rust/Cargo.toml --lib
+      - run: cargo test --locked --manifest-path sdks/rust/Cargo.toml --doc
+      - name: Compile-test public #[query] README examples
+        run: |
+          cargo check --locked --manifest-path sdks/rust/Cargo.toml --example basic_query
+          cargo check --locked --manifest-path sdks/rust/Cargo.toml --example readme_sdk_query
+          cargo check --locked --manifest-path sdks/rust/Cargo.toml --example readme_macros_query
       - run: cargo test --locked -p helixdb-uniffi
 
   embedded-go-generator:

--- a/.github/workflows/sdk-query-parity.yml
+++ b/.github/workflows/sdk-query-parity.yml
@@ -4,21 +4,29 @@ on:
   pull_request:
     paths:
       - ".github/workflows/sdk-query-parity.yml"
+      - "README.md"
       - "bindings/uniffi/**"
       - "bindings/uniffi-bindgen/**"
       - "crates/ast/**"
       - "crates/db/**"
       - "crates/server/**"
+      - "docs/database/helix-db/start-here/sdk-setup/rust-project-setup.mdx"
+      - "docs/database/helix-db/core-concepts/overview.mdx"
+      - "docs/database/helix-db/query-guides/parameters.mdx"
       - "sdks/**"
   push:
     branches: [main]
     paths:
       - ".github/workflows/sdk-query-parity.yml"
+      - "README.md"
       - "bindings/uniffi/**"
       - "bindings/uniffi-bindgen/**"
       - "crates/ast/**"
       - "crates/db/**"
       - "crates/server/**"
+      - "docs/database/helix-db/start-here/sdk-setup/rust-project-setup.mdx"
+      - "docs/database/helix-db/core-concepts/overview.mdx"
+      - "docs/database/helix-db/query-guides/parameters.mdx"
       - "sdks/**"
 
 permissions:
@@ -85,7 +93,9 @@ jobs:
           raise SystemExit(doctest.testmod(module).failed)'
       - run: go test ./...
         working-directory: sdks/go
-      - run: cargo test --locked --manifest-path sdks/rust/Cargo.toml --lib
+      - run: cargo test --locked --manifest-path sdks/rust/Cargo.toml --lib --doc
+      - name: Compile-test #[query] end-to-end example
+        run: cargo check --locked --manifest-path sdks/rust/Cargo.toml --example basic_query
       - run: cargo test --locked -p helixdb-uniffi
 
   embedded-go-generator:

--- a/README.md
+++ b/README.md
@@ -116,24 +116,23 @@ pub fn get_user(name: String) -> ReadBatch {
 }
 
 #[tokio::main]
-async fn main() {
-    let client = Client::new(None).unwrap(); // defaults to http://localhost:6969
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new(None)?; // defaults to http://localhost:6969
 
-    // add user
+    // add user — #[query] helpers return Result<QueryRequest, QueryError>
     let new_user: sonic_rs::Value = client
-        .query(add_user("John Doe".to_string()))
+        .query(add_user("John Doe".to_string())?)
         .send()
-        .await
-        .unwrap();
-    println!("new user: {:#}", sonic_rs::to_string_pretty(&new_user).unwrap());
+        .await?;
+    println!("new user: {:#}", sonic_rs::to_string_pretty(&new_user)?);
 
     // get user
     let user: sonic_rs::Value = client
-        .query(get_user("John Doe".to_string()))
+        .query(get_user("John Doe".to_string())?)
         .send()
-        .await
-        .unwrap();
-    println!("user: {:#}", sonic_rs::to_string_pretty(&user).unwrap());
+        .await?;
+    println!("user: {:#}", sonic_rs::to_string_pretty(&user)?);
+    Ok(())
 }
 ```
 

--- a/docs/database/helix-db/core-concepts/overview.mdx
+++ b/docs/database/helix-db/core-concepts/overview.mdx
@@ -510,7 +510,7 @@ execute; they are simply not serialized back to the client.
 <CodeGroup>
 
 ```rust Rust
-let request = write_users();
+let request = write_users()?;
 ```
 
 ```ts TypeScript
@@ -533,9 +533,10 @@ request = query.to_query_request(query_name="write_users")
 
 </CodeGroup>
 
-Rust's `#[query]` macro rewrites the function to return a request and sets `query_name`
-from the function name. TypeScript and Python convert a batch with `toQueryRequest` /
-`to_query_request`, and Go's `WriteQuery(name)` took the name up front.
+Rust's `#[query]` macro rewrites the function to return
+`Result<QueryRequest, QueryError>` and sets `query_name` from the function name.
+TypeScript and Python convert a batch with `toQueryRequest` / `to_query_request`,
+and Go's `WriteQuery(name)` took the name up front.
 
 `query_name` is optional diagnostic metadata for gateway logs and query diagnostics. It
 does not create a stored endpoint or deploy anything; a missing or `null` name is

--- a/docs/database/helix-db/query-guides/parameters.mdx
+++ b/docs/database/helix-db/query-guides/parameters.mdx
@@ -32,7 +32,7 @@ fn find_users(tenant_id: String, limit: i64) -> ReadBatch {
         .returning(["users"])
 }
 
-let request = find_users("acme".to_string(), 25);
+let request = find_users("acme".to_string(), 25)?;
 ```
 
 ```ts TypeScript

--- a/docs/database/helix-db/start-here/sdk-setup/rust-project-setup.mdx
+++ b/docs/database/helix-db/start-here/sdk-setup/rust-project-setup.mdx
@@ -91,12 +91,15 @@ for storage, cache, and handle configuration.
 
 ## Verify
 
-Rust SDK crate docs are doctests, and the public `#[query]` journey is
-compile-tested as `examples/basic_query.rs`:
+Rust SDK crate docs are doctests, and the public `#[query]` README journeys are
+compile-tested as examples:
 
 ```bash
-cargo test --manifest-path sdks/rust/Cargo.toml --lib --doc
+cargo test --manifest-path sdks/rust/Cargo.toml --lib
+cargo test --manifest-path sdks/rust/Cargo.toml --doc
 cargo check --manifest-path sdks/rust/Cargo.toml --example basic_query
+cargo check --manifest-path sdks/rust/Cargo.toml --example readme_sdk_query
+cargo check --manifest-path sdks/rust/Cargo.toml --example readme_macros_query
 ```
 
 ## Next steps

--- a/docs/database/helix-db/start-here/sdk-setup/rust-project-setup.mdx
+++ b/docs/database/helix-db/start-here/sdk-setup/rust-project-setup.mdx
@@ -51,8 +51,8 @@ fn find_users(tenant_id: String, limit: i64) -> ReadBatch {
 }
 ```
 
-`#[query]` converts typed arguments into request parameters and sets `query_name` to
-the function name.
+`#[query]` converts typed arguments into request parameters, sets `query_name` to
+the function name, and returns `Result<QueryRequest, QueryError>`.
 
 ## Execute
 
@@ -60,7 +60,7 @@ the function name.
 use helix_db::Client;
 
 let client = Client::new(Some("http://localhost:6969"))?;
-let request = find_users("acme".to_string(), 25);
+let request = find_users("acme".to_string(), 25)?;
 let response: serde_json::Value = client.query(request).send().await?;
 ```
 
@@ -91,10 +91,12 @@ for storage, cache, and handle configuration.
 
 ## Verify
 
-Rust SDK documentation examples are doctests:
+Rust SDK crate docs are doctests, and the public `#[query]` journey is
+compile-tested as `examples/basic_query.rs`:
 
 ```bash
-cargo test --manifest-path sdks/rust/Cargo.toml --doc
+cargo test --manifest-path sdks/rust/Cargo.toml --lib --doc
+cargo check --manifest-path sdks/rust/Cargo.toml --example basic_query
 ```
 
 ## Next steps

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -748,8 +748,8 @@ fn find_users(tenant_id: String, limit: i64) -> ReadBatch {
 }
 ```
 
-`#[query]` converts typed arguments into request parameters and sets `query_name` to
-the function name.
+`#[query]` converts typed arguments into request parameters, sets `query_name` to
+the function name, and returns `Result<QueryRequest, QueryError>`.
 
 ## Execute
 
@@ -757,7 +757,7 @@ the function name.
 use helix_db::Client;
 
 let client = Client::new(Some("http://localhost:6969"))?;
-let request = find_users("acme".to_string(), 25);
+let request = find_users("acme".to_string(), 25)?;
 let response: serde_json::Value = client.query(request).send().await?;
 ```
 
@@ -788,10 +788,12 @@ for storage, cache, and handle configuration.
 
 ## Verify
 
-Rust SDK documentation examples are doctests:
+Rust SDK crate docs are doctests, and the public `#[query]` journey is
+compile-tested as `examples/basic_query.rs`:
 
 ```bash
-cargo test --manifest-path sdks/rust/Cargo.toml --doc
+cargo test --manifest-path sdks/rust/Cargo.toml --lib --doc
+cargo check --manifest-path sdks/rust/Cargo.toml --example basic_query
 ```
 
 ## Next steps
@@ -1818,7 +1820,7 @@ execute; they are simply not serialized back to the client.
 ## 6. Name the request
 
 ```rust Rust
-let request = write_users();
+let request = write_users()?;
 ```
 
 ```ts TypeScript
@@ -1839,9 +1841,10 @@ request = query.to_query_request(query_name="write_users")
 }
 ```
 
-Rust's `#[query]` macro rewrites the function to return a request and sets `query_name`
-from the function name. TypeScript and Python convert a batch with `toQueryRequest` /
-`to_query_request`, and Go's `WriteQuery(name)` took the name up front.
+Rust's `#[query]` macro rewrites the function to return
+`Result<QueryRequest, QueryError>` and sets `query_name` from the function name.
+TypeScript and Python convert a batch with `toQueryRequest` / `to_query_request`,
+and Go's `WriteQuery(name)` took the name up front.
 
 `query_name` is optional diagnostic metadata for gateway logs and query diagnostics. It
 does not create a stored endpoint or deploy anything; a missing or `null` name is
@@ -3757,7 +3760,7 @@ fn find_users(tenant_id: String, limit: i64) -> ReadBatch {
         .returning(["users"])
 }
 
-let request = find_users("acme".to_string(), 25);
+let request = find_users("acme".to_string(), 25)?;
 ```
 
 ```ts TypeScript

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -788,12 +788,15 @@ for storage, cache, and handle configuration.
 
 ## Verify
 
-Rust SDK crate docs are doctests, and the public `#[query]` journey is
-compile-tested as `examples/basic_query.rs`:
+Rust SDK crate docs are doctests, and the public `#[query]` README journeys are
+compile-tested as examples:
 
 ```bash
-cargo test --manifest-path sdks/rust/Cargo.toml --lib --doc
+cargo test --manifest-path sdks/rust/Cargo.toml --lib
+cargo test --manifest-path sdks/rust/Cargo.toml --doc
 cargo check --manifest-path sdks/rust/Cargo.toml --example basic_query
+cargo check --manifest-path sdks/rust/Cargo.toml --example readme_sdk_query
+cargo check --manifest-path sdks/rust/Cargo.toml --example readme_macros_query
 ```
 
 ## Next steps

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -249,8 +249,11 @@ Annotate a query builder with `#[query]` to get a callable helper that builds a
 `DateTime`, unsupported bytes) returns `QueryError` rather than panicking, so a
 failed conversion cannot leave a partially populated request.
 
-The compile-tested end-to-end example is
-[`examples/basic_query.rs`](./examples/basic_query.rs).
+The compile-tested end-to-end examples are:
+
+- [`examples/basic_query.rs`](./examples/basic_query.rs) — root README journey
+- [`examples/readme_sdk_query.rs`](./examples/readme_sdk_query.rs) — this section
+- [`examples/readme_macros_query.rs`](./examples/readme_macros_query.rs) — macros README usage
 
 ```rust
 use helix_db::dsl::prelude::*;

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -244,9 +244,13 @@ payload instead.
 ### Query functions
 
 Annotate a query builder with `#[query]` to get a callable helper that builds a
-`QueryRequest` directly from typed arguments. The generated function returns the request
-value itself (not a `Result`) — parameter coercion that can fail (e.g. `DateTime`, bytes) panics
-with a descriptive message rather than returning an error.
+`QueryRequest` directly from typed arguments. The generated function returns
+`Result<QueryRequest, QueryError>`. Parameter coercion that can fail (e.g.
+`DateTime`, unsupported bytes) returns `QueryError` rather than panicking, so a
+failed conversion cannot leave a partially populated request.
+
+The compile-tested end-to-end example is
+[`examples/basic_query.rs`](./examples/basic_query.rs).
 
 ```rust
 use helix_db::dsl::prelude::*;
@@ -270,8 +274,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new(Some("https://11e2fc88c410fa5eb13e.cluster.helix-db.com"))?
         .with_api_key(Some("hx_your_api_key"));
 
-    // Building the request is infallible — no `?` needed here.
-    let request = add_user("John".to_string());
+    // Handle QueryError from parameter coercion / request construction.
+    let request = add_user("John".to_string())?;
 
     let response: AddUserResponse = client.query(request).send().await?;
     println!("created user {}", response.user_id);

--- a/sdks/rust/examples/basic_query.rs
+++ b/sdks/rust/examples/basic_query.rs
@@ -1,0 +1,53 @@
+//! End-to-end `#[query]` example: build a request and send it through [`Client`].
+//!
+//! Compile-checked in CI via:
+//! `cargo check --locked --manifest-path sdks/rust/Cargo.toml --example basic_query`
+//!
+//! Matches the public contract in the root README and `sdks/rust/README.md`:
+//! `#[query]` helpers return `Result<QueryRequest, QueryError>`.
+
+#![recursion_limit = "256"]
+
+use helix_db::dsl::prelude::*;
+use helix_db::Client;
+
+#[query]
+fn add_user(name: String) -> WriteBatch {
+    write_batch()
+        .var_as(
+            "user",
+            g().add_n("User", vec![("name", name)])
+                .value_map(None::<Vec<String>>),
+        )
+        .returning(["user"])
+}
+
+#[query]
+fn get_user(name: String) -> ReadBatch {
+    read_batch()
+        .var_as(
+            "user",
+            g().n_with_label("User")
+                .where_(Predicate::eq("name", name))
+                .value_map(None::<Vec<String>>),
+        )
+        .returning(["user"])
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new(None)?; // defaults to http://localhost:6969
+
+    let new_user: sonic_rs::Value = client
+        .query(add_user("John Doe".to_string())?)
+        .send()
+        .await?;
+    println!("new user: {:#}", sonic_rs::to_string_pretty(&new_user)?);
+
+    let user: sonic_rs::Value = client
+        .query(get_user("John Doe".to_string())?)
+        .send()
+        .await?;
+    println!("user: {:#}", sonic_rs::to_string_pretty(&user)?);
+    Ok(())
+}

--- a/sdks/rust/examples/basic_query.rs
+++ b/sdks/rust/examples/basic_query.rs
@@ -3,8 +3,12 @@
 //! Compile-checked in CI via:
 //! `cargo check --locked --manifest-path sdks/rust/Cargo.toml --example basic_query`
 //!
-//! Matches the public contract in the root README and `sdks/rust/README.md`:
+//! Matches the public contract in the root README (`README.md` at repo root):
 //! `#[query]` helpers return `Result<QueryRequest, QueryError>`.
+//!
+//! Companion compile-tested README mirrors:
+//! - [`readme_sdk_query`](./readme_sdk_query.rs)
+//! - [`readme_macros_query`](./readme_macros_query.rs)
 
 #![recursion_limit = "256"]
 

--- a/sdks/rust/examples/readme_macros_query.rs
+++ b/sdks/rust/examples/readme_macros_query.rs
@@ -1,0 +1,34 @@
+//! Compile-tested mirror of the Usage example in
+//! [`helix-dsl-macros/README.md`](../helix-dsl-macros/README.md).
+//!
+//! `#[query]` helpers return `Result<QueryRequest, QueryError>`.
+
+#![recursion_limit = "256"]
+
+use helix_db::dsl::prelude::*;
+
+#[query]
+fn find_user(username: String) -> ReadBatch {
+    read_batch()
+        .var_as(
+            "user",
+            g().n_where(SourcePredicate::eq("username", username)),
+        )
+        .returning(["user"])
+}
+
+#[query]
+fn create_post(title: String) -> WriteBatch {
+    write_batch()
+        .var_as("post", g().add_n("Post", vec![("title", title)]))
+        .returning(["post"])
+}
+
+fn main() -> Result<(), QueryError> {
+    let request = find_user("alice".to_string())?;
+    assert_eq!(request.query_name(), Some("find_user"));
+
+    let request = create_post("hello".to_string())?;
+    assert_eq!(request.query_name(), Some("create_post"));
+    Ok(())
+}

--- a/sdks/rust/examples/readme_sdk_query.rs
+++ b/sdks/rust/examples/readme_sdk_query.rs
@@ -1,0 +1,35 @@
+//! Compile-tested mirror of the `### Query functions` example in
+//! [`sdks/rust/README.md`](../README.md).
+//!
+//! `#[query]` helpers return `Result<QueryRequest, QueryError>`.
+
+#![recursion_limit = "256"]
+
+use helix_db::dsl::prelude::*;
+use helix_db::Client;
+use serde::Deserialize;
+
+#[query]
+pub fn add_user(name: String) -> WriteBatch {
+    write_batch()
+        .var_as("user_id", g().add_n("user", vec![("name", name)]))
+        .returning(vec!["user_id"])
+}
+
+#[derive(Deserialize)]
+struct AddUserResponse {
+    user_id: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new(Some("https://11e2fc88c410fa5eb13e.cluster.helix-db.com"))?
+        .with_api_key(Some("hx_your_api_key"));
+
+    // Handle QueryError from parameter coercion / request construction.
+    let request = add_user("John".to_string())?;
+
+    let response: AddUserResponse = client.query(request).send().await?;
+    println!("created user {}", response.user_id);
+    Ok(())
+}

--- a/sdks/rust/helix-dsl-macros/README.md
+++ b/sdks/rust/helix-dsl-macros/README.md
@@ -24,7 +24,10 @@ fn create_post(payload: ParamObject) -> WriteBatch {
         .create_node("Post", payload)
 }
 
-let request = find_user("alice".to_string())?;
+fn main() -> Result<(), QueryError> {
+    let request = find_user("alice".to_string())?;
+    Ok(())
+}
 ```
 
 The macro preserves the function's visibility and parameters, builds the query

--- a/sdks/rust/helix-dsl-macros/README.md
+++ b/sdks/rust/helix-dsl-macros/README.md
@@ -3,7 +3,8 @@
 Procedural macros for the [`helix-db`](../README.md) query DSL.
 
 This crate provides the `#[query]` attribute macro, which transforms a typed
-query-building function into a callable function returning `QueryRequest`.
+query-building function into a callable function returning
+`Result<QueryRequest, QueryError>`.
 
 ## Usage
 
@@ -22,12 +23,15 @@ fn create_post(payload: ParamObject) -> WriteBatch {
     write_batch()
         .create_node("Post", payload)
 }
+
+let request = find_user("alice".to_string())?;
 ```
 
 The macro preserves the function's visibility and parameters, builds the query
 AST with `Expr::param(...)` references, inserts parameter values and types, sets
-`query_name` to the function name, and returns the complete request. It does not
-register or persist queries.
+`query_name` to the function name, and returns the complete request (or a
+`QueryError` if parameter coercion fails). It does not register or persist
+queries.
 
 ## Supported parameter types
 

--- a/sdks/rust/helix-dsl-macros/README.md
+++ b/sdks/rust/helix-dsl-macros/README.md
@@ -8,20 +8,27 @@ query-building function into a callable function returning
 
 ## Usage
 
+The compile-tested mirror of this example is
+[`examples/readme_macros_query.rs`](../examples/readme_macros_query.rs).
+
 ```rust
-use helix_db::prelude::*;
+use helix_db::dsl::prelude::*;
 
 #[query]
 fn find_user(username: String) -> ReadBatch {
     read_batch()
-        .var_as("user", g().n_where(SourcePredicate::eq("username", username)))
+        .var_as(
+            "user",
+            g().n_where(SourcePredicate::eq("username", username)),
+        )
         .returning(["user"])
 }
 
 #[query]
-fn create_post(payload: ParamObject) -> WriteBatch {
+fn create_post(title: String) -> WriteBatch {
     write_batch()
-        .create_node("Post", payload)
+        .var_as("post", g().add_n("Post", vec![("title", title)]))
+        .returning(["post"])
 }
 
 fn main() -> Result<(), QueryError> {

--- a/sdks/rust/helix-dsl-macros/README.md
+++ b/sdks/rust/helix-dsl-macros/README.md
@@ -33,6 +33,10 @@ fn create_post(title: String) -> WriteBatch {
 
 fn main() -> Result<(), QueryError> {
     let request = find_user("alice".to_string())?;
+    assert_eq!(request.query_name(), Some("find_user"));
+
+    let request = create_post("hello".to_string())?;
+    assert_eq!(request.query_name(), Some("create_post"));
     Ok(())
 }
 ```

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -45,6 +45,31 @@
 //! use helix_db::dsl::prelude::*;
 //! ```
 //!
+//! ## Query helpers
+//!
+//! Annotate a builder with [`query`] to get a callable function that returns
+//! [`Result<QueryRequest, QueryError>`]. Parameter coercion failures surface as
+//! [`QueryError`] instead of panicking:
+//!
+//! ```
+//! #![recursion_limit = "256"]
+//! use helix_db::dsl::prelude::*;
+//!
+//! #[query]
+//! fn find_user(name: String) -> ReadBatch {
+//!     read_batch()
+//!         .var_as(
+//!             "user",
+//!             g().n_where(SourcePredicate::eq("username", name)),
+//!         )
+//!         .returning(["user"])
+//! }
+//!
+//! let request = find_user("alice".to_string())?;
+//! assert_eq!(request.query_name(), Some("find_user"));
+//! # Ok::<(), helix_db::QueryError>(())
+//! ```
+//!
 //! ## Running queries
 //!
 //! Build a [`Client`], then send a [`QueryRequest`] to `/v2/query`:
@@ -58,17 +83,29 @@
 //! #[derive(Deserialize)]
 //! struct Friends { friends: Vec<u64> }
 //!
-//! # async fn run(request: QueryRequest) -> Result<(), helix_db::HelixError> {
+//! #[query]
+//! fn friends_of(name: String) -> ReadBatch {
+//!     read_batch()
+//!         .var_as(
+//!             "friends",
+//!             g().n_where(SourcePredicate::eq("username", name))
+//!                 .out(Some("FOLLOWS")),
+//!         )
+//!         .returning(["friends"])
+//! }
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = Client::new(Some("https://cluster.helix-db.com"))?
 //!     .with_api_key(Some("hx_your_api_key"));
 //!
-//! let response: Friends = client.query(request).send().await?;
+//! let response: Friends = client.query(friends_of("alice".to_string())?).send().await?;
 //! # let _ = response.friends;
 //! # Ok(())
 //! # }
 //! ```
 //!
 //! See [`Client`] for the full request-building surface and error handling.
+//! The compile-tested end-to-end binary is `examples/basic_query.rs`.
 
 pub mod dsl;
 pub mod graph;

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -105,7 +105,8 @@
 //! ```
 //!
 //! See [`Client`] for the full request-building surface and error handling.
-//! The compile-tested end-to-end binary is `examples/basic_query.rs`.
+//! Compile-tested README mirrors live under `examples/`:
+//! `basic_query`, `readme_sdk_query`, and `readme_macros_query`.
 
 pub mod dsl;
 pub mod graph;


### PR DESCRIPTION
## Summary

Fixes #987.

`#[query]` rewrites helpers to return `Result<QueryRequest, QueryError>`, but public copy-paste examples (root README, Rust SDK README, docs site) passed the value straight into `Client::query`. That made the first Rust onboarding journey fail to compile.

This PR:

- Updates every public `#[query]` call site to handle `Result` with `?` (or documents the same contract).
- Corrects README/docs text that claimed the helper returned a bare `QueryRequest` / panicked on coercion failure. Parameter coercion failures now surface as `QueryError`.
- Adds `sdks/rust/examples/basic_query.rs`: a small end-to-end example that builds a request and sends it through `Client`.
- Extends crate doctests to cover the `#[query]` → `Client::query` path.
- Aligns the root README, SDK README, macros README, and docs site (`rust-project-setup`, `overview`, `parameters`) on the same contract, and regenerates `docs/llms-full.txt`.
- Teaches CI (`sdk-query-parity`) to run Rust doctests and `cargo check --example basic_query`, and to watch the related README/docs paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns public Rust `#[query]` documentation with its `Result<QueryRequest, QueryError>` contract and adds CI coverage for doctests and an end-to-end example.
- Updates README and documentation call sites to propagate `QueryError` with `?`.
- Adds and compile-checks `examples/basic_query.rs`.
- Expands Rust SDK crate doctests and sdk-query-parity workflow path coverage.
- The macros README's newly added call is outside a function and therefore is not valid copy-paste Rust.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/sdk-query-parity.yml | Expands workflow path filters and adds Rust doctest and end-to-end example compilation coverage. |
| sdks/rust/examples/basic_query.rs | Adds an end-to-end example that correctly propagates query-construction and client errors. |
| sdks/rust/src/lib.rs | Adds crate doctests covering the Result-returning query helper and Client integration. |
| sdks/rust/helix-dsl-macros/README.md | Corrects the documented return contract but places the new `?` call at invalid module scope. |
| sdks/rust/README.md | Replaces the obsolete infallible-helper guidance with the current QueryError contract. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rust-sdk): align #\[query\] examples w..."](https://github.com/helixdb/helix-db/commit/453b1b0ec49d115834fdc8f5d0f5134d3be4b90e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56297037)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->