### PR TITLE
fix(go): quote sdk path in external consumer boundary test

### DIFF
--- a/sdks/go/module_boundary_test.go
+++ b/sdks/go/module_boundary_test.go
@@ -22,7 +22,7 @@ go 1.22
 
 require github.com/helixdb/helix-db/sdks/go v0.0.0
 
-replace github.com/helixdb/helix-db/sdks/go => %s
+replace github.com/helixdb/helix-db/sdks/go => %q
 `, moduleDir)
 	if err := os.WriteFile(filepath.Join(consumer, "go.mod"), []byte(goMod), 0o600); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Problem

`TestExternalConsumerCanTidyModule` generates its consumer `go.mod` by interpolating the SDK checkout directory into a `replace` directive unquoted:

```go
moduleDir = filepath.ToSlash(moduleDir)
goMod := fmt.Sprintf(`...
replace github.com/helixdb/helix-db/sdks/go => %s
`, moduleDir)
```

When the checkout lives under a path containing a space, the generated line becomes `... => D:/pers/open source/helix-db/sdks/go` and the module parser stops at the first whitespace. Running the suite from such a directory fails every time:

```
go: errors parsing go.mod:
        go.mod:7: malformed module path "D:/pers/open": invalid char ':'
FAIL    github.com/helixdb/helix-db/sdks/go
```

This reproduces on any Windows/macOS/home-directory layout with a space; CI runners only pass because their default paths happen not to contain one.

## Fix

Emit the replacement target as a quoted Go string with `%q`. Quoted file-system targets are valid in `go.mod` replace directives whether or not they contain spaces, so this is safe for every existing environment.

## Testing

From a checkout at `D:\pers\open source\helix-db` (contains a space), on `main` before this change the test fails with the `malformed module path "D:/pers/open"` error above; after the change:

- `go test . -run '^TestExternalConsumerCanTidyModule$' -v` — PASS (`--- PASS: TestExternalConsumerCanTidyModule (6.87s)`)
- `go test .` — full package suite PASS
- `gofmt -l .` clean


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the external Go SDK consumer boundary test when the repository path contains whitespace.
- Quotes the generated local SDK replacement path using `%q`.
- Preserves cross-platform path normalization before generating `go.mod`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdks/go/module_boundary_test.go | Correctly quotes the normalized SDK checkout path in the generated `replace` directive so paths containing spaces remain valid. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(go): quote sdk path in external cons..."](https://github.com/helixdb/helix-db/commit/9798295800953faa157636680586ffb83c589390) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56613202)</sub>

<!-- /greptile_comment -->