### PR TITLE
fix(go): accept every integer width in typed float parameters

### DIFF
--- a/sdks/go/dsl.go
+++ b/sdks/go/dsl.go
@@ -2944,7 +2944,23 @@ func queryFloat64(value any) (float64, error) {
 		return f, nil
 	case int:
 		return float64(v), nil
+	case int8:
+		return float64(v), nil
+	case int16:
+		return float64(v), nil
+	case int32:
+		return float64(v), nil
 	case int64:
+		return float64(v), nil
+	case uint:
+		return float64(v), nil
+	case uint8:
+		return float64(v), nil
+	case uint16:
+		return float64(v), nil
+	case uint32:
+		return float64(v), nil
+	case uint64:
 		return float64(v), nil
 	default:
 		return 0, ErrInvalidParameterType

--- a/sdks/go/dsl_test.go
+++ b/sdks/go/dsl_test.go
@@ -534,6 +534,39 @@ func TestAtomicTypedAndExplicitUntypedParameterStates(t *testing.T) {
 	}
 }
 
+func TestFloatParametersAcceptEveryIntegerWidth(t *testing.T) {
+	request := NewReadQueryRequest(Read())
+	values := []struct {
+		name  string
+		value any
+	}{
+		{"i", int(-2)}, {"i8", int8(-3)}, {"i16", int16(-4)}, {"i32", int32(-5)}, {"i64", int64(-6)},
+		{"u", uint(7)}, {"u8", uint8(8)}, {"u16", uint16(9)}, {"u32", uint32(10)}, {"u64", uint64(11)},
+	}
+	for _, value := range values {
+		request.ParamF64("f64_"+value.name, value.value)
+		request.ParamF32("f32_"+value.name, value.value)
+	}
+	if err := request.Validate(); err != nil {
+		t.Fatalf("integer-width float parameters failed: %v", err)
+	}
+	body, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{`"f64_i":-2`, `"f32_u64":11`} {
+		if !strings.Contains(string(body), expected) {
+			t.Fatalf("float parameter missing %s: %s", expected, body)
+		}
+	}
+
+	rejected := NewReadQueryRequest(Read())
+	rejected.ParamF64("text", "not-a-number")
+	if !errors.Is(rejected.Validate(), ErrInvalidParameterType) {
+		t.Fatal("non-numeric float parameter unexpectedly accepted")
+	}
+}
+
 func TestBatchDecodersCoverClosedVariantsAndMalformedShapes(t *testing.T) {
 	for _, input := range []string{
 		`"prev_not_empty"`,


### PR DESCRIPTION
## Problem

`QueryRequest.ParamF64` and `ParamF32` reject most of Go's integer types. Their normalizer, `queryFloat64`, hand-rolls a type switch covering only `float64`, `float32`, `int`, and `int64`, while the sibling `queryI64` helper routes through `PropertyValueOf`, whose canonical conversion table accepts `int8`-`int64` and `uint`-`uint64`. The same value therefore behaves inconsistently across typed parameter helpers:

```go
q.ParamI64("n", uint(5)) // ok
q.ParamF64("x", uint(5)) // ErrInvalidParameterType
```

Every integer width that is a valid `PropertyValueOf` input is equally representable as an F64/F32 parameter value, so the narrow switch is the root cause rather than a deliberate restriction.

## Fix

Extend the `queryFloat64` switch with the missing signed (`int8`, `int16`, `int32`) and unsigned (`uint`, `uint8`, `uint16`, `uint32`, `uint64`) widths, mirroring the acceptance table in `PropertyValueOf`. Error sentinels are unchanged; non-numeric values still fail with `ErrInvalidParameterType`.

## Testing

- `go test . -run 'TestFloatParametersAcceptEveryIntegerWidth|TestAtomicTypedAndExplicitUntypedParameterStates|TestQueryParamTypesCoverEveryValidAndInvalidState' -v` — all pass, including the new table test asserting every width is accepted for both `ParamF64` and `ParamF32`, serialized values land in the request JSON, and non-numeric input is still rejected.
- `gofmt -l .` clean, `go vet .` clean.
- `go test . -skip '^TestExternalConsumerCanTidyModule$'` — full package suite passes. (`TestExternalConsumerCanTidyModule` fails on machines whose checkout path contains a space for a reason unrelated to this change; fixing that separately.)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR broadens Go float parameter normalization to accept every built-in signed and unsigned integer width already supported by the canonical property conversion table.
- Adds the missing integer cases to `queryFloat64`.
- Adds coverage for all integer widths through both `ParamF64` and `ParamF32`.
- Confirms request validation, representative JSON serialization, and rejection of non-numeric input.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdks/go/dsl.go | Extends float parameter normalization with the missing built-in integer widths without changing error handling. |
| sdks/go/dsl_test.go | Verifies all built-in integer widths are accepted by F64 and F32 parameters and that non-numeric values remain invalid. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(go): accept every integer width in t..."](https://github.com/helixdb/helix-db/commit/959c1f91e28fda6675a172c6ebb7dd805f3723e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56611675)</sub>

<!-- /greptile_comment -->