### PR TITLE
fix: check container runtime is available in stop and restart

### DIFF
--- a/crates/cli/src/local_runtime.rs
+++ b/crates/cli/src/local_runtime.rs
@@ -314,6 +314,7 @@ impl LocalRuntime {
     }
 
     pub fn stop(&self, instance_name: &str) -> Result<bool> {
+        Self::check_available(self.runtime)?;
         let name = self.container_name(instance_name);
         let removed_helix = self.remove_container(&name)?;
         let removed_disk_resources = self.remove_disk_resources(instance_name, false)?;
@@ -325,6 +326,7 @@ impl LocalRuntime {
             return self.run_detached(instance_name, config);
         }
 
+        Self::check_available(self.runtime)?;
         let name = self.container_name(instance_name);
         let output = self
             .runtime_command()


### PR DESCRIPTION
`helix start` already checks the container runtime is there before it does anything. if docker is configured but not installed, it stops with an error that names the missing binary and tells you podman is available instead. stop and restart skip that check and spawn the binary directly, so on the same machine they fail with a bare os error.

on a host with podman and no docker, using the `container_runtime = "docker"` that `helix init` writes by default:

```
$ helix start dev
error: Docker is not installed (`docker` not found on PATH)
   │ No such file or directory (os error 2)
   = help: Podman is installed — set `container_runtime = "podman"` under [project] in
     helix.toml to use it instead, or install Docker.

$ helix restart dev
Failed to restart helix-helixproj-dev: No such file or directory (os error 2)

$ helix stop dev
Failed to remove helix-helixproj-dev: No such file or directory (os error 2)
```

os error 2 never says which binary was missing, so there is nothing in it to act on. you get it on first run too, because init writes docker into helix.toml without looking at what is installed, so a podman user hits this before anything else works.

the fix is already in the file. run_detached and run_foreground both open with `Self::check_available(self.runtime)?`, and check_available is what routes a spawn failure through not_installed_error to produce the podman hint above. this adds the same line to stop and restart so they land on the error that was already written for this case. no new error text and no new behaviour, two commands just stop bypassing it.

in restart the check sits after the disk and s3 early return, not before it. those paths hand off to run_detached, which already checks, so checking first would probe the daemon twice.

stop and restart are the two commands here that go on to change container state, which is why auto-starting a stopped daemon is reasonable for them, the same as it already is for start. `logs` and `status` have the same bare error but they are read only, and `check_available` will start docker desktop or colima when the binary is present but the daemon is down. starting a daemon as a side effect of reading logs is not something i wanted to slip into this pr. both would be better served by a preflight that checks the binary is installed without auto-starting, which is a different change. happy to send it if you want it.

tested on wsl2, ubuntu 24.04 arm64, podman 4.9.3, docker not installed. after the change both print the same error as start, and with podman configured the normal lifecycle still works: start, status, query, restart, query again, logs, stop.

- cargo build -p helix-cli
- cargo clippy -p helix-cli -- -D warnings, clean
- cargo test -p helix-cli, all suites pass
- rustfmt --edition 2024 --check crates/cli/src/local_runtime.rs, clean

the typescript_runtime suite needs `npm ci` in `sdks/typescript` and node on PATH before it will pass; with those in place it is green here too.
