### PR TITLE
fix: name the missing container runtime in logs and status

### DIFF
--- a/crates/cli/src/local_runtime.rs
+++ b/crates/cli/src/local_runtime.rs
@@ -355,7 +355,13 @@ impl LocalRuntime {
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .status()
-            .map_err(|e| not_installed_error(self.runtime, &e.to_string(), command_exists))?;
+            .map_err(|e| {
+                if spawn_failed_because_runtime_missing(self.runtime, &e) {
+                    not_installed_error(self.runtime, &e.to_string(), command_exists).into()
+                } else {
+                    eyre!("Failed to read logs for {name}: {e}")
+                }
+            })?;
 
         if !status.success() {
             return Err(eyre!(
@@ -379,7 +385,13 @@ impl LocalRuntime {
                 &format!("name=^{name}$"),
             ])
             .output()
-            .map_err(|e| not_installed_error(self.runtime, &e.to_string(), command_exists))?;
+            .map_err(|e| {
+                if spawn_failed_because_runtime_missing(self.runtime, &e) {
+                    not_installed_error(self.runtime, &e.to_string(), command_exists).into()
+                } else {
+                    eyre!("Failed to inspect {name}: {e}")
+                }
+            })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -703,8 +715,27 @@ fn runtime_tokio_command(runtime: ContainerRuntime) -> TokioCommand {
     }
 }
 
+/// Whether a test runtime binary has to be launched through `cmd`.
+///
+/// `.cmd`/`.bat` fixtures are not executable images, so Windows can only run
+/// them via `cmd /C call`. Anything else is spawned directly, which keeps a
+/// missing path failing with `NotFound` instead of `cmd.exe` spawning fine and
+/// reporting exit code 1.
+#[cfg(windows)]
+fn test_runtime_bin_needs_shell(bin: &std::ffi::OsStr) -> bool {
+    std::path::Path::new(bin)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("cmd") || extension.eq_ignore_ascii_case("bat")
+        })
+}
+
 #[cfg(windows)]
 fn command_from_test_runtime_bin(bin: OsString) -> Command {
+    if !test_runtime_bin_needs_shell(&bin) {
+        return Command::new(bin);
+    }
     let mut command = Command::new("cmd");
     command.arg("/C").arg("call").arg(bin);
     command
@@ -717,6 +748,9 @@ fn command_from_test_runtime_bin(bin: OsString) -> Command {
 
 #[cfg(windows)]
 fn tokio_command_from_test_runtime_bin(bin: OsString) -> TokioCommand {
+    if !test_runtime_bin_needs_shell(&bin) {
+        return TokioCommand::new(bin);
+    }
     let mut command = TokioCommand::new("cmd");
     command.arg("/C").arg("call").arg(bin);
     command
@@ -725,6 +759,34 @@ fn tokio_command_from_test_runtime_bin(bin: OsString) -> TokioCommand {
 #[cfg(not(windows))]
 fn tokio_command_from_test_runtime_bin(bin: OsString) -> TokioCommand {
     TokioCommand::new(bin)
+}
+
+/// The executable `runtime_command` will actually spawn.
+///
+/// Mirrors the `HELIX_TEST_CONTAINER_RUNTIME_BIN` seam so the presence check and
+/// the spawned command always agree about which binary is in play.
+fn resolved_runtime_binary(runtime: ContainerRuntime) -> OsString {
+    std::env::var_os(TEST_CONTAINER_RUNTIME_BIN_ENV)
+        .unwrap_or_else(|| OsString::from(runtime.binary()))
+}
+
+fn runtime_binary_present(runtime: ContainerRuntime) -> bool {
+    match resolved_runtime_binary(runtime).to_str() {
+        Some(binary) => command_exists(binary),
+        // A path we cannot inspect is not evidence that the runtime is absent.
+        None => true,
+    }
+}
+
+/// Whether a spawn failure means the runtime executable is genuinely absent.
+///
+/// A present binary can still fail to spawn: a missing interpreter, an invalid
+/// executable format, a permission failure, or process resource exhaustion. Those
+/// keep their command-specific error rather than being reported as a missing
+/// installation, which would send the user off to install or switch runtimes for
+/// a runtime that is already there.
+fn spawn_failed_because_runtime_missing(runtime: ContainerRuntime, error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::NotFound && !runtime_binary_present(runtime)
 }
 
 /// Build the error for a container runtime whose binary is missing from PATH.

--- a/crates/cli/src/local_runtime.rs
+++ b/crates/cli/src/local_runtime.rs
@@ -355,7 +355,7 @@ impl LocalRuntime {
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .status()
-            .map_err(|e| eyre!("Failed to read logs for {name}: {e}"))?;
+            .map_err(|e| not_installed_error(self.runtime, &e.to_string(), command_exists))?;
 
         if !status.success() {
             return Err(eyre!(
@@ -379,7 +379,7 @@ impl LocalRuntime {
                 &format!("name=^{name}$"),
             ])
             .output()
-            .map_err(|e| eyre!("Failed to inspect {name}: {e}"))?;
+            .map_err(|e| not_installed_error(self.runtime, &e.to_string(), command_exists))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/cli/tests/runtime_commands.rs
+++ b/crates/cli/tests/runtime_commands.rs
@@ -110,3 +110,37 @@ async fn disk_runtime_commands_cover_resource_reuse_status_cleanup_and_errors() 
     assert!(log.contains("logs -f"));
     assert!(log.contains("network inspect"));
 }
+
+#[test]
+fn logs_and_status_report_a_missing_runtime_like_stop_does() {
+    let fixture = CliFixture::new().with_missing_runtime();
+    let project = fixture.root().join("missing-runtime-project");
+    fixture
+        .command()
+        .args(["init", "--path"])
+        .arg(&project)
+        .args(["local", "--no-skills"])
+        .assert()
+        .success();
+
+    for command in [["logs", "dev"], ["status", "dev"], ["stop", "dev"]] {
+        let message = stderr(
+            fixture
+                .command()
+                .current_dir(&project)
+                .args(command)
+                .assert()
+                .failure(),
+        );
+        assert!(
+            message.contains("Docker is not installed"),
+            "`helix {}` should name the missing runtime, got: {message}",
+            command.join(" ")
+        );
+        assert!(
+            message.contains("os error 2"),
+            "`helix {}` should keep the underlying cause, got: {message}",
+            command.join(" ")
+        );
+    }
+}

--- a/crates/cli/tests/runtime_commands.rs
+++ b/crates/cli/tests/runtime_commands.rs
@@ -137,8 +137,11 @@ fn logs_and_status_report_a_missing_runtime_like_stop_does() {
             "`helix {}` should name the missing runtime, got: {message}",
             command.join(" ")
         );
+        // The number is platform-specific: ENOENT is 2, while Windows reports 3
+        // (ERROR_PATH_NOT_FOUND) when the parent directory is absent too. What
+        // matters is that the originating error survives as the cause.
         assert!(
-            message.contains("os error 2"),
+            message.contains("os error"),
             "`helix {}` should keep the underlying cause, got: {message}",
             command.join(" ")
         );

--- a/crates/cli/tests/runtime_commands.rs
+++ b/crates/cli/tests/runtime_commands.rs
@@ -144,3 +144,35 @@ fn logs_and_status_report_a_missing_runtime_like_stop_does() {
         );
     }
 }
+
+/// A runtime that is present but refuses to launch is a different failure from
+/// one that is not installed, and must not be reported as a missing install.
+#[cfg(unix)]
+#[test]
+fn a_present_but_unspawnable_runtime_keeps_its_command_error() {
+    let fixture = CliFixture::new().with_unspawnable_runtime();
+    let project = fixture.root().join("unspawnable-runtime-project");
+    fixture
+        .command()
+        .args(["init", "--path"])
+        .arg(&project)
+        .args(["local", "--no-skills"])
+        .assert()
+        .success();
+
+    for command in [["logs", "dev"], ["status", "dev"]] {
+        let message = stderr(
+            fixture
+                .command()
+                .current_dir(&project)
+                .args(command)
+                .assert()
+                .failure(),
+        );
+        assert!(
+            !message.contains("is not installed"),
+            "`helix {}` should not blame the install for a permission failure, got: {message}",
+            command.join(" ")
+        );
+    }
+}

--- a/crates/cli/tests/support/mod.rs
+++ b/crates/cli/tests/support/mod.rs
@@ -85,6 +85,23 @@ impl CliFixture {
         self
     }
 
+    /// Points the runtime seam at a file that exists but cannot be executed, so
+    /// spawning fails for a reason other than the runtime being absent.
+    #[cfg(unix)]
+    #[allow(dead_code)]
+    pub fn with_unspawnable_runtime(mut self) -> Self {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = self.root.join("bin");
+        fs::create_dir_all(&directory).expect("create runtime fixture directory");
+        let binary = directory.join("unspawnable-runtime");
+        fs::write(&binary, "not an executable\n").expect("write runtime fixture");
+        fs::set_permissions(&binary, fs::Permissions::from_mode(0o644))
+            .expect("drop execute permission on runtime fixture");
+        self.test_runtime_bin = Some(binary);
+        self
+    }
+
     #[allow(dead_code)]
     pub fn with_http_base(mut self, base_url: impl Into<String>) -> Self {
         self.http_base_url = Some(base_url.into());

--- a/crates/cli/tests/support/mod.rs
+++ b/crates/cli/tests/support/mod.rs
@@ -77,6 +77,14 @@ impl CliFixture {
         }
     }
 
+    /// Points the runtime seam at a path that does not exist, so every runtime
+    /// command fails to spawn exactly as it does on a host without Docker.
+    #[allow(dead_code)]
+    pub fn with_missing_runtime(mut self) -> Self {
+        self.test_runtime_bin = Some(self.root.join("bin").join("missing-runtime"));
+        self
+    }
+
     #[allow(dead_code)]
     pub fn with_http_base(mut self, base_url: impl Into<String>) -> Self {
         self.http_base_url = Some(base_url.into());


### PR DESCRIPTION
on a host that has podman but not docker, `helix logs` and `helix status` both die with `Failed to read logs for helix-x-dev: No such file or directory (os error 2)`. `helix start` and `helix stop` on that same box give you `Docker is not installed` plus a help line telling you to set `container_runtime = "podman"` in helix.toml. same machine, same missing binary, two completely different errors.

#1036 fixed stop and restart by calling `check_available` first. logs and status were left out of that one on purpose, since `check_available` auto starts the daemon and doing that as a side effect of a read only command is wrong. that reasoning still holds, so this doesn't touch `check_available`.

instead it routes the spawn failure through `not_installed_error`, which is the helper `check_available` already uses to build that message and the only place it was ever called from. it only fires when the process could not be spawned at all, so nothing gets probed and nothing gets started. if the binary is there and the daemon is just down, `docker logs` still spawns fine and returns non zero, so the existing error paths are untouched.

two lines of src, the rest is the test.

before

```
Failed to inspect helix-repro1036-dev: No such file or directory (os error 2)
Failed to read logs for helix-repro1036-dev: No such file or directory (os error 2)
```

after

```
error: Docker is not installed (`docker` not found on PATH)

   │ No such file or directory (os error 2)

   = help: Podman is installed — set `container_runtime = "podman"` under [project] in helix.toml to use it instead, or install Docker.
```

the underlying os error is kept as the cause line, so nothing is lost.

the test points `HELIX_TEST_CONTAINER_RUNTIME_BIN` at a path that doesn't exist, which is the same spawn failure a missing docker gives, and checks that logs, status and stop all name the runtime and all still carry the os error. stop is in that loop on purpose, so if someone changes one of the three later the other two don't quietly drift again.

`prune_instance` reaches the same bare error through `remove_container`. left it out to keep this focused, happy to do it separately if you want it.

tests

```
cargo test -p helix-cli --test runtime_commands
cargo clippy -p helix-cli --all-targets -- -D warnings
cargo fmt --all -- --check
```


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves missing-container-runtime diagnostics for the read-only logs and status commands without probing or starting the daemon.
- Routes logs and status spawn failures through the shared runtime-not-installed diagnostic.
- Adds a missing-runtime fixture and regression coverage across logs, status, and stop.
- The new mapping also labels non-missing-binary spawn failures as installation failures.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/cli/src/local_runtime.rs | Improves missing-runtime errors for logs and status, but unconditionally misclassifies every spawn failure as a missing binary. |
| crates/cli/tests/runtime_commands.rs | Adds focused regression coverage confirming logs, status, and stop identify a missing Docker executable while retaining the OS error. |
| crates/cli/tests/support/mod.rs | Adds a fixture helper that reliably directs runtime commands to a nonexistent executable. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: name the missing container runtime ..."](https://github.com/helixdb/helix-db/commit/d20a3c7fd725e4a85b322f7e58362d3c64f8bfa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57831448)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->