### PR TITLE
Make graph removals conflict by logical member

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3595,7 +3595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -3616,7 +3616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4683,7 +4683,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=7a843f8025568e09e7d186aedbe487eae31bc87a#7a843f8025568e09e7d186aedbe487eae31bc87a"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=d8619d5475f3e76ab7ab7e216f57cb4dd7005711#d8619d5475f3e76ab7ab7e216f57cb4dd7005711"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=7a843f8025568e09e7d186aedbe487eae31bc87a#7a843f8025568e09e7d186aedbe487eae31bc87a"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=d8619d5475f3e76ab7ab7e216f57cb4dd7005711#d8619d5475f3e76ab7ab7e216f57cb4dd7005711"
 dependencies = [
  "chrono",
  "log",
@@ -4743,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=7a843f8025568e09e7d186aedbe487eae31bc87a#7a843f8025568e09e7d186aedbe487eae31bc87a"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=d8619d5475f3e76ab7ab7e216f57cb4dd7005711#d8619d5475f3e76ab7ab7e216f57cb4dd7005711"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,8 +4683,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=b7b876ca533d88e78884b2c20c05827a58819a22#b7b876ca533d88e78884b2c20c05827a58819a22"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=85ffcf7acfe429dcbda6380aec07b44d53ab1584#85ffcf7acfe429dcbda6380aec07b44d53ab1584"
 dependencies = [
+ "ahash",
  "async-channel",
  "async-trait",
  "atomic",
@@ -4728,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=b7b876ca533d88e78884b2c20c05827a58819a22#b7b876ca533d88e78884b2c20c05827a58819a22"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=85ffcf7acfe429dcbda6380aec07b44d53ab1584#85ffcf7acfe429dcbda6380aec07b44d53ab1584"
 dependencies = [
  "chrono",
  "log",
@@ -4743,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=b7b876ca533d88e78884b2c20c05827a58819a22#b7b876ca533d88e78884b2c20c05827a58819a22"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=85ffcf7acfe429dcbda6380aec07b44d53ab1584#85ffcf7acfe429dcbda6380aec07b44d53ab1584"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=7a843f8025568e09e7d186aedbe487eae31bc87a#7a843f8025568e09e7d186aedbe487eae31bc87a"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=7a843f8025568e09e7d186aedbe487eae31bc87a#7a843f8025568e09e7d186aedbe487eae31bc87a"
 dependencies = [
  "chrono",
  "log",
@@ -4743,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=7a843f8025568e09e7d186aedbe487eae31bc87a#7a843f8025568e09e7d186aedbe487eae31bc87a"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=d8619d5475f3e76ab7ab7e216f57cb4dd7005711#d8619d5475f3e76ab7ab7e216f57cb4dd7005711"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=b7b876ca533d88e78884b2c20c05827a58819a22#b7b876ca533d88e78884b2c20c05827a58819a22"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=d8619d5475f3e76ab7ab7e216f57cb4dd7005711#d8619d5475f3e76ab7ab7e216f57cb4dd7005711"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=b7b876ca533d88e78884b2c20c05827a58819a22#b7b876ca533d88e78884b2c20c05827a58819a22"
 dependencies = [
  "chrono",
  "log",
@@ -4743,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=d8619d5475f3e76ab7ab7e216f57cb4dd7005711#d8619d5475f3e76ab7ab7e216f57cb4dd7005711"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=b7b876ca533d88e78884b2c20c05827a58819a22#b7b876ca533d88e78884b2c20c05827a58819a22"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "b7b876ca533d88e78884b2c20c05827a58819a22" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "85ffcf7acfe429dcbda6380aec07b44d53ab1584" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "d8619d5475f3e76ab7ab7e216f57cb4dd7005711" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "b7b876ca533d88e78884b2c20c05827a58819a22" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "7a843f8025568e09e7d186aedbe487eae31bc87a" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "d8619d5475f3e76ab7ab7e216f57cb4dd7005711" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "30d9f28cfeb93cf95652aac2b7724811c5c49630" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "7a843f8025568e09e7d186aedbe487eae31bc87a" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/db/src/encoding/v2/keys/indexes/direction.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/direction.rs
@@ -2,7 +2,7 @@
 
 use crate::encoding::error::EncodingError;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub(crate) enum EdgeDirection {
     Out = 0x00,

--- a/crates/db/src/encoding/v2/values/adjacency.rs
+++ b/crates/db/src/encoding/v2/values/adjacency.rs
@@ -141,6 +141,14 @@ impl AdjacencyMembershipDelta {
         self.incoming.apply_to(&mut edges.nxts_in);
     }
 
+    pub(crate) fn outgoing_members(&self) -> impl Iterator<Item = NodeId> + '_ {
+        self.outgoing.members()
+    }
+
+    pub(crate) fn incoming_members(&self) -> impl Iterator<Item = NodeId> + '_ {
+        self.incoming.members()
+    }
+
     pub(crate) fn encode(&self) -> Bytes {
         let outgoing = self.outgoing.encode();
         let incoming = self.incoming.encode();

--- a/crates/db/src/encoding/v2/values/adjacency.rs
+++ b/crates/db/src/encoding/v2/values/adjacency.rs
@@ -1,10 +1,13 @@
-use bytes::Bytes;
+use bytes::{BufMut, Bytes};
 use roaring::RoaringTreemap;
 
 use super::codec::{take_slice, take_u32_le, take_u8, ENCODING_TYPE_LEN, U32_LEN};
+use super::indexes::BitmapMembershipDelta;
 use crate::encoding::{error::EncodingError, NodeId};
 
 const BITMAP_LEN_PREFIX_LEN: usize = U32_LEN;
+const ADJACENCY_MEMBERSHIP_DELTA_MAGIC: &[u8; 8] = b"HLXADJ2\0";
+const ADJACENCY_RESET_OUT_LEN: usize = core::mem::size_of::<u8>();
 
 /// Encoding type: No compression
 ///
@@ -79,6 +82,127 @@ pub struct Edges {
     pub(crate) nxts_out: RoaringTreemap,
     /// Incoming edges (neighbor -> this node)
     pub(crate) nxts_in: RoaringTreemap,
+}
+
+/// Associative last-write-wins membership changes for one adjacency row.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct AdjacencyMembershipDelta {
+    reset_out: bool,
+    outgoing: BitmapMembershipDelta,
+    incoming: BitmapMembershipDelta,
+}
+
+impl AdjacencyMembershipDelta {
+    pub(crate) fn from_edges(edges: &Edges) -> Self {
+        Self {
+            reset_out: false,
+            outgoing: BitmapMembershipDelta::from_additions(edges.nxts_out.clone()),
+            incoming: BitmapMembershipDelta::from_additions(edges.nxts_in.clone()),
+        }
+    }
+
+    pub(crate) fn add_out(&mut self, neighbor: NodeId) {
+        self.outgoing.add(neighbor);
+    }
+
+    pub(crate) fn remove_out(&mut self, neighbor: NodeId) {
+        self.outgoing.remove(neighbor);
+    }
+
+    pub(crate) fn add_in(&mut self, neighbor: NodeId) {
+        self.incoming.add(neighbor);
+    }
+
+    pub(crate) fn remove_in(&mut self, neighbor: NodeId) {
+        self.incoming.remove(neighbor);
+    }
+
+    pub(crate) fn reset_out(&mut self) {
+        self.reset_out = true;
+        self.outgoing = BitmapMembershipDelta::default();
+    }
+
+    /// Applies a newer delta after this delta.
+    pub(crate) fn compose(&mut self, newer: &Self) {
+        if newer.reset_out {
+            self.reset_out = true;
+            self.outgoing = newer.outgoing.clone();
+        } else {
+            self.outgoing.compose(&newer.outgoing);
+        }
+        self.incoming.compose(&newer.incoming);
+    }
+
+    pub(crate) fn apply_to(&self, edges: &mut Edges) {
+        if self.reset_out {
+            edges.nxts_out.clear();
+        }
+        self.outgoing.apply_to(&mut edges.nxts_out);
+        self.incoming.apply_to(&mut edges.nxts_in);
+    }
+
+    pub(crate) fn encode(&self) -> Bytes {
+        let outgoing = self.outgoing.encode();
+        let incoming = self.incoming.encode();
+        let mut bytes = Vec::with_capacity(
+            ADJACENCY_MEMBERSHIP_DELTA_MAGIC.len()
+                + ADJACENCY_RESET_OUT_LEN
+                + BITMAP_LEN_PREFIX_LEN
+                + outgoing.len()
+                + BITMAP_LEN_PREFIX_LEN
+                + incoming.len(),
+        );
+        bytes.extend_from_slice(ADJACENCY_MEMBERSHIP_DELTA_MAGIC);
+        bytes.put_u8(u8::from(self.reset_out));
+        bytes.put_u32_le(u32::try_from(outgoing.len()).expect("outgoing delta length fits u32"));
+        bytes.extend_from_slice(&outgoing);
+        bytes.put_u32_le(u32::try_from(incoming.len()).expect("incoming delta length fits u32"));
+        bytes.extend_from_slice(&incoming);
+        Bytes::from(bytes)
+    }
+
+    pub(crate) fn decode_if_delta(bytes: &[u8]) -> Result<Option<Self>, EncodingError> {
+        if !bytes.starts_with(ADJACENCY_MEMBERSHIP_DELTA_MAGIC) {
+            return Ok(None);
+        }
+        let mut offset = ADJACENCY_MEMBERSHIP_DELTA_MAGIC.len();
+        let reset_out = match take_u8(bytes, &mut offset)? {
+            0 => false,
+            1 => true,
+            value => {
+                return Err(EncodingError::Custom(format!(
+                    "invalid adjacency reset flag {value}"
+                )))
+            }
+        };
+        let outgoing_len = take_u32_le(bytes, &mut offset)?;
+        let outgoing_bytes = take_slice(bytes, &mut offset, outgoing_len)?;
+        let outgoing =
+            BitmapMembershipDelta::decode_if_delta(outgoing_bytes)?.ok_or_else(|| {
+                EncodingError::Custom(
+                    "adjacency outgoing membership delta is malformed".to_string(),
+                )
+            })?;
+        let incoming_len = take_u32_le(bytes, &mut offset)?;
+        let incoming_bytes = take_slice(bytes, &mut offset, incoming_len)?;
+        let incoming =
+            BitmapMembershipDelta::decode_if_delta(incoming_bytes)?.ok_or_else(|| {
+                EncodingError::Custom(
+                    "adjacency incoming membership delta is malformed".to_string(),
+                )
+            })?;
+        if offset != bytes.len() {
+            return Err(EncodingError::Custom(format!(
+                "adjacency membership delta has {} trailing bytes",
+                bytes.len() - offset
+            )));
+        }
+        Ok(Some(Self {
+            reset_out,
+            outgoing,
+            incoming,
+        }))
+    }
 }
 
 impl Edges {
@@ -225,6 +349,11 @@ pub fn decode_edges(data: &[u8]) -> Result<Edges, EncodingError> {
     if data.is_empty() {
         return Ok(Edges::new());
     }
+    if let Some(delta) = AdjacencyMembershipDelta::decode_if_delta(data)? {
+        let mut edges = Edges::new();
+        delta.apply_to(&mut edges);
+        return Ok(edges);
+    }
 
     let mut offset = 0;
     let encoding_type = take_u8(data, &mut offset)?;
@@ -254,6 +383,11 @@ pub fn decode_out_edges(data: &[u8]) -> Result<Edges, EncodingError> {
     if data.is_empty() {
         return Ok(Edges::new());
     }
+    if AdjacencyMembershipDelta::decode_if_delta(data)?.is_some() {
+        let mut edges = decode_edges(data)?;
+        edges.nxts_in.clear();
+        return Ok(edges);
+    }
 
     let mut offset = 0;
     let encoding_type = take_u8(data, &mut offset)?;
@@ -279,6 +413,11 @@ pub fn decode_out_edges(data: &[u8]) -> Result<Edges, EncodingError> {
 pub fn decode_in_edges(data: &[u8]) -> Result<Edges, EncodingError> {
     if data.is_empty() {
         return Ok(Edges::new());
+    }
+    if AdjacencyMembershipDelta::decode_if_delta(data)?.is_some() {
+        let mut edges = decode_edges(data)?;
+        edges.nxts_out.clear();
+        return Ok(edges);
     }
 
     let mut offset = 0;
@@ -398,6 +537,66 @@ mod tests {
         assert!(out.iter_in().collect::<Vec<_>>().is_empty());
         assert!(incoming.iter_out().collect::<Vec<_>>().is_empty());
         assert_eq!(incoming.iter_in().collect::<Vec<_>>(), vec![2]);
+    }
+
+    #[test]
+    fn adjacency_membership_delta_round_trips_composes_and_resets() {
+        let mut older = AdjacencyMembershipDelta::default();
+        older.add_out(1);
+        older.add_out(2);
+        older.remove_in(3);
+        let mut newer = AdjacencyMembershipDelta::default();
+        newer.reset_out();
+        newer.add_out(4);
+        newer.add_in(3);
+        older.compose(&newer);
+
+        let decoded = AdjacencyMembershipDelta::decode_if_delta(&older.encode())
+            .unwrap()
+            .expect("adjacency delta marker is recognized");
+        let mut base = Edges::new();
+        base.add_out(9);
+        base.add_in(8);
+        decoded.apply_to(&mut base);
+
+        assert_eq!(base.iter_out().collect::<Vec<_>>(), vec![4]);
+        assert_eq!(base.iter_in().collect::<Vec<_>>(), vec![3, 8]);
+        assert_eq!(
+            decode_out_edges(&decoded.encode())
+                .unwrap()
+                .iter_out()
+                .collect::<Vec<_>>(),
+            vec![4]
+        );
+        assert_eq!(
+            decode_in_edges(&decoded.encode())
+                .unwrap()
+                .iter_in()
+                .collect::<Vec<_>>(),
+            vec![3]
+        );
+    }
+
+    #[test]
+    fn adjacency_membership_delta_decoder_rejects_invalid_boundaries() {
+        let mut delta = AdjacencyMembershipDelta::default();
+        delta.add_out(1);
+        let encoded = delta.encode();
+        assert_eq!(
+            AdjacencyMembershipDelta::decode_if_delta(&encode_edges(&Edges::new())).unwrap(),
+            None
+        );
+        for length in ADJACENCY_MEMBERSHIP_DELTA_MAGIC.len()..encoded.len() {
+            assert!(AdjacencyMembershipDelta::decode_if_delta(&encoded[0..length]).is_err());
+        }
+
+        let mut invalid_reset = encoded.to_vec();
+        invalid_reset[ADJACENCY_MEMBERSHIP_DELTA_MAGIC.len()] = 2;
+        assert!(AdjacencyMembershipDelta::decode_if_delta(&invalid_reset).is_err());
+
+        let mut trailing = encoded.to_vec();
+        trailing.push(0xFF);
+        assert!(AdjacencyMembershipDelta::decode_if_delta(&trailing).is_err());
     }
 
     #[test]

--- a/crates/db/src/encoding/v2/values/indexes/equality.rs
+++ b/crates/db/src/encoding/v2/values/indexes/equality.rs
@@ -2,7 +2,7 @@
 
 use std::io::Cursor;
 
-use bytes::Bytes;
+use bytes::{BufMut, Bytes};
 use roaring::RoaringTreemap;
 
 use crate::encoding::error::EncodingError;
@@ -16,6 +16,141 @@ use super::super::{
 };
 
 const SECONDARY_ENTRY_KIND: u8 = 0x05;
+const BITMAP_MEMBERSHIP_DELTA_MAGIC: &[u8; 8] = b"HLXRBM2\0";
+const BITMAP_MEMBERSHIP_DELTA_LEN_PREFIX_LEN: usize = core::mem::size_of::<u32>();
+
+/// Associative last-write-wins membership changes for one physical bitmap row.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct BitmapMembershipDelta {
+    additions: RoaringTreemap,
+    removals: RoaringTreemap,
+}
+
+impl BitmapMembershipDelta {
+    pub(crate) fn from_additions(additions: RoaringTreemap) -> Self {
+        Self {
+            additions,
+            removals: RoaringTreemap::new(),
+        }
+    }
+
+    pub(crate) fn add(&mut self, id: u64) {
+        self.removals.remove(id);
+        self.additions.insert(id);
+    }
+
+    pub(crate) fn remove(&mut self, id: u64) {
+        self.additions.remove(id);
+        self.removals.insert(id);
+    }
+
+    /// Applies a newer delta after this delta.
+    pub(crate) fn compose(&mut self, newer: &Self) {
+        self.removals -= &newer.additions;
+        self.additions |= &newer.additions;
+        self.additions -= &newer.removals;
+        self.removals |= &newer.removals;
+    }
+
+    pub(crate) fn apply_to(&self, ids: &mut RoaringTreemap) {
+        *ids -= &self.removals;
+        *ids |= &self.additions;
+    }
+
+    pub(crate) fn encode(&self) -> Bytes {
+        let mut additions = Vec::new();
+        self.additions
+            .serialize_into(&mut additions)
+            .expect("serializing membership additions into memory is infallible");
+        let mut removals = Vec::new();
+        self.removals
+            .serialize_into(&mut removals)
+            .expect("serializing membership removals into memory is infallible");
+        let mut bytes = Vec::with_capacity(
+            BITMAP_MEMBERSHIP_DELTA_MAGIC.len()
+                + BITMAP_MEMBERSHIP_DELTA_LEN_PREFIX_LEN
+                + additions.len()
+                + BITMAP_MEMBERSHIP_DELTA_LEN_PREFIX_LEN
+                + removals.len(),
+        );
+        bytes.extend_from_slice(BITMAP_MEMBERSHIP_DELTA_MAGIC);
+        bytes.put_u32(u32::try_from(additions.len()).expect("roaring additions fit u32"));
+        bytes.extend_from_slice(&additions);
+        bytes.put_u32(u32::try_from(removals.len()).expect("roaring removals fit u32"));
+        bytes.extend_from_slice(&removals);
+        Bytes::from(bytes)
+    }
+
+    pub(crate) fn decode_if_delta(bytes: &[u8]) -> Result<Option<Self>, EncodingError> {
+        if !bytes.starts_with(BITMAP_MEMBERSHIP_DELTA_MAGIC) {
+            return Ok(None);
+        }
+        let mut offset = BITMAP_MEMBERSHIP_DELTA_MAGIC.len();
+        let additions = take_delta_bitmap(bytes, &mut offset, "additions")?;
+        let removals = take_delta_bitmap(bytes, &mut offset, "removals")?;
+        if offset != bytes.len() {
+            return Err(EncodingError::Custom(format!(
+                "bitmap membership delta has {} trailing bytes",
+                bytes.len() - offset
+            )));
+        }
+        if !additions.is_disjoint(&removals) {
+            return Err(EncodingError::Custom(
+                "bitmap membership delta additions and removals overlap".to_string(),
+            ));
+        }
+        Ok(Some(Self {
+            additions,
+            removals,
+        }))
+    }
+}
+
+fn take_delta_bitmap(
+    bytes: &[u8],
+    offset: &mut usize,
+    name: &str,
+) -> Result<RoaringTreemap, EncodingError> {
+    let length_end = offset
+        .checked_add(BITMAP_MEMBERSHIP_DELTA_LEN_PREFIX_LEN)
+        .ok_or_else(|| EncodingError::Custom("bitmap delta length overflow".to_string()))?;
+    if length_end > bytes.len() {
+        return Err(EncodingError::BufferTooShort {
+            expected: length_end,
+            actual: bytes.len(),
+        });
+    }
+    let length = u32::from_be_bytes(
+        bytes[*offset..*offset + BITMAP_MEMBERSHIP_DELTA_LEN_PREFIX_LEN]
+            .try_into()
+            .expect("validated bitmap delta length slice is four bytes"),
+    ) as usize;
+    *offset = length_end;
+    let value_end = offset
+        .checked_add(length)
+        .ok_or_else(|| EncodingError::Custom("bitmap delta value overflow".to_string()))?;
+    if value_end > bytes.len() {
+        return Err(EncodingError::BufferTooShort {
+            expected: value_end,
+            actual: bytes.len(),
+        });
+    }
+    let mut cursor = Cursor::new(&bytes[*offset..*offset + length]);
+    let bitmap = RoaringTreemap::deserialize_from(&mut cursor).map_err(|error| {
+        EncodingError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("failed to decode bitmap membership delta {name}: {error}"),
+        ))
+    })?;
+    if cursor.position() != length as u64 {
+        return Err(EncodingError::Custom(format!(
+            "bitmap membership delta {name} has {} trailing bytes",
+            length as u64 - cursor.position()
+        )));
+    }
+    *offset = value_end;
+    Ok(bitmap)
+}
 
 /// Portable V4 value for one non-unique equality key.
 #[derive(Debug, Clone, PartialEq)]
@@ -35,6 +170,9 @@ impl SecondaryEqualityBitmapValue {
     }
 
     pub(crate) fn decode(bytes: &[u8]) -> Result<Self, EncodingError> {
+        if let Some(delta) = BitmapMembershipDelta::decode_if_delta(bytes)? {
+            return Ok(Self(delta.additions));
+        }
         let mut cursor = Cursor::new(bytes);
         let ids = RoaringTreemap::deserialize_from(&mut cursor).map_err(|error| {
             EncodingError::Io(std::io::Error::new(
@@ -132,6 +270,80 @@ mod tests {
     }
 
     #[test]
+    fn bitmap_membership_delta_round_trips_and_composes_last_write_wins() {
+        let mut older = BitmapMembershipDelta::default();
+        older.add(1);
+        older.add(2);
+        older.remove(3);
+        let mut newer = BitmapMembershipDelta::default();
+        newer.remove(1);
+        newer.add(3);
+        newer.remove(4);
+        older.compose(&newer);
+
+        let decoded = BitmapMembershipDelta::decode_if_delta(&older.encode())
+            .unwrap()
+            .expect("membership delta marker is recognized");
+        let mut base = RoaringTreemap::from_iter([1, 4, 5]);
+        decoded.apply_to(&mut base);
+
+        assert_eq!(base.iter().collect::<Vec<_>>(), vec![2, 3, 5]);
+        assert!(decoded.additions.contains(2));
+        assert!(decoded.additions.contains(3));
+        assert!(decoded.removals.contains(1));
+        assert!(decoded.removals.contains(4));
+    }
+
+    #[test]
+    fn bitmap_membership_delta_decoder_rejects_every_invalid_boundary() {
+        let mut delta = BitmapMembershipDelta::default();
+        delta.add(1);
+        let encoded = delta.encode();
+        assert_eq!(
+            BitmapMembershipDelta::decode_if_delta(b"portable-roaring").unwrap(),
+            None
+        );
+        for length in BITMAP_MEMBERSHIP_DELTA_MAGIC.len()..encoded.len() {
+            assert!(BitmapMembershipDelta::decode_if_delta(&encoded[0..length]).is_err());
+        }
+
+        let mut trailing = encoded.to_vec();
+        trailing.push(0xFF);
+        assert!(BitmapMembershipDelta::decode_if_delta(&trailing).is_err());
+
+        let overlapping = BitmapMembershipDelta {
+            additions: RoaringTreemap::from_iter([7]),
+            removals: RoaringTreemap::from_iter([7]),
+        };
+        assert!(BitmapMembershipDelta::decode_if_delta(&overlapping.encode()).is_err());
+    }
+
+    #[test]
+    fn equality_value_decoders_project_delta_against_an_empty_base() {
+        let mut delta = BitmapMembershipDelta::default();
+        delta.add(3);
+        delta.remove(4);
+        let encoded = delta.encode();
+
+        assert_eq!(
+            SecondaryEqualityBitmapValue::decode(&encoded)
+                .unwrap()
+                .into_ids()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![3]
+        );
+        assert_eq!(
+            SecondaryEqualityValue::decode(&encoded)
+                .unwrap()
+                .into_ids()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![3]
+        );
+    }
+
+    #[test]
     fn equality_entry_value_is_lane_bound_and_byte_frozen() {
         let value = SecondaryEntryValue {
             index_id: crate::index_lifecycle::IndexId::new(1).unwrap(),
@@ -174,6 +386,9 @@ impl SecondaryEqualityValue {
 
     /// Decodes the exact current portable Roaring equality-row value.
     pub(crate) fn decode(data: &[u8]) -> Result<Self, EncodingError> {
+        if let Some(delta) = BitmapMembershipDelta::decode_if_delta(data)? {
+            return Ok(Self(delta.additions));
+        }
         let ids = RoaringTreemap::deserialize_from(Cursor::new(data)).map_err(|error| {
             EncodingError::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,

--- a/crates/db/src/encoding/v2/values/indexes/equality.rs
+++ b/crates/db/src/encoding/v2/values/indexes/equality.rs
@@ -57,6 +57,10 @@ impl BitmapMembershipDelta {
         *ids |= &self.additions;
     }
 
+    pub(crate) fn members(&self) -> impl Iterator<Item = u64> + '_ {
+        self.additions.iter().chain(self.removals.iter())
+    }
+
     pub(crate) fn encode(&self) -> Bytes {
         let mut additions = Vec::new();
         self.additions

--- a/crates/db/src/encoding/v2/values/indexes/mod.rs
+++ b/crates/db/src/encoding/v2/values/indexes/mod.rs
@@ -6,5 +6,7 @@ mod secondary_entry;
 pub(crate) mod text;
 pub mod vector;
 
-pub(crate) use equality::{SecondaryEqualityBitmapValue, SecondaryEqualityValue};
+pub(crate) use equality::{
+    BitmapMembershipDelta, SecondaryEqualityBitmapValue, SecondaryEqualityValue,
+};
 pub(crate) use secondary_entry::{decode_secondary_entry, encode_secondary_entry};

--- a/crates/db/src/encoding/v2/values/mod.rs
+++ b/crates/db/src/encoding/v2/values/mod.rs
@@ -20,7 +20,8 @@ pub(crate) use indexes::text::{
 };
 pub(crate) use indexes::vector::{decode_partition_mapping, encode_partition_mapping};
 pub(crate) use indexes::{
-    decode_secondary_entry, encode_secondary_entry, SecondaryEqualityBitmapValue,
+    decode_secondary_entry, encode_secondary_entry, BitmapMembershipDelta,
+    SecondaryEqualityBitmapValue,
 };
 pub(crate) use lifecycle::{
     decode_applied_state, decode_build_delta, decode_index_record, decode_operation_record,

--- a/crates/db/src/execution/interpreter/mutation/topology.rs
+++ b/crates/db/src/execution/interpreter/mutation/topology.rs
@@ -26,17 +26,76 @@ enum MembershipMutation {
     Absent,
 }
 
-/// Direction local to adjacency rows; `Both` is represented by two entries.
+/// Logical identity for one shared bitmap row. Physical keys are encoded once
+/// when the coalesced epoch is flushed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum AdjacencyDirection {
-    Out,
-    In,
+enum BitmapRow {
+    NodeLabel {
+        scope: DataScope,
+        label_hash: [u8; 8],
+    },
+    EdgePair {
+        scope: DataScope,
+        from: u64,
+        to: u64,
+    },
+    EdgeLabelNeighbor {
+        scope: DataScope,
+        direction: EdgeDirection,
+        node: u64,
+        label_hash: [u8; 8],
+    },
+    GlobalEdgeLabel {
+        scope: DataScope,
+        label_hash: [u8; 8],
+    },
+}
+
+impl BitmapRow {
+    fn to_bytes(self) -> Bytes {
+        match self {
+            Self::NodeLabel { scope, label_hash } => DataKey::Data {
+                scope,
+                kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(
+                    crate::encoding::indexes::equality::EqualityIndexKey::new(
+                        hash_property_name("$label"),
+                        label_hash,
+                    ),
+                )),
+            }
+            .to_bytes(),
+            Self::EdgePair { scope, from, to } => DataKey::Data {
+                scope,
+                kind: DataKeyKind::EdgePairIndex(EdgePairIndexKey::new(from, to)),
+            }
+            .to_bytes(),
+            Self::EdgeLabelNeighbor {
+                scope,
+                direction,
+                node,
+                label_hash,
+            } => DataKey::Data {
+                scope,
+                kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
+                    EdgeLabelNeighborKey::new(direction, node, label_hash),
+                )),
+            }
+            .to_bytes(),
+            Self::GlobalEdgeLabel { scope, label_hash } => DataKey::Data {
+                scope,
+                kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(
+                    label_hash,
+                ))),
+            }
+            .to_bytes(),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
 struct TopologyMutationBatch {
-    bitmaps: BTreeMap<Bytes, BTreeMap<u64, MembershipMutation>>,
-    adjacency: BTreeMap<Bytes, BTreeMap<(AdjacencyDirection, u64), MembershipMutation>>,
+    bitmaps: BTreeMap<BitmapRow, secondary::BitmapMembershipDelta>,
+    adjacency: BTreeMap<(DataScope, u64), edges::AdjacencyMembershipDelta>,
 }
 
 /// Transaction-owned topology mutations with a terminal prepared state.
@@ -91,7 +150,10 @@ impl TopologyMutationRuntime {
         node_id: u64,
     ) -> Result<()> {
         self.record_bitmap(
-            node_label_key(scope, label),
+            BitmapRow::NodeLabel {
+                scope,
+                label_hash: hash_property_value(label),
+            },
             node_id,
             MembershipMutation::Present,
         )
@@ -105,7 +167,10 @@ impl TopologyMutationRuntime {
         node_id: u64,
     ) -> Result<()> {
         self.record_bitmap(
-            node_label_key(scope, label),
+            BitmapRow::NodeLabel {
+                scope,
+                label_hash: hash_property_value(label),
+            },
             node_id,
             MembershipMutation::Absent,
         )
@@ -120,7 +185,7 @@ impl TopologyMutationRuntime {
         edge_id: u64,
     ) -> Result<()> {
         self.record_bitmap(
-            edge_pair_key(scope, from, to),
+            BitmapRow::EdgePair { scope, from, to },
             edge_id,
             MembershipMutation::Present,
         )
@@ -135,7 +200,7 @@ impl TopologyMutationRuntime {
         edge_id: u64,
     ) -> Result<()> {
         self.record_bitmap(
-            edge_pair_key(scope, from, to),
+            BitmapRow::EdgePair { scope, from, to },
             edge_id,
             MembershipMutation::Absent,
         )
@@ -151,17 +216,30 @@ impl TopologyMutationRuntime {
         edge_id: u64,
     ) -> Result<()> {
         self.record_bitmap(
-            edge_label_neighbor_key(scope, EdgeDirection::Out, from, label),
+            BitmapRow::EdgeLabelNeighbor {
+                scope,
+                direction: EdgeDirection::Out,
+                node: from,
+                label_hash: hash_property_value(label),
+            },
             to,
             MembershipMutation::Present,
         )?;
         self.record_bitmap(
-            edge_label_neighbor_key(scope, EdgeDirection::In, to, label),
+            BitmapRow::EdgeLabelNeighbor {
+                scope,
+                direction: EdgeDirection::In,
+                node: to,
+                label_hash: hash_property_value(label),
+            },
             from,
             MembershipMutation::Present,
         )?;
         self.record_bitmap(
-            global_edge_label_key(scope, label),
+            BitmapRow::GlobalEdgeLabel {
+                scope,
+                label_hash: hash_property_value(label),
+            },
             edge_id,
             MembershipMutation::Present,
         )
@@ -175,7 +253,10 @@ impl TopologyMutationRuntime {
         edge_id: u64,
     ) -> Result<()> {
         self.record_bitmap(
-            global_edge_label_key(scope, label),
+            BitmapRow::GlobalEdgeLabel {
+                scope,
+                label_hash: hash_property_value(label),
+            },
             edge_id,
             MembershipMutation::Absent,
         )
@@ -190,12 +271,22 @@ impl TopologyMutationRuntime {
         label: &str,
     ) -> Result<()> {
         self.record_bitmap(
-            edge_label_neighbor_key(scope, EdgeDirection::Out, from, label),
+            BitmapRow::EdgeLabelNeighbor {
+                scope,
+                direction: EdgeDirection::Out,
+                node: from,
+                label_hash: hash_property_value(label),
+            },
             to,
             MembershipMutation::Absent,
         )?;
         self.record_bitmap(
-            edge_label_neighbor_key(scope, EdgeDirection::In, to, label),
+            BitmapRow::EdgeLabelNeighbor {
+                scope,
+                direction: EdgeDirection::In,
+                node: to,
+                label_hash: hash_property_value(label),
+            },
             from,
             MembershipMutation::Absent,
         )
@@ -229,9 +320,17 @@ impl TopologyMutationRuntime {
         self.record_adjacency(scope, node, neighbor, direction, MembershipMutation::Absent)
     }
 
-    fn record_bitmap(&mut self, key: Bytes, id: u64, mutation: MembershipMutation) -> Result<()> {
-        let batch = self.collecting_batch()?;
-        batch.bitmaps.entry(key).or_default().insert(id, mutation);
+    fn record_bitmap(
+        &mut self,
+        row: BitmapRow,
+        id: u64,
+        mutation: MembershipMutation,
+    ) -> Result<()> {
+        let delta = self.collecting_batch()?.bitmaps.entry(row).or_default();
+        match mutation {
+            MembershipMutation::Present => delta.add(id),
+            MembershipMutation::Absent => delta.remove(id),
+        }
         Ok(())
     }
 
@@ -243,22 +342,31 @@ impl TopologyMutationRuntime {
         direction: helix_planner::ir::ExpandDirection,
         mutation: MembershipMutation,
     ) -> Result<()> {
-        let key = DataKey::Data {
-            scope,
-            kind: DataKeyKind::Adjacency(AdjacencyKey::new(node)),
-        }
-        .to_bytes();
-        let row = self.collecting_batch()?.adjacency.entry(key).or_default();
-        match direction {
-            helix_planner::ir::ExpandDirection::Out => {
-                row.insert((AdjacencyDirection::Out, neighbor), mutation);
+        let delta = self
+            .collecting_batch()?
+            .adjacency
+            .entry((scope, node))
+            .or_default();
+        match (direction, mutation) {
+            (helix_planner::ir::ExpandDirection::Out, MembershipMutation::Present) => {
+                delta.add_out(neighbor);
             }
-            helix_planner::ir::ExpandDirection::In => {
-                row.insert((AdjacencyDirection::In, neighbor), mutation);
+            (helix_planner::ir::ExpandDirection::In, MembershipMutation::Present) => {
+                delta.add_in(neighbor);
             }
-            helix_planner::ir::ExpandDirection::Both => {
-                row.insert((AdjacencyDirection::Out, neighbor), mutation);
-                row.insert((AdjacencyDirection::In, neighbor), mutation);
+            (helix_planner::ir::ExpandDirection::Both, MembershipMutation::Present) => {
+                delta.add_out(neighbor);
+                delta.add_in(neighbor);
+            }
+            (helix_planner::ir::ExpandDirection::Out, MembershipMutation::Absent) => {
+                delta.remove_out(neighbor);
+            }
+            (helix_planner::ir::ExpandDirection::In, MembershipMutation::Absent) => {
+                delta.remove_in(neighbor);
+            }
+            (helix_planner::ir::ExpandDirection::Both, MembershipMutation::Absent) => {
+                delta.remove_out(neighbor);
+                delta.remove_in(neighbor);
             }
         }
         Ok(())
@@ -296,52 +404,40 @@ impl TopologyMutationRuntime {
             }
         };
 
-        for (key, mutations) in batch.bitmaps {
-            let mut delta = secondary::BitmapMembershipDelta::default();
-            let mut discriminators = Vec::with_capacity(mutations.len());
-            for (id, mutation) in &mutations {
-                discriminators.push(Bytes::copy_from_slice(&id.to_be_bytes()));
-                match mutation {
-                    MembershipMutation::Present => {
-                        delta.add(*id);
-                    }
-                    MembershipMutation::Absent => {
-                        delta.remove(*id);
-                    }
-                }
-            }
-            transaction.merge_disjoint(&key, discriminators, delta.encode())?;
+        for (row, delta) in batch.bitmaps {
+            let key = row.to_bytes();
+            transaction.merge_disjoint(
+                &key,
+                delta.members().map(|id| id.to_be_bytes()),
+                delta.encode(),
+            )?;
             self.staged_keys.insert(key);
         }
 
-        for (key, mutations) in batch.adjacency {
-            let mut delta = edges::AdjacencyMembershipDelta::default();
-            let mut discriminators = Vec::with_capacity(mutations.len());
-            for ((direction, neighbor), mutation) in &mutations {
-                let mut discriminator =
-                    Vec::with_capacity(core::mem::size_of::<u8>() + core::mem::size_of::<u64>());
-                discriminator.push(match direction {
-                    AdjacencyDirection::Out => 0,
-                    AdjacencyDirection::In => 1,
-                });
-                discriminator.extend_from_slice(&neighbor.to_be_bytes());
-                discriminators.push(Bytes::from(discriminator));
-                match (direction, mutation) {
-                    (AdjacencyDirection::Out, MembershipMutation::Present) => {
-                        delta.add_out(*neighbor);
-                    }
-                    (AdjacencyDirection::In, MembershipMutation::Present) => {
-                        delta.add_in(*neighbor);
-                    }
-                    (AdjacencyDirection::Out, MembershipMutation::Absent) => {
-                        delta.remove_out(*neighbor);
-                    }
-                    (AdjacencyDirection::In, MembershipMutation::Absent) => {
-                        delta.remove_in(*neighbor);
-                    }
-                }
+        for ((scope, node), delta) in batch.adjacency {
+            const DIRECTION_LEN: usize = core::mem::size_of::<u8>();
+            const NODE_ID_LEN: usize = core::mem::size_of::<u64>();
+
+            let key = DataKey::Data {
+                scope,
+                kind: DataKeyKind::Adjacency(AdjacencyKey::new(node)),
             }
-            transaction.merge_disjoint(&key, discriminators, delta.encode())?;
+            .to_bytes();
+            let outgoing = delta.outgoing_members().map(|neighbor| {
+                let mut discriminator = [0; DIRECTION_LEN + NODE_ID_LEN];
+                discriminator[0] = 0;
+                discriminator[DIRECTION_LEN..DIRECTION_LEN + NODE_ID_LEN]
+                    .copy_from_slice(&neighbor.to_be_bytes());
+                discriminator
+            });
+            let incoming = delta.incoming_members().map(|neighbor| {
+                let mut discriminator = [0; DIRECTION_LEN + NODE_ID_LEN];
+                discriminator[0] = 1;
+                discriminator[DIRECTION_LEN..DIRECTION_LEN + NODE_ID_LEN]
+                    .copy_from_slice(&neighbor.to_be_bytes());
+                discriminator
+            });
+            transaction.merge_disjoint(&key, outgoing.chain(incoming), delta.encode())?;
             self.staged_keys.insert(key);
         }
         Ok(())
@@ -370,6 +466,7 @@ impl TopologyMutationRuntime {
     }
 }
 
+#[cfg(test)]
 fn node_label_key(scope: DataScope, label: &str) -> Bytes {
     DataKey::Data {
         scope,
@@ -383,6 +480,7 @@ fn node_label_key(scope: DataScope, label: &str) -> Bytes {
     .to_bytes()
 }
 
+#[cfg(test)]
 fn edge_pair_key(scope: DataScope, from: u64, to: u64) -> Bytes {
     DataKey::Data {
         scope,
@@ -391,6 +489,7 @@ fn edge_pair_key(scope: DataScope, from: u64, to: u64) -> Bytes {
     .to_bytes()
 }
 
+#[cfg(test)]
 fn edge_label_neighbor_key(
     scope: DataScope,
     direction: EdgeDirection,
@@ -406,6 +505,7 @@ fn edge_label_neighbor_key(
     .to_bytes()
 }
 
+#[cfg(test)]
 fn global_edge_label_key(scope: DataScope, label: &str) -> Bytes {
     DataKey::Data {
         scope,
@@ -1010,6 +1110,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn coalesced_membership_deltas_keep_the_last_mutation_per_member() {
+        let db = database("coalesced-last-membership-mutation").await;
+        let transaction = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .unwrap();
+        let scope = DataScope::LegacyUnscoped;
+        let mut runtime = TopologyMutationRuntime::default();
+
+        runtime.add_node_label(scope, "User", 1).unwrap();
+        runtime.remove_node_label(scope, "User", 1).unwrap();
+        runtime.remove_node_label(scope, "User", 2).unwrap();
+        runtime.add_node_label(scope, "User", 2).unwrap();
+        runtime
+            .add_adjacency(scope, 9, 1, helix_planner::ir::ExpandDirection::Both)
+            .unwrap();
+        runtime
+            .remove_adjacency(scope, 9, 1, helix_planner::ir::ExpandDirection::Out)
+            .unwrap();
+        runtime
+            .remove_adjacency(scope, 9, 2, helix_planner::ir::ExpandDirection::Both)
+            .unwrap();
+        runtime
+            .add_adjacency(scope, 9, 2, helix_planner::ir::ExpandDirection::Out)
+            .unwrap();
+        runtime.prepare(&transaction).await.unwrap();
+        runtime.consume_prepared().unwrap();
+        transaction.commit().await.unwrap();
+
+        assert_eq!(
+            secondary::SecondaryEqualityValue::decode(
+                &db.get(node_label_key(scope, "User"))
+                    .await
+                    .unwrap()
+                    .expect("coalesced node-label row exists"),
+            )
+            .unwrap()
+            .into_ids()
+            .iter()
+            .collect::<Vec<_>>(),
+            vec![2]
+        );
+        let adjacency = edges::decode_edges(
+            &db.get(
+                DataKey::Data {
+                    scope,
+                    kind: DataKeyKind::Adjacency(AdjacencyKey::new(9)),
+                }
+                .to_bytes(),
+            )
+            .await
+            .unwrap()
+            .expect("coalesced adjacency row exists"),
+        )
+        .unwrap();
+        assert_eq!(adjacency.iter_out().collect::<Vec<_>>(), vec![2]);
+        assert_eq!(adjacency.iter_in().collect::<Vec<_>>(), vec![1]);
+
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn prepared_runtime_rejects_further_collection() {
         let transaction = transaction("prepared-rejects-collection").await;
         let mut runtime = TopologyMutationRuntime::default();
@@ -1028,12 +1190,19 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct SweepBenchmarkResult {
-        elapsed: Duration,
+    struct SweepConflictBenchmarkResult {
         writer_conflicts: usize,
         sweeper_conflicts: usize,
         writer_commits: usize,
         sweeper_commits: usize,
+    }
+
+    #[derive(Debug)]
+    struct SweepPreparationBenchmarkResult {
+        minimum: Duration,
+        median: Duration,
+        maximum: Duration,
+        samples: usize,
     }
 
     async fn stage_benchmark_memberships(
@@ -1159,13 +1328,13 @@ mod tests {
         transaction
     }
 
-    async fn run_sweep_benchmark(
+    async fn run_sweep_conflict_benchmark(
         strategy: SweepBenchmarkStrategy,
         expired_members: u64,
         inserted_members: u64,
         sweep_chunk: u64,
         writer_chunk: u64,
-    ) -> SweepBenchmarkResult {
+    ) -> SweepConflictBenchmarkResult {
         const PARENT_ID: u64 = u64::MAX - 1;
         const LABEL: &str = "KubernetesEvent";
 
@@ -1208,8 +1377,6 @@ mod tests {
             .collect::<Vec<_>>();
         let writer_progress = Arc::new(AtomicUsize::new(0));
         let writer_notify = Arc::new(tokio::sync::Notify::new());
-        let started = Instant::now();
-
         let writer = {
             let db = Arc::clone(&db);
             let barriers = barriers.clone();
@@ -1281,8 +1448,6 @@ mod tests {
         };
         let writer_conflicts = writer.await.expect("benchmark writer joins");
         let sweeper_conflicts = sweeper.await.expect("benchmark sweeper joins");
-        let elapsed = started.elapsed();
-
         let labels = secondary::SecondaryEqualityValue::decode(
             &db.get(&label_key)
                 .await
@@ -1294,10 +1459,26 @@ mod tests {
         assert_eq!(labels.len(), inserted_members);
         assert_eq!(labels.min(), Some(expired_members));
         assert_eq!(labels.max(), Some(expired_members + inserted_members - 1));
+        let adjacency = edges::decode_edges(
+            &db.get(
+                DataKey::Data {
+                    scope: DataScope::LegacyUnscoped,
+                    kind: DataKeyKind::Adjacency(AdjacencyKey::new(PARENT_ID)),
+                }
+                .to_bytes(),
+            )
+            .await
+            .expect("benchmark adjacency result reads")
+            .expect("inserted adjacency memberships remain"),
+        )
+        .expect("benchmark adjacency result decodes");
+        let outgoing = adjacency.iter_out().collect::<RoaringTreemap>();
+        assert_eq!(outgoing.len(), inserted_members);
+        assert_eq!(outgoing.min(), Some(expired_members));
+        assert_eq!(outgoing.max(), Some(expired_members + inserted_members - 1));
         db.close().await.expect("benchmark database closes");
 
-        SweepBenchmarkResult {
-            elapsed,
+        SweepConflictBenchmarkResult {
             writer_conflicts,
             sweeper_conflicts,
             writer_commits: writer_chunks,
@@ -1305,9 +1486,85 @@ mod tests {
         }
     }
 
+    async fn run_sweep_preparation_benchmark(
+        strategy: SweepBenchmarkStrategy,
+        expired_members: u64,
+        sweep_chunk: u64,
+        samples: usize,
+    ) -> SweepPreparationBenchmarkResult {
+        const PARENT_ID: u64 = u64::MAX - 1;
+        const LABEL: &str = "KubernetesEvent";
+
+        let db = database(match strategy {
+            SweepBenchmarkStrategy::ExclusiveReadModifyWrite => "prepare-exclusive",
+            SweepBenchmarkStrategy::DisjointDelta => "prepare-disjoint",
+        })
+        .await;
+        db.put(
+            node_label_key(DataScope::LegacyUnscoped, LABEL),
+            secondary::SecondaryEqualityValue::encode_ids(
+                &(0..expired_members).collect::<RoaringTreemap>(),
+            ),
+        )
+        .await
+        .expect("preparation benchmark label seed persists");
+        let mut adjacency = edges::Edges::new();
+        for id in 0..expired_members {
+            adjacency.add_out(id);
+        }
+        db.put(
+            DataKey::Data {
+                scope: DataScope::LegacyUnscoped,
+                kind: DataKeyKind::Adjacency(AdjacencyKey::new(PARENT_ID)),
+            }
+            .to_bytes(),
+            edges::encode_edges(&adjacency),
+        )
+        .await
+        .expect("preparation benchmark adjacency seed persists");
+
+        // Warm storage and codec paths before collecting paired samples. The
+        // transaction is deliberately not committed so every sample stages a
+        // sweep against the same full hot rows.
+        drop(
+            stage_benchmark_memberships(&db, strategy, 0..sweep_chunk.min(expired_members), false)
+                .await,
+        );
+
+        let mut elapsed = Vec::with_capacity(samples);
+        for _ in 0..samples {
+            let started = Instant::now();
+            for start in (0..expired_members).step_by(sweep_chunk as usize) {
+                drop(
+                    stage_benchmark_memberships(
+                        &db,
+                        strategy,
+                        start..(start + sweep_chunk).min(expired_members),
+                        false,
+                    )
+                    .await,
+                );
+            }
+            elapsed.push(started.elapsed());
+        }
+        elapsed.sort_unstable();
+        db.close()
+            .await
+            .expect("preparation benchmark database closes");
+
+        SweepPreparationBenchmarkResult {
+            minimum: elapsed[0],
+            median: elapsed[elapsed.len() / 2],
+            maximum: elapsed[elapsed.len() - 1],
+            samples: elapsed.len(),
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    #[ignore = "manual 100K-member conflict and throughput comparison"]
+    #[ignore = "manual 100K-member conflict and preparation-performance comparison"]
     async fn benchmark_exclusive_vs_disjoint_linked_event_sweep() {
+        const MAX_PREPARATION_TIME_RATIO: f64 = 5.0;
+
         let expired_members = std::env::var("HELIX_SWEEP_BENCH_EXPIRED")
             .ok()
             .and_then(|value| value.parse().ok())
@@ -1324,12 +1581,18 @@ mod tests {
             .ok()
             .and_then(|value| value.parse().ok())
             .unwrap_or(250);
+        let performance_samples = std::env::var("HELIX_SWEEP_BENCH_SAMPLES")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(5);
         assert!(expired_members > 0);
         assert!(inserted_members > 0);
         assert!(sweep_chunk > 0);
         assert!(writer_chunk > 0);
+        assert!(performance_samples >= 3);
+        assert!(performance_samples % 2 == 1);
 
-        let before = run_sweep_benchmark(
+        let before_conflicts = run_sweep_conflict_benchmark(
             SweepBenchmarkStrategy::ExclusiveReadModifyWrite,
             expired_members,
             inserted_members,
@@ -1337,7 +1600,7 @@ mod tests {
             writer_chunk,
         )
         .await;
-        let after = run_sweep_benchmark(
+        let after_conflicts = run_sweep_conflict_benchmark(
             SweepBenchmarkStrategy::DisjointDelta,
             expired_members,
             inserted_members,
@@ -1346,41 +1609,77 @@ mod tests {
         )
         .await;
         let before_sweep_conflict_rate =
-            before.sweeper_conflicts as f64 / before.sweeper_commits as f64;
+            before_conflicts.sweeper_conflicts as f64 / before_conflicts.sweeper_commits as f64;
         let after_sweep_conflict_rate =
-            after.sweeper_conflicts as f64 / after.sweeper_commits as f64;
-        let operations = expired_members + inserted_members;
-        let before_throughput = operations as f64 / before.elapsed.as_secs_f64();
-        let after_throughput = operations as f64 / after.elapsed.as_secs_f64();
+            after_conflicts.sweeper_conflicts as f64 / after_conflicts.sweeper_commits as f64;
+
+        let before_preparation = run_sweep_preparation_benchmark(
+            SweepBenchmarkStrategy::ExclusiveReadModifyWrite,
+            expired_members,
+            sweep_chunk,
+            performance_samples,
+        )
+        .await;
+        let after_preparation = run_sweep_preparation_benchmark(
+            SweepBenchmarkStrategy::DisjointDelta,
+            expired_members,
+            sweep_chunk,
+            performance_samples,
+        )
+        .await;
+        let before_preparation_throughput =
+            expired_members as f64 / before_preparation.median.as_secs_f64();
+        let after_preparation_throughput =
+            expired_members as f64 / after_preparation.median.as_secs_f64();
+        let preparation_time_ratio =
+            after_preparation.median.as_secs_f64() / before_preparation.median.as_secs_f64();
 
         println!(
-            "SWEEP_BENCH before elapsed_ms={} sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={} throughput_members_per_s={:.0}",
-            before.elapsed.as_millis(),
-            before.sweeper_commits,
-            before.sweeper_conflicts,
+            "SWEEP_CONFLICT before sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={}",
+            before_conflicts.sweeper_commits,
+            before_conflicts.sweeper_conflicts,
             before_sweep_conflict_rate,
-            before.writer_commits,
-            before.writer_conflicts,
-            before_throughput,
+            before_conflicts.writer_commits,
+            before_conflicts.writer_conflicts,
         );
         println!(
-            "SWEEP_BENCH after elapsed_ms={} sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={} throughput_members_per_s={:.0}",
-            after.elapsed.as_millis(),
-            after.sweeper_commits,
-            after.sweeper_conflicts,
+            "SWEEP_CONFLICT after sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={}",
+            after_conflicts.sweeper_commits,
+            after_conflicts.sweeper_conflicts,
             after_sweep_conflict_rate,
-            after.writer_commits,
-            after.writer_conflicts,
-            after_throughput,
+            after_conflicts.writer_commits,
+            after_conflicts.writer_conflicts,
         );
         println!(
-            "SWEEP_BENCH delta conflict_rate_points={:.2} throughput_ratio={:.3}",
+            "SWEEP_PREP before samples={} min_ms={} median_ms={} max_ms={} throughput_members_per_s={:.0}",
+            before_preparation.samples,
+            before_preparation.minimum.as_millis(),
+            before_preparation.median.as_millis(),
+            before_preparation.maximum.as_millis(),
+            before_preparation_throughput,
+        );
+        println!(
+            "SWEEP_PREP after samples={} min_ms={} median_ms={} max_ms={} throughput_members_per_s={:.0}",
+            after_preparation.samples,
+            after_preparation.minimum.as_millis(),
+            after_preparation.median.as_millis(),
+            after_preparation.maximum.as_millis(),
+            after_preparation_throughput,
+        );
+        println!(
+            "SWEEP_DELTA conflict_rate_points={:.2} preparation_time_ratio={:.3}",
             (after_sweep_conflict_rate - before_sweep_conflict_rate) * 100.0,
-            after_throughput / before_throughput,
+            preparation_time_ratio,
         );
 
-        assert!(before.sweeper_conflicts > 0);
-        assert_eq!(after.sweeper_conflicts, 0);
-        assert_eq!(after.writer_conflicts, 0);
+        assert!(before_conflicts.sweeper_conflicts > 0);
+        assert_eq!(after_conflicts.sweeper_conflicts, 0);
+        assert_eq!(after_conflicts.writer_conflicts, 0);
+        assert!(
+            preparation_time_ratio <= MAX_PREPARATION_TIME_RATIO,
+            "disjoint conflict metadata preparation exceeded the {MAX_PREPARATION_TIME_RATIO:.1}x regression budget: before={:?}, after={:?}",
+            before_preparation,
+            after_preparation,
+        );
     }
 }

--- a/crates/db/src/execution/interpreter/mutation/topology.rs
+++ b/crates/db/src/execution/interpreter/mutation/topology.rs
@@ -406,38 +406,27 @@ impl TopologyMutationRuntime {
 
         for (row, delta) in batch.bitmaps {
             let key = row.to_bytes();
-            transaction.merge_disjoint(
+            transaction.merge_disjoint_tokens(
                 &key,
-                delta.members().map(|id| id.to_be_bytes()),
+                delta.members().map(u128::from),
                 delta.encode(),
             )?;
             self.staged_keys.insert(key);
         }
 
         for ((scope, node), delta) in batch.adjacency {
-            const DIRECTION_LEN: usize = core::mem::size_of::<u8>();
-            const NODE_ID_LEN: usize = core::mem::size_of::<u64>();
+            const INCOMING_DIRECTION_TOKEN: u128 = 1_u128 << u64::BITS;
 
             let key = DataKey::Data {
                 scope,
                 kind: DataKeyKind::Adjacency(AdjacencyKey::new(node)),
             }
             .to_bytes();
-            let outgoing = delta.outgoing_members().map(|neighbor| {
-                let mut discriminator = [0; DIRECTION_LEN + NODE_ID_LEN];
-                discriminator[0] = 0;
-                discriminator[DIRECTION_LEN..DIRECTION_LEN + NODE_ID_LEN]
-                    .copy_from_slice(&neighbor.to_be_bytes());
-                discriminator
-            });
-            let incoming = delta.incoming_members().map(|neighbor| {
-                let mut discriminator = [0; DIRECTION_LEN + NODE_ID_LEN];
-                discriminator[0] = 1;
-                discriminator[DIRECTION_LEN..DIRECTION_LEN + NODE_ID_LEN]
-                    .copy_from_slice(&neighbor.to_be_bytes());
-                discriminator
-            });
-            transaction.merge_disjoint(&key, outgoing.chain(incoming), delta.encode())?;
+            let outgoing = delta.outgoing_members().map(u128::from);
+            let incoming = delta
+                .incoming_members()
+                .map(|neighbor| INCOMING_DIRECTION_TOKEN | u128::from(neighbor));
+            transaction.merge_disjoint_tokens(&key, outgoing.chain(incoming), delta.encode())?;
             self.staged_keys.insert(key);
         }
         Ok(())
@@ -831,6 +820,92 @@ mod tests {
         }
 
         db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn incoming_and_outgoing_tokens_do_not_alias_at_the_id_boundary() {
+        const NODE: u64 = 300;
+        const NEIGHBOR: u64 = u64::MAX;
+
+        for outgoing_commits_first in [false, true] {
+            let db = database(&format!(
+                "adjacency-direction-token-boundary-{outgoing_commits_first}"
+            ))
+            .await;
+            let scope = DataScope::LegacyUnscoped;
+            let seed = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut seed_runtime = TopologyMutationRuntime::default();
+            seed_runtime
+                .add_adjacency(
+                    scope,
+                    NODE,
+                    NEIGHBOR,
+                    helix_planner::ir::ExpandDirection::In,
+                )
+                .unwrap();
+            seed_runtime.prepare(&seed).await.unwrap();
+            seed_runtime.consume_prepared().unwrap();
+            seed.commit().await.unwrap();
+
+            let outgoing = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let incoming = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut outgoing_runtime = TopologyMutationRuntime::default();
+            outgoing_runtime
+                .add_adjacency(
+                    scope,
+                    NODE,
+                    NEIGHBOR,
+                    helix_planner::ir::ExpandDirection::Out,
+                )
+                .unwrap();
+            outgoing_runtime.prepare(&outgoing).await.unwrap();
+            outgoing_runtime.consume_prepared().unwrap();
+            let mut incoming_runtime = TopologyMutationRuntime::default();
+            incoming_runtime
+                .remove_adjacency(
+                    scope,
+                    NODE,
+                    NEIGHBOR,
+                    helix_planner::ir::ExpandDirection::In,
+                )
+                .unwrap();
+            incoming_runtime.prepare(&incoming).await.unwrap();
+            incoming_runtime.consume_prepared().unwrap();
+
+            if outgoing_commits_first {
+                outgoing.commit().await.unwrap();
+                incoming.commit().await.unwrap();
+            } else {
+                incoming.commit().await.unwrap();
+                outgoing.commit().await.unwrap();
+            }
+
+            let adjacency = edges::decode_edges(
+                &db.get(
+                    DataKey::Data {
+                        scope,
+                        kind: DataKeyKind::Adjacency(AdjacencyKey::new(NODE)),
+                    }
+                    .to_bytes(),
+                )
+                .await
+                .unwrap()
+                .expect("adjacency row remains present"),
+            )
+            .unwrap();
+            assert_eq!(adjacency.iter_out().collect::<Vec<_>>(), vec![NEIGHBOR]);
+            assert_eq!(adjacency.iter_in().collect::<Vec<_>>(), Vec::<u64>::new());
+            db.close().await.unwrap();
+        }
     }
 
     #[tokio::test]

--- a/crates/db/src/execution/interpreter/mutation/topology.rs
+++ b/crates/db/src/execution/interpreter/mutation/topology.rs
@@ -1,15 +1,13 @@
 //! Transaction-local coalescing for current-format graph topology rows.
 //!
-//! Add-only bitmap and adjacency rows need no observation: one current-format
-//! merge operand represents the complete union. Any key whose final mutation
-//! removes membership participates in one sorted `multi_get`, after which this
-//! runtime stages one final current-format put/delete. No runtime state is
-//! serialized.
+//! Bitmap and adjacency rows are staged as associative membership deltas. The
+//! transaction conflict metadata names each logical member, so mutations to
+//! disjoint members of one physical row can commit concurrently without a
+//! read/modify/write cycle.
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use bytes::Bytes;
-use roaring::RoaringTreemap;
 use slatedb::DbTransaction;
 
 use crate::encoding::indexes::label::{EdgeLabelKey, EdgeLabelNeighborKey};
@@ -18,7 +16,6 @@ use crate::encoding::indexes::{
 };
 use crate::encoding::v2::keys::scope::DataScope;
 use crate::encoding::v2::keys::{AdjacencyKey, DataKey, DataKeyKind, EdgePairIndexKey};
-use crate::encoding::v2::values::adjacency::Edges;
 use crate::encoding::v2::values::{adjacency as edges, indexes as secondary};
 use crate::{HelixDbError, Result};
 
@@ -299,129 +296,52 @@ impl TopologyMutationRuntime {
             }
         };
 
-        let mut observation_keys = batch
-            .bitmaps
-            .iter()
-            .filter(|(_, mutations)| {
-                mutations
-                    .values()
-                    .any(|mutation| *mutation == MembershipMutation::Absent)
-            })
-            .map(|(key, _)| key.clone())
-            .chain(
-                batch
-                    .adjacency
-                    .iter()
-                    .filter(|(_, mutations)| {
-                        mutations
-                            .values()
-                            .any(|mutation| *mutation == MembershipMutation::Absent)
-                    })
-                    .map(|(key, _)| key.clone()),
-            )
-            .collect::<Vec<_>>();
-        observation_keys.sort_unstable();
-        observation_keys.dedup();
-        let (staged_keys, snapshot_keys): (Vec<_>, Vec<_>) = observation_keys
-            .into_iter()
-            .partition(|key| self.staged_keys.contains(key));
-        let snapshot_values = if snapshot_keys.is_empty() {
-            Vec::new()
-        } else {
-            transaction.multi_get(&snapshot_keys).await?
-        };
-        let mut observations = snapshot_keys
-            .into_iter()
-            .zip(snapshot_values)
-            .collect::<BTreeMap<_, _>>();
-        for key in staged_keys {
-            observations.insert(key.clone(), transaction.get(&key).await?);
-        }
-
         for (key, mutations) in batch.bitmaps {
-            if mutations
-                .values()
-                .all(|mutation| *mutation == MembershipMutation::Present)
-            {
-                let additions = mutations.keys().copied().collect::<RoaringTreemap>();
-                transaction.merge_commutative(
-                    &key,
-                    secondary::SecondaryEqualityValue::encode_ids(&additions),
-                )?;
-                self.staged_keys.insert(key);
-                continue;
-            }
-            let mut bitmap = observations
-                .get(&key)
-                .cloned()
-                .flatten()
-                .map(|value| {
-                    secondary::SecondaryEqualityValue::decode(&value).map(|value| value.into_ids())
-                })
-                .transpose()?
-                .unwrap_or_default();
-            for (id, mutation) in mutations {
+            let mut delta = secondary::BitmapMembershipDelta::default();
+            let mut discriminators = Vec::with_capacity(mutations.len());
+            for (id, mutation) in &mutations {
+                discriminators.push(Bytes::copy_from_slice(&id.to_be_bytes()));
                 match mutation {
                     MembershipMutation::Present => {
-                        bitmap.insert(id);
+                        delta.add(*id);
                     }
                     MembershipMutation::Absent => {
-                        bitmap.remove(id);
+                        delta.remove(*id);
                     }
                 }
             }
-            if bitmap.is_empty() {
-                transaction.delete(&key)?;
-            } else {
-                transaction.put(&key, secondary::SecondaryEqualityValue::encode_ids(&bitmap))?;
-            }
+            transaction.merge_disjoint(&key, discriminators, delta.encode())?;
             self.staged_keys.insert(key);
         }
 
         for (key, mutations) in batch.adjacency {
-            if mutations
-                .values()
-                .all(|mutation| *mutation == MembershipMutation::Present)
-            {
-                let mut additions = Edges::new();
-                for ((direction, neighbor), _) in mutations {
-                    match direction {
-                        AdjacencyDirection::Out => additions.add_out(neighbor),
-                        AdjacencyDirection::In => additions.add_in(neighbor),
-                    }
-                }
-                transaction.merge_commutative(&key, edges::encode_edges(&additions))?;
-                self.staged_keys.insert(key);
-                continue;
-            }
-            let mut adjacency = observations
-                .get(&key)
-                .cloned()
-                .flatten()
-                .map(|value| edges::decode_edges(&value))
-                .transpose()?
-                .unwrap_or_default();
-            for ((direction, neighbor), mutation) in mutations {
+            let mut delta = edges::AdjacencyMembershipDelta::default();
+            let mut discriminators = Vec::with_capacity(mutations.len());
+            for ((direction, neighbor), mutation) in &mutations {
+                let mut discriminator =
+                    Vec::with_capacity(core::mem::size_of::<u8>() + core::mem::size_of::<u64>());
+                discriminator.push(match direction {
+                    AdjacencyDirection::Out => 0,
+                    AdjacencyDirection::In => 1,
+                });
+                discriminator.extend_from_slice(&neighbor.to_be_bytes());
+                discriminators.push(Bytes::from(discriminator));
                 match (direction, mutation) {
                     (AdjacencyDirection::Out, MembershipMutation::Present) => {
-                        adjacency.add_out(neighbor);
+                        delta.add_out(*neighbor);
                     }
                     (AdjacencyDirection::In, MembershipMutation::Present) => {
-                        adjacency.add_in(neighbor);
+                        delta.add_in(*neighbor);
                     }
                     (AdjacencyDirection::Out, MembershipMutation::Absent) => {
-                        adjacency.remove_out(neighbor);
+                        delta.remove_out(*neighbor);
                     }
                     (AdjacencyDirection::In, MembershipMutation::Absent) => {
-                        adjacency.remove_in(neighbor);
+                        delta.remove_in(*neighbor);
                     }
                 }
             }
-            if adjacency.is_empty() {
-                transaction.delete(&key)?;
-            } else {
-                transaction.put(&key, edges::encode_edges(&adjacency))?;
-            }
+            transaction.merge_disjoint(&key, discriminators, delta.encode())?;
             self.staged_keys.insert(key);
         }
         Ok(())
@@ -498,8 +418,11 @@ fn global_edge_label_key(scope: DataScope, label: &str) -> Bytes {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
+    use roaring::RoaringTreemap;
     use slatedb::object_store::memory::InMemory;
     use slatedb::{Db, IsolationLevel};
 
@@ -560,18 +483,20 @@ mod tests {
 
         async fn ids(self, db: &Db, scope: DataScope) -> Vec<u64> {
             match self {
-                Self::NodeLabel(label) => secondary::SecondaryEqualityValue::decode(
-                    &db.get(node_label_key(scope, label))
-                        .await
-                        .unwrap()
-                        .expect("node label race row exists"),
-                )
-                .unwrap()
-                .into_ids()
-                .iter()
-                .collect(),
-                Self::OutAdjacency(node) => edges::decode_edges(
-                    &db.get(
+                Self::NodeLabel(label) => db
+                    .get(node_label_key(scope, label))
+                    .await
+                    .unwrap()
+                    .map(|value| {
+                        secondary::SecondaryEqualityValue::decode(&value)
+                            .unwrap()
+                            .into_ids()
+                            .iter()
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                Self::OutAdjacency(node) => db
+                    .get(
                         DataKey::Data {
                             scope,
                             kind: DataKeyKind::Adjacency(AdjacencyKey::new(node)),
@@ -580,11 +505,77 @@ mod tests {
                     )
                     .await
                     .unwrap()
-                    .expect("adjacency race row exists"),
-                )
-                .unwrap()
-                .iter_out()
-                .collect(),
+                    .map(|value| edges::decode_edges(&value).unwrap().iter_out().collect())
+                    .unwrap_or_default(),
+            }
+        }
+    }
+
+    fn stage_linked_event(
+        runtime: &mut TopologyMutationRuntime,
+        scope: DataScope,
+        parent_id: u64,
+        event_id: u64,
+        edge_id: u64,
+        node_label: &str,
+        edge_label: &str,
+        mutation: MembershipMutation,
+    ) {
+        match mutation {
+            MembershipMutation::Present => {
+                runtime.add_node_label(scope, node_label, event_id).unwrap();
+                runtime
+                    .add_edge_pair(scope, parent_id, event_id, edge_id)
+                    .unwrap();
+                runtime
+                    .add_edge_label(scope, parent_id, event_id, edge_label, edge_id)
+                    .unwrap();
+                runtime
+                    .add_adjacency(
+                        scope,
+                        parent_id,
+                        event_id,
+                        helix_planner::ir::ExpandDirection::Out,
+                    )
+                    .unwrap();
+                runtime
+                    .add_adjacency(
+                        scope,
+                        event_id,
+                        parent_id,
+                        helix_planner::ir::ExpandDirection::In,
+                    )
+                    .unwrap();
+            }
+            MembershipMutation::Absent => {
+                runtime
+                    .remove_node_label(scope, node_label, event_id)
+                    .unwrap();
+                runtime
+                    .remove_edge_pair(scope, parent_id, event_id, edge_id)
+                    .unwrap();
+                runtime
+                    .remove_global_edge_label(scope, edge_label, edge_id)
+                    .unwrap();
+                runtime
+                    .remove_edge_label_neighbors(scope, parent_id, event_id, edge_label)
+                    .unwrap();
+                runtime
+                    .remove_adjacency(
+                        scope,
+                        parent_id,
+                        event_id,
+                        helix_planner::ir::ExpandDirection::Out,
+                    )
+                    .unwrap();
+                runtime
+                    .remove_adjacency(
+                        scope,
+                        event_id,
+                        parent_id,
+                        helix_planner::ir::ExpandDirection::In,
+                    )
+                    .unwrap();
             }
         }
     }
@@ -691,7 +682,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn topology_insert_remove_races_conflict_in_both_commit_orders() {
+    async fn topology_insert_remove_races_on_disjoint_members_commit_in_both_orders() {
         let db = database("insert-remove-races").await;
         let scope = DataScope::LegacyUnscoped;
         let cases = [
@@ -729,33 +720,219 @@ mod tests {
             remove_runtime.prepare(&remove).await.unwrap();
             remove_runtime.consume_prepared().unwrap();
 
-            let retry_mutation = if insert_commits_first {
+            if insert_commits_first {
+                insert.commit().await.unwrap();
+                remove.commit().await.unwrap();
+            } else {
+                remove.commit().await.unwrap();
+                insert.commit().await.unwrap();
+            }
+            assert_eq!(row.ids(&db, scope).await, vec![2]);
+        }
+
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn topology_insert_remove_races_on_same_member_conflict_in_both_orders() {
+        let db = database("same-member-insert-remove-races").await;
+        let scope = DataScope::LegacyUnscoped;
+        let cases = [
+            (RaceRow::NodeLabel("insert-first"), true),
+            (RaceRow::NodeLabel("remove-first"), false),
+            (RaceRow::OutAdjacency(200), true),
+            (RaceRow::OutAdjacency(201), false),
+        ];
+
+        for (row, insert_commits_first) in cases {
+            let seed = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut seed_runtime = TopologyMutationRuntime::default();
+            row.stage(&mut seed_runtime, scope, 1, MembershipMutation::Present);
+            seed_runtime.prepare(&seed).await.unwrap();
+            seed_runtime.consume_prepared().unwrap();
+            seed.commit().await.unwrap();
+
+            let insert = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let remove = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut insert_runtime = TopologyMutationRuntime::default();
+            row.stage(&mut insert_runtime, scope, 1, MembershipMutation::Present);
+            insert_runtime.prepare(&insert).await.unwrap();
+            insert_runtime.consume_prepared().unwrap();
+            let mut remove_runtime = TopologyMutationRuntime::default();
+            row.stage(&mut remove_runtime, scope, 1, MembershipMutation::Absent);
+            remove_runtime.prepare(&remove).await.unwrap();
+            remove_runtime.consume_prepared().unwrap();
+
+            if insert_commits_first {
                 insert.commit().await.unwrap();
                 let error = remove.commit().await.expect_err("remove must conflict");
                 assert_eq!(error.kind(), slatedb::ErrorKind::Transaction);
-                MembershipMutation::Absent
+                assert_eq!(row.ids(&db, scope).await, vec![1]);
             } else {
                 remove.commit().await.unwrap();
                 let error = insert.commit().await.expect_err("insert must conflict");
                 assert_eq!(error.kind(), slatedb::ErrorKind::Transaction);
-                MembershipMutation::Present
-            };
+                assert_eq!(row.ids(&db, scope).await, Vec::<u64>::new());
+            }
+        }
 
-            let retry = db
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn linked_event_insert_and_expiry_preserve_every_shared_topology_row() {
+        let db = database("linked-event-insert-expiry-races").await;
+        let scope = DataScope::LegacyUnscoped;
+
+        for (case, insert_commits_first) in [(0_u64, false), (1, true)] {
+            let parent_id = 1_000 + case * 100;
+            let expired_event_id = parent_id + 1;
+            let inserted_event_id = parent_id + 2;
+            let expired_edge_id = parent_id + 10;
+            let inserted_edge_id = parent_id + 11;
+            let node_label = format!("Event-{case}");
+            let edge_label = format!("HAS_EVENT-{case}");
+
+            let seed = db
                 .begin(IsolationLevel::SerializableSnapshot)
                 .await
                 .unwrap();
-            let mut retry_runtime = TopologyMutationRuntime::default();
-            row.stage(
-                &mut retry_runtime,
+            let mut seed_runtime = TopologyMutationRuntime::default();
+            stage_linked_event(
+                &mut seed_runtime,
                 scope,
-                if insert_commits_first { 1 } else { 2 },
-                retry_mutation,
+                parent_id,
+                expired_event_id,
+                expired_edge_id,
+                &node_label,
+                &edge_label,
+                MembershipMutation::Present,
             );
-            retry_runtime.prepare(&retry).await.unwrap();
-            retry_runtime.consume_prepared().unwrap();
-            retry.commit().await.unwrap();
-            assert_eq!(row.ids(&db, scope).await, vec![2]);
+            seed_runtime.prepare(&seed).await.unwrap();
+            seed_runtime.consume_prepared().unwrap();
+            seed.commit().await.unwrap();
+
+            let insert = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let remove = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut insert_runtime = TopologyMutationRuntime::default();
+            stage_linked_event(
+                &mut insert_runtime,
+                scope,
+                parent_id,
+                inserted_event_id,
+                inserted_edge_id,
+                &node_label,
+                &edge_label,
+                MembershipMutation::Present,
+            );
+            insert_runtime.prepare(&insert).await.unwrap();
+            insert_runtime.consume_prepared().unwrap();
+            let mut remove_runtime = TopologyMutationRuntime::default();
+            stage_linked_event(
+                &mut remove_runtime,
+                scope,
+                parent_id,
+                expired_event_id,
+                expired_edge_id,
+                &node_label,
+                &edge_label,
+                MembershipMutation::Absent,
+            );
+            remove_runtime.prepare(&remove).await.unwrap();
+            remove_runtime.consume_prepared().unwrap();
+
+            if insert_commits_first {
+                insert.commit().await.unwrap();
+                remove.commit().await.unwrap();
+            } else {
+                remove.commit().await.unwrap();
+                insert.commit().await.unwrap();
+            }
+
+            let bitmap_ids = |key| async {
+                db.get(key)
+                    .await
+                    .unwrap()
+                    .map(|value| {
+                        secondary::SecondaryEqualityValue::decode(&value)
+                            .unwrap()
+                            .into_ids()
+                            .iter()
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            };
+            assert_eq!(
+                bitmap_ids(node_label_key(scope, &node_label)).await,
+                vec![inserted_event_id]
+            );
+            assert_eq!(
+                bitmap_ids(edge_label_neighbor_key(
+                    scope,
+                    EdgeDirection::Out,
+                    parent_id,
+                    &edge_label,
+                ))
+                .await,
+                vec![inserted_event_id]
+            );
+            assert_eq!(
+                bitmap_ids(global_edge_label_key(scope, &edge_label)).await,
+                vec![inserted_edge_id]
+            );
+            assert_eq!(
+                bitmap_ids(edge_pair_key(scope, parent_id, expired_event_id)).await,
+                Vec::<u64>::new()
+            );
+            assert_eq!(
+                bitmap_ids(edge_pair_key(scope, parent_id, inserted_event_id)).await,
+                vec![inserted_edge_id]
+            );
+            let parent_adjacency = edges::decode_edges(
+                &db.get(
+                    DataKey::Data {
+                        scope,
+                        kind: DataKeyKind::Adjacency(AdjacencyKey::new(parent_id)),
+                    }
+                    .to_bytes(),
+                )
+                .await
+                .unwrap()
+                .expect("parent adjacency remains"),
+            )
+            .unwrap();
+            assert_eq!(
+                parent_adjacency.iter_out().collect::<Vec<_>>(),
+                vec![inserted_event_id]
+            );
+            let expired_adjacency = db
+                .get(
+                    DataKey::Data {
+                        scope,
+                        kind: DataKeyKind::Adjacency(AdjacencyKey::new(expired_event_id)),
+                    }
+                    .to_bytes(),
+                )
+                .await
+                .unwrap()
+                .map(|value| edges::decode_edges(&value).unwrap())
+                .unwrap_or_default();
+            assert!(expired_adjacency.is_empty());
         }
 
         db.close().await.unwrap();
@@ -842,5 +1019,368 @@ mod tests {
             runtime.add_node_label(DataScope::LegacyUnscoped, "User", 1),
             Err(HelixDbError::InvariantViolation(_))
         ));
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum SweepBenchmarkStrategy {
+        ExclusiveReadModifyWrite,
+        DisjointDelta,
+    }
+
+    #[derive(Debug)]
+    struct SweepBenchmarkResult {
+        elapsed: Duration,
+        writer_conflicts: usize,
+        sweeper_conflicts: usize,
+        writer_commits: usize,
+        sweeper_commits: usize,
+    }
+
+    async fn stage_benchmark_memberships(
+        db: &Db,
+        strategy: SweepBenchmarkStrategy,
+        ids: std::ops::Range<u64>,
+        present: bool,
+    ) -> DbTransaction {
+        const PARENT_ID: u64 = u64::MAX - 1;
+        const LABEL: &str = "KubernetesEvent";
+
+        let transaction = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .expect("benchmark transaction begins");
+        match strategy {
+            SweepBenchmarkStrategy::ExclusiveReadModifyWrite if present => {
+                let additions = ids.clone().collect::<RoaringTreemap>();
+                transaction
+                    .merge_commutative(
+                        node_label_key(DataScope::LegacyUnscoped, LABEL),
+                        secondary::SecondaryEqualityValue::encode_ids(&additions),
+                    )
+                    .expect("exclusive benchmark label additions stage");
+                let mut adjacency = edges::Edges::new();
+                for id in ids {
+                    adjacency.add_out(id);
+                }
+                transaction
+                    .merge_commutative(
+                        DataKey::Data {
+                            scope: DataScope::LegacyUnscoped,
+                            kind: DataKeyKind::Adjacency(AdjacencyKey::new(PARENT_ID)),
+                        }
+                        .to_bytes(),
+                        edges::encode_edges(&adjacency),
+                    )
+                    .expect("exclusive benchmark adjacency additions stage");
+            }
+            SweepBenchmarkStrategy::ExclusiveReadModifyWrite => {
+                let label_key = node_label_key(DataScope::LegacyUnscoped, LABEL);
+                let adjacency_key = DataKey::Data {
+                    scope: DataScope::LegacyUnscoped,
+                    kind: DataKeyKind::Adjacency(AdjacencyKey::new(PARENT_ID)),
+                }
+                .to_bytes();
+                let values = transaction
+                    .multi_get(&[label_key.clone(), adjacency_key.clone()])
+                    .await
+                    .expect("exclusive benchmark rows read");
+                let mut labels = values[0]
+                    .as_deref()
+                    .map(secondary::SecondaryEqualityValue::decode)
+                    .transpose()
+                    .expect("exclusive benchmark labels decode")
+                    .map(secondary::SecondaryEqualityValue::into_ids)
+                    .unwrap_or_default();
+                let mut adjacency = values[1]
+                    .as_deref()
+                    .map(edges::decode_edges)
+                    .transpose()
+                    .expect("exclusive benchmark adjacency decodes")
+                    .unwrap_or_default();
+                for id in ids {
+                    labels.remove(id);
+                    adjacency.remove_out(id);
+                }
+                if labels.is_empty() {
+                    transaction
+                        .delete(label_key)
+                        .expect("exclusive benchmark empty label row deletes");
+                } else {
+                    transaction
+                        .put(
+                            label_key,
+                            secondary::SecondaryEqualityValue::encode_ids(&labels),
+                        )
+                        .expect("exclusive benchmark label replacement stages");
+                }
+                if adjacency.is_empty() {
+                    transaction
+                        .delete(adjacency_key)
+                        .expect("exclusive benchmark empty adjacency row deletes");
+                } else {
+                    transaction
+                        .put(adjacency_key, edges::encode_edges(&adjacency))
+                        .expect("exclusive benchmark adjacency replacement stages");
+                }
+            }
+            SweepBenchmarkStrategy::DisjointDelta => {
+                let mut runtime = TopologyMutationRuntime::default();
+                for id in ids {
+                    if present {
+                        runtime
+                            .add_node_label(DataScope::LegacyUnscoped, LABEL, id)
+                            .unwrap();
+                        runtime
+                            .add_adjacency(
+                                DataScope::LegacyUnscoped,
+                                PARENT_ID,
+                                id,
+                                helix_planner::ir::ExpandDirection::Out,
+                            )
+                            .unwrap();
+                    } else {
+                        runtime
+                            .remove_node_label(DataScope::LegacyUnscoped, LABEL, id)
+                            .unwrap();
+                        runtime
+                            .remove_adjacency(
+                                DataScope::LegacyUnscoped,
+                                PARENT_ID,
+                                id,
+                                helix_planner::ir::ExpandDirection::Out,
+                            )
+                            .unwrap();
+                    }
+                }
+                runtime.prepare(&transaction).await.unwrap();
+                runtime.consume_prepared().unwrap();
+            }
+        }
+        transaction
+    }
+
+    async fn run_sweep_benchmark(
+        strategy: SweepBenchmarkStrategy,
+        expired_members: u64,
+        inserted_members: u64,
+        sweep_chunk: u64,
+        writer_chunk: u64,
+    ) -> SweepBenchmarkResult {
+        const PARENT_ID: u64 = u64::MAX - 1;
+        const LABEL: &str = "KubernetesEvent";
+
+        let db = Arc::new(
+            database(match strategy {
+                SweepBenchmarkStrategy::ExclusiveReadModifyWrite => "benchmark-exclusive",
+                SweepBenchmarkStrategy::DisjointDelta => "benchmark-disjoint",
+            })
+            .await,
+        );
+        let label_key = node_label_key(DataScope::LegacyUnscoped, LABEL);
+        db.put(
+            &label_key,
+            secondary::SecondaryEqualityValue::encode_ids(
+                &(0..expired_members).collect::<RoaringTreemap>(),
+            ),
+        )
+        .await
+        .expect("benchmark label seed persists");
+        let mut adjacency = edges::Edges::new();
+        for id in 0..expired_members {
+            adjacency.add_out(id);
+        }
+        db.put(
+            DataKey::Data {
+                scope: DataScope::LegacyUnscoped,
+                kind: DataKeyKind::Adjacency(AdjacencyKey::new(PARENT_ID)),
+            }
+            .to_bytes(),
+            edges::encode_edges(&adjacency),
+        )
+        .await
+        .expect("benchmark adjacency seed persists");
+
+        let writer_chunks = inserted_members.div_ceil(writer_chunk) as usize;
+        let sweeper_chunks = expired_members.div_ceil(sweep_chunk) as usize;
+        let synchronized_chunks = writer_chunks.min(sweeper_chunks);
+        let barriers = (0..synchronized_chunks)
+            .map(|_| Arc::new(tokio::sync::Barrier::new(2)))
+            .collect::<Vec<_>>();
+        let writer_progress = Arc::new(AtomicUsize::new(0));
+        let writer_notify = Arc::new(tokio::sync::Notify::new());
+        let started = Instant::now();
+
+        let writer = {
+            let db = Arc::clone(&db);
+            let barriers = barriers.clone();
+            let writer_progress = Arc::clone(&writer_progress);
+            let writer_notify = Arc::clone(&writer_notify);
+            tokio::spawn(async move {
+                let mut conflicts = 0;
+                for chunk in 0..writer_chunks {
+                    let start = expired_members + chunk as u64 * writer_chunk;
+                    let end = (start + writer_chunk).min(expired_members + inserted_members);
+                    let mut first_attempt = true;
+                    loop {
+                        let transaction =
+                            stage_benchmark_memberships(&db, strategy, start..end, true).await;
+                        if first_attempt && chunk < synchronized_chunks {
+                            barriers[chunk].wait().await;
+                        }
+                        match transaction.commit().await {
+                            Ok(_) => break,
+                            Err(error) if error.kind() == slatedb::ErrorKind::Transaction => {
+                                conflicts += 1;
+                                first_attempt = false;
+                            }
+                            Err(error) => panic!("benchmark writer commit failed: {error}"),
+                        }
+                    }
+                    writer_progress.store(chunk + 1, Ordering::Release);
+                    writer_notify.notify_waiters();
+                }
+                conflicts
+            })
+        };
+        let sweeper = {
+            let db = Arc::clone(&db);
+            let barriers = barriers.clone();
+            let writer_progress = Arc::clone(&writer_progress);
+            let writer_notify = Arc::clone(&writer_notify);
+            tokio::spawn(async move {
+                let mut conflicts = 0;
+                for chunk in 0..sweeper_chunks {
+                    let start = chunk as u64 * sweep_chunk;
+                    let end = (start + sweep_chunk).min(expired_members);
+                    let mut first_attempt = true;
+                    loop {
+                        let transaction =
+                            stage_benchmark_memberships(&db, strategy, start..end, false).await;
+                        if first_attempt && chunk < synchronized_chunks {
+                            barriers[chunk].wait().await;
+                            loop {
+                                let notified = writer_notify.notified();
+                                if writer_progress.load(Ordering::Acquire) > chunk {
+                                    break;
+                                }
+                                notified.await;
+                            }
+                        }
+                        match transaction.commit().await {
+                            Ok(_) => break,
+                            Err(error) if error.kind() == slatedb::ErrorKind::Transaction => {
+                                conflicts += 1;
+                                first_attempt = false;
+                            }
+                            Err(error) => panic!("benchmark sweeper commit failed: {error}"),
+                        }
+                    }
+                }
+                conflicts
+            })
+        };
+        let writer_conflicts = writer.await.expect("benchmark writer joins");
+        let sweeper_conflicts = sweeper.await.expect("benchmark sweeper joins");
+        let elapsed = started.elapsed();
+
+        let labels = secondary::SecondaryEqualityValue::decode(
+            &db.get(&label_key)
+                .await
+                .expect("benchmark result reads")
+                .expect("inserted memberships remain"),
+        )
+        .expect("benchmark result decodes")
+        .into_ids();
+        assert_eq!(labels.len(), inserted_members);
+        assert_eq!(labels.min(), Some(expired_members));
+        assert_eq!(labels.max(), Some(expired_members + inserted_members - 1));
+        db.close().await.expect("benchmark database closes");
+
+        SweepBenchmarkResult {
+            elapsed,
+            writer_conflicts,
+            sweeper_conflicts,
+            writer_commits: writer_chunks,
+            sweeper_commits: sweeper_chunks,
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore = "manual 100K-member conflict and throughput comparison"]
+    async fn benchmark_exclusive_vs_disjoint_linked_event_sweep() {
+        let expired_members = std::env::var("HELIX_SWEEP_BENCH_EXPIRED")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(100_000);
+        let inserted_members = std::env::var("HELIX_SWEEP_BENCH_INSERTED")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(10_000);
+        let sweep_chunk = std::env::var("HELIX_SWEEP_BENCH_SWEEP_CHUNK")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(1_000);
+        let writer_chunk = std::env::var("HELIX_SWEEP_BENCH_WRITER_CHUNK")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(250);
+        assert!(expired_members > 0);
+        assert!(inserted_members > 0);
+        assert!(sweep_chunk > 0);
+        assert!(writer_chunk > 0);
+
+        let before = run_sweep_benchmark(
+            SweepBenchmarkStrategy::ExclusiveReadModifyWrite,
+            expired_members,
+            inserted_members,
+            sweep_chunk,
+            writer_chunk,
+        )
+        .await;
+        let after = run_sweep_benchmark(
+            SweepBenchmarkStrategy::DisjointDelta,
+            expired_members,
+            inserted_members,
+            sweep_chunk,
+            writer_chunk,
+        )
+        .await;
+        let before_sweep_conflict_rate =
+            before.sweeper_conflicts as f64 / before.sweeper_commits as f64;
+        let after_sweep_conflict_rate =
+            after.sweeper_conflicts as f64 / after.sweeper_commits as f64;
+        let operations = expired_members + inserted_members;
+        let before_throughput = operations as f64 / before.elapsed.as_secs_f64();
+        let after_throughput = operations as f64 / after.elapsed.as_secs_f64();
+
+        println!(
+            "SWEEP_BENCH before elapsed_ms={} sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={} throughput_members_per_s={:.0}",
+            before.elapsed.as_millis(),
+            before.sweeper_commits,
+            before.sweeper_conflicts,
+            before_sweep_conflict_rate,
+            before.writer_commits,
+            before.writer_conflicts,
+            before_throughput,
+        );
+        println!(
+            "SWEEP_BENCH after elapsed_ms={} sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={} throughput_members_per_s={:.0}",
+            after.elapsed.as_millis(),
+            after.sweeper_commits,
+            after.sweeper_conflicts,
+            after_sweep_conflict_rate,
+            after.writer_commits,
+            after.writer_conflicts,
+            after_throughput,
+        );
+        println!(
+            "SWEEP_BENCH delta conflict_rate_points={:.2} throughput_ratio={:.3}",
+            (after_sweep_conflict_rate - before_sweep_conflict_rate) * 100.0,
+            after_throughput / before_throughput,
+        );
+
+        assert!(before.sweeper_conflicts > 0);
+        assert_eq!(after.sweeper_conflicts, 0);
+        assert_eq!(after.writer_conflicts, 0);
     }
 }

--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -53,7 +53,8 @@ use crate::encoding::v2::values::property::range_index_value::{
 };
 use crate::encoding::v2::values::{
     decode_applied_state, decode_build_delta, decode_index_record, decode_secondary_entry,
-    encode_applied_state, encode_build_delta, encode_secondary_entry, SecondaryEqualityBitmapValue,
+    encode_applied_state, encode_build_delta, encode_secondary_entry, BitmapMembershipDelta,
+    SecondaryEqualityBitmapValue,
 };
 use crate::error::{HelixDbError, Result, SecondaryIndexValueError};
 use crate::index_lifecycle::outbox::{
@@ -2553,52 +2554,19 @@ async fn stage_bitmap_changes(
     transaction: &DbTransaction,
     changes: &BTreeMap<Bytes, BTreeMap<u64, bool>>,
 ) -> Result<()> {
-    let exclusive_keys = changes
-        .iter()
-        .filter(|(_, changes)| changes.values().any(|present| !present))
-        .map(|(key, _)| key.clone())
-        .collect::<Vec<_>>();
-    let exclusive_values = if exclusive_keys.is_empty() {
-        Vec::new()
-    } else {
-        transaction.multi_get(&exclusive_keys).await?
-    };
-    let mut exclusive_values = exclusive_keys
-        .into_iter()
-        .zip(exclusive_values)
-        .collect::<BTreeMap<_, _>>();
-
     for (key, changes) in changes {
-        if changes.values().all(|present| *present) {
-            let additions = roaring::RoaringTreemap::from_iter(changes.keys().copied());
-            transaction
-                .merge_commutative(key, SecondaryEqualityBitmapValue::new(additions).encode())?;
-            continue;
-        }
-
-        let existing = exclusive_values
-            .remove(key)
-            .expect("each removal-bearing bitmap key was read exactly once");
-        let mut bitmap = existing
-            .as_deref()
-            .map(SecondaryEqualityBitmapValue::decode)
-            .transpose()?
-            .map(SecondaryEqualityBitmapValue::into_ids)
-            .unwrap_or_default();
+        let mut delta = BitmapMembershipDelta::default();
+        let mut discriminators = Vec::with_capacity(changes.len());
         for (entity_id, present) in changes {
+            discriminators.push(Bytes::copy_from_slice(&entity_id.to_be_bytes()));
             if *present {
-                bitmap.insert(*entity_id);
+                delta.add(*entity_id);
             } else {
-                bitmap.remove(*entity_id);
+                delta.remove(*entity_id);
             }
         }
-        if bitmap.is_empty() {
-            transaction.delete(key)?;
-        } else {
-            transaction.put(key, SecondaryEqualityBitmapValue::new(bitmap).encode())?;
-        }
+        transaction.merge_disjoint(key, discriminators, delta.encode())?;
     }
-    assert!(exclusive_values.is_empty());
     Ok(())
 }
 
@@ -5712,7 +5680,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn removal_bearing_bitmap_changes_replace_or_delete_exclusively() {
+    async fn removal_bearing_bitmap_changes_merge_or_tombstone() {
         let db = test_db("secondary-mixed-bitmap-changes").await;
         let handle = active_read_handle(
             &db,
@@ -5790,7 +5758,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pure_bitmap_additions_commit_without_conflicts() {
+    async fn pure_bitmap_additions_commit_as_disjoint_merges() {
         let db = test_db("secondary-commutative-bitmap-additions").await;
         let handle = active_read_handle(
             &db,
@@ -5857,6 +5825,135 @@ mod tests {
         db.close()
             .await
             .expect("commutative bitmap database closes");
+    }
+
+    #[tokio::test]
+    async fn secondary_bitmap_insert_remove_races_respect_logical_members() {
+        let db = test_db("secondary-disjoint-bitmap-races").await;
+        let handle = active_read_handle(
+            &db,
+            SecondaryIndexDefinition::node_equality("User", "status")
+                .expect("node equality definition validates"),
+        )
+        .await;
+        let definition = handle
+            .secondary_definition()
+            .expect("secondary handle retains its definition");
+
+        for insert_commits_first in [false, true] {
+            let key = secondary_entry_key(
+                handle.scope(),
+                handle.index_id(),
+                handle.generation(),
+                definition,
+                CanonicalSecondaryValue::equality_string(&format!(
+                    "disjoint-{insert_commits_first}"
+                )),
+                IndexEntityId::initial(),
+            )
+            .expect("bitmap key validates");
+            db.put(
+                &key,
+                SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1])).encode(),
+            )
+            .await
+            .expect("initial bitmap persists");
+            let insert = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("insert transaction begins");
+            let remove = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("remove transaction begins");
+            stage_bitmap_changes(
+                &insert,
+                &BTreeMap::from([(key.clone(), BTreeMap::from([(2, true)]))]),
+            )
+            .await
+            .expect("insert stages");
+            stage_bitmap_changes(
+                &remove,
+                &BTreeMap::from([(key.clone(), BTreeMap::from([(1, false)]))]),
+            )
+            .await
+            .expect("remove stages");
+            if insert_commits_first {
+                insert.commit().await.expect("insert commits");
+                remove.commit().await.expect("disjoint remove commits");
+            } else {
+                remove.commit().await.expect("remove commits");
+                insert.commit().await.expect("disjoint insert commits");
+            }
+            assert_eq!(
+                SecondaryEqualityBitmapValue::decode(
+                    &db.get(&key)
+                        .await
+                        .expect("result bitmap reads")
+                        .expect("result bitmap exists"),
+                )
+                .unwrap()
+                .into_ids()
+                .iter()
+                .collect::<Vec<_>>(),
+                vec![2]
+            );
+        }
+
+        for insert_commits_first in [false, true] {
+            let key = secondary_entry_key(
+                handle.scope(),
+                handle.index_id(),
+                handle.generation(),
+                definition,
+                CanonicalSecondaryValue::equality_string(&format!(
+                    "overlap-{insert_commits_first}"
+                )),
+                IndexEntityId::initial(),
+            )
+            .expect("bitmap key validates");
+            db.put(
+                &key,
+                SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1])).encode(),
+            )
+            .await
+            .expect("initial bitmap persists");
+            let insert = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("insert transaction begins");
+            let remove = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("remove transaction begins");
+            stage_bitmap_changes(
+                &insert,
+                &BTreeMap::from([(key.clone(), BTreeMap::from([(1, true)]))]),
+            )
+            .await
+            .expect("insert stages");
+            stage_bitmap_changes(
+                &remove,
+                &BTreeMap::from([(key, BTreeMap::from([(1, false)]))]),
+            )
+            .await
+            .expect("remove stages");
+            if insert_commits_first {
+                insert.commit().await.expect("insert commits");
+                assert_eq!(
+                    remove.commit().await.unwrap_err().kind(),
+                    slatedb::ErrorKind::Transaction
+                );
+            } else {
+                remove.commit().await.expect("remove commits");
+                assert_eq!(
+                    insert.commit().await.unwrap_err().kind(),
+                    slatedb::ErrorKind::Transaction
+                );
+            }
+        }
+
+        db.close().await.expect("bitmap race database closes");
     }
 
     #[tokio::test]

--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -2556,16 +2556,14 @@ async fn stage_bitmap_changes(
 ) -> Result<()> {
     for (key, changes) in changes {
         let mut delta = BitmapMembershipDelta::default();
-        let mut discriminators = Vec::with_capacity(changes.len());
         for (entity_id, present) in changes {
-            discriminators.push(Bytes::copy_from_slice(&entity_id.to_be_bytes()));
             if *present {
                 delta.add(*entity_id);
             } else {
                 delta.remove(*entity_id);
             }
         }
-        transaction.merge_disjoint(key, discriminators, delta.encode())?;
+        transaction.merge_disjoint_tokens(key, delta.members().map(u128::from), delta.encode())?;
     }
     Ok(())
 }

--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -5828,132 +5828,144 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn secondary_bitmap_insert_remove_races_respect_logical_members() {
-        let db = test_db("secondary-disjoint-bitmap-races").await;
-        let handle = active_read_handle(
-            &db,
-            SecondaryIndexDefinition::node_equality("User", "status")
-                .expect("node equality definition validates"),
-        )
-        .await;
-        let definition = handle
-            .secondary_definition()
-            .expect("secondary handle retains its definition");
+    async fn node_and_edge_equality_bitmap_races_respect_logical_members() {
+        let fixtures = [
+            (
+                "node",
+                SecondaryIndexDefinition::node_equality("User", "status")
+                    .expect("node equality definition validates"),
+            ),
+            (
+                "edge",
+                SecondaryIndexDefinition::edge_equality("FOLLOWS", "status")
+                    .expect("edge equality definition validates"),
+            ),
+        ];
 
-        for insert_commits_first in [false, true] {
-            let key = secondary_entry_key(
-                handle.scope(),
-                handle.index_id(),
-                handle.generation(),
-                definition,
-                CanonicalSecondaryValue::equality_string(&format!(
-                    "disjoint-{insert_commits_first}"
-                )),
-                IndexEntityId::initial(),
-            )
-            .expect("bitmap key validates");
-            db.put(
-                &key,
-                SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1])).encode(),
-            )
-            .await
-            .expect("initial bitmap persists");
-            let insert = db
-                .begin(IsolationLevel::SerializableSnapshot)
-                .await
-                .expect("insert transaction begins");
-            let remove = db
-                .begin(IsolationLevel::SerializableSnapshot)
-                .await
-                .expect("remove transaction begins");
-            stage_bitmap_changes(
-                &insert,
-                &BTreeMap::from([(key.clone(), BTreeMap::from([(2, true)]))]),
-            )
-            .await
-            .expect("insert stages");
-            stage_bitmap_changes(
-                &remove,
-                &BTreeMap::from([(key.clone(), BTreeMap::from([(1, false)]))]),
-            )
-            .await
-            .expect("remove stages");
-            if insert_commits_first {
-                insert.commit().await.expect("insert commits");
-                remove.commit().await.expect("disjoint remove commits");
-            } else {
-                remove.commit().await.expect("remove commits");
-                insert.commit().await.expect("disjoint insert commits");
-            }
-            assert_eq!(
-                SecondaryEqualityBitmapValue::decode(
-                    &db.get(&key)
-                        .await
-                        .expect("result bitmap reads")
-                        .expect("result bitmap exists"),
+        for (kind, fixture) in fixtures {
+            let db = test_db(&format!("secondary-disjoint-{kind}-bitmap-races")).await;
+            let handle = active_read_handle(&db, fixture).await;
+            let definition = handle
+                .secondary_definition()
+                .expect("secondary handle retains its definition");
+
+            for insert_commits_first in [false, true] {
+                let key = secondary_entry_key(
+                    handle.scope(),
+                    handle.index_id(),
+                    handle.generation(),
+                    definition,
+                    CanonicalSecondaryValue::equality_string(&format!(
+                        "disjoint-{insert_commits_first}"
+                    )),
+                    IndexEntityId::initial(),
                 )
-                .unwrap()
-                .into_ids()
-                .iter()
-                .collect::<Vec<_>>(),
-                vec![2]
-            );
-        }
-
-        for insert_commits_first in [false, true] {
-            let key = secondary_entry_key(
-                handle.scope(),
-                handle.index_id(),
-                handle.generation(),
-                definition,
-                CanonicalSecondaryValue::equality_string(&format!(
-                    "overlap-{insert_commits_first}"
-                )),
-                IndexEntityId::initial(),
-            )
-            .expect("bitmap key validates");
-            db.put(
-                &key,
-                SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1])).encode(),
-            )
-            .await
-            .expect("initial bitmap persists");
-            let insert = db
-                .begin(IsolationLevel::SerializableSnapshot)
+                .expect("bitmap key validates");
+                db.put(
+                    &key,
+                    SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1]))
+                        .encode(),
+                )
                 .await
-                .expect("insert transaction begins");
-            let remove = db
-                .begin(IsolationLevel::SerializableSnapshot)
+                .expect("initial bitmap persists");
+                let insert = db
+                    .begin(IsolationLevel::SerializableSnapshot)
+                    .await
+                    .expect("insert transaction begins");
+                let remove = db
+                    .begin(IsolationLevel::SerializableSnapshot)
+                    .await
+                    .expect("remove transaction begins");
+                stage_bitmap_changes(
+                    &insert,
+                    &BTreeMap::from([(key.clone(), BTreeMap::from([(2, true)]))]),
+                )
                 .await
-                .expect("remove transaction begins");
-            stage_bitmap_changes(
-                &insert,
-                &BTreeMap::from([(key.clone(), BTreeMap::from([(1, true)]))]),
-            )
-            .await
-            .expect("insert stages");
-            stage_bitmap_changes(
-                &remove,
-                &BTreeMap::from([(key, BTreeMap::from([(1, false)]))]),
-            )
-            .await
-            .expect("remove stages");
-            if insert_commits_first {
-                insert.commit().await.expect("insert commits");
+                .expect("insert stages");
+                stage_bitmap_changes(
+                    &remove,
+                    &BTreeMap::from([(key.clone(), BTreeMap::from([(1, false)]))]),
+                )
+                .await
+                .expect("remove stages");
+                if insert_commits_first {
+                    insert.commit().await.expect("insert commits");
+                    remove.commit().await.expect("disjoint remove commits");
+                } else {
+                    remove.commit().await.expect("remove commits");
+                    insert.commit().await.expect("disjoint insert commits");
+                }
                 assert_eq!(
-                    remove.commit().await.unwrap_err().kind(),
-                    slatedb::ErrorKind::Transaction
-                );
-            } else {
-                remove.commit().await.expect("remove commits");
-                assert_eq!(
-                    insert.commit().await.unwrap_err().kind(),
-                    slatedb::ErrorKind::Transaction
+                    SecondaryEqualityBitmapValue::decode(
+                        &db.get(&key)
+                            .await
+                            .expect("result bitmap reads")
+                            .expect("result bitmap exists"),
+                    )
+                    .unwrap()
+                    .into_ids()
+                    .iter()
+                    .collect::<Vec<_>>(),
+                    vec![2]
                 );
             }
-        }
 
-        db.close().await.expect("bitmap race database closes");
+            for insert_commits_first in [false, true] {
+                let key = secondary_entry_key(
+                    handle.scope(),
+                    handle.index_id(),
+                    handle.generation(),
+                    definition,
+                    CanonicalSecondaryValue::equality_string(&format!(
+                        "overlap-{insert_commits_first}"
+                    )),
+                    IndexEntityId::initial(),
+                )
+                .expect("bitmap key validates");
+                db.put(
+                    &key,
+                    SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1]))
+                        .encode(),
+                )
+                .await
+                .expect("initial bitmap persists");
+                let insert = db
+                    .begin(IsolationLevel::SerializableSnapshot)
+                    .await
+                    .expect("insert transaction begins");
+                let remove = db
+                    .begin(IsolationLevel::SerializableSnapshot)
+                    .await
+                    .expect("remove transaction begins");
+                stage_bitmap_changes(
+                    &insert,
+                    &BTreeMap::from([(key.clone(), BTreeMap::from([(1, true)]))]),
+                )
+                .await
+                .expect("insert stages");
+                stage_bitmap_changes(
+                    &remove,
+                    &BTreeMap::from([(key, BTreeMap::from([(1, false)]))]),
+                )
+                .await
+                .expect("remove stages");
+                if insert_commits_first {
+                    insert.commit().await.expect("insert commits");
+                    assert_eq!(
+                        remove.commit().await.unwrap_err().kind(),
+                        slatedb::ErrorKind::Transaction
+                    );
+                } else {
+                    remove.commit().await.expect("remove commits");
+                    assert_eq!(
+                        insert.commit().await.unwrap_err().kind(),
+                        slatedb::ErrorKind::Transaction
+                    );
+                }
+            }
+
+            db.close().await.expect("bitmap race database closes");
+        }
     }
 
     #[tokio::test]

--- a/crates/db/src/merge_operator.rs
+++ b/crates/db/src/merge_operator.rs
@@ -2,7 +2,7 @@
 
 use bytes::Bytes;
 use roaring::RoaringTreemap;
-use slatedb::{MergeOperator, MergeOperatorError};
+use slatedb::{MergeOperator, MergeOperatorError, MergeResult};
 
 use crate::encoding::keys::scope::DataScope;
 use crate::encoding::v2::keys::indexes::vector::{
@@ -10,8 +10,8 @@ use crate::encoding::v2::keys::indexes::vector::{
 };
 use crate::encoding::v2::keys::{DataKeyKind, KeyPrefix};
 use crate::encoding::v2::keys::{ManagedIndexKey as V2Key, ScopedKey as V2ScopedKey};
-use crate::encoding::v2::values::SecondaryEqualityBitmapValue;
 use crate::encoding::v2::values::{adjacency as edges, indexes::vector as vectors};
+use crate::encoding::v2::values::{BitmapMembershipDelta, SecondaryEqualityBitmapValue};
 use crate::encoding::NodeId;
 
 const EDGE_DELTA_MIN_LEN: usize = core::mem::size_of::<u8>();
@@ -61,14 +61,19 @@ fn decode_bitmap_add(bytes: &[u8]) -> Option<u64> {
 struct BitmapMergeOperator;
 
 impl BitmapMergeOperator {
-    fn apply(bitmap: &mut RoaringTreemap, bytes: &[u8]) -> Result<(), MergeOperatorError> {
+    fn decode_operand(bytes: &[u8]) -> Result<BitmapMembershipDelta, MergeOperatorError> {
         if let Some(id) = decode_bitmap_add(bytes) {
-            bitmap.insert(id);
-            return Ok(());
+            let mut delta = BitmapMembershipDelta::default();
+            delta.add(id);
+            return Ok(delta);
+        }
+        if let Some(delta) =
+            BitmapMembershipDelta::decode_if_delta(bytes).map_err(merge_decode_error)?
+        {
+            return Ok(delta);
         }
         let decoded = SecondaryEqualityBitmapValue::decode(bytes).map_err(merge_decode_error)?;
-        *bitmap |= decoded.ids();
-        Ok(())
+        Ok(BitmapMembershipDelta::from_additions(decoded.into_ids()))
     }
 
     fn encode(bitmap: &RoaringTreemap) -> Result<Bytes, MergeOperatorError> {
@@ -87,15 +92,20 @@ impl MergeOperator for BitmapMergeOperator {
         existing_value: Option<Bytes>,
         operand: Bytes,
     ) -> Result<Bytes, MergeOperatorError> {
-        let mut bitmap = RoaringTreemap::new();
-        if let Some(existing) = existing_value {
-            Self::apply(&mut bitmap, &existing)?;
+        let operand = Self::decode_operand(&operand)?;
+        let Some(existing) = existing_value else {
+            return Ok(operand.encode());
+        };
+        if let Some(mut delta) =
+            BitmapMembershipDelta::decode_if_delta(&existing).map_err(merge_decode_error)?
+        {
+            delta.compose(&operand);
+            return Ok(delta.encode());
         }
-        if let Some(id) = decode_bitmap_add(&operand) {
-            bitmap.insert(id);
-        } else {
-            Self::apply(&mut bitmap, &operand)?;
-        }
+        let mut bitmap = SecondaryEqualityBitmapValue::decode(&existing)
+            .map_err(merge_decode_error)?
+            .into_ids();
+        operand.apply_to(&mut bitmap);
         Self::encode(&bitmap)
     }
 
@@ -105,14 +115,47 @@ impl MergeOperator for BitmapMergeOperator {
         existing_value: Option<Bytes>,
         operands: &[Bytes],
     ) -> Result<Bytes, MergeOperatorError> {
-        let mut bitmap = RoaringTreemap::new();
-        if let Some(existing) = existing_value {
-            Self::apply(&mut bitmap, &existing)?;
+        let mut delta = BitmapMembershipDelta::default();
+        for operand in operands {
+            delta.compose(&Self::decode_operand(operand)?);
         }
-        for operand in operands.iter().rev() {
-            Self::apply(&mut bitmap, operand)?;
+        let Some(existing) = existing_value else {
+            return Ok(delta.encode());
+        };
+        if let Some(mut existing_delta) =
+            BitmapMembershipDelta::decode_if_delta(&existing).map_err(merge_decode_error)?
+        {
+            existing_delta.compose(&delta);
+            return Ok(existing_delta.encode());
         }
+        let mut bitmap = SecondaryEqualityBitmapValue::decode(&existing)
+            .map_err(merge_decode_error)?
+            .into_ids();
+        delta.apply_to(&mut bitmap);
         Self::encode(&bitmap)
+    }
+
+    fn merge_batch_with_base(
+        &self,
+        _key: &Bytes,
+        existing_value: Option<Bytes>,
+        operands: &[Bytes],
+    ) -> Result<MergeResult, MergeOperatorError> {
+        let mut bitmap = existing_value
+            .as_deref()
+            .map(SecondaryEqualityBitmapValue::decode)
+            .transpose()
+            .map_err(merge_decode_error)?
+            .map(SecondaryEqualityBitmapValue::into_ids)
+            .unwrap_or_default();
+        for operand in operands {
+            Self::decode_operand(operand)?.apply_to(&mut bitmap);
+        }
+        if bitmap.is_empty() {
+            Ok(MergeResult::Tombstone)
+        } else {
+            Self::encode(&bitmap).map(MergeResult::Value)
+        }
     }
 }
 
@@ -168,6 +211,7 @@ fn is_edge_delta(data: &[u8]) -> bool {
 struct EdgeMergeOperator;
 
 impl EdgeMergeOperator {
+    #[cfg(test)]
     fn apply_delta(edges: &mut edges::Edges, op: EdgeDeltaOp, node_id: NodeId) {
         match op {
             EdgeDeltaOp::AddOut => edges.add_out(node_id),
@@ -182,14 +226,31 @@ impl EdgeMergeOperator {
         }
     }
 
-    fn apply_operand(edges: &mut edges::Edges, operand: &[u8]) {
+    fn decode_operand(
+        operand: &[u8],
+    ) -> Result<edges::AdjacencyMembershipDelta, MergeOperatorError> {
+        if let Some(delta) =
+            edges::AdjacencyMembershipDelta::decode_if_delta(operand).map_err(merge_decode_error)?
+        {
+            return Ok(delta);
+        }
         if let Some((op, node_id)) = decode_edge_delta(operand) {
-            Self::apply_delta(edges, op, node_id);
-            return;
+            let mut delta = edges::AdjacencyMembershipDelta::default();
+            match op {
+                EdgeDeltaOp::AddOut => delta.add_out(node_id),
+                EdgeDeltaOp::RemoveOut => delta.remove_out(node_id),
+                EdgeDeltaOp::AddIn => delta.add_in(node_id),
+                EdgeDeltaOp::RemoveIn => delta.remove_in(node_id),
+                EdgeDeltaOp::ResetOut => delta.reset_out(),
+            }
+            return Ok(delta);
         }
-        if let Ok(other) = edges::decode_edges(operand) {
-            edges.merge(&other);
+        if is_edge_delta(operand) {
+            return Err(merge_decode_error("malformed adjacency delta"));
         }
+        edges::decode_edges(operand)
+            .map(|edges| edges::AdjacencyMembershipDelta::from_edges(&edges))
+            .map_err(merge_decode_error)
     }
 }
 
@@ -200,20 +261,23 @@ impl MergeOperator for EdgeMergeOperator {
         existing_value: Option<Bytes>,
         operand: Bytes,
     ) -> Result<Bytes, MergeOperatorError> {
-        let mut merged = existing_value
-            .as_deref()
-            .filter(|value| !is_edge_delta(value))
-            .map(edges::decode_edges)
-            .transpose()
+        let operand = Self::decode_operand(&operand)?;
+        let Some(existing) = existing_value else {
+            return Ok(operand.encode());
+        };
+        if let Some(mut delta) = edges::AdjacencyMembershipDelta::decode_if_delta(&existing)
             .map_err(merge_decode_error)?
-            .unwrap_or_default();
-        if let Some(existing) = existing_value
-            .as_deref()
-            .filter(|value| is_edge_delta(value))
         {
-            Self::apply_operand(&mut merged, existing);
+            delta.compose(&operand);
+            return Ok(delta.encode());
         }
-        Self::apply_operand(&mut merged, &operand);
+        if is_edge_delta(&existing) {
+            let mut delta = Self::decode_operand(&existing)?;
+            delta.compose(&operand);
+            return Ok(delta.encode());
+        }
+        let mut merged = edges::decode_edges(&existing).map_err(merge_decode_error)?;
+        operand.apply_to(&mut merged);
         Ok(edges::encode_edges(&merged))
     }
 
@@ -223,23 +287,50 @@ impl MergeOperator for EdgeMergeOperator {
         existing_value: Option<Bytes>,
         operands: &[Bytes],
     ) -> Result<Bytes, MergeOperatorError> {
+        let mut delta = edges::AdjacencyMembershipDelta::default();
+        for operand in operands {
+            delta.compose(&Self::decode_operand(operand)?);
+        }
+        let Some(existing) = existing_value else {
+            return Ok(delta.encode());
+        };
+        if let Some(mut existing_delta) =
+            edges::AdjacencyMembershipDelta::decode_if_delta(&existing)
+                .map_err(merge_decode_error)?
+        {
+            existing_delta.compose(&delta);
+            return Ok(existing_delta.encode());
+        }
+        if is_edge_delta(&existing) {
+            let mut existing_delta = Self::decode_operand(&existing)?;
+            existing_delta.compose(&delta);
+            return Ok(existing_delta.encode());
+        }
+        let mut merged = edges::decode_edges(&existing).map_err(merge_decode_error)?;
+        delta.apply_to(&mut merged);
+        Ok(edges::encode_edges(&merged))
+    }
+
+    fn merge_batch_with_base(
+        &self,
+        _key: &Bytes,
+        existing_value: Option<Bytes>,
+        operands: &[Bytes],
+    ) -> Result<MergeResult, MergeOperatorError> {
         let mut merged = existing_value
             .as_deref()
-            .filter(|value| !is_edge_delta(value))
             .map(edges::decode_edges)
             .transpose()
             .map_err(merge_decode_error)?
             .unwrap_or_default();
-        if let Some(existing) = existing_value
-            .as_deref()
-            .filter(|value| is_edge_delta(value))
-        {
-            Self::apply_operand(&mut merged, existing);
+        for operand in operands {
+            Self::decode_operand(operand)?.apply_to(&mut merged);
         }
-        for operand in operands.iter().rev() {
-            Self::apply_operand(&mut merged, operand);
+        if merged.is_empty() {
+            Ok(MergeResult::Tombstone)
+        } else {
+            Ok(MergeResult::Value(edges::encode_edges(&merged)))
         }
-        Ok(edges::encode_edges(&merged))
     }
 }
 
@@ -483,6 +574,37 @@ impl MergeOperator for HelixMergeOperator {
                 .ok_or(MergeOperatorError::EmptyBatch),
         }
     }
+
+    fn merge_batch_with_base(
+        &self,
+        key: &Bytes,
+        existing_value: Option<Bytes>,
+        operands: &[Bytes],
+    ) -> Result<MergeResult, MergeOperatorError> {
+        match Self::key_type(key) {
+            MergeKeyType::Edge => self
+                .edge
+                .merge_batch_with_base(key, existing_value, operands),
+            MergeKeyType::Bitmap => {
+                self.bitmap
+                    .merge_batch_with_base(key, existing_value, operands)
+            }
+            MergeKeyType::Layer0 => self
+                .layer0
+                .merge_batch(key, existing_value, operands)
+                .map(MergeResult::Value),
+            MergeKeyType::Counter => self
+                .counter
+                .merge_batch(key, existing_value, operands)
+                .map(MergeResult::Value),
+            MergeKeyType::Other => operands
+                .first()
+                .cloned()
+                .or(existing_value)
+                .map(MergeResult::Value)
+                .ok_or(MergeOperatorError::EmptyBatch),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -592,8 +714,9 @@ mod tests {
     }
 
     fn decode_bitmap(bytes: Bytes) -> Vec<u64> {
-        RoaringTreemap::deserialize_from(Cursor::new(bytes))
+        SecondaryEqualityBitmapValue::decode(&bytes)
             .expect("merged bitmap decodes")
+            .into_ids()
             .iter()
             .collect()
     }
@@ -618,7 +741,7 @@ mod tests {
             )
             .expect("merge succeeds");
         let edges = edges::decode_edges(&merged).expect("edges decode");
-        assert_eq!(edges.iter_out().collect::<Vec<_>>(), vec![7]);
+        assert_eq!(edges.iter_out().collect::<Vec<_>>(), vec![5, 7]);
     }
 
     #[test]
@@ -640,10 +763,99 @@ mod tests {
                 &[base, encode_bitmap_add(42), encode_bitmap_add(42)],
             )
             .expect("bitmap operands merge");
-        let bitmap =
-            RoaringTreemap::deserialize_from(Cursor::new(merged)).expect("merged bitmap decodes");
+        assert_eq!(decode_bitmap(merged), vec![41, 42]);
+    }
 
-        assert_eq!(bitmap.iter().collect::<Vec<_>>(), vec![41, 42]);
+    #[test]
+    fn bitmap_delta_preserves_removals_across_intermediate_merge_batches() {
+        let key = DataKey::Data {
+            scope: DataScope::LegacyUnscoped,
+            kind: DataKeyKind::EdgePairIndex(EdgePairIndexKey::new(1, 3)),
+        }
+        .to_bytes();
+        let operator = HelixMergeOperator::new();
+        let mut older = BitmapMembershipDelta::default();
+        older.remove(1);
+        older.add(3);
+        let mut newer = BitmapMembershipDelta::default();
+        newer.remove(2);
+        newer.add(4);
+        let intermediate = operator
+            .merge_batch(&key, None, &[older.encode(), newer.encode()])
+            .expect("intermediate bitmap delta merges");
+        assert!(BitmapMembershipDelta::decode_if_delta(&intermediate)
+            .unwrap()
+            .is_some());
+
+        let resolved = operator
+            .merge_batch_with_base(&key, Some(portable_bitmap([1, 2, 5])), &[intermediate])
+            .expect("intermediate bitmap delta resolves against its base");
+        let MergeResult::Value(resolved) = resolved else {
+            panic!("non-empty bitmap resolves to a value")
+        };
+        assert_eq!(decode_bitmap(resolved), vec![3, 4, 5]);
+
+        let mut remove_last = BitmapMembershipDelta::default();
+        remove_last.remove(9);
+        assert_eq!(
+            operator
+                .merge_batch_with_base(&key, Some(portable_bitmap([9])), &[remove_last.encode()],)
+                .unwrap(),
+            MergeResult::Tombstone
+        );
+    }
+
+    #[test]
+    fn adjacency_delta_preserves_directional_removals_and_tombstones() {
+        let key = DataKey::Data {
+            scope: DataScope::LegacyUnscoped,
+            kind: DataKeyKind::Adjacency(AdjacencyKey::new(1)),
+        }
+        .to_bytes();
+        let operator = HelixMergeOperator::new();
+        let mut base = edges::Edges::new();
+        base.add_out(1);
+        base.add_out(2);
+        base.add_in(3);
+        let mut older = edges::AdjacencyMembershipDelta::default();
+        older.remove_out(1);
+        older.add_in(4);
+        let mut newer = edges::AdjacencyMembershipDelta::default();
+        newer.remove_in(3);
+        newer.add_out(5);
+        let intermediate = operator
+            .merge_batch(&key, None, &[older.encode(), newer.encode()])
+            .expect("intermediate adjacency delta merges");
+        assert!(
+            edges::AdjacencyMembershipDelta::decode_if_delta(&intermediate)
+                .unwrap()
+                .is_some()
+        );
+
+        let resolved = operator
+            .merge_batch_with_base(&key, Some(edges::encode_edges(&base)), &[intermediate])
+            .expect("intermediate adjacency delta resolves against its base");
+        let MergeResult::Value(resolved) = resolved else {
+            panic!("non-empty adjacency resolves to a value")
+        };
+        let resolved = edges::decode_edges(&resolved).unwrap();
+        assert_eq!(resolved.iter_out().collect::<Vec<_>>(), vec![2, 5]);
+        assert_eq!(resolved.iter_in().collect::<Vec<_>>(), vec![4]);
+
+        let mut remove_last = edges::AdjacencyMembershipDelta::default();
+        remove_last.remove_out(7);
+        let mut last = edges::Edges::new();
+        last.add_out(7);
+        assert_eq!(
+            operator
+                .merge_batch_with_base(
+                    &key,
+                    Some(edges::encode_edges(&last)),
+                    &[remove_last.encode()],
+                )
+                .unwrap(),
+            MergeResult::Tombstone
+        );
     }
 
     #[test]
@@ -777,8 +989,7 @@ mod tests {
             let merged = HelixMergeOperator::new()
                 .merge_batch(&key, None, &[encode_bitmap_add(5), encode_bitmap_add(8)])
                 .unwrap();
-            let bitmap = RoaringTreemap::deserialize_from(Cursor::new(merged)).unwrap();
-            assert_eq!(bitmap, RoaringTreemap::from_iter([5, 8]));
+            assert_eq!(decode_bitmap(merged), vec![5, 8]);
         }
     }
 
@@ -910,6 +1121,58 @@ mod tests {
             .expect("reopened bitmap database closes");
     }
 
+    #[tokio::test]
+    async fn batched_bitmap_removals_survive_cold_reopen_without_empty_rows() {
+        const MEMBERS: u64 = 250;
+
+        let store = Arc::new(InMemory::new());
+        let path = "merge-operator-batched-removals";
+        let db = slatedb::Db::builder(path, store.clone())
+            .with_merge_operator(Arc::new(HelixMergeOperator::new()))
+            .build()
+            .await
+            .expect("batched removal database opens");
+        let key = v4_bitmap_key(DataScope::LegacyUnscoped);
+        db.put(&key, portable_bitmap(0..MEMBERS))
+            .await
+            .expect("bitmap base persists");
+
+        let transaction = db
+            .begin(slatedb::IsolationLevel::SerializableSnapshot)
+            .await
+            .expect("batched removal transaction begins");
+        for id in 0..MEMBERS {
+            let mut delta = BitmapMembershipDelta::default();
+            delta.remove(id);
+            transaction
+                .merge_disjoint(&key, [id.to_be_bytes()], delta.encode())
+                .expect("batched removal stages");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("batched removal transaction commits");
+        assert_eq!(db.get(&key).await.expect("removed bitmap reads"), None);
+
+        db.close().await.expect("batched removal database closes");
+        let reopened = slatedb::Db::builder(path, store)
+            .with_merge_operator(Arc::new(HelixMergeOperator::new()))
+            .build()
+            .await
+            .expect("batched removal database reopens");
+        assert_eq!(
+            reopened
+                .get(&key)
+                .await
+                .expect("reopened removed bitmap reads"),
+            None
+        );
+        reopened
+            .close()
+            .await
+            .expect("reopened removal database closes");
+    }
+
     #[test]
     fn bitmap_add_operands_commute_for_every_existing_bitmap() {
         let key = DataKey::Data {
@@ -989,8 +1252,10 @@ mod tests {
         let mut encoded = edges::Edges::new();
         encoded.add_out(17);
         encoded.add_in(19);
-        EdgeMergeOperator::apply_operand(&mut state, &edges::encode_edges(&encoded));
-        EdgeMergeOperator::apply_operand(&mut state, b"not-an-edge-value");
+        EdgeMergeOperator::decode_operand(&edges::encode_edges(&encoded))
+            .unwrap()
+            .apply_to(&mut state);
+        assert!(EdgeMergeOperator::decode_operand(b"not-an-edge-value").is_err());
         assert!(state.contains_out(17));
         assert!(state.contains_in(19));
     }
@@ -1015,7 +1280,7 @@ mod tests {
             )
             .expect("batch deltas merge from oldest to newest");
         let decoded = edges::decode_edges(&batch).expect("batch edges decode");
-        assert_eq!(decoded.iter_out().collect::<Vec<_>>(), Vec::<u64>::new());
+        assert_eq!(decoded.iter_out().collect::<Vec<_>>(), vec![9]);
 
         assert!(operator
             .merge(


### PR DESCRIPTION
## Summary

Make graph membership removals conflict on logical entity IDs instead of the shared physical label, topology, or equality-index row. This allows expiry sweeps to delete disjoint Kubernetes event nodes while writers continue inserting into the same hot rows.

Depends on HelixDB/slatedb#10 and pins its exact commit, 85ffcf7.

## Changes

- Add associative bitmap and adjacency membership-delta encodings.
- Stage node-label, edge-label, edge-pair, adjacency, and non-unique node/edge equality-index removals as disjoint merges.
- Use member IDs as bitmap conflict tokens and direction plus neighbor IDs for adjacency tokens.
- Preserve exclusive conflicts for overlapping logical members, unique equality ownership, ordinary writes, and SSI observations.
- Add both commit-order races, overlap conflicts, empty-result handling, reopen behavior, malformed encodings, parallel edges, and node/edge equality-index coverage.
- Use compact fixed-width conflict tokens to keep the preparation phase bounded.

This PR intentionally does not include the later physical-row `drop_nodes` batching or direct-token-accumulation experiments.

## Results

Release contention workload with 100K removals and 10K concurrent inserts:

- Sweep conflicts: 40/100 to 0/100.
- Writer conflicts: 39 to 0.
- Preparation median after compact tokens: approximately 6–7 ms per 100K memberships.

## Validation

- `cargo test --workspace`
- TypeScript CLI runtime integration
- workspace doctests
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- focused coverage, concurrency, compaction, and contention benchmarks

SlateDB must merge and publish first because this branch pins the exact dependency revision.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes graph membership removals from physical-row conflicts to logical-member conflicts while retaining conflicts for overlapping members.

- Adds associative bitmap and adjacency membership-delta codecs.
- Stages topology and non-unique equality-index updates through disjoint conflict tokens.
- Updates the merge operator to compose deltas and materialize empty results as tombstones.
- Pins the SlateDB revision providing disjoint-token merge support.
- Adds concurrency, compatibility, malformed-input, reopen, and compaction coverage.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/execution/interpreter/mutation/topology.rs | Replaces row-level read-modify-write topology updates with coalesced membership deltas and direction-aware logical conflict tokens. |
| crates/db/src/encoding/v2/values/indexes/equality.rs | Adds a validated, associative bitmap membership-delta encoding with last-write-wins composition. |
| crates/db/src/encoding/v2/values/adjacency.rs | Adds adjacency membership deltas, outgoing-reset support, composition, and compatibility decoding. |
| crates/db/src/merge_operator.rs | Extends bitmap and adjacency merge operators to compose the new delta formats and emit tombstones for empty materialized rows. |
| crates/db/src/index_lifecycle/secondary.rs | Stages non-unique equality-index additions and removals using entity-specific disjoint merge tokens. |
| crates/db/Cargo.toml | Pins SlateDB to the revision supplying disjoint-token transaction merge support. |
| Cargo.lock | Updates the pinned SlateDB packages and their resolved dependency metadata. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant M as Mutation runtime
    participant T as SlateDB transaction
    participant O as Helix merge operator
    participant R as Shared graph row
    M->>M: Coalesce changes by logical member
    M->>T: merge_disjoint_tokens(member tokens, delta)
    T->>T: Conflict only on overlapping tokens
    T->>O: Apply committed operands in order
    O->>R: Compose delta with existing value
    O-->>T: Materialized value or tombstone
```
</details>

<sub>Reviews (1): Last reviewed commit: ["use compact merge conflict tokens"](https://github.com/helixdb/helix-db/commit/ed966885f3aaa086f5badf4223b7936f2c089810) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58210641)</sub>

<!-- /greptile_comment -->