### PR TITLE
docs: document the Linux C toolchain and OpenSSL build prerequisites

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,6 +51,15 @@ We welcome contributions from the community! This guide will help you get starte
 - **Rust**: 1.97.1 (installed automatically from `rust-toolchain.toml` by [rustup](https://rustup.rs/))
 - **Cargo**: Comes with Rust
 - **Git**: For version control
+- **A C toolchain and OpenSSL development headers (Linux only)**: `helix-cli` depends on
+  `reqwest` with its default features, which enables `native-tls`. On Linux that builds
+  `openssl-sys`, which needs a C compiler, `pkg-config`, and the OpenSSL headers. macOS
+  and Windows do not need them, because `native-tls` uses Security.framework and SChannel
+  there. Most Linux desktops already have the packages, but a clean container, CI image,
+  or WSL install does not, and `cargo build` fails there with
+  `Could not find directory of OpenSSL installation`.
+  - Debian/Ubuntu: `sudo apt-get install -y build-essential pkg-config libssl-dev`
+  - Other Linux distributions: install the equivalent OpenSSL development package
 
 ### Optional Tools
 - **cargo-watch**: For development auto-reloading


### PR DESCRIPTION
`cargo build` on a clean ubuntu 24.04 image fails before any helix code compiles:

```
error: failed to run custom build command for `openssl-sys v0.9.117`

  Could not find directory of OpenSSL installation, and this `-sys` crate cannot
  proceed without this knowledge.
  ...
  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.
```

Required Tools in the contributor guide lists rust, cargo and git, so there is nothing in it that points at what is actually missing. it does not show up on most laptops because those packages are already there, but a fresh container, a ci image or a new wsl install hits it straight away. this adds the c toolchain and the openssl headers to that list, with the ubuntu package names and the error string so it is searchable.

it is scoped to linux. `native-tls` only pulls openssl on targets that are neither windows nor apple, so macos gets Security.framework and windows gets SChannel and neither needs the headers.

worth knowing where it comes from, in case you would rather close it at the source. `crates/cli/Cargo.toml` has

```toml
reqwest = { version = "0.12.23", features = ["json"] }
```

with default features left on, which turns on `default-tls`, which pulls native-tls and then openssl-sys. `crates/metrics/Cargo.toml` already avoids exactly that on the same reqwest version:

```toml
reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
```

since cargo unifies features per crate version, the cli leaving defaults on puts openssl back into the build for the whole workspace, so the metrics crate does not actually get the rustls only build it asks for. i checked the other two: `self_update`'s only default feature is `reqwest/default-tls` and it has a `rustls` feature, and `reqwest-eventsource` already sets `default-features = false`, so moving the cli over would be a small change.

i deliberately did not do that in this pr. `rustls-tls` uses bundled webpki roots instead of the system trust store, so it would change behaviour for anyone behind a corporate ca or a proxy that re-signs traffic, and that seems like your call rather than mine. if you want it i will send it separately, either with `rustls-tls` to match the metrics crate or `rustls-tls-native-roots` to keep the system store. this one is just the docs so the next person is not stuck.

found on wsl2 ubuntu 24.04 arm64. after `apt-get install -y build-essential pkg-config libssl-dev` the workspace builds clean, `cargo check --workspace --all-targets` finishes with no errors and no warnings.
