### PR TITLE
build: drop the system OpenSSL dependency from helix-cli

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,15 +51,10 @@ We welcome contributions from the community! This guide will help you get starte
 - **Rust**: 1.97.1 (installed automatically from `rust-toolchain.toml` by [rustup](https://rustup.rs/))
 - **Cargo**: Comes with Rust
 - **Git**: For version control
-- **A C toolchain and OpenSSL development headers (Linux only)**: `helix-cli` depends on
-  `reqwest` with its default features, which enables `native-tls`. On Linux that builds
-  `openssl-sys`, which needs a C compiler, `pkg-config`, and the OpenSSL headers. macOS
-  and Windows do not need them, because `native-tls` uses Security.framework and SChannel
-  there. Most Linux desktops already have the packages, but a clean container, CI image,
-  or WSL install does not, and `cargo build` fails there with
-  `Could not find directory of OpenSSL installation`.
-  - Debian/Ubuntu: `sudo apt-get install -y build-essential pkg-config libssl-dev`
-  - Other Linux distributions: install the equivalent OpenSSL development package
+- **A C toolchain**: `ring` and `aws-lc-sys`, pulled in through rustls, compile C code, so
+  a working C compiler is needed. Most desktop machines already have one, but a clean
+  container, CI image, or WSL install may not. System OpenSSL headers are *not* required.
+  - Debian/Ubuntu: `sudo apt-get install -y build-essential`
 
 ### Optional Tools
 - **cargo-watch**: For development auto-reloading

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,21 +1659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2356,22 +2341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3029,23 +2998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3286,47 +3238,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -4161,12 +4076,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4178,7 +4091,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -5402,16 +5314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6028,12 +5930,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,12 +13,12 @@ toml = "0.9.5"
 dirs = "6.0.0"
 dotenvy = "0.15.7"
 dunce = "1.0.5"
-reqwest = { version = "0.12.23", features = ["json"] }
+reqwest = { version = "0.12.23", default-features = false, features = ["json", "charset", "http2", "system-proxy", "rustls-tls-native-roots"] }
 serde_json = "1.0.143"
 color-eyre = "0.6.5"
 cliclack = "0.3.7"
 thiserror = "2.0.12"
-self_update = "0.42.0"
+self_update = { version = "0.42.0", default-features = false, features = ["rustls"] }
 chrono = "0.4.42"
 futures-util = "0.3.31"
 regex = "1.11.2"


### PR DESCRIPTION
follow up to #1037. that documented the openssl prerequisite, this gets rid of the need for it.

`crates/cli/Cargo.toml` took reqwest with default features still on, which turns on `default-tls` and pulls native-tls and then openssl-sys. `crates/metrics` already asks for `default-features = false` with `rustls-tls` on the same reqwest version, but cargo unifies features per crate version, so the cli turning defaults back on put openssl into the build for everything and metrics never actually got the rustls only build it was asking for. that is also why a clean linux image could not build the workspace until you apt-get install libssl-dev.

`cargo tree --workspace -i openssl-sys`, before and after:

```
before:  openssl-sys v0.9.117
         ├── native-tls v0.2.18
         │   ├── hyper-tls v0.6.0 ...

after:   error: package ID specification `openssl-sys` did not match any packages
```

Cargo.lock loses 104 lines and all of it is openssl.

on which rustls variant: you said it seemed fine but did not say which one, so i went with the one that changes nothing. `rustls-tls-native-roots` still reads the system trust store, which is what native-tls was already doing, so anyone behind a corporate ca or a proxy that re-signs traffic sees no difference. `rustls-native-certs` was already in the tree before this change anyway. if you would rather have the bundled webpki roots it is a one word swap to `rustls-tls`, just say and i will change it.

`charset`, `http2` and `system-proxy` are listed explicitly because turning default features off would otherwise drop those too. losing system-proxy would have quietly broken HTTP_PROXY support, so this keeps everything reqwest gives you by default and only swaps the tls backend. `self_update` gets `default-features = false, features = ["rustls"]`, since its only default feature was `reqwest/default-tls` and it has no archive features enabled here.

CONTRIBUTORS.md needed a correction because of this, otherwise what we just merged in #1037 would be wrong. i checked what is actually left and `ring` and `aws-lc-sys` were already in the tree before this change, so a c compiler is still needed, it just was never openssl that made it so. the bullet now says c toolchain and says outright that openssl headers are not required.

wsl2 ubuntu 24.04 arm64, rustc 1.97.1:

- cargo check --workspace --all-targets, no errors and no warnings
- cargo clippy -p helix-cli -- -D warnings, clean
- cargo test -p helix-cli, all suites pass
- cargo tree --workspace -i openssl-sys, no match


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes helix-cli’s system OpenSSL dependency by configuring reqwest and self_update to use rustls while preserving reqwest’s existing non-TLS defaults.
- Selects native-root rustls TLS for CLI HTTP clients.
- Selects rustls for self-update downloads.
- Removes native-tls/OpenSSL packages from the workspace lockfile.
- Updates contributor prerequisites to require a C toolchain without OpenSSL headers.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/cli/Cargo.toml | Replaces default native-tls features with an explicit rustls-native-roots reqwest configuration and rustls-backed self_update. |
| Cargo.lock | Removes the native-tls, OpenSSL, and associated transitive packages from the resolved workspace graph. |
| CONTRIBUTORS.md | Correctly updates Linux build prerequisites to remove OpenSSL headers while retaining the C toolchain requirement. |

</details>

<sub>Reviews (1): Last reviewed commit: ["build: drop the system OpenSSL dependenc..."](https://github.com/helixdb/helix-db/commit/fba379dd006fe1318d68a7d33902cf322313325a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57193366)</sub>

<!-- /greptile_comment -->