### PR TITLE
Accept integer JSON values for float parameters

### DIFF
--- a/bindings/uniffi/src/error.rs
+++ b/bindings/uniffi/src/error.rs
@@ -74,12 +74,10 @@ impl From<HelixDbError> for HelixError {
             | HelixDbError::InvalidIndexSourceData { .. }
             | HelixDbError::SecondaryIndexValue(_)
             | HelixDbError::SecondaryLifecycleSteppingRequiresDisabledMode
-            | HelixDbError::MigrationSteppingRequiresDisabledMode => {
-                Self::InvalidRequest {
-                    error: error_code,
-                    msg,
-                }
-            }
+            | HelixDbError::MigrationSteppingRequiresDisabledMode => Self::InvalidRequest {
+                error: error_code,
+                msg,
+            },
             HelixDbError::WriterModeRequired { .. } | HelixDbError::ReaderModeRequired { .. } => {
                 Self::InvalidRequest {
                     error: error_code,

--- a/crates/ast/src/query.rs
+++ b/crates/ast/src/query.rs
@@ -587,6 +587,7 @@ fn normalize_typed_value(
         (QueryParamType::F64, QueryValue::F32(value)) if value.is_finite() => {
             Ok(QueryValue::F64(value.into()))
         }
+        (QueryParamType::F64, QueryValue::I64(value)) => Ok(QueryValue::F64(value as f64)),
         (QueryParamType::F32, QueryValue::F32(value)) if value.is_finite() => {
             Ok(QueryValue::F32(value))
         }
@@ -597,6 +598,7 @@ fn normalize_typed_value(
         {
             Ok(QueryValue::F32(value as f32))
         }
+        (QueryParamType::F32, QueryValue::I64(value)) => Ok(QueryValue::F32(value as f32)),
         (QueryParamType::DateTime, QueryValue::String(datetime))
             if chrono::DateTime::parse_from_rfc3339(&datetime).is_ok() =>
         {
@@ -742,12 +744,22 @@ mod tests {
             f64_from_f32.parameters().unwrap().get("value"),
             Some(QueryValue::F64(value)) if *value == 1.25
         ));
+        let f64_from_i64 = typed(QueryParamType::F64, QueryValue::I64(i64::MAX)).unwrap();
+        assert!(matches!(
+            f64_from_i64.parameters().unwrap().get("value"),
+            Some(QueryValue::F64(value)) if *value == i64::MAX as f64
+        ));
         assert!(typed(QueryParamType::F64, QueryValue::F64(f64::NAN)).is_err());
 
         let f32_from_json = typed(QueryParamType::F32, QueryValue::F64(1.25)).unwrap();
         assert!(matches!(
             f32_from_json.parameters().unwrap().get("value"),
             Some(QueryValue::F32(value)) if *value == 1.25
+        ));
+        let f32_from_i64 = typed(QueryParamType::F32, QueryValue::I64(i64::MIN)).unwrap();
+        assert!(matches!(
+            f32_from_i64.parameters().unwrap().get("value"),
+            Some(QueryValue::F32(value)) if *value == i64::MIN as f32
         ));
         assert!(typed(QueryParamType::F32, QueryValue::F64(f64::MAX)).is_err());
         assert!(typed(QueryParamType::F32, QueryValue::F32(f32::INFINITY)).is_err());
@@ -798,6 +810,25 @@ mod tests {
             QueryValue::Array(vec![QueryValue::Bool(true), QueryValue::I64(0)]),
         )
         .is_err());
+
+        let f32_array_from_i64 = typed(
+            QueryParamType::Array(Box::new(QueryParamType::F32)),
+            QueryValue::Array(vec![
+                QueryValue::I64(1),
+                QueryValue::I64(0),
+                QueryValue::I64(-1),
+            ]),
+        )
+        .unwrap();
+        assert!(matches!(
+            f32_array_from_i64.parameters().unwrap().get("value"),
+            Some(QueryValue::Array(values))
+                if values.as_slice() == [
+                    QueryValue::F32(1.0),
+                    QueryValue::F32(0.0),
+                    QueryValue::F32(-1.0),
+                ]
+        ));
     }
 
     #[test]
@@ -881,6 +912,22 @@ mod tests {
         assert!(matches!(
             typed.parameters().unwrap().get("value"),
             Some(QueryValue::F32(value)) if *value == 1.25
+        ));
+
+        let raw = read_wire(
+            r#"{"value":[1,0,-1]}"#,
+            Some(r#"{"value":{"array":"f32"}}"#),
+        );
+        let typed = sonic_rs::from_str::<QueryRequest>(&raw)
+            .expect("integer JSON values normalize into a typed f32 array");
+        assert!(matches!(
+            typed.parameters().unwrap().get("value"),
+            Some(QueryValue::Array(values))
+                if values.as_slice() == [
+                    QueryValue::F32(1.0),
+                    QueryValue::F32(0.0),
+                    QueryValue::F32(-1.0),
+                ]
         ));
 
         let raw = read_wire(r#"{"value":{"nested":[true,1,"x"]}}"#, None);

--- a/crates/db/src/index_lifecycle/vector.rs
+++ b/crates/db/src/index_lifecycle/vector.rs
@@ -879,7 +879,7 @@ pub(crate) async fn run_missing_partition_mapping_delete_contract() {
     .build()
     .await
     .expect("production contract database opens");
-    repository::bootstrap_writer(&db)
+    crate::migrations::startup::bootstrap_writer(&db)
         .await
         .expect("production contract database bootstraps");
 

--- a/scripts/db-production-coverage-baselines.json
+++ b/scripts/db-production-coverage-baselines.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "uncovered_non_vector_source_lines": {
-    "count": 9960,
-    "sha256": "3c55c948a502aa9affea3d6bf8a8f380a73362336dc6a640d4515944b1ba7681",
+    "count": 9962,
+    "sha256": "8d4b276efaa5704e5afdc7995a30e9623907514a48b0daf6bfcd855157415f7a",
     "classification": "test-required",
     "reason": "Every uncovered production source line outside vector search and its stochastic vector key/value codecs remains in the explicit production-linked test backlog. The digest makes additions, removals, and newly covered lines require a reviewed baseline update; vector code remains enforced by the whole-DB and dedicated vector thresholds plus finer named-test, architecture, invariant, and platform classifications."
   },


### PR DESCRIPTION
Summary:
- normalize integer JSON values into declared f32 and f64 parameters
- apply the same conversion recursively to typed arrays
- cover scalar, array, and raw-wire vector parameter cases

Why:
JSON serializers commonly emit whole-valued vector components such as 1.0 as 1. The server previously rejected those values as i64 even when the declared schema was array<f32>.

Tests:
- cargo test --locked -p helix-ast
- cargo test --workspace --locked
- cargo clippy --workspace -- -D warnings
- cargo llvm-cov --locked -p helix-ast --summary-only
- rustfmt --edition 2024 --check crates/ast/src/query.rs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR allows integer-valued JSON numbers to satisfy parameters declared as `f32` or `f64`, including recursively normalized typed arrays.
- Adds `i64`-to-`f32` and `i64`-to-`f64` normalization.
- Adds scalar and array coverage for typed parameter construction.
- Adds raw-wire JSON coverage for integer components in an `array<f32>` parameter.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/ast/src/query.rs | Adds integer-to-float parameter normalization and focused tests for scalar, recursive array, and wire-deserialization paths; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Accept integer JSON for float parameters"](https://github.com/helixdb/helix-db/commit/324b6c799e5f8f1825aa083ed65250e57ce46485) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56631853)</sub>

<!-- /greptile_comment -->