### PR TITLE
Make shared-row graph deletes conflict by logical member

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3595,7 +3595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -3616,7 +3616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4683,7 +4683,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=7a843f8025568e09e7d186aedbe487eae31bc87a#7a843f8025568e09e7d186aedbe487eae31bc87a"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=d8619d5475f3e76ab7ab7e216f57cb4dd7005711#d8619d5475f3e76ab7ab7e216f57cb4dd7005711"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=7a843f8025568e09e7d186aedbe487eae31bc87a#7a843f8025568e09e7d186aedbe487eae31bc87a"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=d8619d5475f3e76ab7ab7e216f57cb4dd7005711#d8619d5475f3e76ab7ab7e216f57cb4dd7005711"
 dependencies = [
  "chrono",
  "log",
@@ -4743,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=7a843f8025568e09e7d186aedbe487eae31bc87a#7a843f8025568e09e7d186aedbe487eae31bc87a"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=d8619d5475f3e76ab7ab7e216f57cb4dd7005711#d8619d5475f3e76ab7ab7e216f57cb4dd7005711"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=85ffcf7acfe429dcbda6380aec07b44d53ab1584#85ffcf7acfe429dcbda6380aec07b44d53ab1584"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2#1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2"
 dependencies = [
  "ahash",
  "async-channel",
@@ -4729,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=85ffcf7acfe429dcbda6380aec07b44d53ab1584#85ffcf7acfe429dcbda6380aec07b44d53ab1584"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2#1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2"
 dependencies = [
  "chrono",
  "log",
@@ -4744,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=85ffcf7acfe429dcbda6380aec07b44d53ab1584#85ffcf7acfe429dcbda6380aec07b44d53ab1584"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2#1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,8 +4683,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=b7b876ca533d88e78884b2c20c05827a58819a22#b7b876ca533d88e78884b2c20c05827a58819a22"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=85ffcf7acfe429dcbda6380aec07b44d53ab1584#85ffcf7acfe429dcbda6380aec07b44d53ab1584"
 dependencies = [
+ "ahash",
  "async-channel",
  "async-trait",
  "atomic",
@@ -4728,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=b7b876ca533d88e78884b2c20c05827a58819a22#b7b876ca533d88e78884b2c20c05827a58819a22"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=85ffcf7acfe429dcbda6380aec07b44d53ab1584#85ffcf7acfe429dcbda6380aec07b44d53ab1584"
 dependencies = [
  "chrono",
  "log",
@@ -4743,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=b7b876ca533d88e78884b2c20c05827a58819a22#b7b876ca533d88e78884b2c20c05827a58819a22"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=85ffcf7acfe429dcbda6380aec07b44d53ab1584#85ffcf7acfe429dcbda6380aec07b44d53ab1584"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=7a843f8025568e09e7d186aedbe487eae31bc87a#7a843f8025568e09e7d186aedbe487eae31bc87a"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=7a843f8025568e09e7d186aedbe487eae31bc87a#7a843f8025568e09e7d186aedbe487eae31bc87a"
 dependencies = [
  "chrono",
  "log",
@@ -4743,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=7a843f8025568e09e7d186aedbe487eae31bc87a#7a843f8025568e09e7d186aedbe487eae31bc87a"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=d8619d5475f3e76ab7ab7e216f57cb4dd7005711#d8619d5475f3e76ab7ab7e216f57cb4dd7005711"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=b7b876ca533d88e78884b2c20c05827a58819a22#b7b876ca533d88e78884b2c20c05827a58819a22"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=d8619d5475f3e76ab7ab7e216f57cb4dd7005711#d8619d5475f3e76ab7ab7e216f57cb4dd7005711"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=b7b876ca533d88e78884b2c20c05827a58819a22#b7b876ca533d88e78884b2c20c05827a58819a22"
 dependencies = [
  "chrono",
  "log",
@@ -4743,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=d8619d5475f3e76ab7ab7e216f57cb4dd7005711#d8619d5475f3e76ab7ab7e216f57cb4dd7005711"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=b7b876ca533d88e78884b2c20c05827a58819a22#b7b876ca533d88e78884b2c20c05827a58819a22"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "85ffcf7acfe429dcbda6380aec07b44d53ab1584" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "b7b876ca533d88e78884b2c20c05827a58819a22" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "85ffcf7acfe429dcbda6380aec07b44d53ab1584" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "d8619d5475f3e76ab7ab7e216f57cb4dd7005711" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "b7b876ca533d88e78884b2c20c05827a58819a22" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "7a843f8025568e09e7d186aedbe487eae31bc87a" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "d8619d5475f3e76ab7ab7e216f57cb4dd7005711" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "30d9f28cfeb93cf95652aac2b7724811c5c49630" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "7a843f8025568e09e7d186aedbe487eae31bc87a" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/db/src/encoding/v2/keys/global.rs
+++ b/crates/db/src/encoding/v2/keys/global.rs
@@ -30,6 +30,7 @@ pub(crate) enum GlobalKind {
     OperationPointer = 0x04,
     LegacyVectorPhysicalReservation = 0x0A,
     TextCompactionPointer = 0x0B,
+    MembershipDeltaWriteMode = 0x0C,
 }
 
 impl GlobalKind {
@@ -45,6 +46,7 @@ impl GlobalKind {
             0x04 => Ok(Self::OperationPointer),
             0x0A => Ok(Self::LegacyVectorPhysicalReservation),
             0x0B => Ok(Self::TextCompactionPointer),
+            0x0C => Ok(Self::MembershipDeltaWriteMode),
             unknown => Err(EncodingError::InvalidKey(format!(
                 "unknown global V2 key kind {unknown:#04x}"
             ))),
@@ -119,6 +121,7 @@ pub(crate) enum GlobalKey {
     OperationPointer(IndexOperationId),
     LegacyVectorPhysicalReservation(VectorPhysicalIndexId),
     TextCompactionPointer(TextCompactionTarget),
+    MembershipDeltaWriteMode,
 }
 
 impl GlobalKey {
@@ -137,6 +140,7 @@ impl GlobalKey {
             Self::OperationPointer(_) => GlobalKind::OperationPointer,
             Self::LegacyVectorPhysicalReservation(_) => GlobalKind::LegacyVectorPhysicalReservation,
             Self::TextCompactionPointer(_) => GlobalKind::TextCompactionPointer,
+            Self::MembershipDeltaWriteMode => GlobalKind::MembershipDeltaWriteMode,
         }
     }
 
@@ -144,7 +148,8 @@ impl GlobalKey {
         let suffix = match self {
             Self::StorageVersion
             | Self::LogicalIndexIdWatermark
-            | Self::VectorPhysicalIdWatermark => 0,
+            | Self::VectorPhysicalIdWatermark
+            | Self::MembershipDeltaWriteMode => 0,
             Self::OperationPointer(_) => UUID_LEN,
             Self::LegacyVectorPhysicalReservation(_) => U64_LEN,
             Self::TextCompactionPointer(target) => {
@@ -166,7 +171,8 @@ impl GlobalKey {
         match self {
             Self::StorageVersion
             | Self::LogicalIndexIdWatermark
-            | Self::VectorPhysicalIdWatermark => {}
+            | Self::VectorPhysicalIdWatermark
+            | Self::MembershipDeltaWriteMode => {}
             Self::OperationPointer(id) => buffer.put_slice(id.as_bytes()),
             Self::LegacyVectorPhysicalReservation(physical_index_id) => {
                 buffer.put_u64(physical_index_id.get());
@@ -244,6 +250,7 @@ impl GlobalKey {
                     decoder.take_u32()?,
                 )?)
             }
+            GlobalKind::MembershipDeltaWriteMode => Self::MembershipDeltaWriteMode,
         };
         decoder.finish()?;
         Ok(key)

--- a/crates/db/src/encoding/v2/keys/indexes/direction.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/direction.rs
@@ -2,7 +2,7 @@
 
 use crate::encoding::error::EncodingError;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub(crate) enum EdgeDirection {
     Out = 0x00,

--- a/crates/db/src/encoding/v2/keys/managed_index.rs
+++ b/crates/db/src/encoding/v2/keys/managed_index.rs
@@ -1045,6 +1045,10 @@ tenant=fd0102030405060708111213141516171806050000000000000001000000000000000201e
                 "text_compaction_pointer",
                 GlobalKey::TextCompactionPointer(target),
             ),
+            (
+                "membership_delta_write_mode",
+                GlobalKey::MembershipDeltaWriteMode,
+            ),
         ];
         let mut rendered = String::new();
         for (name, key) in fixtures {
@@ -1059,6 +1063,7 @@ vector_physical_watermark=fefefefefefefefefefefefefefefefefe03
 operation_pointer=fefefefefefefefefefefefefefefefefe0411111111111111111111111111111111
 legacy_vector_reservation=fefefefefefefefefefefefefefefefefe0a0000000000000009
 text_compaction_pointer=fefefefefefefefefefefefefefefefefe0b01000000000000000000000000000000070401000000014c000000017000000000000000010000000000000002222222222222222222222222222222222222222222222222222222222222222200000004
+membership_delta_write_mode=fefefefefefefefefefefefefefefefefe0c
 ");
     }
 }

--- a/crates/db/src/encoding/v2/values/adjacency.rs
+++ b/crates/db/src/encoding/v2/values/adjacency.rs
@@ -141,6 +141,14 @@ impl AdjacencyMembershipDelta {
         self.incoming.apply_to(&mut edges.nxts_in);
     }
 
+    pub(crate) fn outgoing_members(&self) -> impl Iterator<Item = NodeId> + '_ {
+        self.outgoing.members()
+    }
+
+    pub(crate) fn incoming_members(&self) -> impl Iterator<Item = NodeId> + '_ {
+        self.incoming.members()
+    }
+
     pub(crate) fn encode(&self) -> Bytes {
         let outgoing = self.outgoing.encode();
         let incoming = self.incoming.encode();

--- a/crates/db/src/encoding/v2/values/adjacency.rs
+++ b/crates/db/src/encoding/v2/values/adjacency.rs
@@ -1,10 +1,13 @@
-use bytes::Bytes;
+use bytes::{BufMut, Bytes};
 use roaring::RoaringTreemap;
 
 use super::codec::{take_slice, take_u32_le, take_u8, ENCODING_TYPE_LEN, U32_LEN};
+use super::indexes::BitmapMembershipDelta;
 use crate::encoding::{error::EncodingError, NodeId};
 
 const BITMAP_LEN_PREFIX_LEN: usize = U32_LEN;
+const ADJACENCY_MEMBERSHIP_DELTA_MAGIC: &[u8; 8] = b"HLXADJ2\0";
+const ADJACENCY_RESET_OUT_LEN: usize = core::mem::size_of::<u8>();
 
 /// Encoding type: No compression
 ///
@@ -79,6 +82,127 @@ pub struct Edges {
     pub(crate) nxts_out: RoaringTreemap,
     /// Incoming edges (neighbor -> this node)
     pub(crate) nxts_in: RoaringTreemap,
+}
+
+/// Associative last-write-wins membership changes for one adjacency row.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct AdjacencyMembershipDelta {
+    reset_out: bool,
+    outgoing: BitmapMembershipDelta,
+    incoming: BitmapMembershipDelta,
+}
+
+impl AdjacencyMembershipDelta {
+    pub(crate) fn from_edges(edges: &Edges) -> Self {
+        Self {
+            reset_out: false,
+            outgoing: BitmapMembershipDelta::from_additions(edges.nxts_out.clone()),
+            incoming: BitmapMembershipDelta::from_additions(edges.nxts_in.clone()),
+        }
+    }
+
+    pub(crate) fn add_out(&mut self, neighbor: NodeId) {
+        self.outgoing.add(neighbor);
+    }
+
+    pub(crate) fn remove_out(&mut self, neighbor: NodeId) {
+        self.outgoing.remove(neighbor);
+    }
+
+    pub(crate) fn add_in(&mut self, neighbor: NodeId) {
+        self.incoming.add(neighbor);
+    }
+
+    pub(crate) fn remove_in(&mut self, neighbor: NodeId) {
+        self.incoming.remove(neighbor);
+    }
+
+    pub(crate) fn reset_out(&mut self) {
+        self.reset_out = true;
+        self.outgoing = BitmapMembershipDelta::default();
+    }
+
+    /// Applies a newer delta after this delta.
+    pub(crate) fn compose(&mut self, newer: &Self) {
+        if newer.reset_out {
+            self.reset_out = true;
+            self.outgoing = newer.outgoing.clone();
+        } else {
+            self.outgoing.compose(&newer.outgoing);
+        }
+        self.incoming.compose(&newer.incoming);
+    }
+
+    pub(crate) fn apply_to(&self, edges: &mut Edges) {
+        if self.reset_out {
+            edges.nxts_out.clear();
+        }
+        self.outgoing.apply_to(&mut edges.nxts_out);
+        self.incoming.apply_to(&mut edges.nxts_in);
+    }
+
+    pub(crate) fn encode(&self) -> Bytes {
+        let outgoing = self.outgoing.encode();
+        let incoming = self.incoming.encode();
+        let mut bytes = Vec::with_capacity(
+            ADJACENCY_MEMBERSHIP_DELTA_MAGIC.len()
+                + ADJACENCY_RESET_OUT_LEN
+                + BITMAP_LEN_PREFIX_LEN
+                + outgoing.len()
+                + BITMAP_LEN_PREFIX_LEN
+                + incoming.len(),
+        );
+        bytes.extend_from_slice(ADJACENCY_MEMBERSHIP_DELTA_MAGIC);
+        bytes.put_u8(u8::from(self.reset_out));
+        bytes.put_u32_le(u32::try_from(outgoing.len()).expect("outgoing delta length fits u32"));
+        bytes.extend_from_slice(&outgoing);
+        bytes.put_u32_le(u32::try_from(incoming.len()).expect("incoming delta length fits u32"));
+        bytes.extend_from_slice(&incoming);
+        Bytes::from(bytes)
+    }
+
+    pub(crate) fn decode_if_delta(bytes: &[u8]) -> Result<Option<Self>, EncodingError> {
+        if !bytes.starts_with(ADJACENCY_MEMBERSHIP_DELTA_MAGIC) {
+            return Ok(None);
+        }
+        let mut offset = ADJACENCY_MEMBERSHIP_DELTA_MAGIC.len();
+        let reset_out = match take_u8(bytes, &mut offset)? {
+            0 => false,
+            1 => true,
+            value => {
+                return Err(EncodingError::Custom(format!(
+                    "invalid adjacency reset flag {value}"
+                )))
+            }
+        };
+        let outgoing_len = take_u32_le(bytes, &mut offset)?;
+        let outgoing_bytes = take_slice(bytes, &mut offset, outgoing_len)?;
+        let outgoing =
+            BitmapMembershipDelta::decode_if_delta(outgoing_bytes)?.ok_or_else(|| {
+                EncodingError::Custom(
+                    "adjacency outgoing membership delta is malformed".to_string(),
+                )
+            })?;
+        let incoming_len = take_u32_le(bytes, &mut offset)?;
+        let incoming_bytes = take_slice(bytes, &mut offset, incoming_len)?;
+        let incoming =
+            BitmapMembershipDelta::decode_if_delta(incoming_bytes)?.ok_or_else(|| {
+                EncodingError::Custom(
+                    "adjacency incoming membership delta is malformed".to_string(),
+                )
+            })?;
+        if offset != bytes.len() {
+            return Err(EncodingError::Custom(format!(
+                "adjacency membership delta has {} trailing bytes",
+                bytes.len() - offset
+            )));
+        }
+        Ok(Some(Self {
+            reset_out,
+            outgoing,
+            incoming,
+        }))
+    }
 }
 
 impl Edges {
@@ -225,6 +349,11 @@ pub fn decode_edges(data: &[u8]) -> Result<Edges, EncodingError> {
     if data.is_empty() {
         return Ok(Edges::new());
     }
+    if let Some(delta) = AdjacencyMembershipDelta::decode_if_delta(data)? {
+        let mut edges = Edges::new();
+        delta.apply_to(&mut edges);
+        return Ok(edges);
+    }
 
     let mut offset = 0;
     let encoding_type = take_u8(data, &mut offset)?;
@@ -254,6 +383,11 @@ pub fn decode_out_edges(data: &[u8]) -> Result<Edges, EncodingError> {
     if data.is_empty() {
         return Ok(Edges::new());
     }
+    if AdjacencyMembershipDelta::decode_if_delta(data)?.is_some() {
+        let mut edges = decode_edges(data)?;
+        edges.nxts_in.clear();
+        return Ok(edges);
+    }
 
     let mut offset = 0;
     let encoding_type = take_u8(data, &mut offset)?;
@@ -279,6 +413,11 @@ pub fn decode_out_edges(data: &[u8]) -> Result<Edges, EncodingError> {
 pub fn decode_in_edges(data: &[u8]) -> Result<Edges, EncodingError> {
     if data.is_empty() {
         return Ok(Edges::new());
+    }
+    if AdjacencyMembershipDelta::decode_if_delta(data)?.is_some() {
+        let mut edges = decode_edges(data)?;
+        edges.nxts_out.clear();
+        return Ok(edges);
     }
 
     let mut offset = 0;
@@ -398,6 +537,66 @@ mod tests {
         assert!(out.iter_in().collect::<Vec<_>>().is_empty());
         assert!(incoming.iter_out().collect::<Vec<_>>().is_empty());
         assert_eq!(incoming.iter_in().collect::<Vec<_>>(), vec![2]);
+    }
+
+    #[test]
+    fn adjacency_membership_delta_round_trips_composes_and_resets() {
+        let mut older = AdjacencyMembershipDelta::default();
+        older.add_out(1);
+        older.add_out(2);
+        older.remove_in(3);
+        let mut newer = AdjacencyMembershipDelta::default();
+        newer.reset_out();
+        newer.add_out(4);
+        newer.add_in(3);
+        older.compose(&newer);
+
+        let decoded = AdjacencyMembershipDelta::decode_if_delta(&older.encode())
+            .unwrap()
+            .expect("adjacency delta marker is recognized");
+        let mut base = Edges::new();
+        base.add_out(9);
+        base.add_in(8);
+        decoded.apply_to(&mut base);
+
+        assert_eq!(base.iter_out().collect::<Vec<_>>(), vec![4]);
+        assert_eq!(base.iter_in().collect::<Vec<_>>(), vec![3, 8]);
+        assert_eq!(
+            decode_out_edges(&decoded.encode())
+                .unwrap()
+                .iter_out()
+                .collect::<Vec<_>>(),
+            vec![4]
+        );
+        assert_eq!(
+            decode_in_edges(&decoded.encode())
+                .unwrap()
+                .iter_in()
+                .collect::<Vec<_>>(),
+            vec![3]
+        );
+    }
+
+    #[test]
+    fn adjacency_membership_delta_decoder_rejects_invalid_boundaries() {
+        let mut delta = AdjacencyMembershipDelta::default();
+        delta.add_out(1);
+        let encoded = delta.encode();
+        assert_eq!(
+            AdjacencyMembershipDelta::decode_if_delta(&encode_edges(&Edges::new())).unwrap(),
+            None
+        );
+        for length in ADJACENCY_MEMBERSHIP_DELTA_MAGIC.len()..encoded.len() {
+            assert!(AdjacencyMembershipDelta::decode_if_delta(&encoded[0..length]).is_err());
+        }
+
+        let mut invalid_reset = encoded.to_vec();
+        invalid_reset[ADJACENCY_MEMBERSHIP_DELTA_MAGIC.len()] = 2;
+        assert!(AdjacencyMembershipDelta::decode_if_delta(&invalid_reset).is_err());
+
+        let mut trailing = encoded.to_vec();
+        trailing.push(0xFF);
+        assert!(AdjacencyMembershipDelta::decode_if_delta(&trailing).is_err());
     }
 
     #[test]

--- a/crates/db/src/encoding/v2/values/global.rs
+++ b/crates/db/src/encoding/v2/values/global.rs
@@ -19,6 +19,7 @@ pub(crate) fn encode_metadata_value(value: &IndexV2MetadataValue) -> Bytes {
         IndexV2MetadataValue::OperationQueuePointer(_) => 0x04,
         IndexV2MetadataValue::LegacyVectorPhysicalReservation(_) => 0x06,
         IndexV2MetadataValue::TextCompactionPointer(_) => 0x07,
+        IndexV2MetadataValue::MembershipDeltaWriteMode(_) => 0x08,
     };
     let mut encoder = ValueEncoder::with_header(kind);
     match value {
@@ -67,6 +68,10 @@ pub(crate) fn encode_metadata_value(value: &IndexV2MetadataValue) -> Bytes {
         IndexV2MetadataValue::TextCompactionPointer(pointer) => {
             encoder.put_u64(pointer.revision.get())
         }
+        IndexV2MetadataValue::MembershipDeltaWriteMode(mode) => encoder.put_u8(match mode {
+            crate::MembershipDeltaWriteMode::LegacyExclusive => 0x00,
+            crate::MembershipDeltaWriteMode::DisjointV2 => 0x01,
+        }),
     }
     encoder.finish()
 }
@@ -115,6 +120,11 @@ pub(crate) fn decode_metadata_value(value: &[u8]) -> Result<IndexV2MetadataValue
         0x07 => IndexV2MetadataValue::TextCompactionPointer(TextCompactionPointerValue {
             revision: crate::index_lifecycle::TextManifestRevision::new(decoder.take_u64()?)
                 .map_err(model_error)?,
+        }),
+        0x08 => IndexV2MetadataValue::MembershipDeltaWriteMode(match decoder.take_u8()? {
+            0x00 => crate::MembershipDeltaWriteMode::LegacyExclusive,
+            0x01 => crate::MembershipDeltaWriteMode::DisjointV2,
+            unknown => return Err(unknown_discriminant("membership delta write mode", unknown)),
         }),
         unknown => return Err(unknown_discriminant("metadata value", unknown)),
     };

--- a/crates/db/src/encoding/v2/values/indexes/equality.rs
+++ b/crates/db/src/encoding/v2/values/indexes/equality.rs
@@ -2,7 +2,7 @@
 
 use std::io::Cursor;
 
-use bytes::Bytes;
+use bytes::{BufMut, Bytes};
 use roaring::RoaringTreemap;
 
 use crate::encoding::error::EncodingError;
@@ -16,6 +16,141 @@ use super::super::{
 };
 
 const SECONDARY_ENTRY_KIND: u8 = 0x05;
+const BITMAP_MEMBERSHIP_DELTA_MAGIC: &[u8; 8] = b"HLXRBM2\0";
+const BITMAP_MEMBERSHIP_DELTA_LEN_PREFIX_LEN: usize = core::mem::size_of::<u32>();
+
+/// Associative last-write-wins membership changes for one physical bitmap row.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct BitmapMembershipDelta {
+    additions: RoaringTreemap,
+    removals: RoaringTreemap,
+}
+
+impl BitmapMembershipDelta {
+    pub(crate) fn from_additions(additions: RoaringTreemap) -> Self {
+        Self {
+            additions,
+            removals: RoaringTreemap::new(),
+        }
+    }
+
+    pub(crate) fn add(&mut self, id: u64) {
+        self.removals.remove(id);
+        self.additions.insert(id);
+    }
+
+    pub(crate) fn remove(&mut self, id: u64) {
+        self.additions.remove(id);
+        self.removals.insert(id);
+    }
+
+    /// Applies a newer delta after this delta.
+    pub(crate) fn compose(&mut self, newer: &Self) {
+        self.removals -= &newer.additions;
+        self.additions |= &newer.additions;
+        self.additions -= &newer.removals;
+        self.removals |= &newer.removals;
+    }
+
+    pub(crate) fn apply_to(&self, ids: &mut RoaringTreemap) {
+        *ids -= &self.removals;
+        *ids |= &self.additions;
+    }
+
+    pub(crate) fn encode(&self) -> Bytes {
+        let mut additions = Vec::new();
+        self.additions
+            .serialize_into(&mut additions)
+            .expect("serializing membership additions into memory is infallible");
+        let mut removals = Vec::new();
+        self.removals
+            .serialize_into(&mut removals)
+            .expect("serializing membership removals into memory is infallible");
+        let mut bytes = Vec::with_capacity(
+            BITMAP_MEMBERSHIP_DELTA_MAGIC.len()
+                + BITMAP_MEMBERSHIP_DELTA_LEN_PREFIX_LEN
+                + additions.len()
+                + BITMAP_MEMBERSHIP_DELTA_LEN_PREFIX_LEN
+                + removals.len(),
+        );
+        bytes.extend_from_slice(BITMAP_MEMBERSHIP_DELTA_MAGIC);
+        bytes.put_u32(u32::try_from(additions.len()).expect("roaring additions fit u32"));
+        bytes.extend_from_slice(&additions);
+        bytes.put_u32(u32::try_from(removals.len()).expect("roaring removals fit u32"));
+        bytes.extend_from_slice(&removals);
+        Bytes::from(bytes)
+    }
+
+    pub(crate) fn decode_if_delta(bytes: &[u8]) -> Result<Option<Self>, EncodingError> {
+        if !bytes.starts_with(BITMAP_MEMBERSHIP_DELTA_MAGIC) {
+            return Ok(None);
+        }
+        let mut offset = BITMAP_MEMBERSHIP_DELTA_MAGIC.len();
+        let additions = take_delta_bitmap(bytes, &mut offset, "additions")?;
+        let removals = take_delta_bitmap(bytes, &mut offset, "removals")?;
+        if offset != bytes.len() {
+            return Err(EncodingError::Custom(format!(
+                "bitmap membership delta has {} trailing bytes",
+                bytes.len() - offset
+            )));
+        }
+        if !additions.is_disjoint(&removals) {
+            return Err(EncodingError::Custom(
+                "bitmap membership delta additions and removals overlap".to_string(),
+            ));
+        }
+        Ok(Some(Self {
+            additions,
+            removals,
+        }))
+    }
+}
+
+fn take_delta_bitmap(
+    bytes: &[u8],
+    offset: &mut usize,
+    name: &str,
+) -> Result<RoaringTreemap, EncodingError> {
+    let length_end = offset
+        .checked_add(BITMAP_MEMBERSHIP_DELTA_LEN_PREFIX_LEN)
+        .ok_or_else(|| EncodingError::Custom("bitmap delta length overflow".to_string()))?;
+    if length_end > bytes.len() {
+        return Err(EncodingError::BufferTooShort {
+            expected: length_end,
+            actual: bytes.len(),
+        });
+    }
+    let length = u32::from_be_bytes(
+        bytes[*offset..*offset + BITMAP_MEMBERSHIP_DELTA_LEN_PREFIX_LEN]
+            .try_into()
+            .expect("validated bitmap delta length slice is four bytes"),
+    ) as usize;
+    *offset = length_end;
+    let value_end = offset
+        .checked_add(length)
+        .ok_or_else(|| EncodingError::Custom("bitmap delta value overflow".to_string()))?;
+    if value_end > bytes.len() {
+        return Err(EncodingError::BufferTooShort {
+            expected: value_end,
+            actual: bytes.len(),
+        });
+    }
+    let mut cursor = Cursor::new(&bytes[*offset..*offset + length]);
+    let bitmap = RoaringTreemap::deserialize_from(&mut cursor).map_err(|error| {
+        EncodingError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("failed to decode bitmap membership delta {name}: {error}"),
+        ))
+    })?;
+    if cursor.position() != length as u64 {
+        return Err(EncodingError::Custom(format!(
+            "bitmap membership delta {name} has {} trailing bytes",
+            length as u64 - cursor.position()
+        )));
+    }
+    *offset = value_end;
+    Ok(bitmap)
+}
 
 /// Portable V4 value for one non-unique equality key.
 #[derive(Debug, Clone, PartialEq)]
@@ -35,6 +170,9 @@ impl SecondaryEqualityBitmapValue {
     }
 
     pub(crate) fn decode(bytes: &[u8]) -> Result<Self, EncodingError> {
+        if let Some(delta) = BitmapMembershipDelta::decode_if_delta(bytes)? {
+            return Ok(Self(delta.additions));
+        }
         let mut cursor = Cursor::new(bytes);
         let ids = RoaringTreemap::deserialize_from(&mut cursor).map_err(|error| {
             EncodingError::Io(std::io::Error::new(
@@ -132,6 +270,80 @@ mod tests {
     }
 
     #[test]
+    fn bitmap_membership_delta_round_trips_and_composes_last_write_wins() {
+        let mut older = BitmapMembershipDelta::default();
+        older.add(1);
+        older.add(2);
+        older.remove(3);
+        let mut newer = BitmapMembershipDelta::default();
+        newer.remove(1);
+        newer.add(3);
+        newer.remove(4);
+        older.compose(&newer);
+
+        let decoded = BitmapMembershipDelta::decode_if_delta(&older.encode())
+            .unwrap()
+            .expect("membership delta marker is recognized");
+        let mut base = RoaringTreemap::from_iter([1, 4, 5]);
+        decoded.apply_to(&mut base);
+
+        assert_eq!(base.iter().collect::<Vec<_>>(), vec![2, 3, 5]);
+        assert!(decoded.additions.contains(2));
+        assert!(decoded.additions.contains(3));
+        assert!(decoded.removals.contains(1));
+        assert!(decoded.removals.contains(4));
+    }
+
+    #[test]
+    fn bitmap_membership_delta_decoder_rejects_every_invalid_boundary() {
+        let mut delta = BitmapMembershipDelta::default();
+        delta.add(1);
+        let encoded = delta.encode();
+        assert_eq!(
+            BitmapMembershipDelta::decode_if_delta(b"portable-roaring").unwrap(),
+            None
+        );
+        for length in BITMAP_MEMBERSHIP_DELTA_MAGIC.len()..encoded.len() {
+            assert!(BitmapMembershipDelta::decode_if_delta(&encoded[0..length]).is_err());
+        }
+
+        let mut trailing = encoded.to_vec();
+        trailing.push(0xFF);
+        assert!(BitmapMembershipDelta::decode_if_delta(&trailing).is_err());
+
+        let overlapping = BitmapMembershipDelta {
+            additions: RoaringTreemap::from_iter([7]),
+            removals: RoaringTreemap::from_iter([7]),
+        };
+        assert!(BitmapMembershipDelta::decode_if_delta(&overlapping.encode()).is_err());
+    }
+
+    #[test]
+    fn equality_value_decoders_project_delta_against_an_empty_base() {
+        let mut delta = BitmapMembershipDelta::default();
+        delta.add(3);
+        delta.remove(4);
+        let encoded = delta.encode();
+
+        assert_eq!(
+            SecondaryEqualityBitmapValue::decode(&encoded)
+                .unwrap()
+                .into_ids()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![3]
+        );
+        assert_eq!(
+            SecondaryEqualityValue::decode(&encoded)
+                .unwrap()
+                .into_ids()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![3]
+        );
+    }
+
+    #[test]
     fn equality_entry_value_is_lane_bound_and_byte_frozen() {
         let value = SecondaryEntryValue {
             index_id: crate::index_lifecycle::IndexId::new(1).unwrap(),
@@ -174,6 +386,9 @@ impl SecondaryEqualityValue {
 
     /// Decodes the exact current portable Roaring equality-row value.
     pub(crate) fn decode(data: &[u8]) -> Result<Self, EncodingError> {
+        if let Some(delta) = BitmapMembershipDelta::decode_if_delta(data)? {
+            return Ok(Self(delta.additions));
+        }
         let ids = RoaringTreemap::deserialize_from(Cursor::new(data)).map_err(|error| {
             EncodingError::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,

--- a/crates/db/src/encoding/v2/values/indexes/equality.rs
+++ b/crates/db/src/encoding/v2/values/indexes/equality.rs
@@ -57,6 +57,10 @@ impl BitmapMembershipDelta {
         *ids |= &self.additions;
     }
 
+    pub(crate) fn members(&self) -> impl Iterator<Item = u64> + '_ {
+        self.additions.iter().chain(self.removals.iter())
+    }
+
     pub(crate) fn encode(&self) -> Bytes {
         let mut additions = Vec::new();
         self.additions

--- a/crates/db/src/encoding/v2/values/indexes/mod.rs
+++ b/crates/db/src/encoding/v2/values/indexes/mod.rs
@@ -6,5 +6,7 @@ mod secondary_entry;
 pub(crate) mod text;
 pub mod vector;
 
-pub(crate) use equality::{SecondaryEqualityBitmapValue, SecondaryEqualityValue};
+pub(crate) use equality::{
+    BitmapMembershipDelta, SecondaryEqualityBitmapValue, SecondaryEqualityValue,
+};
 pub(crate) use secondary_entry::{decode_secondary_entry, encode_secondary_entry};

--- a/crates/db/src/encoding/v2/values/lifecycle/operation_record.rs
+++ b/crates/db/src/encoding/v2/values/lifecycle/operation_record.rs
@@ -945,6 +945,18 @@ operation_record=010211111111111111111111111111111111000000000000000101010000000
                     revision: TextManifestRevision::new(4).unwrap(),
                 }),
             ),
+            (
+                "membership_delta_legacy",
+                IndexV2MetadataValue::MembershipDeltaWriteMode(
+                    crate::MembershipDeltaWriteMode::LegacyExclusive,
+                ),
+            ),
+            (
+                "membership_delta_disjoint_v2",
+                IndexV2MetadataValue::MembershipDeltaWriteMode(
+                    crate::MembershipDeltaWriteMode::DisjointV2,
+                ),
+            ),
         ];
 
         let mut rendered = String::new();
@@ -963,6 +975,8 @@ legacy_vector_adoption=010602000000000000000100000000000000021111111111111111111
 legacy_vector_active=01060300000000000000010000000000000002
 legacy_vector_retiring=01060400000000000000010000000000000002
 text_compaction_pointer=01070000000000000004
+membership_delta_legacy=010800
+membership_delta_disjoint_v2=010801
 ");
     }
 }

--- a/crates/db/src/encoding/v2/values/mod.rs
+++ b/crates/db/src/encoding/v2/values/mod.rs
@@ -20,7 +20,8 @@ pub(crate) use indexes::text::{
 };
 pub(crate) use indexes::vector::{decode_partition_mapping, encode_partition_mapping};
 pub(crate) use indexes::{
-    decode_secondary_entry, encode_secondary_entry, SecondaryEqualityBitmapValue,
+    decode_secondary_entry, encode_secondary_entry, BitmapMembershipDelta,
+    SecondaryEqualityBitmapValue,
 };
 pub(crate) use lifecycle::{
     decode_applied_state, decode_build_delta, decode_index_record, decode_operation_record,

--- a/crates/db/src/execution/interpreter/mutation/node.rs
+++ b/crates/db/src/execution/interpreter/mutation/node.rs
@@ -499,6 +499,8 @@ impl<'db> ExecutionContext<'db> {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
+    use helix_ast::value::PropertyValue as AstPropertyValue;
     use helix_planner::context;
     use slatedb::IsolationLevel;
 
@@ -509,6 +511,216 @@ mod tests {
         MutationIndexContext::for_configured_index_test(std::sync::Arc::clone(
             db.simhasher_registry(),
         ))
+    }
+
+    async fn all_rows(db: &HelixDB) -> BTreeMap<Bytes, Bytes> {
+        let mut scan = db.inner_db().scan(..).await.unwrap();
+        let mut rows = BTreeMap::new();
+        while let Some(row) = scan.next().await.unwrap() {
+            rows.insert(row.key, row.value);
+        }
+        rows
+    }
+
+    #[tokio::test]
+    async fn rejected_cascade_delete_preserves_every_graph_and_index_row() {
+        let scope = keys::scope::DataScope::LegacyUnscoped;
+        for mode in [
+            crate::MembershipDeltaWriteMode::LegacyExclusive,
+            crate::MembershipDeltaWriteMode::DisjointV2,
+        ] {
+            let config = test_support::in_memory_config(&format!(
+                "mutation-corrupt-cascade-delete-{mode:?}"
+            ))
+            .with_equality_index("User", "status")
+            .with_edge_equality_index("FOLLOWS", "status");
+            let db = test_support::open_db_with_config(config).await;
+            if mode == crate::MembershipDeltaWriteMode::DisjointV2 {
+                db.activate_membership_delta_v2().await.unwrap();
+            }
+            let target = test_support::add_node_with_properties(
+                &db,
+                "User",
+                vec![("status", AstPropertyValue::from("shared"))],
+            )
+            .await;
+            let neighbor = test_support::add_node_with_properties(
+                &db,
+                "User",
+                vec![("status", AstPropertyValue::from("shared"))],
+            )
+            .await;
+            let outgoing = test_support::add_edge_with_properties(
+                &db,
+                target,
+                neighbor,
+                "FOLLOWS",
+                vec![("status", AstPropertyValue::from("shared"))],
+            )
+            .await;
+            let incoming = test_support::add_edge_with_properties(
+                &db,
+                neighbor,
+                target,
+                "FOLLOWS",
+                vec![("status", AstPropertyValue::from("shared"))],
+            )
+            .await;
+
+            let handles = db.active_index_handles_loaded(scope);
+            let node_equality = handles
+                .iter()
+                .find(|handle| {
+                    handle.secondary_definition().is_some_and(|definition| {
+                        definition.element_kind() == crate::index_lifecycle::IndexElementKind::Node
+                    })
+                })
+                .expect("the node equality generation is active");
+            let edge_equality = handles
+                .iter()
+                .find(|handle| {
+                    handle.secondary_definition().is_some_and(|definition| {
+                        definition.element_kind() == crate::index_lifecycle::IndexElementKind::Edge
+                    })
+                })
+                .expect("the edge equality generation is active");
+            let cases = [
+                (
+                    "node-label",
+                    super::super::topology::node_label_key(scope, "User"),
+                ),
+                (
+                    "edge-pair",
+                    super::super::topology::edge_pair_key(scope, target, neighbor),
+                ),
+                (
+                    "edge-label-out",
+                    super::super::topology::edge_label_neighbor_key(
+                        scope,
+                        crate::encoding::indexes::EdgeDirection::Out,
+                        target,
+                        "FOLLOWS",
+                    ),
+                ),
+                (
+                    "edge-label-in",
+                    super::super::topology::edge_label_neighbor_key(
+                        scope,
+                        crate::encoding::indexes::EdgeDirection::In,
+                        target,
+                        "FOLLOWS",
+                    ),
+                ),
+                (
+                    "global-edge-label",
+                    super::super::topology::global_edge_label_key(scope, "FOLLOWS"),
+                ),
+                (
+                    "adjacency",
+                    keys::DataKey::Data {
+                        scope,
+                        kind: keys::DataKeyKind::Adjacency(keys::AdjacencyKey::new(target)),
+                    }
+                    .to_bytes(),
+                ),
+                (
+                    "node-equality",
+                    crate::index_lifecycle::secondary::equality_bitmap_key_for_test(
+                        node_equality,
+                        "shared",
+                    ),
+                ),
+                (
+                    "edge-equality",
+                    crate::index_lifecycle::secondary::equality_bitmap_key_for_test(
+                        edge_equality,
+                        "shared",
+                    ),
+                ),
+            ];
+            let node_key = keys::DataKey::Data {
+                scope,
+                kind: keys::DataKeyKind::NodeProperty(keys::NodePropertyKey::new(target)),
+            }
+            .to_bytes();
+            let outgoing_key = keys::DataKey::Data {
+                scope,
+                kind: keys::DataKeyKind::EdgePropertyById(keys::EdgePropertyByIdKey::new(outgoing)),
+            }
+            .to_bytes();
+            let incoming_key = keys::DataKey::Data {
+                scope,
+                kind: keys::DataKeyKind::EdgePropertyById(keys::EdgePropertyByIdKey::new(incoming)),
+            }
+            .to_bytes();
+            let node_param = test_support::name("node");
+            let access_id = exec::ExecStepId::new(1).unwrap();
+            let drop_node = test_support::executable(
+                ir::PlanKind::Write,
+                vec![
+                    test_support::step(
+                        1,
+                        Vec::new(),
+                        exec::ExecOp::Access {
+                            plan: Box::new(exec::ExecAccessPlan::Node(
+                                exec::ExecNodeAccessPlan::FromParam {
+                                    param: node_param.clone(),
+                                },
+                            )),
+                        },
+                    ),
+                    test_support::step(
+                        2,
+                        vec![access_id],
+                        exec::ExecOp::Mutation {
+                            plan: exec::ExecMutationPlan::Drop,
+                        },
+                    ),
+                ],
+                2,
+            );
+
+            for (name, key) in cases {
+                let original = db
+                    .inner_db()
+                    .get(&key)
+                    .await
+                    .unwrap()
+                    .unwrap_or_else(|| panic!("{name} fixture row exists"));
+                db.inner_db()
+                    .put(&key, Bytes::from_static(b"corrupt-membership-row"))
+                    .await
+                    .unwrap();
+                let before = all_rows(&db).await;
+                db.execute(
+                    &drop_node,
+                    context::ParamBindings::default()
+                        .with_value(node_param.clone(), AstPropertyValue::I64(target as i64)),
+                )
+                .await
+                .expect_err("corrupt membership rows reject the cascade delete");
+                assert_eq!(all_rows(&db).await, before, "{mode:?} {name}");
+                for record_key in [&node_key, &outgoing_key, &incoming_key] {
+                    assert!(
+                        db.inner_db().get(record_key).await.unwrap().is_some(),
+                        "{mode:?} {name} preserves node and edge records"
+                    );
+                }
+                db.inner_db().put(&key, original).await.unwrap();
+            }
+
+            db.execute(
+                &drop_node,
+                context::ParamBindings::default()
+                    .with_value(node_param, AstPropertyValue::I64(target as i64)),
+            )
+            .await
+            .expect("the repaired fixture still permits a complete cascade delete");
+            for record_key in [&node_key, &outgoing_key, &incoming_key] {
+                assert!(db.inner_db().get(record_key).await.unwrap().is_none());
+            }
+            db.close().await.unwrap();
+        }
     }
 
     #[tokio::test]

--- a/crates/db/src/execution/interpreter/mutation/topology.rs
+++ b/crates/db/src/execution/interpreter/mutation/topology.rs
@@ -26,17 +26,76 @@ enum MembershipMutation {
     Absent,
 }
 
-/// Direction local to adjacency rows; `Both` is represented by two entries.
+/// Logical identity for one shared bitmap row. Physical keys are encoded once
+/// when the coalesced epoch is flushed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum AdjacencyDirection {
-    Out,
-    In,
+enum BitmapRow {
+    NodeLabel {
+        scope: DataScope,
+        label_hash: [u8; 8],
+    },
+    EdgePair {
+        scope: DataScope,
+        from: u64,
+        to: u64,
+    },
+    EdgeLabelNeighbor {
+        scope: DataScope,
+        direction: EdgeDirection,
+        node: u64,
+        label_hash: [u8; 8],
+    },
+    GlobalEdgeLabel {
+        scope: DataScope,
+        label_hash: [u8; 8],
+    },
+}
+
+impl BitmapRow {
+    fn to_bytes(self) -> Bytes {
+        match self {
+            Self::NodeLabel { scope, label_hash } => DataKey::Data {
+                scope,
+                kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(
+                    crate::encoding::indexes::equality::EqualityIndexKey::new(
+                        hash_property_name("$label"),
+                        label_hash,
+                    ),
+                )),
+            }
+            .to_bytes(),
+            Self::EdgePair { scope, from, to } => DataKey::Data {
+                scope,
+                kind: DataKeyKind::EdgePairIndex(EdgePairIndexKey::new(from, to)),
+            }
+            .to_bytes(),
+            Self::EdgeLabelNeighbor {
+                scope,
+                direction,
+                node,
+                label_hash,
+            } => DataKey::Data {
+                scope,
+                kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
+                    EdgeLabelNeighborKey::new(direction, node, label_hash),
+                )),
+            }
+            .to_bytes(),
+            Self::GlobalEdgeLabel { scope, label_hash } => DataKey::Data {
+                scope,
+                kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(
+                    label_hash,
+                ))),
+            }
+            .to_bytes(),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
 struct TopologyMutationBatch {
-    bitmaps: BTreeMap<Bytes, BTreeMap<u64, MembershipMutation>>,
-    adjacency: BTreeMap<Bytes, BTreeMap<(AdjacencyDirection, u64), MembershipMutation>>,
+    bitmaps: BTreeMap<BitmapRow, secondary::BitmapMembershipDelta>,
+    adjacency: BTreeMap<(DataScope, u64), edges::AdjacencyMembershipDelta>,
 }
 
 /// Transaction-owned topology mutations with a terminal prepared state.
@@ -91,7 +150,10 @@ impl TopologyMutationRuntime {
         node_id: u64,
     ) -> Result<()> {
         self.record_bitmap(
-            node_label_key(scope, label),
+            BitmapRow::NodeLabel {
+                scope,
+                label_hash: hash_property_value(label),
+            },
             node_id,
             MembershipMutation::Present,
         )
@@ -105,7 +167,10 @@ impl TopologyMutationRuntime {
         node_id: u64,
     ) -> Result<()> {
         self.record_bitmap(
-            node_label_key(scope, label),
+            BitmapRow::NodeLabel {
+                scope,
+                label_hash: hash_property_value(label),
+            },
             node_id,
             MembershipMutation::Absent,
         )
@@ -120,7 +185,7 @@ impl TopologyMutationRuntime {
         edge_id: u64,
     ) -> Result<()> {
         self.record_bitmap(
-            edge_pair_key(scope, from, to),
+            BitmapRow::EdgePair { scope, from, to },
             edge_id,
             MembershipMutation::Present,
         )
@@ -135,7 +200,7 @@ impl TopologyMutationRuntime {
         edge_id: u64,
     ) -> Result<()> {
         self.record_bitmap(
-            edge_pair_key(scope, from, to),
+            BitmapRow::EdgePair { scope, from, to },
             edge_id,
             MembershipMutation::Absent,
         )
@@ -151,17 +216,30 @@ impl TopologyMutationRuntime {
         edge_id: u64,
     ) -> Result<()> {
         self.record_bitmap(
-            edge_label_neighbor_key(scope, EdgeDirection::Out, from, label),
+            BitmapRow::EdgeLabelNeighbor {
+                scope,
+                direction: EdgeDirection::Out,
+                node: from,
+                label_hash: hash_property_value(label),
+            },
             to,
             MembershipMutation::Present,
         )?;
         self.record_bitmap(
-            edge_label_neighbor_key(scope, EdgeDirection::In, to, label),
+            BitmapRow::EdgeLabelNeighbor {
+                scope,
+                direction: EdgeDirection::In,
+                node: to,
+                label_hash: hash_property_value(label),
+            },
             from,
             MembershipMutation::Present,
         )?;
         self.record_bitmap(
-            global_edge_label_key(scope, label),
+            BitmapRow::GlobalEdgeLabel {
+                scope,
+                label_hash: hash_property_value(label),
+            },
             edge_id,
             MembershipMutation::Present,
         )
@@ -175,7 +253,10 @@ impl TopologyMutationRuntime {
         edge_id: u64,
     ) -> Result<()> {
         self.record_bitmap(
-            global_edge_label_key(scope, label),
+            BitmapRow::GlobalEdgeLabel {
+                scope,
+                label_hash: hash_property_value(label),
+            },
             edge_id,
             MembershipMutation::Absent,
         )
@@ -190,12 +271,22 @@ impl TopologyMutationRuntime {
         label: &str,
     ) -> Result<()> {
         self.record_bitmap(
-            edge_label_neighbor_key(scope, EdgeDirection::Out, from, label),
+            BitmapRow::EdgeLabelNeighbor {
+                scope,
+                direction: EdgeDirection::Out,
+                node: from,
+                label_hash: hash_property_value(label),
+            },
             to,
             MembershipMutation::Absent,
         )?;
         self.record_bitmap(
-            edge_label_neighbor_key(scope, EdgeDirection::In, to, label),
+            BitmapRow::EdgeLabelNeighbor {
+                scope,
+                direction: EdgeDirection::In,
+                node: to,
+                label_hash: hash_property_value(label),
+            },
             from,
             MembershipMutation::Absent,
         )
@@ -229,9 +320,17 @@ impl TopologyMutationRuntime {
         self.record_adjacency(scope, node, neighbor, direction, MembershipMutation::Absent)
     }
 
-    fn record_bitmap(&mut self, key: Bytes, id: u64, mutation: MembershipMutation) -> Result<()> {
-        let batch = self.collecting_batch()?;
-        batch.bitmaps.entry(key).or_default().insert(id, mutation);
+    fn record_bitmap(
+        &mut self,
+        row: BitmapRow,
+        id: u64,
+        mutation: MembershipMutation,
+    ) -> Result<()> {
+        let delta = self.collecting_batch()?.bitmaps.entry(row).or_default();
+        match mutation {
+            MembershipMutation::Present => delta.add(id),
+            MembershipMutation::Absent => delta.remove(id),
+        }
         Ok(())
     }
 
@@ -243,22 +342,31 @@ impl TopologyMutationRuntime {
         direction: helix_planner::ir::ExpandDirection,
         mutation: MembershipMutation,
     ) -> Result<()> {
-        let key = DataKey::Data {
-            scope,
-            kind: DataKeyKind::Adjacency(AdjacencyKey::new(node)),
-        }
-        .to_bytes();
-        let row = self.collecting_batch()?.adjacency.entry(key).or_default();
-        match direction {
-            helix_planner::ir::ExpandDirection::Out => {
-                row.insert((AdjacencyDirection::Out, neighbor), mutation);
+        let delta = self
+            .collecting_batch()?
+            .adjacency
+            .entry((scope, node))
+            .or_default();
+        match (direction, mutation) {
+            (helix_planner::ir::ExpandDirection::Out, MembershipMutation::Present) => {
+                delta.add_out(neighbor);
             }
-            helix_planner::ir::ExpandDirection::In => {
-                row.insert((AdjacencyDirection::In, neighbor), mutation);
+            (helix_planner::ir::ExpandDirection::In, MembershipMutation::Present) => {
+                delta.add_in(neighbor);
             }
-            helix_planner::ir::ExpandDirection::Both => {
-                row.insert((AdjacencyDirection::Out, neighbor), mutation);
-                row.insert((AdjacencyDirection::In, neighbor), mutation);
+            (helix_planner::ir::ExpandDirection::Both, MembershipMutation::Present) => {
+                delta.add_out(neighbor);
+                delta.add_in(neighbor);
+            }
+            (helix_planner::ir::ExpandDirection::Out, MembershipMutation::Absent) => {
+                delta.remove_out(neighbor);
+            }
+            (helix_planner::ir::ExpandDirection::In, MembershipMutation::Absent) => {
+                delta.remove_in(neighbor);
+            }
+            (helix_planner::ir::ExpandDirection::Both, MembershipMutation::Absent) => {
+                delta.remove_out(neighbor);
+                delta.remove_in(neighbor);
             }
         }
         Ok(())
@@ -296,52 +404,40 @@ impl TopologyMutationRuntime {
             }
         };
 
-        for (key, mutations) in batch.bitmaps {
-            let mut delta = secondary::BitmapMembershipDelta::default();
-            let mut discriminators = Vec::with_capacity(mutations.len());
-            for (id, mutation) in &mutations {
-                discriminators.push(Bytes::copy_from_slice(&id.to_be_bytes()));
-                match mutation {
-                    MembershipMutation::Present => {
-                        delta.add(*id);
-                    }
-                    MembershipMutation::Absent => {
-                        delta.remove(*id);
-                    }
-                }
-            }
-            transaction.merge_disjoint(&key, discriminators, delta.encode())?;
+        for (row, delta) in batch.bitmaps {
+            let key = row.to_bytes();
+            transaction.merge_disjoint(
+                &key,
+                delta.members().map(|id| id.to_be_bytes()),
+                delta.encode(),
+            )?;
             self.staged_keys.insert(key);
         }
 
-        for (key, mutations) in batch.adjacency {
-            let mut delta = edges::AdjacencyMembershipDelta::default();
-            let mut discriminators = Vec::with_capacity(mutations.len());
-            for ((direction, neighbor), mutation) in &mutations {
-                let mut discriminator =
-                    Vec::with_capacity(core::mem::size_of::<u8>() + core::mem::size_of::<u64>());
-                discriminator.push(match direction {
-                    AdjacencyDirection::Out => 0,
-                    AdjacencyDirection::In => 1,
-                });
-                discriminator.extend_from_slice(&neighbor.to_be_bytes());
-                discriminators.push(Bytes::from(discriminator));
-                match (direction, mutation) {
-                    (AdjacencyDirection::Out, MembershipMutation::Present) => {
-                        delta.add_out(*neighbor);
-                    }
-                    (AdjacencyDirection::In, MembershipMutation::Present) => {
-                        delta.add_in(*neighbor);
-                    }
-                    (AdjacencyDirection::Out, MembershipMutation::Absent) => {
-                        delta.remove_out(*neighbor);
-                    }
-                    (AdjacencyDirection::In, MembershipMutation::Absent) => {
-                        delta.remove_in(*neighbor);
-                    }
-                }
+        for ((scope, node), delta) in batch.adjacency {
+            const DIRECTION_LEN: usize = core::mem::size_of::<u8>();
+            const NODE_ID_LEN: usize = core::mem::size_of::<u64>();
+
+            let key = DataKey::Data {
+                scope,
+                kind: DataKeyKind::Adjacency(AdjacencyKey::new(node)),
             }
-            transaction.merge_disjoint(&key, discriminators, delta.encode())?;
+            .to_bytes();
+            let outgoing = delta.outgoing_members().map(|neighbor| {
+                let mut discriminator = [0; DIRECTION_LEN + NODE_ID_LEN];
+                discriminator[0] = 0;
+                discriminator[DIRECTION_LEN..DIRECTION_LEN + NODE_ID_LEN]
+                    .copy_from_slice(&neighbor.to_be_bytes());
+                discriminator
+            });
+            let incoming = delta.incoming_members().map(|neighbor| {
+                let mut discriminator = [0; DIRECTION_LEN + NODE_ID_LEN];
+                discriminator[0] = 1;
+                discriminator[DIRECTION_LEN..DIRECTION_LEN + NODE_ID_LEN]
+                    .copy_from_slice(&neighbor.to_be_bytes());
+                discriminator
+            });
+            transaction.merge_disjoint(&key, outgoing.chain(incoming), delta.encode())?;
             self.staged_keys.insert(key);
         }
         Ok(())
@@ -370,6 +466,7 @@ impl TopologyMutationRuntime {
     }
 }
 
+#[cfg(test)]
 fn node_label_key(scope: DataScope, label: &str) -> Bytes {
     DataKey::Data {
         scope,
@@ -383,6 +480,7 @@ fn node_label_key(scope: DataScope, label: &str) -> Bytes {
     .to_bytes()
 }
 
+#[cfg(test)]
 fn edge_pair_key(scope: DataScope, from: u64, to: u64) -> Bytes {
     DataKey::Data {
         scope,
@@ -391,6 +489,7 @@ fn edge_pair_key(scope: DataScope, from: u64, to: u64) -> Bytes {
     .to_bytes()
 }
 
+#[cfg(test)]
 fn edge_label_neighbor_key(
     scope: DataScope,
     direction: EdgeDirection,
@@ -406,6 +505,7 @@ fn edge_label_neighbor_key(
     .to_bytes()
 }
 
+#[cfg(test)]
 fn global_edge_label_key(scope: DataScope, label: &str) -> Bytes {
     DataKey::Data {
         scope,
@@ -1010,6 +1110,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn coalesced_membership_deltas_keep_the_last_mutation_per_member() {
+        let db = database("coalesced-last-membership-mutation").await;
+        let transaction = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .unwrap();
+        let scope = DataScope::LegacyUnscoped;
+        let mut runtime = TopologyMutationRuntime::default();
+
+        runtime.add_node_label(scope, "User", 1).unwrap();
+        runtime.remove_node_label(scope, "User", 1).unwrap();
+        runtime.remove_node_label(scope, "User", 2).unwrap();
+        runtime.add_node_label(scope, "User", 2).unwrap();
+        runtime
+            .add_adjacency(scope, 9, 1, helix_planner::ir::ExpandDirection::Both)
+            .unwrap();
+        runtime
+            .remove_adjacency(scope, 9, 1, helix_planner::ir::ExpandDirection::Out)
+            .unwrap();
+        runtime
+            .remove_adjacency(scope, 9, 2, helix_planner::ir::ExpandDirection::Both)
+            .unwrap();
+        runtime
+            .add_adjacency(scope, 9, 2, helix_planner::ir::ExpandDirection::Out)
+            .unwrap();
+        runtime.prepare(&transaction).await.unwrap();
+        runtime.consume_prepared().unwrap();
+        transaction.commit().await.unwrap();
+
+        assert_eq!(
+            secondary::SecondaryEqualityValue::decode(
+                &db.get(node_label_key(scope, "User"))
+                    .await
+                    .unwrap()
+                    .expect("coalesced node-label row exists"),
+            )
+            .unwrap()
+            .into_ids()
+            .iter()
+            .collect::<Vec<_>>(),
+            vec![2]
+        );
+        let adjacency = edges::decode_edges(
+            &db.get(
+                DataKey::Data {
+                    scope,
+                    kind: DataKeyKind::Adjacency(AdjacencyKey::new(9)),
+                }
+                .to_bytes(),
+            )
+            .await
+            .unwrap()
+            .expect("coalesced adjacency row exists"),
+        )
+        .unwrap();
+        assert_eq!(adjacency.iter_out().collect::<Vec<_>>(), vec![2]);
+        assert_eq!(adjacency.iter_in().collect::<Vec<_>>(), vec![1]);
+
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn prepared_runtime_rejects_further_collection() {
         let transaction = transaction("prepared-rejects-collection").await;
         let mut runtime = TopologyMutationRuntime::default();
@@ -1028,12 +1190,19 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct SweepBenchmarkResult {
-        elapsed: Duration,
+    struct SweepConflictBenchmarkResult {
         writer_conflicts: usize,
         sweeper_conflicts: usize,
         writer_commits: usize,
         sweeper_commits: usize,
+    }
+
+    #[derive(Debug)]
+    struct SweepPreparationBenchmarkResult {
+        minimum: Duration,
+        median: Duration,
+        maximum: Duration,
+        samples: usize,
     }
 
     async fn stage_benchmark_memberships(
@@ -1159,13 +1328,13 @@ mod tests {
         transaction
     }
 
-    async fn run_sweep_benchmark(
+    async fn run_sweep_conflict_benchmark(
         strategy: SweepBenchmarkStrategy,
         expired_members: u64,
         inserted_members: u64,
         sweep_chunk: u64,
         writer_chunk: u64,
-    ) -> SweepBenchmarkResult {
+    ) -> SweepConflictBenchmarkResult {
         const PARENT_ID: u64 = u64::MAX - 1;
         const LABEL: &str = "KubernetesEvent";
 
@@ -1208,8 +1377,6 @@ mod tests {
             .collect::<Vec<_>>();
         let writer_progress = Arc::new(AtomicUsize::new(0));
         let writer_notify = Arc::new(tokio::sync::Notify::new());
-        let started = Instant::now();
-
         let writer = {
             let db = Arc::clone(&db);
             let barriers = barriers.clone();
@@ -1281,8 +1448,6 @@ mod tests {
         };
         let writer_conflicts = writer.await.expect("benchmark writer joins");
         let sweeper_conflicts = sweeper.await.expect("benchmark sweeper joins");
-        let elapsed = started.elapsed();
-
         let labels = secondary::SecondaryEqualityValue::decode(
             &db.get(&label_key)
                 .await
@@ -1294,10 +1459,26 @@ mod tests {
         assert_eq!(labels.len(), inserted_members);
         assert_eq!(labels.min(), Some(expired_members));
         assert_eq!(labels.max(), Some(expired_members + inserted_members - 1));
+        let adjacency = edges::decode_edges(
+            &db.get(
+                DataKey::Data {
+                    scope: DataScope::LegacyUnscoped,
+                    kind: DataKeyKind::Adjacency(AdjacencyKey::new(PARENT_ID)),
+                }
+                .to_bytes(),
+            )
+            .await
+            .expect("benchmark adjacency result reads")
+            .expect("inserted adjacency memberships remain"),
+        )
+        .expect("benchmark adjacency result decodes");
+        let outgoing = adjacency.iter_out().collect::<RoaringTreemap>();
+        assert_eq!(outgoing.len(), inserted_members);
+        assert_eq!(outgoing.min(), Some(expired_members));
+        assert_eq!(outgoing.max(), Some(expired_members + inserted_members - 1));
         db.close().await.expect("benchmark database closes");
 
-        SweepBenchmarkResult {
-            elapsed,
+        SweepConflictBenchmarkResult {
             writer_conflicts,
             sweeper_conflicts,
             writer_commits: writer_chunks,
@@ -1305,9 +1486,85 @@ mod tests {
         }
     }
 
+    async fn run_sweep_preparation_benchmark(
+        strategy: SweepBenchmarkStrategy,
+        expired_members: u64,
+        sweep_chunk: u64,
+        samples: usize,
+    ) -> SweepPreparationBenchmarkResult {
+        const PARENT_ID: u64 = u64::MAX - 1;
+        const LABEL: &str = "KubernetesEvent";
+
+        let db = database(match strategy {
+            SweepBenchmarkStrategy::ExclusiveReadModifyWrite => "prepare-exclusive",
+            SweepBenchmarkStrategy::DisjointDelta => "prepare-disjoint",
+        })
+        .await;
+        db.put(
+            node_label_key(DataScope::LegacyUnscoped, LABEL),
+            secondary::SecondaryEqualityValue::encode_ids(
+                &(0..expired_members).collect::<RoaringTreemap>(),
+            ),
+        )
+        .await
+        .expect("preparation benchmark label seed persists");
+        let mut adjacency = edges::Edges::new();
+        for id in 0..expired_members {
+            adjacency.add_out(id);
+        }
+        db.put(
+            DataKey::Data {
+                scope: DataScope::LegacyUnscoped,
+                kind: DataKeyKind::Adjacency(AdjacencyKey::new(PARENT_ID)),
+            }
+            .to_bytes(),
+            edges::encode_edges(&adjacency),
+        )
+        .await
+        .expect("preparation benchmark adjacency seed persists");
+
+        // Warm storage and codec paths before collecting paired samples. The
+        // transaction is deliberately not committed so every sample stages a
+        // sweep against the same full hot rows.
+        drop(
+            stage_benchmark_memberships(&db, strategy, 0..sweep_chunk.min(expired_members), false)
+                .await,
+        );
+
+        let mut elapsed = Vec::with_capacity(samples);
+        for _ in 0..samples {
+            let started = Instant::now();
+            for start in (0..expired_members).step_by(sweep_chunk as usize) {
+                drop(
+                    stage_benchmark_memberships(
+                        &db,
+                        strategy,
+                        start..(start + sweep_chunk).min(expired_members),
+                        false,
+                    )
+                    .await,
+                );
+            }
+            elapsed.push(started.elapsed());
+        }
+        elapsed.sort_unstable();
+        db.close()
+            .await
+            .expect("preparation benchmark database closes");
+
+        SweepPreparationBenchmarkResult {
+            minimum: elapsed[0],
+            median: elapsed[elapsed.len() / 2],
+            maximum: elapsed[elapsed.len() - 1],
+            samples: elapsed.len(),
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    #[ignore = "manual 100K-member conflict and throughput comparison"]
+    #[ignore = "manual 100K-member conflict and preparation-performance comparison"]
     async fn benchmark_exclusive_vs_disjoint_linked_event_sweep() {
+        const MAX_PREPARATION_TIME_RATIO: f64 = 5.0;
+
         let expired_members = std::env::var("HELIX_SWEEP_BENCH_EXPIRED")
             .ok()
             .and_then(|value| value.parse().ok())
@@ -1324,12 +1581,18 @@ mod tests {
             .ok()
             .and_then(|value| value.parse().ok())
             .unwrap_or(250);
+        let performance_samples = std::env::var("HELIX_SWEEP_BENCH_SAMPLES")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(5);
         assert!(expired_members > 0);
         assert!(inserted_members > 0);
         assert!(sweep_chunk > 0);
         assert!(writer_chunk > 0);
+        assert!(performance_samples >= 3);
+        assert!(performance_samples % 2 == 1);
 
-        let before = run_sweep_benchmark(
+        let before_conflicts = run_sweep_conflict_benchmark(
             SweepBenchmarkStrategy::ExclusiveReadModifyWrite,
             expired_members,
             inserted_members,
@@ -1337,7 +1600,7 @@ mod tests {
             writer_chunk,
         )
         .await;
-        let after = run_sweep_benchmark(
+        let after_conflicts = run_sweep_conflict_benchmark(
             SweepBenchmarkStrategy::DisjointDelta,
             expired_members,
             inserted_members,
@@ -1346,41 +1609,77 @@ mod tests {
         )
         .await;
         let before_sweep_conflict_rate =
-            before.sweeper_conflicts as f64 / before.sweeper_commits as f64;
+            before_conflicts.sweeper_conflicts as f64 / before_conflicts.sweeper_commits as f64;
         let after_sweep_conflict_rate =
-            after.sweeper_conflicts as f64 / after.sweeper_commits as f64;
-        let operations = expired_members + inserted_members;
-        let before_throughput = operations as f64 / before.elapsed.as_secs_f64();
-        let after_throughput = operations as f64 / after.elapsed.as_secs_f64();
+            after_conflicts.sweeper_conflicts as f64 / after_conflicts.sweeper_commits as f64;
+
+        let before_preparation = run_sweep_preparation_benchmark(
+            SweepBenchmarkStrategy::ExclusiveReadModifyWrite,
+            expired_members,
+            sweep_chunk,
+            performance_samples,
+        )
+        .await;
+        let after_preparation = run_sweep_preparation_benchmark(
+            SweepBenchmarkStrategy::DisjointDelta,
+            expired_members,
+            sweep_chunk,
+            performance_samples,
+        )
+        .await;
+        let before_preparation_throughput =
+            expired_members as f64 / before_preparation.median.as_secs_f64();
+        let after_preparation_throughput =
+            expired_members as f64 / after_preparation.median.as_secs_f64();
+        let preparation_time_ratio =
+            after_preparation.median.as_secs_f64() / before_preparation.median.as_secs_f64();
 
         println!(
-            "SWEEP_BENCH before elapsed_ms={} sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={} throughput_members_per_s={:.0}",
-            before.elapsed.as_millis(),
-            before.sweeper_commits,
-            before.sweeper_conflicts,
+            "SWEEP_CONFLICT before sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={}",
+            before_conflicts.sweeper_commits,
+            before_conflicts.sweeper_conflicts,
             before_sweep_conflict_rate,
-            before.writer_commits,
-            before.writer_conflicts,
-            before_throughput,
+            before_conflicts.writer_commits,
+            before_conflicts.writer_conflicts,
         );
         println!(
-            "SWEEP_BENCH after elapsed_ms={} sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={} throughput_members_per_s={:.0}",
-            after.elapsed.as_millis(),
-            after.sweeper_commits,
-            after.sweeper_conflicts,
+            "SWEEP_CONFLICT after sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={}",
+            after_conflicts.sweeper_commits,
+            after_conflicts.sweeper_conflicts,
             after_sweep_conflict_rate,
-            after.writer_commits,
-            after.writer_conflicts,
-            after_throughput,
+            after_conflicts.writer_commits,
+            after_conflicts.writer_conflicts,
         );
         println!(
-            "SWEEP_BENCH delta conflict_rate_points={:.2} throughput_ratio={:.3}",
+            "SWEEP_PREP before samples={} min_ms={} median_ms={} max_ms={} throughput_members_per_s={:.0}",
+            before_preparation.samples,
+            before_preparation.minimum.as_millis(),
+            before_preparation.median.as_millis(),
+            before_preparation.maximum.as_millis(),
+            before_preparation_throughput,
+        );
+        println!(
+            "SWEEP_PREP after samples={} min_ms={} median_ms={} max_ms={} throughput_members_per_s={:.0}",
+            after_preparation.samples,
+            after_preparation.minimum.as_millis(),
+            after_preparation.median.as_millis(),
+            after_preparation.maximum.as_millis(),
+            after_preparation_throughput,
+        );
+        println!(
+            "SWEEP_DELTA conflict_rate_points={:.2} preparation_time_ratio={:.3}",
             (after_sweep_conflict_rate - before_sweep_conflict_rate) * 100.0,
-            after_throughput / before_throughput,
+            preparation_time_ratio,
         );
 
-        assert!(before.sweeper_conflicts > 0);
-        assert_eq!(after.sweeper_conflicts, 0);
-        assert_eq!(after.writer_conflicts, 0);
+        assert!(before_conflicts.sweeper_conflicts > 0);
+        assert_eq!(after_conflicts.sweeper_conflicts, 0);
+        assert_eq!(after_conflicts.writer_conflicts, 0);
+        assert!(
+            preparation_time_ratio <= MAX_PREPARATION_TIME_RATIO,
+            "disjoint conflict metadata preparation exceeded the {MAX_PREPARATION_TIME_RATIO:.1}x regression budget: before={:?}, after={:?}",
+            before_preparation,
+            after_preparation,
+        );
     }
 }

--- a/crates/db/src/execution/interpreter/mutation/topology.rs
+++ b/crates/db/src/execution/interpreter/mutation/topology.rs
@@ -1594,6 +1594,11 @@ mod tests {
             })
             .await,
         );
+        if !matches!(strategy, SweepBenchmarkStrategy::ExclusiveReadModifyWrite) {
+            crate::membership_delta::activate(db.as_ref())
+                .await
+                .expect("disjoint conflict benchmark activates V2 membership deltas");
+        }
         let label_key = node_label_key(DataScope::LegacyUnscoped, LABEL);
         db.put(
             &label_key,
@@ -1750,6 +1755,11 @@ mod tests {
             SweepBenchmarkStrategy::DisjointDelta => "prepare-disjoint",
         })
         .await;
+        if !matches!(strategy, SweepBenchmarkStrategy::ExclusiveReadModifyWrite) {
+            crate::membership_delta::activate(&db)
+                .await
+                .expect("disjoint preparation benchmark activates V2 membership deltas");
+        }
         db.put(
             node_label_key(DataScope::LegacyUnscoped, LABEL),
             secondary::SecondaryEqualityValue::encode_ids(

--- a/crates/db/src/execution/interpreter/mutation/topology.rs
+++ b/crates/db/src/execution/interpreter/mutation/topology.rs
@@ -103,6 +103,8 @@ struct TopologyMutationBatch {
 pub(in crate::execution::interpreter) struct TopologyMutationRuntime {
     state: TopologyMutationRuntimeState,
     staged_keys: BTreeSet<Bytes>,
+    #[cfg(test)]
+    unchecked_disjoint_for_benchmark: bool,
 }
 
 #[derive(Debug, Default)]
@@ -424,8 +426,8 @@ impl TopologyMutationRuntime {
                         transaction.put_with_options(
                             &key,
                             secondary::SecondaryEqualityBitmapValue::new(bitmap).encode(),
-                            &slatedb::PutOptions {
-                                ttl: slatedb::Ttl::NoExpiry,
+                            &slatedb::config::PutOptions {
+                                ttl: slatedb::config::Ttl::NoExpiry,
                             },
                         )?;
                     }
@@ -451,8 +453,8 @@ impl TopologyMutationRuntime {
                         transaction.put_with_options(
                             &key,
                             edges::encode_edges(&adjacency),
-                            &slatedb::PutOptions {
-                                ttl: slatedb::Ttl::NoExpiry,
+                            &slatedb::config::PutOptions {
+                                ttl: slatedb::config::Ttl::NoExpiry,
                             },
                         )?;
                     }
@@ -460,16 +462,26 @@ impl TopologyMutationRuntime {
                 }
             }
             MembershipDeltaWriteMode::DisjointV2 => {
+                let mut merges = Vec::with_capacity(batch.bitmaps.len() + batch.adjacency.len());
+                let mut staged_keys = Vec::with_capacity(merges.capacity());
                 for (row, delta) in batch.bitmaps {
                     let key = row.to_bytes();
-                    transaction
-                        .merge_disjoint_tokens_checked(
+                    #[cfg(test)]
+                    if self.unchecked_disjoint_for_benchmark {
+                        transaction.merge_disjoint_tokens(
                             &key,
                             delta.members().map(u128::from),
                             delta.encode(),
-                        )
-                        .await?;
-                    self.staged_keys.insert(key);
+                        )?;
+                        self.staged_keys.insert(key);
+                        continue;
+                    }
+                    staged_keys.push(key.clone());
+                    merges.push(slatedb::DisjointMergeBatchEntry::from_tokens(
+                        key,
+                        delta.members().map(u128::from),
+                        delta.encode(),
+                    ));
                 }
 
                 for ((scope, node), delta) in batch.adjacency {
@@ -484,15 +496,30 @@ impl TopologyMutationRuntime {
                     let incoming = delta
                         .incoming_members()
                         .map(|neighbor| INCOMING_DIRECTION_TOKEN | u128::from(neighbor));
-                    transaction
-                        .merge_disjoint_tokens_checked(
+                    #[cfg(test)]
+                    if self.unchecked_disjoint_for_benchmark {
+                        transaction.merge_disjoint_tokens(
                             &key,
                             outgoing.chain(incoming),
                             delta.encode(),
-                        )
-                        .await?;
-                    self.staged_keys.insert(key);
+                        )?;
+                        self.staged_keys.insert(key);
+                        continue;
+                    }
+                    staged_keys.push(key.clone());
+                    merges.push(slatedb::DisjointMergeBatchEntry::from_tokens(
+                        key,
+                        outgoing.chain(incoming),
+                        delta.encode(),
+                    ));
                 }
+
+                #[cfg(test)]
+                if self.unchecked_disjoint_for_benchmark {
+                    return Ok(());
+                }
+                transaction.merge_disjoint_checked_batch(merges).await?;
+                self.staged_keys.extend(staged_keys);
             }
         }
         Ok(())
@@ -1403,6 +1430,7 @@ mod tests {
     #[derive(Debug, Clone, Copy)]
     enum SweepBenchmarkStrategy {
         ExclusiveReadModifyWrite,
+        UncheckedDisjointDelta,
         DisjointDelta,
     }
 
@@ -1509,8 +1537,11 @@ mod tests {
                         .expect("exclusive benchmark adjacency replacement stages");
                 }
             }
-            SweepBenchmarkStrategy::DisjointDelta => {
+            SweepBenchmarkStrategy::UncheckedDisjointDelta
+            | SweepBenchmarkStrategy::DisjointDelta => {
                 let mut runtime = TopologyMutationRuntime::default();
+                runtime.unchecked_disjoint_for_benchmark =
+                    matches!(strategy, SweepBenchmarkStrategy::UncheckedDisjointDelta);
                 for id in ids {
                     if present {
                         runtime
@@ -1558,6 +1589,7 @@ mod tests {
         let db = Arc::new(
             database(match strategy {
                 SweepBenchmarkStrategy::ExclusiveReadModifyWrite => "benchmark-exclusive",
+                SweepBenchmarkStrategy::UncheckedDisjointDelta => "benchmark-unchecked-disjoint",
                 SweepBenchmarkStrategy::DisjointDelta => "benchmark-disjoint",
             })
             .await,
@@ -1714,6 +1746,7 @@ mod tests {
 
         let db = database(match strategy {
             SweepBenchmarkStrategy::ExclusiveReadModifyWrite => "prepare-exclusive",
+            SweepBenchmarkStrategy::UncheckedDisjointDelta => "prepare-unchecked-disjoint",
             SweepBenchmarkStrategy::DisjointDelta => "prepare-disjoint",
         })
         .await;
@@ -1780,7 +1813,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[ignore = "manual 100K-member conflict and preparation-performance comparison"]
     async fn benchmark_exclusive_vs_disjoint_linked_event_sweep() {
-        const MAX_PREPARATION_TIME_RATIO: f64 = 5.0;
+        const MAX_CHECKED_PREPARATION_REGRESSION: f64 = 1.10;
 
         let expired_members = std::env::var("HELIX_SWEEP_BENCH_EXPIRED")
             .ok()
@@ -1801,7 +1834,7 @@ mod tests {
         let performance_samples = std::env::var("HELIX_SWEEP_BENCH_SAMPLES")
             .ok()
             .and_then(|value| value.parse().ok())
-            .unwrap_or(5);
+            .unwrap_or(9);
         assert!(expired_members > 0);
         assert!(inserted_members > 0);
         assert!(sweep_chunk > 0);
@@ -1844,12 +1877,23 @@ mod tests {
             performance_samples,
         )
         .await;
+        let unchecked_preparation = run_sweep_preparation_benchmark(
+            SweepBenchmarkStrategy::UncheckedDisjointDelta,
+            expired_members,
+            sweep_chunk,
+            performance_samples,
+        )
+        .await;
         let before_preparation_throughput =
             expired_members as f64 / before_preparation.median.as_secs_f64();
         let after_preparation_throughput =
             expired_members as f64 / after_preparation.median.as_secs_f64();
-        let preparation_time_ratio =
+        let unchecked_preparation_throughput =
+            expired_members as f64 / unchecked_preparation.median.as_secs_f64();
+        let exclusive_preparation_time_ratio =
             after_preparation.median.as_secs_f64() / before_preparation.median.as_secs_f64();
+        let checked_preparation_time_ratio =
+            after_preparation.median.as_secs_f64() / unchecked_preparation.median.as_secs_f64();
 
         println!(
             "SWEEP_CONFLICT before sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={}",
@@ -1876,6 +1920,14 @@ mod tests {
             before_preparation_throughput,
         );
         println!(
+            "SWEEP_PREP unchecked samples={} min_ms={} median_ms={} max_ms={} throughput_members_per_s={:.0}",
+            unchecked_preparation.samples,
+            unchecked_preparation.minimum.as_millis(),
+            unchecked_preparation.median.as_millis(),
+            unchecked_preparation.maximum.as_millis(),
+            unchecked_preparation_throughput,
+        );
+        println!(
             "SWEEP_PREP after samples={} min_ms={} median_ms={} max_ms={} throughput_members_per_s={:.0}",
             after_preparation.samples,
             after_preparation.minimum.as_millis(),
@@ -1884,18 +1936,20 @@ mod tests {
             after_preparation_throughput,
         );
         println!(
-            "SWEEP_DELTA conflict_rate_points={:.2} preparation_time_ratio={:.3}",
+            "SWEEP_DELTA conflict_rate_points={:.2} exclusive_preparation_time_ratio={:.3} checked_preparation_time_ratio={:.3}",
             (after_sweep_conflict_rate - before_sweep_conflict_rate) * 100.0,
-            preparation_time_ratio,
+            exclusive_preparation_time_ratio,
+            checked_preparation_time_ratio,
         );
 
         assert!(before_conflicts.sweeper_conflicts > 0);
         assert_eq!(after_conflicts.sweeper_conflicts, 0);
         assert_eq!(after_conflicts.writer_conflicts, 0);
         assert!(
-            preparation_time_ratio <= MAX_PREPARATION_TIME_RATIO,
-            "disjoint conflict metadata preparation exceeded the {MAX_PREPARATION_TIME_RATIO:.1}x regression budget: before={:?}, after={:?}",
-            before_preparation,
+            checked_preparation_time_ratio <= MAX_CHECKED_PREPARATION_REGRESSION,
+            "checked validation exceeded the {:.0}% preparation regression budget: unchecked={:?}, checked={:?}",
+            (MAX_CHECKED_PREPARATION_REGRESSION - 1.0) * 100.0,
+            unchecked_preparation,
             after_preparation,
         );
     }

--- a/crates/db/src/execution/interpreter/mutation/topology.rs
+++ b/crates/db/src/execution/interpreter/mutation/topology.rs
@@ -17,7 +17,7 @@ use crate::encoding::indexes::{
 use crate::encoding::v2::keys::scope::DataScope;
 use crate::encoding::v2::keys::{AdjacencyKey, DataKey, DataKeyKind, EdgePairIndexKey};
 use crate::encoding::v2::values::{adjacency as edges, indexes as secondary};
-use crate::{HelixDbError, Result};
+use crate::{HelixDbError, MembershipDeltaWriteMode, Result};
 
 /// A final membership operation for one ID within the current epoch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -404,30 +404,96 @@ impl TopologyMutationRuntime {
             }
         };
 
-        for (row, delta) in batch.bitmaps {
-            let key = row.to_bytes();
-            transaction.merge_disjoint_tokens(
-                &key,
-                delta.members().map(u128::from),
-                delta.encode(),
-            )?;
-            self.staged_keys.insert(key);
-        }
+        match crate::membership_delta::transaction_write_mode(transaction).await? {
+            MembershipDeltaWriteMode::LegacyExclusive => {
+                for (row, delta) in batch.bitmaps {
+                    let key = row.to_bytes();
+                    let mut bitmap = transaction
+                        .get(&key)
+                        .await?
+                        .map(|value| {
+                            secondary::SecondaryEqualityBitmapValue::decode(&value)
+                                .map(secondary::SecondaryEqualityBitmapValue::into_ids)
+                        })
+                        .transpose()?
+                        .unwrap_or_default();
+                    delta.apply_to(&mut bitmap);
+                    if bitmap.is_empty() {
+                        transaction.delete(&key)?;
+                    } else {
+                        transaction.put_with_options(
+                            &key,
+                            secondary::SecondaryEqualityBitmapValue::new(bitmap).encode(),
+                            &slatedb::PutOptions {
+                                ttl: slatedb::Ttl::NoExpiry,
+                            },
+                        )?;
+                    }
+                    self.staged_keys.insert(key);
+                }
 
-        for ((scope, node), delta) in batch.adjacency {
-            const INCOMING_DIRECTION_TOKEN: u128 = 1_u128 << u64::BITS;
-
-            let key = DataKey::Data {
-                scope,
-                kind: DataKeyKind::Adjacency(AdjacencyKey::new(node)),
+                for ((scope, node), delta) in batch.adjacency {
+                    let key = DataKey::Data {
+                        scope,
+                        kind: DataKeyKind::Adjacency(AdjacencyKey::new(node)),
+                    }
+                    .to_bytes();
+                    let mut adjacency = transaction
+                        .get(&key)
+                        .await?
+                        .map(|value| edges::decode_edges(&value))
+                        .transpose()?
+                        .unwrap_or_default();
+                    delta.apply_to(&mut adjacency);
+                    if adjacency.is_empty() {
+                        transaction.delete(&key)?;
+                    } else {
+                        transaction.put_with_options(
+                            &key,
+                            edges::encode_edges(&adjacency),
+                            &slatedb::PutOptions {
+                                ttl: slatedb::Ttl::NoExpiry,
+                            },
+                        )?;
+                    }
+                    self.staged_keys.insert(key);
+                }
             }
-            .to_bytes();
-            let outgoing = delta.outgoing_members().map(u128::from);
-            let incoming = delta
-                .incoming_members()
-                .map(|neighbor| INCOMING_DIRECTION_TOKEN | u128::from(neighbor));
-            transaction.merge_disjoint_tokens(&key, outgoing.chain(incoming), delta.encode())?;
-            self.staged_keys.insert(key);
+            MembershipDeltaWriteMode::DisjointV2 => {
+                for (row, delta) in batch.bitmaps {
+                    let key = row.to_bytes();
+                    transaction
+                        .merge_disjoint_tokens_checked(
+                            &key,
+                            delta.members().map(u128::from),
+                            delta.encode(),
+                        )
+                        .await?;
+                    self.staged_keys.insert(key);
+                }
+
+                for ((scope, node), delta) in batch.adjacency {
+                    const INCOMING_DIRECTION_TOKEN: u128 = 1_u128 << u64::BITS;
+
+                    let key = DataKey::Data {
+                        scope,
+                        kind: DataKeyKind::Adjacency(AdjacencyKey::new(node)),
+                    }
+                    .to_bytes();
+                    let outgoing = delta.outgoing_members().map(u128::from);
+                    let incoming = delta
+                        .incoming_members()
+                        .map(|neighbor| INCOMING_DIRECTION_TOKEN | u128::from(neighbor));
+                    transaction
+                        .merge_disjoint_tokens_checked(
+                            &key,
+                            outgoing.chain(incoming),
+                            delta.encode(),
+                        )
+                        .await?;
+                    self.staged_keys.insert(key);
+                }
+            }
         }
         Ok(())
     }
@@ -456,7 +522,7 @@ impl TopologyMutationRuntime {
 }
 
 #[cfg(test)]
-fn node_label_key(scope: DataScope, label: &str) -> Bytes {
+pub(super) fn node_label_key(scope: DataScope, label: &str) -> Bytes {
     DataKey::Data {
         scope,
         kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(
@@ -470,7 +536,7 @@ fn node_label_key(scope: DataScope, label: &str) -> Bytes {
 }
 
 #[cfg(test)]
-fn edge_pair_key(scope: DataScope, from: u64, to: u64) -> Bytes {
+pub(super) fn edge_pair_key(scope: DataScope, from: u64, to: u64) -> Bytes {
     DataKey::Data {
         scope,
         kind: DataKeyKind::EdgePairIndex(EdgePairIndexKey::new(from, to)),
@@ -479,7 +545,7 @@ fn edge_pair_key(scope: DataScope, from: u64, to: u64) -> Bytes {
 }
 
 #[cfg(test)]
-fn edge_label_neighbor_key(
+pub(super) fn edge_label_neighbor_key(
     scope: DataScope,
     direction: EdgeDirection,
     node: u64,
@@ -495,7 +561,7 @@ fn edge_label_neighbor_key(
 }
 
 #[cfg(test)]
-fn global_edge_label_key(scope: DataScope, label: &str) -> Bytes {
+pub(super) fn global_edge_label_key(scope: DataScope, label: &str) -> Bytes {
     DataKey::Data {
         scope,
         kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(
@@ -517,15 +583,28 @@ mod tests {
 
     use super::*;
 
-    async fn database(name: &str) -> Db {
-        Db::builder(
+    async fn database_with_mode(name: &str, mode: MembershipDeltaWriteMode) -> Db {
+        let db = Db::builder(
             format!("topology-mutation-runtime/{name}"),
             Arc::new(InMemory::new()),
         )
         .with_merge_operator(Arc::new(crate::merge_operator::HelixMergeOperator::new()))
         .build()
         .await
-        .expect("topology test database opens")
+        .expect("topology test database opens");
+        crate::migrations::startup::bootstrap_writer(&db)
+            .await
+            .expect("topology test database bootstraps storage metadata");
+        if mode == MembershipDeltaWriteMode::DisjointV2 {
+            crate::membership_delta::activate(&db)
+                .await
+                .expect("topology test database activates V2 deltas");
+        }
+        db
+    }
+
+    async fn database(name: &str) -> Db {
+        database_with_mode(name, MembershipDeltaWriteMode::DisjointV2).await
     }
 
     async fn transaction(name: &str) -> DbTransaction {
@@ -665,6 +744,69 @@ mod tests {
                         helix_planner::ir::ExpandDirection::In,
                     )
                     .unwrap();
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn corrupt_topology_rows_fail_closed_in_every_write_mode() {
+        let scope = DataScope::LegacyUnscoped;
+        for mode in [
+            MembershipDeltaWriteMode::LegacyExclusive,
+            MembershipDeltaWriteMode::DisjointV2,
+        ] {
+            for row in [
+                "node-label",
+                "edge-pair",
+                "edge-neighbor-out",
+                "edge-neighbor-in",
+                "global-edge-label",
+                "adjacency",
+            ] {
+                let db = database_with_mode(&format!("corrupt-{mode:?}-{row}"), mode).await;
+                let key = match row {
+                    "node-label" => node_label_key(scope, "Corrupt"),
+                    "edge-pair" => edge_pair_key(scope, 10, 11),
+                    "edge-neighbor-out" => {
+                        edge_label_neighbor_key(scope, EdgeDirection::Out, 10, "CORRUPT")
+                    }
+                    "edge-neighbor-in" => {
+                        edge_label_neighbor_key(scope, EdgeDirection::In, 11, "CORRUPT")
+                    }
+                    "global-edge-label" => global_edge_label_key(scope, "CORRUPT"),
+                    "adjacency" => DataKey::Data {
+                        scope,
+                        kind: DataKeyKind::Adjacency(AdjacencyKey::new(10)),
+                    }
+                    .to_bytes(),
+                    _ => unreachable!("the fixture lists every topology row"),
+                };
+                let corrupt = Bytes::from_static(b"corrupt-topology-value");
+                db.put(&key, corrupt.clone()).await.unwrap();
+
+                let transaction = db
+                    .begin(IsolationLevel::SerializableSnapshot)
+                    .await
+                    .unwrap();
+                let mut runtime = TopologyMutationRuntime::default();
+                match row {
+                    "node-label" => runtime.remove_node_label(scope, "Corrupt", 1).unwrap(),
+                    "edge-pair" => runtime.remove_edge_pair(scope, 10, 11, 1).unwrap(),
+                    "edge-neighbor-out" | "edge-neighbor-in" => runtime
+                        .remove_edge_label_neighbors(scope, 10, 11, "CORRUPT")
+                        .unwrap(),
+                    "global-edge-label" => runtime
+                        .remove_global_edge_label(scope, "CORRUPT", 1)
+                        .unwrap(),
+                    "adjacency" => runtime
+                        .remove_adjacency(scope, 10, 11, helix_planner::ir::ExpandDirection::Out)
+                        .unwrap(),
+                    _ => unreachable!("the fixture lists every topology row"),
+                }
+                assert!(runtime.flush(&transaction).await.is_err(), "{mode:?} {row}");
+                transaction.rollback();
+                assert_eq!(db.get(&key).await.unwrap(), Some(corrupt), "{mode:?} {row}");
+                db.close().await.unwrap();
             }
         }
     }

--- a/crates/db/src/execution/interpreter/mutation/topology.rs
+++ b/crates/db/src/execution/interpreter/mutation/topology.rs
@@ -406,38 +406,27 @@ impl TopologyMutationRuntime {
 
         for (row, delta) in batch.bitmaps {
             let key = row.to_bytes();
-            transaction.merge_disjoint(
+            transaction.merge_disjoint_tokens(
                 &key,
-                delta.members().map(|id| id.to_be_bytes()),
+                delta.members().map(u128::from),
                 delta.encode(),
             )?;
             self.staged_keys.insert(key);
         }
 
         for ((scope, node), delta) in batch.adjacency {
-            const DIRECTION_LEN: usize = core::mem::size_of::<u8>();
-            const NODE_ID_LEN: usize = core::mem::size_of::<u64>();
+            const INCOMING_DIRECTION_TOKEN: u128 = 1_u128 << u64::BITS;
 
             let key = DataKey::Data {
                 scope,
                 kind: DataKeyKind::Adjacency(AdjacencyKey::new(node)),
             }
             .to_bytes();
-            let outgoing = delta.outgoing_members().map(|neighbor| {
-                let mut discriminator = [0; DIRECTION_LEN + NODE_ID_LEN];
-                discriminator[0] = 0;
-                discriminator[DIRECTION_LEN..DIRECTION_LEN + NODE_ID_LEN]
-                    .copy_from_slice(&neighbor.to_be_bytes());
-                discriminator
-            });
-            let incoming = delta.incoming_members().map(|neighbor| {
-                let mut discriminator = [0; DIRECTION_LEN + NODE_ID_LEN];
-                discriminator[0] = 1;
-                discriminator[DIRECTION_LEN..DIRECTION_LEN + NODE_ID_LEN]
-                    .copy_from_slice(&neighbor.to_be_bytes());
-                discriminator
-            });
-            transaction.merge_disjoint(&key, outgoing.chain(incoming), delta.encode())?;
+            let outgoing = delta.outgoing_members().map(u128::from);
+            let incoming = delta
+                .incoming_members()
+                .map(|neighbor| INCOMING_DIRECTION_TOKEN | u128::from(neighbor));
+            transaction.merge_disjoint_tokens(&key, outgoing.chain(incoming), delta.encode())?;
             self.staged_keys.insert(key);
         }
         Ok(())
@@ -831,6 +820,92 @@ mod tests {
         }
 
         db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn incoming_and_outgoing_tokens_do_not_alias_at_the_id_boundary() {
+        const NODE: u64 = 300;
+        const NEIGHBOR: u64 = u64::MAX;
+
+        for outgoing_commits_first in [false, true] {
+            let db = database(&format!(
+                "adjacency-direction-token-boundary-{outgoing_commits_first}"
+            ))
+            .await;
+            let scope = DataScope::LegacyUnscoped;
+            let seed = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut seed_runtime = TopologyMutationRuntime::default();
+            seed_runtime
+                .add_adjacency(
+                    scope,
+                    NODE,
+                    NEIGHBOR,
+                    helix_planner::ir::ExpandDirection::In,
+                )
+                .unwrap();
+            seed_runtime.prepare(&seed).await.unwrap();
+            seed_runtime.consume_prepared().unwrap();
+            seed.commit().await.unwrap();
+
+            let outgoing = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let incoming = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut outgoing_runtime = TopologyMutationRuntime::default();
+            outgoing_runtime
+                .add_adjacency(
+                    scope,
+                    NODE,
+                    NEIGHBOR,
+                    helix_planner::ir::ExpandDirection::Out,
+                )
+                .unwrap();
+            outgoing_runtime.prepare(&outgoing).await.unwrap();
+            outgoing_runtime.consume_prepared().unwrap();
+            let mut incoming_runtime = TopologyMutationRuntime::default();
+            incoming_runtime
+                .remove_adjacency(
+                    scope,
+                    NODE,
+                    NEIGHBOR,
+                    helix_planner::ir::ExpandDirection::In,
+                )
+                .unwrap();
+            incoming_runtime.prepare(&incoming).await.unwrap();
+            incoming_runtime.consume_prepared().unwrap();
+
+            if outgoing_commits_first {
+                outgoing.commit().await.unwrap();
+                incoming.commit().await.unwrap();
+            } else {
+                incoming.commit().await.unwrap();
+                outgoing.commit().await.unwrap();
+            }
+
+            let adjacency = edges::decode_edges(
+                &db.get(
+                    DataKey::Data {
+                        scope,
+                        kind: DataKeyKind::Adjacency(AdjacencyKey::new(NODE)),
+                    }
+                    .to_bytes(),
+                )
+                .await
+                .unwrap()
+                .expect("adjacency row remains present"),
+            )
+            .unwrap();
+            assert_eq!(adjacency.iter_out().collect::<Vec<_>>(), vec![NEIGHBOR]);
+            assert_eq!(adjacency.iter_in().collect::<Vec<_>>(), Vec::<u64>::new());
+            db.close().await.unwrap();
+        }
     }
 
     #[tokio::test]

--- a/crates/db/src/execution/interpreter/mutation/topology.rs
+++ b/crates/db/src/execution/interpreter/mutation/topology.rs
@@ -1,15 +1,13 @@
 //! Transaction-local coalescing for current-format graph topology rows.
 //!
-//! Add-only bitmap and adjacency rows need no observation: one current-format
-//! merge operand represents the complete union. Any key whose final mutation
-//! removes membership participates in one sorted `multi_get`, after which this
-//! runtime stages one final current-format put/delete. No runtime state is
-//! serialized.
+//! Bitmap and adjacency rows are staged as associative membership deltas. The
+//! transaction conflict metadata names each logical member, so mutations to
+//! disjoint members of one physical row can commit concurrently without a
+//! read/modify/write cycle.
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use bytes::Bytes;
-use roaring::RoaringTreemap;
 use slatedb::DbTransaction;
 
 use crate::encoding::indexes::label::{EdgeLabelKey, EdgeLabelNeighborKey};
@@ -18,7 +16,6 @@ use crate::encoding::indexes::{
 };
 use crate::encoding::v2::keys::scope::DataScope;
 use crate::encoding::v2::keys::{AdjacencyKey, DataKey, DataKeyKind, EdgePairIndexKey};
-use crate::encoding::v2::values::adjacency::Edges;
 use crate::encoding::v2::values::{adjacency as edges, indexes as secondary};
 use crate::{HelixDbError, Result};
 
@@ -299,129 +296,52 @@ impl TopologyMutationRuntime {
             }
         };
 
-        let mut observation_keys = batch
-            .bitmaps
-            .iter()
-            .filter(|(_, mutations)| {
-                mutations
-                    .values()
-                    .any(|mutation| *mutation == MembershipMutation::Absent)
-            })
-            .map(|(key, _)| key.clone())
-            .chain(
-                batch
-                    .adjacency
-                    .iter()
-                    .filter(|(_, mutations)| {
-                        mutations
-                            .values()
-                            .any(|mutation| *mutation == MembershipMutation::Absent)
-                    })
-                    .map(|(key, _)| key.clone()),
-            )
-            .collect::<Vec<_>>();
-        observation_keys.sort_unstable();
-        observation_keys.dedup();
-        let (staged_keys, snapshot_keys): (Vec<_>, Vec<_>) = observation_keys
-            .into_iter()
-            .partition(|key| self.staged_keys.contains(key));
-        let snapshot_values = if snapshot_keys.is_empty() {
-            Vec::new()
-        } else {
-            transaction.multi_get(&snapshot_keys).await?
-        };
-        let mut observations = snapshot_keys
-            .into_iter()
-            .zip(snapshot_values)
-            .collect::<BTreeMap<_, _>>();
-        for key in staged_keys {
-            observations.insert(key.clone(), transaction.get(&key).await?);
-        }
-
         for (key, mutations) in batch.bitmaps {
-            if mutations
-                .values()
-                .all(|mutation| *mutation == MembershipMutation::Present)
-            {
-                let additions = mutations.keys().copied().collect::<RoaringTreemap>();
-                transaction.merge_commutative(
-                    &key,
-                    secondary::SecondaryEqualityValue::encode_ids(&additions),
-                )?;
-                self.staged_keys.insert(key);
-                continue;
-            }
-            let mut bitmap = observations
-                .get(&key)
-                .cloned()
-                .flatten()
-                .map(|value| {
-                    secondary::SecondaryEqualityValue::decode(&value).map(|value| value.into_ids())
-                })
-                .transpose()?
-                .unwrap_or_default();
-            for (id, mutation) in mutations {
+            let mut delta = secondary::BitmapMembershipDelta::default();
+            let mut discriminators = Vec::with_capacity(mutations.len());
+            for (id, mutation) in &mutations {
+                discriminators.push(Bytes::copy_from_slice(&id.to_be_bytes()));
                 match mutation {
                     MembershipMutation::Present => {
-                        bitmap.insert(id);
+                        delta.add(*id);
                     }
                     MembershipMutation::Absent => {
-                        bitmap.remove(id);
+                        delta.remove(*id);
                     }
                 }
             }
-            if bitmap.is_empty() {
-                transaction.delete(&key)?;
-            } else {
-                transaction.put(&key, secondary::SecondaryEqualityValue::encode_ids(&bitmap))?;
-            }
+            transaction.merge_disjoint(&key, discriminators, delta.encode())?;
             self.staged_keys.insert(key);
         }
 
         for (key, mutations) in batch.adjacency {
-            if mutations
-                .values()
-                .all(|mutation| *mutation == MembershipMutation::Present)
-            {
-                let mut additions = Edges::new();
-                for ((direction, neighbor), _) in mutations {
-                    match direction {
-                        AdjacencyDirection::Out => additions.add_out(neighbor),
-                        AdjacencyDirection::In => additions.add_in(neighbor),
-                    }
-                }
-                transaction.merge_commutative(&key, edges::encode_edges(&additions))?;
-                self.staged_keys.insert(key);
-                continue;
-            }
-            let mut adjacency = observations
-                .get(&key)
-                .cloned()
-                .flatten()
-                .map(|value| edges::decode_edges(&value))
-                .transpose()?
-                .unwrap_or_default();
-            for ((direction, neighbor), mutation) in mutations {
+            let mut delta = edges::AdjacencyMembershipDelta::default();
+            let mut discriminators = Vec::with_capacity(mutations.len());
+            for ((direction, neighbor), mutation) in &mutations {
+                let mut discriminator =
+                    Vec::with_capacity(core::mem::size_of::<u8>() + core::mem::size_of::<u64>());
+                discriminator.push(match direction {
+                    AdjacencyDirection::Out => 0,
+                    AdjacencyDirection::In => 1,
+                });
+                discriminator.extend_from_slice(&neighbor.to_be_bytes());
+                discriminators.push(Bytes::from(discriminator));
                 match (direction, mutation) {
                     (AdjacencyDirection::Out, MembershipMutation::Present) => {
-                        adjacency.add_out(neighbor);
+                        delta.add_out(*neighbor);
                     }
                     (AdjacencyDirection::In, MembershipMutation::Present) => {
-                        adjacency.add_in(neighbor);
+                        delta.add_in(*neighbor);
                     }
                     (AdjacencyDirection::Out, MembershipMutation::Absent) => {
-                        adjacency.remove_out(neighbor);
+                        delta.remove_out(*neighbor);
                     }
                     (AdjacencyDirection::In, MembershipMutation::Absent) => {
-                        adjacency.remove_in(neighbor);
+                        delta.remove_in(*neighbor);
                     }
                 }
             }
-            if adjacency.is_empty() {
-                transaction.delete(&key)?;
-            } else {
-                transaction.put(&key, edges::encode_edges(&adjacency))?;
-            }
+            transaction.merge_disjoint(&key, discriminators, delta.encode())?;
             self.staged_keys.insert(key);
         }
         Ok(())
@@ -498,8 +418,11 @@ fn global_edge_label_key(scope: DataScope, label: &str) -> Bytes {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
+    use roaring::RoaringTreemap;
     use slatedb::object_store::memory::InMemory;
     use slatedb::{Db, IsolationLevel};
 
@@ -560,18 +483,20 @@ mod tests {
 
         async fn ids(self, db: &Db, scope: DataScope) -> Vec<u64> {
             match self {
-                Self::NodeLabel(label) => secondary::SecondaryEqualityValue::decode(
-                    &db.get(node_label_key(scope, label))
-                        .await
-                        .unwrap()
-                        .expect("node label race row exists"),
-                )
-                .unwrap()
-                .into_ids()
-                .iter()
-                .collect(),
-                Self::OutAdjacency(node) => edges::decode_edges(
-                    &db.get(
+                Self::NodeLabel(label) => db
+                    .get(node_label_key(scope, label))
+                    .await
+                    .unwrap()
+                    .map(|value| {
+                        secondary::SecondaryEqualityValue::decode(&value)
+                            .unwrap()
+                            .into_ids()
+                            .iter()
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                Self::OutAdjacency(node) => db
+                    .get(
                         DataKey::Data {
                             scope,
                             kind: DataKeyKind::Adjacency(AdjacencyKey::new(node)),
@@ -580,11 +505,77 @@ mod tests {
                     )
                     .await
                     .unwrap()
-                    .expect("adjacency race row exists"),
-                )
-                .unwrap()
-                .iter_out()
-                .collect(),
+                    .map(|value| edges::decode_edges(&value).unwrap().iter_out().collect())
+                    .unwrap_or_default(),
+            }
+        }
+    }
+
+    fn stage_linked_event(
+        runtime: &mut TopologyMutationRuntime,
+        scope: DataScope,
+        parent_id: u64,
+        event_id: u64,
+        edge_id: u64,
+        node_label: &str,
+        edge_label: &str,
+        mutation: MembershipMutation,
+    ) {
+        match mutation {
+            MembershipMutation::Present => {
+                runtime.add_node_label(scope, node_label, event_id).unwrap();
+                runtime
+                    .add_edge_pair(scope, parent_id, event_id, edge_id)
+                    .unwrap();
+                runtime
+                    .add_edge_label(scope, parent_id, event_id, edge_label, edge_id)
+                    .unwrap();
+                runtime
+                    .add_adjacency(
+                        scope,
+                        parent_id,
+                        event_id,
+                        helix_planner::ir::ExpandDirection::Out,
+                    )
+                    .unwrap();
+                runtime
+                    .add_adjacency(
+                        scope,
+                        event_id,
+                        parent_id,
+                        helix_planner::ir::ExpandDirection::In,
+                    )
+                    .unwrap();
+            }
+            MembershipMutation::Absent => {
+                runtime
+                    .remove_node_label(scope, node_label, event_id)
+                    .unwrap();
+                runtime
+                    .remove_edge_pair(scope, parent_id, event_id, edge_id)
+                    .unwrap();
+                runtime
+                    .remove_global_edge_label(scope, edge_label, edge_id)
+                    .unwrap();
+                runtime
+                    .remove_edge_label_neighbors(scope, parent_id, event_id, edge_label)
+                    .unwrap();
+                runtime
+                    .remove_adjacency(
+                        scope,
+                        parent_id,
+                        event_id,
+                        helix_planner::ir::ExpandDirection::Out,
+                    )
+                    .unwrap();
+                runtime
+                    .remove_adjacency(
+                        scope,
+                        event_id,
+                        parent_id,
+                        helix_planner::ir::ExpandDirection::In,
+                    )
+                    .unwrap();
             }
         }
     }
@@ -691,7 +682,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn topology_insert_remove_races_conflict_in_both_commit_orders() {
+    async fn topology_insert_remove_races_on_disjoint_members_commit_in_both_orders() {
         let db = database("insert-remove-races").await;
         let scope = DataScope::LegacyUnscoped;
         let cases = [
@@ -729,33 +720,219 @@ mod tests {
             remove_runtime.prepare(&remove).await.unwrap();
             remove_runtime.consume_prepared().unwrap();
 
-            let retry_mutation = if insert_commits_first {
+            if insert_commits_first {
+                insert.commit().await.unwrap();
+                remove.commit().await.unwrap();
+            } else {
+                remove.commit().await.unwrap();
+                insert.commit().await.unwrap();
+            }
+            assert_eq!(row.ids(&db, scope).await, vec![2]);
+        }
+
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn topology_insert_remove_races_on_same_member_conflict_in_both_orders() {
+        let db = database("same-member-insert-remove-races").await;
+        let scope = DataScope::LegacyUnscoped;
+        let cases = [
+            (RaceRow::NodeLabel("insert-first"), true),
+            (RaceRow::NodeLabel("remove-first"), false),
+            (RaceRow::OutAdjacency(200), true),
+            (RaceRow::OutAdjacency(201), false),
+        ];
+
+        for (row, insert_commits_first) in cases {
+            let seed = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut seed_runtime = TopologyMutationRuntime::default();
+            row.stage(&mut seed_runtime, scope, 1, MembershipMutation::Present);
+            seed_runtime.prepare(&seed).await.unwrap();
+            seed_runtime.consume_prepared().unwrap();
+            seed.commit().await.unwrap();
+
+            let insert = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let remove = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut insert_runtime = TopologyMutationRuntime::default();
+            row.stage(&mut insert_runtime, scope, 1, MembershipMutation::Present);
+            insert_runtime.prepare(&insert).await.unwrap();
+            insert_runtime.consume_prepared().unwrap();
+            let mut remove_runtime = TopologyMutationRuntime::default();
+            row.stage(&mut remove_runtime, scope, 1, MembershipMutation::Absent);
+            remove_runtime.prepare(&remove).await.unwrap();
+            remove_runtime.consume_prepared().unwrap();
+
+            if insert_commits_first {
                 insert.commit().await.unwrap();
                 let error = remove.commit().await.expect_err("remove must conflict");
                 assert_eq!(error.kind(), slatedb::ErrorKind::Transaction);
-                MembershipMutation::Absent
+                assert_eq!(row.ids(&db, scope).await, vec![1]);
             } else {
                 remove.commit().await.unwrap();
                 let error = insert.commit().await.expect_err("insert must conflict");
                 assert_eq!(error.kind(), slatedb::ErrorKind::Transaction);
-                MembershipMutation::Present
-            };
+                assert_eq!(row.ids(&db, scope).await, Vec::<u64>::new());
+            }
+        }
 
-            let retry = db
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn linked_event_insert_and_expiry_preserve_every_shared_topology_row() {
+        let db = database("linked-event-insert-expiry-races").await;
+        let scope = DataScope::LegacyUnscoped;
+
+        for (case, insert_commits_first) in [(0_u64, false), (1, true)] {
+            let parent_id = 1_000 + case * 100;
+            let expired_event_id = parent_id + 1;
+            let inserted_event_id = parent_id + 2;
+            let expired_edge_id = parent_id + 10;
+            let inserted_edge_id = parent_id + 11;
+            let node_label = format!("Event-{case}");
+            let edge_label = format!("HAS_EVENT-{case}");
+
+            let seed = db
                 .begin(IsolationLevel::SerializableSnapshot)
                 .await
                 .unwrap();
-            let mut retry_runtime = TopologyMutationRuntime::default();
-            row.stage(
-                &mut retry_runtime,
+            let mut seed_runtime = TopologyMutationRuntime::default();
+            stage_linked_event(
+                &mut seed_runtime,
                 scope,
-                if insert_commits_first { 1 } else { 2 },
-                retry_mutation,
+                parent_id,
+                expired_event_id,
+                expired_edge_id,
+                &node_label,
+                &edge_label,
+                MembershipMutation::Present,
             );
-            retry_runtime.prepare(&retry).await.unwrap();
-            retry_runtime.consume_prepared().unwrap();
-            retry.commit().await.unwrap();
-            assert_eq!(row.ids(&db, scope).await, vec![2]);
+            seed_runtime.prepare(&seed).await.unwrap();
+            seed_runtime.consume_prepared().unwrap();
+            seed.commit().await.unwrap();
+
+            let insert = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let remove = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .unwrap();
+            let mut insert_runtime = TopologyMutationRuntime::default();
+            stage_linked_event(
+                &mut insert_runtime,
+                scope,
+                parent_id,
+                inserted_event_id,
+                inserted_edge_id,
+                &node_label,
+                &edge_label,
+                MembershipMutation::Present,
+            );
+            insert_runtime.prepare(&insert).await.unwrap();
+            insert_runtime.consume_prepared().unwrap();
+            let mut remove_runtime = TopologyMutationRuntime::default();
+            stage_linked_event(
+                &mut remove_runtime,
+                scope,
+                parent_id,
+                expired_event_id,
+                expired_edge_id,
+                &node_label,
+                &edge_label,
+                MembershipMutation::Absent,
+            );
+            remove_runtime.prepare(&remove).await.unwrap();
+            remove_runtime.consume_prepared().unwrap();
+
+            if insert_commits_first {
+                insert.commit().await.unwrap();
+                remove.commit().await.unwrap();
+            } else {
+                remove.commit().await.unwrap();
+                insert.commit().await.unwrap();
+            }
+
+            let bitmap_ids = |key| async {
+                db.get(key)
+                    .await
+                    .unwrap()
+                    .map(|value| {
+                        secondary::SecondaryEqualityValue::decode(&value)
+                            .unwrap()
+                            .into_ids()
+                            .iter()
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            };
+            assert_eq!(
+                bitmap_ids(node_label_key(scope, &node_label)).await,
+                vec![inserted_event_id]
+            );
+            assert_eq!(
+                bitmap_ids(edge_label_neighbor_key(
+                    scope,
+                    EdgeDirection::Out,
+                    parent_id,
+                    &edge_label,
+                ))
+                .await,
+                vec![inserted_event_id]
+            );
+            assert_eq!(
+                bitmap_ids(global_edge_label_key(scope, &edge_label)).await,
+                vec![inserted_edge_id]
+            );
+            assert_eq!(
+                bitmap_ids(edge_pair_key(scope, parent_id, expired_event_id)).await,
+                Vec::<u64>::new()
+            );
+            assert_eq!(
+                bitmap_ids(edge_pair_key(scope, parent_id, inserted_event_id)).await,
+                vec![inserted_edge_id]
+            );
+            let parent_adjacency = edges::decode_edges(
+                &db.get(
+                    DataKey::Data {
+                        scope,
+                        kind: DataKeyKind::Adjacency(AdjacencyKey::new(parent_id)),
+                    }
+                    .to_bytes(),
+                )
+                .await
+                .unwrap()
+                .expect("parent adjacency remains"),
+            )
+            .unwrap();
+            assert_eq!(
+                parent_adjacency.iter_out().collect::<Vec<_>>(),
+                vec![inserted_event_id]
+            );
+            let expired_adjacency = db
+                .get(
+                    DataKey::Data {
+                        scope,
+                        kind: DataKeyKind::Adjacency(AdjacencyKey::new(expired_event_id)),
+                    }
+                    .to_bytes(),
+                )
+                .await
+                .unwrap()
+                .map(|value| edges::decode_edges(&value).unwrap())
+                .unwrap_or_default();
+            assert!(expired_adjacency.is_empty());
         }
 
         db.close().await.unwrap();
@@ -842,5 +1019,368 @@ mod tests {
             runtime.add_node_label(DataScope::LegacyUnscoped, "User", 1),
             Err(HelixDbError::InvariantViolation(_))
         ));
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum SweepBenchmarkStrategy {
+        ExclusiveReadModifyWrite,
+        DisjointDelta,
+    }
+
+    #[derive(Debug)]
+    struct SweepBenchmarkResult {
+        elapsed: Duration,
+        writer_conflicts: usize,
+        sweeper_conflicts: usize,
+        writer_commits: usize,
+        sweeper_commits: usize,
+    }
+
+    async fn stage_benchmark_memberships(
+        db: &Db,
+        strategy: SweepBenchmarkStrategy,
+        ids: std::ops::Range<u64>,
+        present: bool,
+    ) -> DbTransaction {
+        const PARENT_ID: u64 = u64::MAX - 1;
+        const LABEL: &str = "KubernetesEvent";
+
+        let transaction = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .expect("benchmark transaction begins");
+        match strategy {
+            SweepBenchmarkStrategy::ExclusiveReadModifyWrite if present => {
+                let additions = ids.clone().collect::<RoaringTreemap>();
+                transaction
+                    .merge_commutative(
+                        node_label_key(DataScope::LegacyUnscoped, LABEL),
+                        secondary::SecondaryEqualityValue::encode_ids(&additions),
+                    )
+                    .expect("exclusive benchmark label additions stage");
+                let mut adjacency = edges::Edges::new();
+                for id in ids {
+                    adjacency.add_out(id);
+                }
+                transaction
+                    .merge_commutative(
+                        DataKey::Data {
+                            scope: DataScope::LegacyUnscoped,
+                            kind: DataKeyKind::Adjacency(AdjacencyKey::new(PARENT_ID)),
+                        }
+                        .to_bytes(),
+                        edges::encode_edges(&adjacency),
+                    )
+                    .expect("exclusive benchmark adjacency additions stage");
+            }
+            SweepBenchmarkStrategy::ExclusiveReadModifyWrite => {
+                let label_key = node_label_key(DataScope::LegacyUnscoped, LABEL);
+                let adjacency_key = DataKey::Data {
+                    scope: DataScope::LegacyUnscoped,
+                    kind: DataKeyKind::Adjacency(AdjacencyKey::new(PARENT_ID)),
+                }
+                .to_bytes();
+                let values = transaction
+                    .multi_get(&[label_key.clone(), adjacency_key.clone()])
+                    .await
+                    .expect("exclusive benchmark rows read");
+                let mut labels = values[0]
+                    .as_deref()
+                    .map(secondary::SecondaryEqualityValue::decode)
+                    .transpose()
+                    .expect("exclusive benchmark labels decode")
+                    .map(secondary::SecondaryEqualityValue::into_ids)
+                    .unwrap_or_default();
+                let mut adjacency = values[1]
+                    .as_deref()
+                    .map(edges::decode_edges)
+                    .transpose()
+                    .expect("exclusive benchmark adjacency decodes")
+                    .unwrap_or_default();
+                for id in ids {
+                    labels.remove(id);
+                    adjacency.remove_out(id);
+                }
+                if labels.is_empty() {
+                    transaction
+                        .delete(label_key)
+                        .expect("exclusive benchmark empty label row deletes");
+                } else {
+                    transaction
+                        .put(
+                            label_key,
+                            secondary::SecondaryEqualityValue::encode_ids(&labels),
+                        )
+                        .expect("exclusive benchmark label replacement stages");
+                }
+                if adjacency.is_empty() {
+                    transaction
+                        .delete(adjacency_key)
+                        .expect("exclusive benchmark empty adjacency row deletes");
+                } else {
+                    transaction
+                        .put(adjacency_key, edges::encode_edges(&adjacency))
+                        .expect("exclusive benchmark adjacency replacement stages");
+                }
+            }
+            SweepBenchmarkStrategy::DisjointDelta => {
+                let mut runtime = TopologyMutationRuntime::default();
+                for id in ids {
+                    if present {
+                        runtime
+                            .add_node_label(DataScope::LegacyUnscoped, LABEL, id)
+                            .unwrap();
+                        runtime
+                            .add_adjacency(
+                                DataScope::LegacyUnscoped,
+                                PARENT_ID,
+                                id,
+                                helix_planner::ir::ExpandDirection::Out,
+                            )
+                            .unwrap();
+                    } else {
+                        runtime
+                            .remove_node_label(DataScope::LegacyUnscoped, LABEL, id)
+                            .unwrap();
+                        runtime
+                            .remove_adjacency(
+                                DataScope::LegacyUnscoped,
+                                PARENT_ID,
+                                id,
+                                helix_planner::ir::ExpandDirection::Out,
+                            )
+                            .unwrap();
+                    }
+                }
+                runtime.prepare(&transaction).await.unwrap();
+                runtime.consume_prepared().unwrap();
+            }
+        }
+        transaction
+    }
+
+    async fn run_sweep_benchmark(
+        strategy: SweepBenchmarkStrategy,
+        expired_members: u64,
+        inserted_members: u64,
+        sweep_chunk: u64,
+        writer_chunk: u64,
+    ) -> SweepBenchmarkResult {
+        const PARENT_ID: u64 = u64::MAX - 1;
+        const LABEL: &str = "KubernetesEvent";
+
+        let db = Arc::new(
+            database(match strategy {
+                SweepBenchmarkStrategy::ExclusiveReadModifyWrite => "benchmark-exclusive",
+                SweepBenchmarkStrategy::DisjointDelta => "benchmark-disjoint",
+            })
+            .await,
+        );
+        let label_key = node_label_key(DataScope::LegacyUnscoped, LABEL);
+        db.put(
+            &label_key,
+            secondary::SecondaryEqualityValue::encode_ids(
+                &(0..expired_members).collect::<RoaringTreemap>(),
+            ),
+        )
+        .await
+        .expect("benchmark label seed persists");
+        let mut adjacency = edges::Edges::new();
+        for id in 0..expired_members {
+            adjacency.add_out(id);
+        }
+        db.put(
+            DataKey::Data {
+                scope: DataScope::LegacyUnscoped,
+                kind: DataKeyKind::Adjacency(AdjacencyKey::new(PARENT_ID)),
+            }
+            .to_bytes(),
+            edges::encode_edges(&adjacency),
+        )
+        .await
+        .expect("benchmark adjacency seed persists");
+
+        let writer_chunks = inserted_members.div_ceil(writer_chunk) as usize;
+        let sweeper_chunks = expired_members.div_ceil(sweep_chunk) as usize;
+        let synchronized_chunks = writer_chunks.min(sweeper_chunks);
+        let barriers = (0..synchronized_chunks)
+            .map(|_| Arc::new(tokio::sync::Barrier::new(2)))
+            .collect::<Vec<_>>();
+        let writer_progress = Arc::new(AtomicUsize::new(0));
+        let writer_notify = Arc::new(tokio::sync::Notify::new());
+        let started = Instant::now();
+
+        let writer = {
+            let db = Arc::clone(&db);
+            let barriers = barriers.clone();
+            let writer_progress = Arc::clone(&writer_progress);
+            let writer_notify = Arc::clone(&writer_notify);
+            tokio::spawn(async move {
+                let mut conflicts = 0;
+                for chunk in 0..writer_chunks {
+                    let start = expired_members + chunk as u64 * writer_chunk;
+                    let end = (start + writer_chunk).min(expired_members + inserted_members);
+                    let mut first_attempt = true;
+                    loop {
+                        let transaction =
+                            stage_benchmark_memberships(&db, strategy, start..end, true).await;
+                        if first_attempt && chunk < synchronized_chunks {
+                            barriers[chunk].wait().await;
+                        }
+                        match transaction.commit().await {
+                            Ok(_) => break,
+                            Err(error) if error.kind() == slatedb::ErrorKind::Transaction => {
+                                conflicts += 1;
+                                first_attempt = false;
+                            }
+                            Err(error) => panic!("benchmark writer commit failed: {error}"),
+                        }
+                    }
+                    writer_progress.store(chunk + 1, Ordering::Release);
+                    writer_notify.notify_waiters();
+                }
+                conflicts
+            })
+        };
+        let sweeper = {
+            let db = Arc::clone(&db);
+            let barriers = barriers.clone();
+            let writer_progress = Arc::clone(&writer_progress);
+            let writer_notify = Arc::clone(&writer_notify);
+            tokio::spawn(async move {
+                let mut conflicts = 0;
+                for chunk in 0..sweeper_chunks {
+                    let start = chunk as u64 * sweep_chunk;
+                    let end = (start + sweep_chunk).min(expired_members);
+                    let mut first_attempt = true;
+                    loop {
+                        let transaction =
+                            stage_benchmark_memberships(&db, strategy, start..end, false).await;
+                        if first_attempt && chunk < synchronized_chunks {
+                            barriers[chunk].wait().await;
+                            loop {
+                                let notified = writer_notify.notified();
+                                if writer_progress.load(Ordering::Acquire) > chunk {
+                                    break;
+                                }
+                                notified.await;
+                            }
+                        }
+                        match transaction.commit().await {
+                            Ok(_) => break,
+                            Err(error) if error.kind() == slatedb::ErrorKind::Transaction => {
+                                conflicts += 1;
+                                first_attempt = false;
+                            }
+                            Err(error) => panic!("benchmark sweeper commit failed: {error}"),
+                        }
+                    }
+                }
+                conflicts
+            })
+        };
+        let writer_conflicts = writer.await.expect("benchmark writer joins");
+        let sweeper_conflicts = sweeper.await.expect("benchmark sweeper joins");
+        let elapsed = started.elapsed();
+
+        let labels = secondary::SecondaryEqualityValue::decode(
+            &db.get(&label_key)
+                .await
+                .expect("benchmark result reads")
+                .expect("inserted memberships remain"),
+        )
+        .expect("benchmark result decodes")
+        .into_ids();
+        assert_eq!(labels.len(), inserted_members);
+        assert_eq!(labels.min(), Some(expired_members));
+        assert_eq!(labels.max(), Some(expired_members + inserted_members - 1));
+        db.close().await.expect("benchmark database closes");
+
+        SweepBenchmarkResult {
+            elapsed,
+            writer_conflicts,
+            sweeper_conflicts,
+            writer_commits: writer_chunks,
+            sweeper_commits: sweeper_chunks,
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore = "manual 100K-member conflict and throughput comparison"]
+    async fn benchmark_exclusive_vs_disjoint_linked_event_sweep() {
+        let expired_members = std::env::var("HELIX_SWEEP_BENCH_EXPIRED")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(100_000);
+        let inserted_members = std::env::var("HELIX_SWEEP_BENCH_INSERTED")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(10_000);
+        let sweep_chunk = std::env::var("HELIX_SWEEP_BENCH_SWEEP_CHUNK")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(1_000);
+        let writer_chunk = std::env::var("HELIX_SWEEP_BENCH_WRITER_CHUNK")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(250);
+        assert!(expired_members > 0);
+        assert!(inserted_members > 0);
+        assert!(sweep_chunk > 0);
+        assert!(writer_chunk > 0);
+
+        let before = run_sweep_benchmark(
+            SweepBenchmarkStrategy::ExclusiveReadModifyWrite,
+            expired_members,
+            inserted_members,
+            sweep_chunk,
+            writer_chunk,
+        )
+        .await;
+        let after = run_sweep_benchmark(
+            SweepBenchmarkStrategy::DisjointDelta,
+            expired_members,
+            inserted_members,
+            sweep_chunk,
+            writer_chunk,
+        )
+        .await;
+        let before_sweep_conflict_rate =
+            before.sweeper_conflicts as f64 / before.sweeper_commits as f64;
+        let after_sweep_conflict_rate =
+            after.sweeper_conflicts as f64 / after.sweeper_commits as f64;
+        let operations = expired_members + inserted_members;
+        let before_throughput = operations as f64 / before.elapsed.as_secs_f64();
+        let after_throughput = operations as f64 / after.elapsed.as_secs_f64();
+
+        println!(
+            "SWEEP_BENCH before elapsed_ms={} sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={} throughput_members_per_s={:.0}",
+            before.elapsed.as_millis(),
+            before.sweeper_commits,
+            before.sweeper_conflicts,
+            before_sweep_conflict_rate,
+            before.writer_commits,
+            before.writer_conflicts,
+            before_throughput,
+        );
+        println!(
+            "SWEEP_BENCH after elapsed_ms={} sweep_commits={} sweep_conflicts={} sweep_conflict_rate={:.4} writer_commits={} writer_conflicts={} throughput_members_per_s={:.0}",
+            after.elapsed.as_millis(),
+            after.sweeper_commits,
+            after.sweeper_conflicts,
+            after_sweep_conflict_rate,
+            after.writer_commits,
+            after.writer_conflicts,
+            after_throughput,
+        );
+        println!(
+            "SWEEP_BENCH delta conflict_rate_points={:.2} throughput_ratio={:.3}",
+            (after_sweep_conflict_rate - before_sweep_conflict_rate) * 100.0,
+            after_throughput / before_throughput,
+        );
+
+        assert!(before.sweeper_conflicts > 0);
+        assert_eq!(after.sweeper_conflicts, 0);
+        assert_eq!(after.writer_conflicts, 0);
     }
 }

--- a/crates/db/src/index_lifecycle/lifecycle.rs
+++ b/crates/db/src/index_lifecycle/lifecycle.rs
@@ -533,7 +533,8 @@ async fn linked_operation(
             | IndexV2MetadataValue::LogicalIndexIdWatermark(_)
             | IndexV2MetadataValue::VectorPhysicalIdWatermark(_)
             | IndexV2MetadataValue::LegacyVectorPhysicalReservation(_)
-            | IndexV2MetadataValue::TextCompactionPointer(_) => Err(corruption(
+            | IndexV2MetadataValue::TextCompactionPointer(_)
+            | IndexV2MetadataValue::MembershipDeltaWriteMode(_) => Err(corruption(
                 "operation pointer key contains the wrong value kind",
             )),
         })

--- a/crates/db/src/index_lifecycle/metadata.rs
+++ b/crates/db/src/index_lifecycle/metadata.rs
@@ -8,6 +8,8 @@ use super::{
 
 /// Canonical V2 index format number written by this implementation.
 pub(crate) const CURRENT_INDEX_STORAGE_VERSION: u16 = 0x0004;
+/// First storage format that permits persisted disjoint membership operands.
+pub(crate) const DISJOINT_MEMBERSHIP_INDEX_STORAGE_VERSION: u16 = 0x0005;
 
 /// Decoded non-zero index storage format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -15,6 +17,8 @@ pub(crate) struct IndexStorageVersion(u16);
 
 impl IndexStorageVersion {
     pub(crate) const CURRENT: Self = Self(CURRENT_INDEX_STORAGE_VERSION);
+    pub(crate) const DISJOINT_MEMBERSHIP: Self = Self(DISJOINT_MEMBERSHIP_INDEX_STORAGE_VERSION);
+    pub(crate) const MAX_SUPPORTED: Self = Self::DISJOINT_MEMBERSHIP;
 
     pub(crate) fn new(value: u16) -> Result<Self, crate::encoding::error::EncodingError> {
         if value == 0 {
@@ -199,6 +203,7 @@ pub(crate) enum IndexV2MetadataValue {
     OperationQueuePointer(OperationQueuePointerValue),
     LegacyVectorPhysicalReservation(LegacyVectorPhysicalReservation),
     TextCompactionPointer(TextCompactionPointerValue),
+    MembershipDeltaWriteMode(crate::MembershipDeltaWriteMode),
 }
 
 #[cfg(test)]

--- a/crates/db/src/index_lifecycle/repository.rs
+++ b/crates/db/src/index_lifecycle/repository.rs
@@ -55,6 +55,7 @@ fn metadata_or_migration_required(
 pub(crate) async fn require_reader_bootstrap_or_legacy(
     reader: &(impl DbReadOps + Send + Sync),
 ) -> Result<()> {
+    crate::membership_delta::read_write_mode(reader).await?;
     let tenant_envelope_ready = crate::migrations::tenant_key_envelope_ready(reader).await?;
     let marker_key = global_key(GlobalKey::StorageVersion);
     let logical_key = global_key(GlobalKey::LogicalIndexIdWatermark);
@@ -167,10 +168,10 @@ fn validate_bootstrap_values(
             ),
         });
     }
-    if version > IndexStorageVersion::CURRENT {
+    if version > IndexStorageVersion::MAX_SUPPORTED {
         return Err(HelixDbError::UnsupportedIndexStorageVersion {
             found: version.get(),
-            supported: IndexStorageVersion::CURRENT.get(),
+            supported: IndexStorageVersion::MAX_SUPPORTED.get(),
         });
     }
     let Some(logical) = logical else {
@@ -1156,15 +1157,15 @@ mod tests {
     }
 
     #[test]
-    fn storage_version_five_is_unsupported() {
-        let version_five =
-            IndexStorageVersion::new(0x0005).expect("storage version five remains representable");
-        let marker = encode_metadata_value(&IndexV2MetadataValue::StorageVersion(version_five));
+    fn storage_version_after_max_supported_is_rejected() {
+        let unsupported = IndexStorageVersion::new(IndexStorageVersion::MAX_SUPPORTED.get() + 1)
+            .expect("the next storage version remains representable");
+        let marker = encode_metadata_value(&IndexV2MetadataValue::StorageVersion(unsupported));
         assert!(matches!(
             validate_bootstrap_values(&marker, None, None),
             Err(HelixDbError::UnsupportedIndexStorageVersion {
-                found: 0x0005,
-                supported: 0x0004,
+                found: 0x0006,
+                supported: 0x0005,
             })
         ));
     }

--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -2554,16 +2554,56 @@ async fn stage_bitmap_changes(
     transaction: &DbTransaction,
     changes: &BTreeMap<Bytes, BTreeMap<u64, bool>>,
 ) -> Result<()> {
-    for (key, changes) in changes {
-        let mut delta = BitmapMembershipDelta::default();
-        for (entity_id, present) in changes {
-            if *present {
-                delta.add(*entity_id);
-            } else {
-                delta.remove(*entity_id);
+    match crate::membership_delta::transaction_write_mode(transaction).await? {
+        crate::MembershipDeltaWriteMode::LegacyExclusive => {
+            for (key, changes) in changes {
+                let mut bitmap = transaction
+                    .get(key)
+                    .await?
+                    .as_deref()
+                    .map(SecondaryEqualityBitmapValue::decode)
+                    .transpose()?
+                    .map(SecondaryEqualityBitmapValue::into_ids)
+                    .unwrap_or_default();
+                for (entity_id, present) in changes {
+                    if *present {
+                        bitmap.insert(*entity_id);
+                    } else {
+                        bitmap.remove(*entity_id);
+                    }
+                }
+                if bitmap.is_empty() {
+                    transaction.delete(key)?;
+                } else {
+                    transaction.put_with_options(
+                        key,
+                        SecondaryEqualityBitmapValue::new(bitmap).encode(),
+                        &slatedb::PutOptions {
+                            ttl: slatedb::Ttl::NoExpiry,
+                        },
+                    )?;
+                }
             }
         }
-        transaction.merge_disjoint_tokens(key, delta.members().map(u128::from), delta.encode())?;
+        crate::MembershipDeltaWriteMode::DisjointV2 => {
+            for (key, changes) in changes {
+                let mut delta = BitmapMembershipDelta::default();
+                for (entity_id, present) in changes {
+                    if *present {
+                        delta.add(*entity_id);
+                    } else {
+                        delta.remove(*entity_id);
+                    }
+                }
+                transaction
+                    .merge_disjoint_tokens_checked(
+                        key,
+                        delta.members().map(u128::from),
+                        delta.encode(),
+                    )
+                    .await?;
+            }
+        }
     }
     Ok(())
 }
@@ -3390,6 +3430,26 @@ fn secondary_entry_key(
     Ok(scoped_index_key(scope, ScopedKey::SecondaryEntry(key)))
 }
 
+#[cfg(test)]
+pub(crate) fn equality_bitmap_key_for_test(handle: &ActiveIndexHandle, value: &str) -> Bytes {
+    let definition = handle
+        .secondary_definition()
+        .expect("an equality bitmap fixture requires a secondary handle");
+    assert!(
+        definition_uses_equality_bitmap(definition),
+        "an equality bitmap fixture requires a non-unique equality definition"
+    );
+    secondary_entry_key(
+        handle.scope(),
+        handle.index_id(),
+        handle.generation(),
+        definition,
+        CanonicalSecondaryValue::equality_string(value),
+        IndexEntityId::initial(),
+    )
+    .expect("an equality bitmap fixture key validates")
+}
+
 fn decode_secondary_entry_value(
     index_id: IndexId,
     generation: IndexGenerationId,
@@ -3623,7 +3683,7 @@ mod tests {
 
     const NOW_MILLIS: u64 = 1;
 
-    pub(super) async fn test_db(name: &str) -> Db {
+    async fn test_db_with_mode(name: &str, mode: crate::MembershipDeltaWriteMode) -> Db {
         let db = Db::builder(name, Arc::new(InMemory::new()))
             .with_merge_operator(Arc::new(crate::merge_operator::HelixMergeOperator::new()))
             .build()
@@ -3632,7 +3692,16 @@ mod tests {
         bootstrap_writer(&db)
             .await
             .expect("secondary test database bootstraps V2 metadata");
+        if mode == crate::MembershipDeltaWriteMode::DisjointV2 {
+            crate::membership_delta::activate(&db)
+                .await
+                .expect("secondary test database activates V2 deltas");
+        }
         db
+    }
+
+    pub(super) async fn test_db(name: &str) -> Db {
+        test_db_with_mode(name, crate::MembershipDeltaWriteMode::DisjointV2).await
     }
 
     fn validated(definition: SecondaryIndexDefinition) -> ValidatedDynamicIndexDefinition {
@@ -5753,6 +5822,66 @@ mod tests {
         );
 
         db.close().await.expect("mixed bitmap database closes");
+    }
+
+    #[tokio::test]
+    async fn corrupt_node_and_edge_equality_rows_fail_closed_in_every_write_mode() {
+        for mode in [
+            crate::MembershipDeltaWriteMode::LegacyExclusive,
+            crate::MembershipDeltaWriteMode::DisjointV2,
+        ] {
+            for (kind, definition) in [
+                (
+                    "node",
+                    SecondaryIndexDefinition::node_equality("User", "status")
+                        .expect("node equality definition validates"),
+                ),
+                (
+                    "edge",
+                    SecondaryIndexDefinition::edge_equality("FOLLOWS", "status")
+                        .expect("edge equality definition validates"),
+                ),
+            ] {
+                let db =
+                    test_db_with_mode(&format!("secondary-corrupt-{mode:?}-{kind}-equality"), mode)
+                        .await;
+                let handle = active_read_handle(&db, definition).await;
+                let key = secondary_entry_key(
+                    handle.scope(),
+                    handle.index_id(),
+                    handle.generation(),
+                    handle
+                        .secondary_definition()
+                        .expect("secondary handle retains its definition"),
+                    CanonicalSecondaryValue::equality_string("corrupt"),
+                    IndexEntityId::initial(),
+                )
+                .expect("equality bitmap key validates");
+                let corrupt = Bytes::from_static(b"corrupt-equality-bitmap");
+                db.put(&key, corrupt.clone()).await.unwrap();
+
+                let transaction = db
+                    .begin(IsolationLevel::SerializableSnapshot)
+                    .await
+                    .unwrap();
+                assert!(
+                    stage_bitmap_changes(
+                        &transaction,
+                        &BTreeMap::from([(key.clone(), BTreeMap::from([(1, false)]))]),
+                    )
+                    .await
+                    .is_err(),
+                    "{mode:?} {kind} equality corruption"
+                );
+                transaction.rollback();
+                assert_eq!(
+                    db.get(&key).await.unwrap(),
+                    Some(corrupt),
+                    "{mode:?} {kind} equality corruption"
+                );
+                db.close().await.unwrap();
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -53,7 +53,8 @@ use crate::encoding::v2::values::property::range_index_value::{
 };
 use crate::encoding::v2::values::{
     decode_applied_state, decode_build_delta, decode_index_record, decode_secondary_entry,
-    encode_applied_state, encode_build_delta, encode_secondary_entry, SecondaryEqualityBitmapValue,
+    encode_applied_state, encode_build_delta, encode_secondary_entry, BitmapMembershipDelta,
+    SecondaryEqualityBitmapValue,
 };
 use crate::error::{HelixDbError, Result, SecondaryIndexValueError};
 use crate::index_lifecycle::outbox::{
@@ -2553,52 +2554,19 @@ async fn stage_bitmap_changes(
     transaction: &DbTransaction,
     changes: &BTreeMap<Bytes, BTreeMap<u64, bool>>,
 ) -> Result<()> {
-    let exclusive_keys = changes
-        .iter()
-        .filter(|(_, changes)| changes.values().any(|present| !present))
-        .map(|(key, _)| key.clone())
-        .collect::<Vec<_>>();
-    let exclusive_values = if exclusive_keys.is_empty() {
-        Vec::new()
-    } else {
-        transaction.multi_get(&exclusive_keys).await?
-    };
-    let mut exclusive_values = exclusive_keys
-        .into_iter()
-        .zip(exclusive_values)
-        .collect::<BTreeMap<_, _>>();
-
     for (key, changes) in changes {
-        if changes.values().all(|present| *present) {
-            let additions = roaring::RoaringTreemap::from_iter(changes.keys().copied());
-            transaction
-                .merge_commutative(key, SecondaryEqualityBitmapValue::new(additions).encode())?;
-            continue;
-        }
-
-        let existing = exclusive_values
-            .remove(key)
-            .expect("each removal-bearing bitmap key was read exactly once");
-        let mut bitmap = existing
-            .as_deref()
-            .map(SecondaryEqualityBitmapValue::decode)
-            .transpose()?
-            .map(SecondaryEqualityBitmapValue::into_ids)
-            .unwrap_or_default();
+        let mut delta = BitmapMembershipDelta::default();
+        let mut discriminators = Vec::with_capacity(changes.len());
         for (entity_id, present) in changes {
+            discriminators.push(Bytes::copy_from_slice(&entity_id.to_be_bytes()));
             if *present {
-                bitmap.insert(*entity_id);
+                delta.add(*entity_id);
             } else {
-                bitmap.remove(*entity_id);
+                delta.remove(*entity_id);
             }
         }
-        if bitmap.is_empty() {
-            transaction.delete(key)?;
-        } else {
-            transaction.put(key, SecondaryEqualityBitmapValue::new(bitmap).encode())?;
-        }
+        transaction.merge_disjoint(key, discriminators, delta.encode())?;
     }
-    assert!(exclusive_values.is_empty());
     Ok(())
 }
 
@@ -5712,7 +5680,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn removal_bearing_bitmap_changes_replace_or_delete_exclusively() {
+    async fn removal_bearing_bitmap_changes_merge_or_tombstone() {
         let db = test_db("secondary-mixed-bitmap-changes").await;
         let handle = active_read_handle(
             &db,
@@ -5790,7 +5758,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pure_bitmap_additions_commit_without_conflicts() {
+    async fn pure_bitmap_additions_commit_as_disjoint_merges() {
         let db = test_db("secondary-commutative-bitmap-additions").await;
         let handle = active_read_handle(
             &db,
@@ -5857,6 +5825,135 @@ mod tests {
         db.close()
             .await
             .expect("commutative bitmap database closes");
+    }
+
+    #[tokio::test]
+    async fn secondary_bitmap_insert_remove_races_respect_logical_members() {
+        let db = test_db("secondary-disjoint-bitmap-races").await;
+        let handle = active_read_handle(
+            &db,
+            SecondaryIndexDefinition::node_equality("User", "status")
+                .expect("node equality definition validates"),
+        )
+        .await;
+        let definition = handle
+            .secondary_definition()
+            .expect("secondary handle retains its definition");
+
+        for insert_commits_first in [false, true] {
+            let key = secondary_entry_key(
+                handle.scope(),
+                handle.index_id(),
+                handle.generation(),
+                definition,
+                CanonicalSecondaryValue::equality_string(&format!(
+                    "disjoint-{insert_commits_first}"
+                )),
+                IndexEntityId::initial(),
+            )
+            .expect("bitmap key validates");
+            db.put(
+                &key,
+                SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1])).encode(),
+            )
+            .await
+            .expect("initial bitmap persists");
+            let insert = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("insert transaction begins");
+            let remove = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("remove transaction begins");
+            stage_bitmap_changes(
+                &insert,
+                &BTreeMap::from([(key.clone(), BTreeMap::from([(2, true)]))]),
+            )
+            .await
+            .expect("insert stages");
+            stage_bitmap_changes(
+                &remove,
+                &BTreeMap::from([(key.clone(), BTreeMap::from([(1, false)]))]),
+            )
+            .await
+            .expect("remove stages");
+            if insert_commits_first {
+                insert.commit().await.expect("insert commits");
+                remove.commit().await.expect("disjoint remove commits");
+            } else {
+                remove.commit().await.expect("remove commits");
+                insert.commit().await.expect("disjoint insert commits");
+            }
+            assert_eq!(
+                SecondaryEqualityBitmapValue::decode(
+                    &db.get(&key)
+                        .await
+                        .expect("result bitmap reads")
+                        .expect("result bitmap exists"),
+                )
+                .unwrap()
+                .into_ids()
+                .iter()
+                .collect::<Vec<_>>(),
+                vec![2]
+            );
+        }
+
+        for insert_commits_first in [false, true] {
+            let key = secondary_entry_key(
+                handle.scope(),
+                handle.index_id(),
+                handle.generation(),
+                definition,
+                CanonicalSecondaryValue::equality_string(&format!(
+                    "overlap-{insert_commits_first}"
+                )),
+                IndexEntityId::initial(),
+            )
+            .expect("bitmap key validates");
+            db.put(
+                &key,
+                SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1])).encode(),
+            )
+            .await
+            .expect("initial bitmap persists");
+            let insert = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("insert transaction begins");
+            let remove = db
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("remove transaction begins");
+            stage_bitmap_changes(
+                &insert,
+                &BTreeMap::from([(key.clone(), BTreeMap::from([(1, true)]))]),
+            )
+            .await
+            .expect("insert stages");
+            stage_bitmap_changes(
+                &remove,
+                &BTreeMap::from([(key, BTreeMap::from([(1, false)]))]),
+            )
+            .await
+            .expect("remove stages");
+            if insert_commits_first {
+                insert.commit().await.expect("insert commits");
+                assert_eq!(
+                    remove.commit().await.unwrap_err().kind(),
+                    slatedb::ErrorKind::Transaction
+                );
+            } else {
+                remove.commit().await.expect("remove commits");
+                assert_eq!(
+                    insert.commit().await.unwrap_err().kind(),
+                    slatedb::ErrorKind::Transaction
+                );
+            }
+        }
+
+        db.close().await.expect("bitmap race database closes");
     }
 
     #[tokio::test]

--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -2578,14 +2578,15 @@ async fn stage_bitmap_changes(
                     transaction.put_with_options(
                         key,
                         SecondaryEqualityBitmapValue::new(bitmap).encode(),
-                        &slatedb::PutOptions {
-                            ttl: slatedb::Ttl::NoExpiry,
+                        &slatedb::config::PutOptions {
+                            ttl: slatedb::config::Ttl::NoExpiry,
                         },
                     )?;
                 }
             }
         }
         crate::MembershipDeltaWriteMode::DisjointV2 => {
+            let mut merges = Vec::with_capacity(changes.len());
             for (key, changes) in changes {
                 let mut delta = BitmapMembershipDelta::default();
                 for (entity_id, present) in changes {
@@ -2595,14 +2596,13 @@ async fn stage_bitmap_changes(
                         delta.remove(*entity_id);
                     }
                 }
-                transaction
-                    .merge_disjoint_tokens_checked(
-                        key,
-                        delta.members().map(u128::from),
-                        delta.encode(),
-                    )
-                    .await?;
+                merges.push(slatedb::DisjointMergeBatchEntry::from_tokens(
+                    key.clone(),
+                    delta.members().map(u128::from),
+                    delta.encode(),
+                ));
             }
+            transaction.merge_disjoint_checked_batch(merges).await?;
         }
     }
     Ok(())

--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -2556,16 +2556,14 @@ async fn stage_bitmap_changes(
 ) -> Result<()> {
     for (key, changes) in changes {
         let mut delta = BitmapMembershipDelta::default();
-        let mut discriminators = Vec::with_capacity(changes.len());
         for (entity_id, present) in changes {
-            discriminators.push(Bytes::copy_from_slice(&entity_id.to_be_bytes()));
             if *present {
                 delta.add(*entity_id);
             } else {
                 delta.remove(*entity_id);
             }
         }
-        transaction.merge_disjoint(key, discriminators, delta.encode())?;
+        transaction.merge_disjoint_tokens(key, delta.members().map(u128::from), delta.encode())?;
     }
     Ok(())
 }

--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -5828,132 +5828,144 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn secondary_bitmap_insert_remove_races_respect_logical_members() {
-        let db = test_db("secondary-disjoint-bitmap-races").await;
-        let handle = active_read_handle(
-            &db,
-            SecondaryIndexDefinition::node_equality("User", "status")
-                .expect("node equality definition validates"),
-        )
-        .await;
-        let definition = handle
-            .secondary_definition()
-            .expect("secondary handle retains its definition");
+    async fn node_and_edge_equality_bitmap_races_respect_logical_members() {
+        let fixtures = [
+            (
+                "node",
+                SecondaryIndexDefinition::node_equality("User", "status")
+                    .expect("node equality definition validates"),
+            ),
+            (
+                "edge",
+                SecondaryIndexDefinition::edge_equality("FOLLOWS", "status")
+                    .expect("edge equality definition validates"),
+            ),
+        ];
 
-        for insert_commits_first in [false, true] {
-            let key = secondary_entry_key(
-                handle.scope(),
-                handle.index_id(),
-                handle.generation(),
-                definition,
-                CanonicalSecondaryValue::equality_string(&format!(
-                    "disjoint-{insert_commits_first}"
-                )),
-                IndexEntityId::initial(),
-            )
-            .expect("bitmap key validates");
-            db.put(
-                &key,
-                SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1])).encode(),
-            )
-            .await
-            .expect("initial bitmap persists");
-            let insert = db
-                .begin(IsolationLevel::SerializableSnapshot)
-                .await
-                .expect("insert transaction begins");
-            let remove = db
-                .begin(IsolationLevel::SerializableSnapshot)
-                .await
-                .expect("remove transaction begins");
-            stage_bitmap_changes(
-                &insert,
-                &BTreeMap::from([(key.clone(), BTreeMap::from([(2, true)]))]),
-            )
-            .await
-            .expect("insert stages");
-            stage_bitmap_changes(
-                &remove,
-                &BTreeMap::from([(key.clone(), BTreeMap::from([(1, false)]))]),
-            )
-            .await
-            .expect("remove stages");
-            if insert_commits_first {
-                insert.commit().await.expect("insert commits");
-                remove.commit().await.expect("disjoint remove commits");
-            } else {
-                remove.commit().await.expect("remove commits");
-                insert.commit().await.expect("disjoint insert commits");
-            }
-            assert_eq!(
-                SecondaryEqualityBitmapValue::decode(
-                    &db.get(&key)
-                        .await
-                        .expect("result bitmap reads")
-                        .expect("result bitmap exists"),
+        for (kind, fixture) in fixtures {
+            let db = test_db(&format!("secondary-disjoint-{kind}-bitmap-races")).await;
+            let handle = active_read_handle(&db, fixture).await;
+            let definition = handle
+                .secondary_definition()
+                .expect("secondary handle retains its definition");
+
+            for insert_commits_first in [false, true] {
+                let key = secondary_entry_key(
+                    handle.scope(),
+                    handle.index_id(),
+                    handle.generation(),
+                    definition,
+                    CanonicalSecondaryValue::equality_string(&format!(
+                        "disjoint-{insert_commits_first}"
+                    )),
+                    IndexEntityId::initial(),
                 )
-                .unwrap()
-                .into_ids()
-                .iter()
-                .collect::<Vec<_>>(),
-                vec![2]
-            );
-        }
-
-        for insert_commits_first in [false, true] {
-            let key = secondary_entry_key(
-                handle.scope(),
-                handle.index_id(),
-                handle.generation(),
-                definition,
-                CanonicalSecondaryValue::equality_string(&format!(
-                    "overlap-{insert_commits_first}"
-                )),
-                IndexEntityId::initial(),
-            )
-            .expect("bitmap key validates");
-            db.put(
-                &key,
-                SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1])).encode(),
-            )
-            .await
-            .expect("initial bitmap persists");
-            let insert = db
-                .begin(IsolationLevel::SerializableSnapshot)
+                .expect("bitmap key validates");
+                db.put(
+                    &key,
+                    SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1]))
+                        .encode(),
+                )
                 .await
-                .expect("insert transaction begins");
-            let remove = db
-                .begin(IsolationLevel::SerializableSnapshot)
+                .expect("initial bitmap persists");
+                let insert = db
+                    .begin(IsolationLevel::SerializableSnapshot)
+                    .await
+                    .expect("insert transaction begins");
+                let remove = db
+                    .begin(IsolationLevel::SerializableSnapshot)
+                    .await
+                    .expect("remove transaction begins");
+                stage_bitmap_changes(
+                    &insert,
+                    &BTreeMap::from([(key.clone(), BTreeMap::from([(2, true)]))]),
+                )
                 .await
-                .expect("remove transaction begins");
-            stage_bitmap_changes(
-                &insert,
-                &BTreeMap::from([(key.clone(), BTreeMap::from([(1, true)]))]),
-            )
-            .await
-            .expect("insert stages");
-            stage_bitmap_changes(
-                &remove,
-                &BTreeMap::from([(key, BTreeMap::from([(1, false)]))]),
-            )
-            .await
-            .expect("remove stages");
-            if insert_commits_first {
-                insert.commit().await.expect("insert commits");
+                .expect("insert stages");
+                stage_bitmap_changes(
+                    &remove,
+                    &BTreeMap::from([(key.clone(), BTreeMap::from([(1, false)]))]),
+                )
+                .await
+                .expect("remove stages");
+                if insert_commits_first {
+                    insert.commit().await.expect("insert commits");
+                    remove.commit().await.expect("disjoint remove commits");
+                } else {
+                    remove.commit().await.expect("remove commits");
+                    insert.commit().await.expect("disjoint insert commits");
+                }
                 assert_eq!(
-                    remove.commit().await.unwrap_err().kind(),
-                    slatedb::ErrorKind::Transaction
-                );
-            } else {
-                remove.commit().await.expect("remove commits");
-                assert_eq!(
-                    insert.commit().await.unwrap_err().kind(),
-                    slatedb::ErrorKind::Transaction
+                    SecondaryEqualityBitmapValue::decode(
+                        &db.get(&key)
+                            .await
+                            .expect("result bitmap reads")
+                            .expect("result bitmap exists"),
+                    )
+                    .unwrap()
+                    .into_ids()
+                    .iter()
+                    .collect::<Vec<_>>(),
+                    vec![2]
                 );
             }
-        }
 
-        db.close().await.expect("bitmap race database closes");
+            for insert_commits_first in [false, true] {
+                let key = secondary_entry_key(
+                    handle.scope(),
+                    handle.index_id(),
+                    handle.generation(),
+                    definition,
+                    CanonicalSecondaryValue::equality_string(&format!(
+                        "overlap-{insert_commits_first}"
+                    )),
+                    IndexEntityId::initial(),
+                )
+                .expect("bitmap key validates");
+                db.put(
+                    &key,
+                    SecondaryEqualityBitmapValue::new(roaring::RoaringTreemap::from_iter([1]))
+                        .encode(),
+                )
+                .await
+                .expect("initial bitmap persists");
+                let insert = db
+                    .begin(IsolationLevel::SerializableSnapshot)
+                    .await
+                    .expect("insert transaction begins");
+                let remove = db
+                    .begin(IsolationLevel::SerializableSnapshot)
+                    .await
+                    .expect("remove transaction begins");
+                stage_bitmap_changes(
+                    &insert,
+                    &BTreeMap::from([(key.clone(), BTreeMap::from([(1, true)]))]),
+                )
+                .await
+                .expect("insert stages");
+                stage_bitmap_changes(
+                    &remove,
+                    &BTreeMap::from([(key, BTreeMap::from([(1, false)]))]),
+                )
+                .await
+                .expect("remove stages");
+                if insert_commits_first {
+                    insert.commit().await.expect("insert commits");
+                    assert_eq!(
+                        remove.commit().await.unwrap_err().kind(),
+                        slatedb::ErrorKind::Transaction
+                    );
+                } else {
+                    remove.commit().await.expect("remove commits");
+                    assert_eq!(
+                        insert.commit().await.unwrap_err().kind(),
+                        slatedb::ErrorKind::Transaction
+                    );
+                }
+            }
+
+            db.close().await.expect("bitmap race database closes");
+        }
     }
 
     #[tokio::test]

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -17,6 +17,7 @@ pub mod id_allocator;
 pub mod index_lifecycle;
 #[cfg(feature = "index-lifecycle-testing")]
 pub mod index_lifecycle_testing;
+mod membership_delta;
 mod merge_operator;
 #[cfg(feature = "migration-parity")]
 pub mod migration_parity;
@@ -101,6 +102,16 @@ pub enum HelixDbMode {
     ReadOnly,
     /// Read/write handle.
     Writer,
+}
+
+/// Persisted write strategy for shared graph membership rows.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum MembershipDeltaWriteMode {
+    /// Emit only canonical values through the legacy exclusive update path.
+    #[default]
+    LegacyExclusive,
+    /// Emit conflict-safe V2 membership delta operands.
+    DisjointV2,
 }
 
 /// Meaning of the byte accounting exposed for one cache tier.
@@ -1232,6 +1243,30 @@ impl HelixDB {
     /// Whether this handle can execute write plans.
     pub fn is_writer_mode(&self) -> bool {
         self.mode() == HelixDbMode::Writer
+    }
+
+    /// Returns the persisted shared-membership write strategy.
+    pub async fn membership_delta_write_mode(&self) -> Result<MembershipDeltaWriteMode> {
+        match self.storage() {
+            HelixStorage::Reader(reader) => {
+                membership_delta::read_write_mode(reader.as_ref()).await
+            }
+            HelixStorage::Writer(writer) => membership_delta::read_write_mode(writer.db()).await,
+        }
+    }
+
+    /// Permanently enables V2 disjoint membership operands for this database.
+    ///
+    /// The caller must first prove that every active reader supports V2 and
+    /// fence all older processes. After activation, rollback to a pre-V2 binary
+    /// is unsafe and must be rejected by deployment tooling.
+    pub async fn activate_membership_delta_v2(&self) -> Result<()> {
+        let HelixStorage::Writer(writer) = self.storage() else {
+            return Err(HelixDbError::WriterModeRequired {
+                actual: self.mode().as_str(),
+            });
+        };
+        membership_delta::activate(writer.db()).await
     }
 
     async fn start_background_migration_worker(&self) {
@@ -3026,6 +3061,51 @@ mod tests {
             .unwrap();
         assert!(Arc::ptr_eq(reader.object_store(), &expected_store,));
         reader.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn membership_delta_activation_is_durable_and_reader_visible() {
+        let token = ProcessLocalDatabaseToken::new("facade-membership-delta-activation").unwrap();
+        let writer = HelixDB::open(HelixDbSource::InMemoryToken {
+            token: token.clone(),
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            writer.membership_delta_write_mode().await.unwrap(),
+            MembershipDeltaWriteMode::LegacyExclusive
+        );
+        writer.activate_membership_delta_v2().await.unwrap();
+        assert_eq!(
+            writer.membership_delta_write_mode().await.unwrap(),
+            MembershipDeltaWriteMode::DisjointV2
+        );
+        writer.inner_db().flush().await.unwrap();
+        writer.close().await.unwrap();
+
+        let reader = HelixDB::open_reader(HelixDbSource::InMemoryToken {
+            token: token.clone(),
+        })
+        .await
+        .expect("a new reader accepts the activated storage fence");
+        assert_eq!(
+            reader.membership_delta_write_mode().await.unwrap(),
+            MembershipDeltaWriteMode::DisjointV2
+        );
+        assert!(matches!(
+            reader.activate_membership_delta_v2().await,
+            Err(HelixDbError::WriterModeRequired { .. })
+        ));
+        reader.close().await.unwrap();
+
+        let writer = HelixDB::open(HelixDbSource::InMemoryToken { token })
+            .await
+            .expect("a writer reopens after the one-way format activation");
+        assert_eq!(
+            writer.membership_delta_write_mode().await.unwrap(),
+            MembershipDeltaWriteMode::DisjointV2
+        );
+        writer.close().await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -105,7 +105,9 @@ pub enum HelixDbMode {
 }
 
 /// Persisted write strategy for shared graph membership rows.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize,
+)]
 pub enum MembershipDeltaWriteMode {
     /// Emit only canonical values through the legacy exclusive update path.
     #[default]

--- a/crates/db/src/membership_delta.rs
+++ b/crates/db/src/membership_delta.rs
@@ -1,0 +1,261 @@
+//! Persisted activation boundary for V2 graph membership delta operands.
+
+use bytes::Bytes;
+use slatedb::{Db, DbReadOps, DbTransaction, IsolationLevel};
+
+use crate::encoding::v2::keys::{GlobalKey, ManagedIndexKey};
+use crate::encoding::v2::values::{decode_metadata_value, encode_metadata_value};
+use crate::index_lifecycle::{IndexStorageVersion, IndexV2MetadataValue};
+use crate::{HelixDbError, MembershipDeltaWriteMode, Result};
+
+fn write_mode_key() -> Bytes {
+    ManagedIndexKey::Global {
+        kind: GlobalKey::MembershipDeltaWriteMode,
+    }
+    .to_bytes()
+}
+
+fn storage_version_key() -> Bytes {
+    ManagedIndexKey::Global {
+        kind: GlobalKey::StorageVersion,
+    }
+    .to_bytes()
+}
+
+fn decode_write_mode(
+    mode: Option<&[u8]>,
+    storage_version: Option<&[u8]>,
+) -> Result<MembershipDeltaWriteMode> {
+    let mode = mode
+        .map(|value| {
+            let IndexV2MetadataValue::MembershipDeltaWriteMode(mode) = decode_metadata_value(value)
+                .map_err(|error| HelixDbError::MigrationRequired {
+                    reason: format!("membership delta write mode is malformed: {error}"),
+                })?
+            else {
+                return Err(HelixDbError::MigrationRequired {
+                    reason: "membership delta write mode contains another metadata value"
+                        .to_string(),
+                });
+            };
+            Ok(mode)
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let storage_version = storage_version
+        .map(|value| {
+            let IndexV2MetadataValue::StorageVersion(version) = decode_metadata_value(value)
+                .map_err(|error| HelixDbError::MigrationRequired {
+                    reason: format!("membership delta storage fence is malformed: {error}"),
+                })?
+            else {
+                return Err(HelixDbError::MigrationRequired {
+                    reason: "membership delta storage fence contains another metadata value"
+                        .to_string(),
+                });
+            };
+            Ok(version)
+        })
+        .transpose()?;
+
+    match (mode, storage_version) {
+        (MembershipDeltaWriteMode::LegacyExclusive, None) => {
+            Ok(MembershipDeltaWriteMode::LegacyExclusive)
+        }
+        (MembershipDeltaWriteMode::LegacyExclusive, Some(version))
+            if version <= IndexStorageVersion::CURRENT =>
+        {
+            Ok(MembershipDeltaWriteMode::LegacyExclusive)
+        }
+        (MembershipDeltaWriteMode::DisjointV2, Some(IndexStorageVersion::DISJOINT_MEMBERSHIP)) => {
+            Ok(MembershipDeltaWriteMode::DisjointV2)
+        }
+        _ => Err(HelixDbError::MigrationRequired {
+            reason: "membership delta write mode and storage format fence disagree".to_string(),
+        }),
+    }
+}
+
+pub(crate) async fn read_write_mode(
+    reader: &(impl DbReadOps + Send + Sync),
+) -> Result<MembershipDeltaWriteMode> {
+    let [mode_key, storage_version_key] = [write_mode_key(), storage_version_key()];
+    let values = reader.multi_get(&[mode_key, storage_version_key]).await?;
+    let [mode, storage_version] = values.as_slice() else {
+        unreachable!("membership delta metadata lookup requests exactly two keys")
+    };
+    decode_write_mode(mode.as_deref(), storage_version.as_deref())
+}
+
+pub(crate) async fn transaction_write_mode(
+    transaction: &DbTransaction,
+) -> Result<MembershipDeltaWriteMode> {
+    read_write_mode(transaction).await
+}
+
+pub(crate) async fn activate(db: &Db) -> Result<()> {
+    let transaction = db.begin(IsolationLevel::SerializableSnapshot).await?;
+    let key = write_mode_key();
+    let version_key = storage_version_key();
+    let mode = transaction.get(&key).await?;
+    let storage_version = transaction.get(&version_key).await?;
+    match decode_write_mode(mode.as_deref(), storage_version.as_deref())? {
+        MembershipDeltaWriteMode::LegacyExclusive => {
+            let Some(storage_version) = storage_version else {
+                return Err(HelixDbError::MigrationRequired {
+                    reason: "membership delta activation requires a bootstrapped storage marker"
+                        .to_string(),
+                });
+            };
+            let IndexV2MetadataValue::StorageVersion(storage_version) =
+                decode_metadata_value(&storage_version)?
+            else {
+                return Err(HelixDbError::MigrationRequired {
+                    reason: "membership delta storage fence contains another metadata value"
+                        .to_string(),
+                });
+            };
+            if storage_version != IndexStorageVersion::CURRENT {
+                return Err(HelixDbError::MigrationRequired {
+                    reason: format!(
+                        "membership delta activation requires storage version {}, found {}",
+                        IndexStorageVersion::CURRENT.get(),
+                        storage_version.get()
+                    ),
+                });
+            }
+            let no_expiry = slatedb::PutOptions {
+                ttl: slatedb::Ttl::NoExpiry,
+            };
+            transaction.put_with_options(
+                key,
+                encode_metadata_value(&IndexV2MetadataValue::MembershipDeltaWriteMode(
+                    MembershipDeltaWriteMode::DisjointV2,
+                )),
+                &no_expiry,
+            )?;
+            transaction.put_with_options(
+                version_key,
+                encode_metadata_value(&IndexV2MetadataValue::StorageVersion(
+                    IndexStorageVersion::DISJOINT_MEMBERSHIP,
+                )),
+                &no_expiry,
+            )?;
+        }
+        MembershipDeltaWriteMode::DisjointV2 => {}
+    }
+    transaction.commit().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use slatedb::object_store::memory::InMemory;
+
+    use super::*;
+    use crate::merge_operator::HelixMergeOperator;
+
+    async fn test_db(name: &str) -> Db {
+        let db = Db::builder(name, Arc::new(InMemory::new()))
+            .with_merge_operator(Arc::new(HelixMergeOperator::new()))
+            .build()
+            .await
+            .unwrap();
+        crate::migrations::startup::bootstrap_writer(&db)
+            .await
+            .unwrap();
+        db
+    }
+
+    #[tokio::test]
+    async fn activation_is_persisted_idempotent_and_monotonic() {
+        let db = test_db("membership-delta-activation").await;
+        assert_eq!(
+            read_write_mode(&db).await.unwrap(),
+            MembershipDeltaWriteMode::LegacyExclusive
+        );
+        activate(&db).await.unwrap();
+        activate(&db).await.unwrap();
+        assert_eq!(
+            read_write_mode(&db).await.unwrap(),
+            MembershipDeltaWriteMode::DisjointV2
+        );
+        let version = db.get(storage_version_key()).await.unwrap().unwrap();
+        assert_eq!(
+            decode_metadata_value(&version).unwrap(),
+            IndexV2MetadataValue::StorageVersion(IndexStorageVersion::DISJOINT_MEMBERSHIP)
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_activation_marker_fails_closed() {
+        let db = test_db("membership-delta-corrupt-activation").await;
+        db.put(write_mode_key(), b"invalid").await.unwrap();
+        assert!(read_write_mode(&db).await.is_err());
+        assert!(activate(&db).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn mode_and_storage_fence_must_change_together() {
+        let db = test_db("membership-delta-inconsistent-activation").await;
+        db.put(
+            write_mode_key(),
+            encode_metadata_value(&IndexV2MetadataValue::MembershipDeltaWriteMode(
+                MembershipDeltaWriteMode::DisjointV2,
+            )),
+        )
+        .await
+        .unwrap();
+        assert!(read_write_mode(&db).await.is_err());
+        assert!(activate(&db).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn legacy_storage_versions_remain_migratable_but_cannot_activate_early() {
+        let db = test_db("membership-delta-legacy-storage-version").await;
+        let legacy_version = IndexStorageVersion::new(0x0003).unwrap();
+        db.put(
+            storage_version_key(),
+            encode_metadata_value(&IndexV2MetadataValue::StorageVersion(legacy_version)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            read_write_mode(&db).await.unwrap(),
+            MembershipDeltaWriteMode::LegacyExclusive
+        );
+        assert!(matches!(
+            activate(&db).await,
+            Err(HelixDbError::MigrationRequired { .. })
+        ));
+        assert_eq!(
+            read_write_mode(&db).await.unwrap(),
+            MembershipDeltaWriteMode::LegacyExclusive
+        );
+    }
+
+    #[tokio::test]
+    async fn activation_conflicts_with_a_writer_that_observed_legacy_mode() {
+        let db = test_db("membership-delta-activation-fences-legacy-writer").await;
+        let legacy_writer = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .unwrap();
+        assert_eq!(
+            transaction_write_mode(&legacy_writer).await.unwrap(),
+            MembershipDeltaWriteMode::LegacyExclusive
+        );
+        legacy_writer.put(b"legacy-write", b"staged").unwrap();
+
+        activate(&db).await.unwrap();
+        assert!(legacy_writer.commit().await.is_err());
+        assert_eq!(db.get(b"legacy-write").await.unwrap(), None);
+        assert_eq!(
+            read_write_mode(&db).await.unwrap(),
+            MembershipDeltaWriteMode::DisjointV2
+        );
+    }
+}

--- a/crates/db/src/membership_delta.rs
+++ b/crates/db/src/membership_delta.rs
@@ -124,8 +124,8 @@ pub(crate) async fn activate(db: &Db) -> Result<()> {
                     ),
                 });
             }
-            let no_expiry = slatedb::PutOptions {
-                ttl: slatedb::Ttl::NoExpiry,
+            let no_expiry = slatedb::config::PutOptions {
+                ttl: slatedb::config::Ttl::NoExpiry,
             };
             transaction.put_with_options(
                 key,

--- a/crates/db/src/membership_delta.rs
+++ b/crates/db/src/membership_delta.rs
@@ -22,7 +22,7 @@ fn storage_version_key() -> Bytes {
     .to_bytes()
 }
 
-fn decode_write_mode(
+pub(crate) fn decode_write_mode(
     mode: Option<&[u8]>,
     storage_version: Option<&[u8]>,
 ) -> Result<MembershipDeltaWriteMode> {

--- a/crates/db/src/merge_operator.rs
+++ b/crates/db/src/merge_operator.rs
@@ -158,6 +158,21 @@ impl MergeOperator for BitmapMergeOperator {
             Self::encode(&bitmap).map(MergeResult::Value)
         }
     }
+
+    fn validate_merge_with_base(
+        &self,
+        _key: &Bytes,
+        existing_value: Option<Bytes>,
+        operands: &[Bytes],
+    ) -> Result<(), MergeOperatorError> {
+        if let Some(existing) = existing_value {
+            SecondaryEqualityBitmapValue::decode(&existing).map_err(merge_decode_error)?;
+        }
+        for operand in operands {
+            Self::decode_operand(operand)?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -332,6 +347,21 @@ impl MergeOperator for EdgeMergeOperator {
         } else {
             Ok(MergeResult::Value(edges::encode_edges(&merged)))
         }
+    }
+
+    fn validate_merge_with_base(
+        &self,
+        _key: &Bytes,
+        existing_value: Option<Bytes>,
+        operands: &[Bytes],
+    ) -> Result<(), MergeOperatorError> {
+        if let Some(existing) = existing_value {
+            edges::decode_edges(&existing).map_err(merge_decode_error)?;
+        }
+        for operand in operands {
+            Self::decode_operand(operand)?;
+        }
+        Ok(())
     }
 }
 
@@ -606,6 +636,36 @@ impl MergeOperator for HelixMergeOperator {
                 .ok_or(MergeOperatorError::EmptyBatch),
         }
     }
+
+    fn validate_merge_with_base(
+        &self,
+        key: &Bytes,
+        existing_value: Option<Bytes>,
+        operands: &[Bytes],
+    ) -> Result<(), MergeOperatorError> {
+        match Self::key_type(key) {
+            MergeKeyType::Edge => self
+                .edge
+                .validate_merge_with_base(key, existing_value, operands),
+            MergeKeyType::Bitmap => {
+                self.bitmap
+                    .validate_merge_with_base(key, existing_value, operands)
+            }
+            MergeKeyType::Layer0 => {
+                self.layer0
+                    .validate_merge_with_base(key, existing_value, operands)
+            }
+            MergeKeyType::Counter => {
+                self.counter
+                    .validate_merge_with_base(key, existing_value, operands)
+            }
+            MergeKeyType::Other => operands
+                .first()
+                .or(existing_value.as_ref())
+                .map(|_| ())
+                .ok_or(MergeOperatorError::EmptyBatch),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -804,6 +864,82 @@ mod tests {
                 .unwrap(),
             MergeResult::Tombstone
         );
+    }
+
+    #[test]
+    fn shared_row_validation_matches_full_resolution_acceptance() {
+        let bitmap_key = DataKey::Data {
+            scope: DataScope::LegacyUnscoped,
+            kind: DataKeyKind::EdgePairIndex(EdgePairIndexKey::new(1, 3)),
+        }
+        .to_bytes();
+        let adjacency_key = DataKey::Data {
+            scope: DataScope::LegacyUnscoped,
+            kind: DataKeyKind::Adjacency(AdjacencyKey::new(1)),
+        }
+        .to_bytes();
+        let operator = HelixMergeOperator::new();
+
+        let mut bitmap_delta = BitmapMembershipDelta::default();
+        bitmap_delta.remove(1);
+        bitmap_delta.add(2);
+        let bitmap_operand = bitmap_delta.encode();
+        let malformed_bitmap_delta = Bytes::copy_from_slice(b"HLXRBM2\0");
+        for (base, operand) in [
+            (Some(portable_bitmap([1, 3])), bitmap_operand.clone()),
+            (None, bitmap_operand),
+            (Some(Bytes::from_static(b"corrupt")), portable_bitmap([2])),
+            (Some(portable_bitmap([1])), malformed_bitmap_delta),
+        ] {
+            assert_eq!(
+                operator
+                    .validate_merge_with_base(
+                        &bitmap_key,
+                        base.clone(),
+                        std::slice::from_ref(&operand),
+                    )
+                    .is_ok(),
+                operator
+                    .merge_batch_with_base(&bitmap_key, base, std::slice::from_ref(&operand))
+                    .is_ok(),
+            );
+        }
+
+        let mut base_edges = edges::Edges::new();
+        base_edges.add_out(1);
+        let mut adjacency_delta = edges::AdjacencyMembershipDelta::default();
+        adjacency_delta.remove_out(1);
+        adjacency_delta.add_in(2);
+        let adjacency_operand = adjacency_delta.encode();
+        let malformed_adjacency_delta = Bytes::copy_from_slice(b"HLXADJ2\0");
+        for (base, operand) in [
+            (
+                Some(edges::encode_edges(&base_edges)),
+                adjacency_operand.clone(),
+            ),
+            (None, adjacency_operand),
+            (
+                Some(Bytes::from_static(b"corrupt")),
+                edges::AdjacencyMembershipDelta::default().encode(),
+            ),
+            (
+                Some(edges::encode_edges(&base_edges)),
+                malformed_adjacency_delta,
+            ),
+        ] {
+            assert_eq!(
+                operator
+                    .validate_merge_with_base(
+                        &adjacency_key,
+                        base.clone(),
+                        std::slice::from_ref(&operand),
+                    )
+                    .is_ok(),
+                operator
+                    .merge_batch_with_base(&adjacency_key, base, std::slice::from_ref(&operand))
+                    .is_ok(),
+            );
+        }
     }
 
     #[test]

--- a/crates/db/src/merge_operator.rs
+++ b/crates/db/src/merge_operator.rs
@@ -34,6 +34,7 @@ const BITMAP_DELTA_LEN: usize =
     BITMAP_DELTA_MAGIC.len() + BITMAP_DELTA_OP_LEN + BITMAP_DELTA_ID_LEN;
 const BITMAP_ADD: u8 = 0x00;
 
+#[cfg(any(test, feature = "fuzzing"))]
 pub(crate) fn encode_bitmap_add(id: u64) -> Bytes {
     let mut bytes = Vec::with_capacity(BITMAP_DELTA_LEN);
     bytes.extend_from_slice(BITMAP_DELTA_MAGIC);

--- a/crates/db/src/merge_operator.rs
+++ b/crates/db/src/merge_operator.rs
@@ -2,7 +2,7 @@
 
 use bytes::Bytes;
 use roaring::RoaringTreemap;
-use slatedb::{MergeOperator, MergeOperatorError};
+use slatedb::{MergeOperator, MergeOperatorError, MergeResult};
 
 use crate::encoding::keys::scope::DataScope;
 use crate::encoding::v2::keys::indexes::vector::{
@@ -10,8 +10,8 @@ use crate::encoding::v2::keys::indexes::vector::{
 };
 use crate::encoding::v2::keys::{DataKeyKind, KeyPrefix};
 use crate::encoding::v2::keys::{ManagedIndexKey as V2Key, ScopedKey as V2ScopedKey};
-use crate::encoding::v2::values::SecondaryEqualityBitmapValue;
 use crate::encoding::v2::values::{adjacency as edges, indexes::vector as vectors};
+use crate::encoding::v2::values::{BitmapMembershipDelta, SecondaryEqualityBitmapValue};
 use crate::encoding::NodeId;
 
 const EDGE_DELTA_MIN_LEN: usize = core::mem::size_of::<u8>();
@@ -61,14 +61,19 @@ fn decode_bitmap_add(bytes: &[u8]) -> Option<u64> {
 struct BitmapMergeOperator;
 
 impl BitmapMergeOperator {
-    fn apply(bitmap: &mut RoaringTreemap, bytes: &[u8]) -> Result<(), MergeOperatorError> {
+    fn decode_operand(bytes: &[u8]) -> Result<BitmapMembershipDelta, MergeOperatorError> {
         if let Some(id) = decode_bitmap_add(bytes) {
-            bitmap.insert(id);
-            return Ok(());
+            let mut delta = BitmapMembershipDelta::default();
+            delta.add(id);
+            return Ok(delta);
+        }
+        if let Some(delta) =
+            BitmapMembershipDelta::decode_if_delta(bytes).map_err(merge_decode_error)?
+        {
+            return Ok(delta);
         }
         let decoded = SecondaryEqualityBitmapValue::decode(bytes).map_err(merge_decode_error)?;
-        *bitmap |= decoded.ids();
-        Ok(())
+        Ok(BitmapMembershipDelta::from_additions(decoded.into_ids()))
     }
 
     fn encode(bitmap: &RoaringTreemap) -> Result<Bytes, MergeOperatorError> {
@@ -87,15 +92,20 @@ impl MergeOperator for BitmapMergeOperator {
         existing_value: Option<Bytes>,
         operand: Bytes,
     ) -> Result<Bytes, MergeOperatorError> {
-        let mut bitmap = RoaringTreemap::new();
-        if let Some(existing) = existing_value {
-            Self::apply(&mut bitmap, &existing)?;
+        let operand = Self::decode_operand(&operand)?;
+        let Some(existing) = existing_value else {
+            return Ok(operand.encode());
+        };
+        if let Some(mut delta) =
+            BitmapMembershipDelta::decode_if_delta(&existing).map_err(merge_decode_error)?
+        {
+            delta.compose(&operand);
+            return Ok(delta.encode());
         }
-        if let Some(id) = decode_bitmap_add(&operand) {
-            bitmap.insert(id);
-        } else {
-            Self::apply(&mut bitmap, &operand)?;
-        }
+        let mut bitmap = SecondaryEqualityBitmapValue::decode(&existing)
+            .map_err(merge_decode_error)?
+            .into_ids();
+        operand.apply_to(&mut bitmap);
         Self::encode(&bitmap)
     }
 
@@ -105,14 +115,47 @@ impl MergeOperator for BitmapMergeOperator {
         existing_value: Option<Bytes>,
         operands: &[Bytes],
     ) -> Result<Bytes, MergeOperatorError> {
-        let mut bitmap = RoaringTreemap::new();
-        if let Some(existing) = existing_value {
-            Self::apply(&mut bitmap, &existing)?;
+        let mut delta = BitmapMembershipDelta::default();
+        for operand in operands {
+            delta.compose(&Self::decode_operand(operand)?);
         }
-        for operand in operands.iter().rev() {
-            Self::apply(&mut bitmap, operand)?;
+        let Some(existing) = existing_value else {
+            return Ok(delta.encode());
+        };
+        if let Some(mut existing_delta) =
+            BitmapMembershipDelta::decode_if_delta(&existing).map_err(merge_decode_error)?
+        {
+            existing_delta.compose(&delta);
+            return Ok(existing_delta.encode());
         }
+        let mut bitmap = SecondaryEqualityBitmapValue::decode(&existing)
+            .map_err(merge_decode_error)?
+            .into_ids();
+        delta.apply_to(&mut bitmap);
         Self::encode(&bitmap)
+    }
+
+    fn merge_batch_with_base(
+        &self,
+        _key: &Bytes,
+        existing_value: Option<Bytes>,
+        operands: &[Bytes],
+    ) -> Result<MergeResult, MergeOperatorError> {
+        let mut bitmap = existing_value
+            .as_deref()
+            .map(SecondaryEqualityBitmapValue::decode)
+            .transpose()
+            .map_err(merge_decode_error)?
+            .map(SecondaryEqualityBitmapValue::into_ids)
+            .unwrap_or_default();
+        for operand in operands {
+            Self::decode_operand(operand)?.apply_to(&mut bitmap);
+        }
+        if bitmap.is_empty() {
+            Ok(MergeResult::Tombstone)
+        } else {
+            Self::encode(&bitmap).map(MergeResult::Value)
+        }
     }
 }
 
@@ -168,6 +211,7 @@ fn is_edge_delta(data: &[u8]) -> bool {
 struct EdgeMergeOperator;
 
 impl EdgeMergeOperator {
+    #[cfg(test)]
     fn apply_delta(edges: &mut edges::Edges, op: EdgeDeltaOp, node_id: NodeId) {
         match op {
             EdgeDeltaOp::AddOut => edges.add_out(node_id),
@@ -182,14 +226,31 @@ impl EdgeMergeOperator {
         }
     }
 
-    fn apply_operand(edges: &mut edges::Edges, operand: &[u8]) {
+    fn decode_operand(
+        operand: &[u8],
+    ) -> Result<edges::AdjacencyMembershipDelta, MergeOperatorError> {
+        if let Some(delta) =
+            edges::AdjacencyMembershipDelta::decode_if_delta(operand).map_err(merge_decode_error)?
+        {
+            return Ok(delta);
+        }
         if let Some((op, node_id)) = decode_edge_delta(operand) {
-            Self::apply_delta(edges, op, node_id);
-            return;
+            let mut delta = edges::AdjacencyMembershipDelta::default();
+            match op {
+                EdgeDeltaOp::AddOut => delta.add_out(node_id),
+                EdgeDeltaOp::RemoveOut => delta.remove_out(node_id),
+                EdgeDeltaOp::AddIn => delta.add_in(node_id),
+                EdgeDeltaOp::RemoveIn => delta.remove_in(node_id),
+                EdgeDeltaOp::ResetOut => delta.reset_out(),
+            }
+            return Ok(delta);
         }
-        if let Ok(other) = edges::decode_edges(operand) {
-            edges.merge(&other);
+        if is_edge_delta(operand) {
+            return Err(merge_decode_error("malformed adjacency delta"));
         }
+        edges::decode_edges(operand)
+            .map(|edges| edges::AdjacencyMembershipDelta::from_edges(&edges))
+            .map_err(merge_decode_error)
     }
 }
 
@@ -200,20 +261,23 @@ impl MergeOperator for EdgeMergeOperator {
         existing_value: Option<Bytes>,
         operand: Bytes,
     ) -> Result<Bytes, MergeOperatorError> {
-        let mut merged = existing_value
-            .as_deref()
-            .filter(|value| !is_edge_delta(value))
-            .map(edges::decode_edges)
-            .transpose()
+        let operand = Self::decode_operand(&operand)?;
+        let Some(existing) = existing_value else {
+            return Ok(operand.encode());
+        };
+        if let Some(mut delta) = edges::AdjacencyMembershipDelta::decode_if_delta(&existing)
             .map_err(merge_decode_error)?
-            .unwrap_or_default();
-        if let Some(existing) = existing_value
-            .as_deref()
-            .filter(|value| is_edge_delta(value))
         {
-            Self::apply_operand(&mut merged, existing);
+            delta.compose(&operand);
+            return Ok(delta.encode());
         }
-        Self::apply_operand(&mut merged, &operand);
+        if is_edge_delta(&existing) {
+            let mut delta = Self::decode_operand(&existing)?;
+            delta.compose(&operand);
+            return Ok(delta.encode());
+        }
+        let mut merged = edges::decode_edges(&existing).map_err(merge_decode_error)?;
+        operand.apply_to(&mut merged);
         Ok(edges::encode_edges(&merged))
     }
 
@@ -223,23 +287,50 @@ impl MergeOperator for EdgeMergeOperator {
         existing_value: Option<Bytes>,
         operands: &[Bytes],
     ) -> Result<Bytes, MergeOperatorError> {
+        let mut delta = edges::AdjacencyMembershipDelta::default();
+        for operand in operands {
+            delta.compose(&Self::decode_operand(operand)?);
+        }
+        let Some(existing) = existing_value else {
+            return Ok(delta.encode());
+        };
+        if let Some(mut existing_delta) =
+            edges::AdjacencyMembershipDelta::decode_if_delta(&existing)
+                .map_err(merge_decode_error)?
+        {
+            existing_delta.compose(&delta);
+            return Ok(existing_delta.encode());
+        }
+        if is_edge_delta(&existing) {
+            let mut existing_delta = Self::decode_operand(&existing)?;
+            existing_delta.compose(&delta);
+            return Ok(existing_delta.encode());
+        }
+        let mut merged = edges::decode_edges(&existing).map_err(merge_decode_error)?;
+        delta.apply_to(&mut merged);
+        Ok(edges::encode_edges(&merged))
+    }
+
+    fn merge_batch_with_base(
+        &self,
+        _key: &Bytes,
+        existing_value: Option<Bytes>,
+        operands: &[Bytes],
+    ) -> Result<MergeResult, MergeOperatorError> {
         let mut merged = existing_value
             .as_deref()
-            .filter(|value| !is_edge_delta(value))
             .map(edges::decode_edges)
             .transpose()
             .map_err(merge_decode_error)?
             .unwrap_or_default();
-        if let Some(existing) = existing_value
-            .as_deref()
-            .filter(|value| is_edge_delta(value))
-        {
-            Self::apply_operand(&mut merged, existing);
+        for operand in operands {
+            Self::decode_operand(operand)?.apply_to(&mut merged);
         }
-        for operand in operands.iter().rev() {
-            Self::apply_operand(&mut merged, operand);
+        if merged.is_empty() {
+            Ok(MergeResult::Tombstone)
+        } else {
+            Ok(MergeResult::Value(edges::encode_edges(&merged)))
         }
-        Ok(edges::encode_edges(&merged))
     }
 }
 
@@ -483,6 +574,37 @@ impl MergeOperator for HelixMergeOperator {
                 .ok_or(MergeOperatorError::EmptyBatch),
         }
     }
+
+    fn merge_batch_with_base(
+        &self,
+        key: &Bytes,
+        existing_value: Option<Bytes>,
+        operands: &[Bytes],
+    ) -> Result<MergeResult, MergeOperatorError> {
+        match Self::key_type(key) {
+            MergeKeyType::Edge => self
+                .edge
+                .merge_batch_with_base(key, existing_value, operands),
+            MergeKeyType::Bitmap => {
+                self.bitmap
+                    .merge_batch_with_base(key, existing_value, operands)
+            }
+            MergeKeyType::Layer0 => self
+                .layer0
+                .merge_batch(key, existing_value, operands)
+                .map(MergeResult::Value),
+            MergeKeyType::Counter => self
+                .counter
+                .merge_batch(key, existing_value, operands)
+                .map(MergeResult::Value),
+            MergeKeyType::Other => operands
+                .first()
+                .cloned()
+                .or(existing_value)
+                .map(MergeResult::Value)
+                .ok_or(MergeOperatorError::EmptyBatch),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -592,8 +714,9 @@ mod tests {
     }
 
     fn decode_bitmap(bytes: Bytes) -> Vec<u64> {
-        RoaringTreemap::deserialize_from(Cursor::new(bytes))
+        SecondaryEqualityBitmapValue::decode(&bytes)
             .expect("merged bitmap decodes")
+            .into_ids()
             .iter()
             .collect()
     }
@@ -618,7 +741,7 @@ mod tests {
             )
             .expect("merge succeeds");
         let edges = edges::decode_edges(&merged).expect("edges decode");
-        assert_eq!(edges.iter_out().collect::<Vec<_>>(), vec![7]);
+        assert_eq!(edges.iter_out().collect::<Vec<_>>(), vec![5, 7]);
     }
 
     #[test]
@@ -640,10 +763,99 @@ mod tests {
                 &[base, encode_bitmap_add(42), encode_bitmap_add(42)],
             )
             .expect("bitmap operands merge");
-        let bitmap =
-            RoaringTreemap::deserialize_from(Cursor::new(merged)).expect("merged bitmap decodes");
+        assert_eq!(decode_bitmap(merged), vec![41, 42]);
+    }
 
-        assert_eq!(bitmap.iter().collect::<Vec<_>>(), vec![41, 42]);
+    #[test]
+    fn bitmap_delta_preserves_removals_across_intermediate_merge_batches() {
+        let key = DataKey::Data {
+            scope: DataScope::LegacyUnscoped,
+            kind: DataKeyKind::EdgePairIndex(EdgePairIndexKey::new(1, 3)),
+        }
+        .to_bytes();
+        let operator = HelixMergeOperator::new();
+        let mut older = BitmapMembershipDelta::default();
+        older.remove(1);
+        older.add(3);
+        let mut newer = BitmapMembershipDelta::default();
+        newer.remove(2);
+        newer.add(4);
+        let intermediate = operator
+            .merge_batch(&key, None, &[older.encode(), newer.encode()])
+            .expect("intermediate bitmap delta merges");
+        assert!(BitmapMembershipDelta::decode_if_delta(&intermediate)
+            .unwrap()
+            .is_some());
+
+        let resolved = operator
+            .merge_batch_with_base(&key, Some(portable_bitmap([1, 2, 5])), &[intermediate])
+            .expect("intermediate bitmap delta resolves against its base");
+        let MergeResult::Value(resolved) = resolved else {
+            panic!("non-empty bitmap resolves to a value")
+        };
+        assert_eq!(decode_bitmap(resolved), vec![3, 4, 5]);
+
+        let mut remove_last = BitmapMembershipDelta::default();
+        remove_last.remove(9);
+        assert_eq!(
+            operator
+                .merge_batch_with_base(&key, Some(portable_bitmap([9])), &[remove_last.encode()],)
+                .unwrap(),
+            MergeResult::Tombstone
+        );
+    }
+
+    #[test]
+    fn adjacency_delta_preserves_directional_removals_and_tombstones() {
+        let key = DataKey::Data {
+            scope: DataScope::LegacyUnscoped,
+            kind: DataKeyKind::Adjacency(AdjacencyKey::new(1)),
+        }
+        .to_bytes();
+        let operator = HelixMergeOperator::new();
+        let mut base = edges::Edges::new();
+        base.add_out(1);
+        base.add_out(2);
+        base.add_in(3);
+        let mut older = edges::AdjacencyMembershipDelta::default();
+        older.remove_out(1);
+        older.add_in(4);
+        let mut newer = edges::AdjacencyMembershipDelta::default();
+        newer.remove_in(3);
+        newer.add_out(5);
+        let intermediate = operator
+            .merge_batch(&key, None, &[older.encode(), newer.encode()])
+            .expect("intermediate adjacency delta merges");
+        assert!(
+            edges::AdjacencyMembershipDelta::decode_if_delta(&intermediate)
+                .unwrap()
+                .is_some()
+        );
+
+        let resolved = operator
+            .merge_batch_with_base(&key, Some(edges::encode_edges(&base)), &[intermediate])
+            .expect("intermediate adjacency delta resolves against its base");
+        let MergeResult::Value(resolved) = resolved else {
+            panic!("non-empty adjacency resolves to a value")
+        };
+        let resolved = edges::decode_edges(&resolved).unwrap();
+        assert_eq!(resolved.iter_out().collect::<Vec<_>>(), vec![2, 5]);
+        assert_eq!(resolved.iter_in().collect::<Vec<_>>(), vec![4]);
+
+        let mut remove_last = edges::AdjacencyMembershipDelta::default();
+        remove_last.remove_out(7);
+        let mut last = edges::Edges::new();
+        last.add_out(7);
+        assert_eq!(
+            operator
+                .merge_batch_with_base(
+                    &key,
+                    Some(edges::encode_edges(&last)),
+                    &[remove_last.encode()],
+                )
+                .unwrap(),
+            MergeResult::Tombstone
+        );
     }
 
     #[test]
@@ -777,8 +989,7 @@ mod tests {
             let merged = HelixMergeOperator::new()
                 .merge_batch(&key, None, &[encode_bitmap_add(5), encode_bitmap_add(8)])
                 .unwrap();
-            let bitmap = RoaringTreemap::deserialize_from(Cursor::new(merged)).unwrap();
-            assert_eq!(bitmap, RoaringTreemap::from_iter([5, 8]));
+            assert_eq!(decode_bitmap(merged), vec![5, 8]);
         }
     }
 
@@ -910,6 +1121,58 @@ mod tests {
             .expect("reopened bitmap database closes");
     }
 
+    #[tokio::test]
+    async fn batched_bitmap_removals_survive_cold_reopen_without_empty_rows() {
+        const MEMBERS: u64 = 250;
+
+        let store = Arc::new(InMemory::new());
+        let path = "merge-operator-batched-removals";
+        let db = slatedb::Db::builder(path, store.clone())
+            .with_merge_operator(Arc::new(HelixMergeOperator::new()))
+            .build()
+            .await
+            .expect("batched removal database opens");
+        let key = v4_bitmap_key(DataScope::LegacyUnscoped);
+        db.put(&key, portable_bitmap(0..MEMBERS))
+            .await
+            .expect("bitmap base persists");
+
+        let transaction = db
+            .begin(slatedb::IsolationLevel::SerializableSnapshot)
+            .await
+            .expect("batched removal transaction begins");
+        for id in 0..MEMBERS {
+            let mut delta = BitmapMembershipDelta::default();
+            delta.remove(id);
+            transaction
+                .merge_disjoint(&key, [id.to_be_bytes()], delta.encode())
+                .expect("batched removal stages");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("batched removal transaction commits");
+        assert_eq!(db.get(&key).await.expect("removed bitmap reads"), None);
+
+        db.close().await.expect("batched removal database closes");
+        let reopened = slatedb::Db::builder(path, store)
+            .with_merge_operator(Arc::new(HelixMergeOperator::new()))
+            .build()
+            .await
+            .expect("batched removal database reopens");
+        assert_eq!(
+            reopened
+                .get(&key)
+                .await
+                .expect("reopened removed bitmap reads"),
+            None
+        );
+        reopened
+            .close()
+            .await
+            .expect("reopened removal database closes");
+    }
+
     #[test]
     fn bitmap_add_operands_commute_for_every_existing_bitmap() {
         let key = DataKey::Data {
@@ -989,8 +1252,10 @@ mod tests {
         let mut encoded = edges::Edges::new();
         encoded.add_out(17);
         encoded.add_in(19);
-        EdgeMergeOperator::apply_operand(&mut state, &edges::encode_edges(&encoded));
-        EdgeMergeOperator::apply_operand(&mut state, b"not-an-edge-value");
+        EdgeMergeOperator::decode_operand(&edges::encode_edges(&encoded))
+            .unwrap()
+            .apply_to(&mut state);
+        assert!(EdgeMergeOperator::decode_operand(b"not-an-edge-value").is_err());
         assert!(state.contains_out(17));
         assert!(state.contains_in(19));
     }
@@ -1015,7 +1280,7 @@ mod tests {
             )
             .expect("batch deltas merge from oldest to newest");
         let decoded = edges::decode_edges(&batch).expect("batch edges decode");
-        assert_eq!(decoded.iter_out().collect::<Vec<_>>(), Vec::<u64>::new());
+        assert_eq!(decoded.iter_out().collect::<Vec<_>>(), vec![9]);
 
         assert!(operator
             .merge(

--- a/crates/db/src/migration_parity.rs
+++ b/crates/db/src/migration_parity.rs
@@ -2094,6 +2094,8 @@ async fn scan_v2_state(
     state.text_term_statistics.sort();
     state.text_entity_statistics.sort();
 
+    let mut storage_version_value = None;
+    let mut membership_delta_write_mode_value = None;
     let mut global = read
         .scan_prefix(Bytes::copy_from_slice(&GLOBAL_SENTINEL), ..)
         .await?;
@@ -2103,6 +2105,7 @@ async fn scan_v2_state(
         increment_count(&mut state.global_row_counts, &kind);
         match key {
             GlobalKey::StorageVersion => {
+                storage_version_value = Some(row.value.clone());
                 let crate::index_lifecycle::IndexV2MetadataValue::StorageVersion(version) =
                     decode_metadata_value(&row.value)?
                 else {
@@ -2213,13 +2216,18 @@ async fn scan_v2_state(
                         })?;
                 }
             }
+            GlobalKey::MembershipDeltaWriteMode => {
+                membership_delta_write_mode_value = Some(row.value);
+            }
             GlobalKey::TextCompactionPointer(_)
             | GlobalKey::LogicalIndexIdWatermark
-            | GlobalKey::VectorPhysicalIdWatermark
-            | GlobalKey::MembershipDeltaWriteMode => {}
+            | GlobalKey::VectorPhysicalIdWatermark => {}
         }
     }
-    state.membership_delta_write_mode = crate::membership_delta::read_write_mode(read).await?;
+    state.membership_delta_write_mode = crate::membership_delta::decode_write_mode(
+        membership_delta_write_mode_value.as_deref(),
+        storage_version_value.as_deref(),
+    )?;
     state.vector_migration.rebuilt_indexes =
         u64::try_from(completed_vector_builds.len()).map_err(|_| {
             crate::error::HelixDbError::InvariantViolation(

--- a/crates/db/src/migration_parity.rs
+++ b/crates/db/src/migration_parity.rs
@@ -320,6 +320,8 @@ fn migration_parity_text_partition(
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MigrationParityV2State {
     pub storage_version: Option<u16>,
+    #[serde(default)]
+    pub membership_delta_write_mode: crate::MembershipDeltaWriteMode,
     pub canonical_records: Vec<MigrationParityV2Record>,
     pub operation_statuses: Vec<String>,
     pub scoped_row_counts: BTreeMap<String, u64>,
@@ -2213,9 +2215,11 @@ async fn scan_v2_state(
             }
             GlobalKey::TextCompactionPointer(_)
             | GlobalKey::LogicalIndexIdWatermark
-            | GlobalKey::VectorPhysicalIdWatermark => {}
+            | GlobalKey::VectorPhysicalIdWatermark
+            | GlobalKey::MembershipDeltaWriteMode => {}
         }
     }
+    state.membership_delta_write_mode = crate::membership_delta::read_write_mode(read).await?;
     state.vector_migration.rebuilt_indexes =
         u64::try_from(completed_vector_builds.len()).map_err(|_| {
             crate::error::HelixDbError::InvariantViolation(
@@ -2592,6 +2596,10 @@ fn increment_count(counts: &mut BTreeMap<String, u64>, name: &str) {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use slatedb::object_store::memory::InMemory;
+
     use super::*;
     use crate::encoding::v1::keys::NodePropertyKey;
     use crate::encoding::v1::property::equality_value::{
@@ -2605,6 +2613,40 @@ mod tests {
     use crate::index_lifecycle::{
         IndexElementKind, IndexEntityId, IndexGenerationId, IndexId, IndexOperationId,
     };
+
+    #[tokio::test]
+    async fn parity_state_tracks_the_validated_membership_delta_mode() {
+        let db = slatedb::Db::builder(
+            "migration-parity-membership-mode",
+            Arc::new(InMemory::new()),
+        )
+        .with_merge_operator(Arc::new(crate::merge_operator::HelixMergeOperator::new()))
+        .build()
+        .await
+        .unwrap();
+        crate::migrations::startup::bootstrap_writer(&db)
+            .await
+            .unwrap();
+
+        let mut legacy = MigrationParityV2State::default();
+        scan_v2_state(&db, DataScope::LegacyUnscoped, &mut legacy)
+            .await
+            .unwrap();
+        assert_eq!(
+            legacy.membership_delta_write_mode,
+            crate::MembershipDeltaWriteMode::LegacyExclusive
+        );
+
+        crate::membership_delta::activate(&db).await.unwrap();
+        let mut activated = MigrationParityV2State::default();
+        scan_v2_state(&db, DataScope::LegacyUnscoped, &mut activated)
+            .await
+            .unwrap();
+        assert_eq!(
+            activated.membership_delta_write_mode,
+            crate::MembershipDeltaWriteMode::DisjointV2
+        );
+    }
 
     #[test]
     fn tenant_envelope_parity_identity_is_typed_and_legacy_shaped() {

--- a/crates/db/src/migrations/mod.rs
+++ b/crates/db/src/migrations/mod.rs
@@ -7673,7 +7673,7 @@ pub(crate) mod production_contracts {
             (
                 "future",
                 encode_metadata_value(&IndexV2MetadataValue::StorageVersion(
-                    IndexStorageVersion::new(IndexStorageVersion::CURRENT.get() + 1)
+                    IndexStorageVersion::new(IndexStorageVersion::MAX_SUPPORTED.get() + 1)
                         .expect("future version is nonzero"),
                 )),
                 true,

--- a/crates/db/src/migrations/startup/bootstrap.rs
+++ b/crates/db/src/migrations/startup/bootstrap.rs
@@ -48,6 +48,7 @@ async fn preflight_writer_bootstrap(db: &Db) -> Result<WriterBootstrapPlan> {
     let vector = transaction.get(&vector_key).await?;
     let cleanup_ready = super::super::index_storage_v4_cleanup_ready(&transaction).await?;
     let tenant_envelope_ready = super::super::tenant_key_envelope_ready(&transaction).await?;
+    crate::membership_delta::transaction_write_mode(&transaction).await?;
 
     let Some(marker) = marker else {
         if logical.is_some() || vector.is_some() || cleanup_ready {
@@ -185,10 +186,10 @@ fn validate_writer_bootstrap_values(
             ),
         });
     }
-    if version > IndexStorageVersion::CURRENT {
+    if version > IndexStorageVersion::MAX_SUPPORTED {
         return Err(HelixDbError::UnsupportedIndexStorageVersion {
             found: version.get(),
-            supported: IndexStorageVersion::CURRENT.get(),
+            supported: IndexStorageVersion::MAX_SUPPORTED.get(),
         });
     }
     let Some(logical) = logical else {

--- a/crates/db/src/search/mod.rs
+++ b/crates/db/src/search/mod.rs
@@ -642,8 +642,8 @@ async fn stage_shared_bitmap_membership(
                 txn.put_with_options(
                     key,
                     encode_roaring_treemap(&bitmap),
-                    &slatedb::PutOptions {
-                        ttl: slatedb::Ttl::NoExpiry,
+                    &slatedb::config::PutOptions {
+                        ttl: slatedb::config::Ttl::NoExpiry,
                     },
                 )?;
             }

--- a/crates/db/src/search/mod.rs
+++ b/crates/db/src/search/mod.rs
@@ -59,9 +59,10 @@ use crate::encoding::v2::legacy::text::storage_keys::{
     self as key_metadata, LegacyTextMetadataElement as TextMetadataElement,
 };
 use crate::encoding::v2::values::edge_endpoints::EdgeEndpointsValue;
-use crate::encoding::v2::values::indexes::SecondaryEqualityValue;
+use crate::encoding::v2::values::indexes::{BitmapMembershipDelta, SecondaryEqualityValue};
 use crate::encoding::{EdgeId, NodeId};
 use crate::error::HelixDbError;
+use crate::MembershipDeltaWriteMode;
 use slatedb::DbReadOps;
 
 fn bounded_prefix_end(prefix: &Bytes) -> Bytes {
@@ -612,6 +613,55 @@ pub fn decode_roaring_treemap(data: &[u8]) -> Result<RoaringTreemap, HelixDbErro
     Ok(SecondaryEqualityValue::decode(data)?.into_ids())
 }
 
+async fn stage_shared_bitmap_membership(
+    txn: &DbTransaction,
+    key: &Bytes,
+    entity_id: u64,
+    present: bool,
+) -> Result<(), HelixDbError> {
+    match crate::membership_delta::transaction_write_mode(txn).await? {
+        MembershipDeltaWriteMode::LegacyExclusive => {
+            let existing = txn.get(key).await?;
+            if existing.is_none() && !present {
+                return Ok(());
+            }
+            let mut bitmap = existing
+                .as_deref()
+                .map(SecondaryEqualityValue::decode)
+                .transpose()?
+                .map(SecondaryEqualityValue::into_ids)
+                .unwrap_or_default();
+            if present {
+                bitmap.insert(entity_id);
+            } else {
+                bitmap.remove(entity_id);
+            }
+            if bitmap.is_empty() {
+                txn.delete(key)?;
+            } else {
+                txn.put_with_options(
+                    key,
+                    encode_roaring_treemap(&bitmap),
+                    &slatedb::PutOptions {
+                        ttl: slatedb::Ttl::NoExpiry,
+                    },
+                )?;
+            }
+        }
+        MembershipDeltaWriteMode::DisjointV2 => {
+            let mut delta = BitmapMembershipDelta::default();
+            if present {
+                delta.add(entity_id);
+            } else {
+                delta.remove(entity_id);
+            }
+            txn.merge_disjoint_tokens_checked(key, [u128::from(entity_id)], delta.encode())
+                .await?;
+        }
+    }
+    Ok(())
+}
+
 /// Add a node to an equality index
 pub async fn add_to_equality_index(
     txn: &DbTransaction,
@@ -638,8 +688,7 @@ pub async fn add_to_equality_index_scoped(
     }
     .to_bytes();
 
-    txn.merge_commutative(&key, crate::merge_operator::encode_bitmap_add(node_id))?;
-    Ok(())
+    stage_shared_bitmap_membership(txn, &key, node_id, true).await
 }
 
 /// Remove a node from an equality index
@@ -669,17 +718,7 @@ pub async fn remove_from_equality_index_scoped(
     }
     .to_bytes();
 
-    if let Some(data) = txn.get(&key).await? {
-        let mut bitmap = decode_roaring_treemap(&data)?;
-        bitmap.remove(node_id);
-
-        if bitmap.is_empty() {
-            txn.delete(&key)?;
-        } else {
-            txn.put(&key, encode_roaring_treemap(&bitmap))?;
-        }
-    }
-    Ok(())
+    stage_shared_bitmap_membership(txn, &key, node_id, false).await
 }
 
 /// Look up nodes by equality index
@@ -1600,7 +1639,7 @@ pub async fn add_to_edge_label_index_scoped(
         )),
     }
     .to_bytes();
-    txn.merge_commutative(&out_key, crate::merge_operator::encode_bitmap_add(to))?;
+    stage_shared_bitmap_membership(txn, &out_key, to, true).await?;
 
     // Update incoming index: to + label -> from
     let in_key = DataKey::Data {
@@ -1610,9 +1649,7 @@ pub async fn add_to_edge_label_index_scoped(
         )),
     }
     .to_bytes();
-    txn.merge_commutative(&in_key, crate::merge_operator::encode_bitmap_add(from))?;
-
-    Ok(())
+    stage_shared_bitmap_membership(txn, &in_key, from, true).await
 }
 
 /// Remove an edge from the edge label index
@@ -1642,15 +1679,7 @@ pub async fn remove_from_edge_label_index_scoped(
         )),
     }
     .to_bytes();
-    if let Some(data) = txn.get(&out_key).await? {
-        let mut bitmap = decode_roaring_treemap(&data)?;
-        bitmap.remove(to);
-        if bitmap.is_empty() {
-            txn.delete(&out_key)?;
-        } else {
-            txn.put(&out_key, encode_roaring_treemap(&bitmap))?;
-        }
-    }
+    stage_shared_bitmap_membership(txn, &out_key, to, false).await?;
 
     // Update incoming index
     let in_key = DataKey::Data {
@@ -1660,17 +1689,7 @@ pub async fn remove_from_edge_label_index_scoped(
         )),
     }
     .to_bytes();
-    if let Some(data) = txn.get(&in_key).await? {
-        let mut bitmap = decode_roaring_treemap(&data)?;
-        bitmap.remove(from);
-        if bitmap.is_empty() {
-            txn.delete(&in_key)?;
-        } else {
-            txn.put(&in_key, encode_roaring_treemap(&bitmap))?;
-        }
-    }
-
-    Ok(())
+    stage_shared_bitmap_membership(txn, &in_key, from, false).await
 }
 
 /// Look up outgoing neighbors by edge label
@@ -1779,7 +1798,7 @@ pub async fn add_to_edge_equality_index_scoped(
         )),
     }
     .to_bytes();
-    txn.merge_commutative(&out_key, crate::merge_operator::encode_bitmap_add(edge_id))?;
+    stage_shared_bitmap_membership(txn, &out_key, edge_id, true).await?;
 
     let in_key = DataKey::Data {
         scope: tenant_scope,
@@ -1793,7 +1812,7 @@ pub async fn add_to_edge_equality_index_scoped(
         )),
     }
     .to_bytes();
-    txn.merge_commutative(&in_key, crate::merge_operator::encode_bitmap_add(edge_id))?;
+    stage_shared_bitmap_membership(txn, &in_key, edge_id, true).await?;
 
     let global_key = DataKey::Data {
         scope: tenant_scope,
@@ -1805,12 +1824,7 @@ pub async fn add_to_edge_equality_index_scoped(
         )),
     }
     .to_bytes();
-    txn.merge_commutative(
-        &global_key,
-        crate::merge_operator::encode_bitmap_add(edge_id),
-    )?;
-
-    Ok(())
+    stage_shared_bitmap_membership(txn, &global_key, edge_id, true).await
 }
 
 /// Remove an edge from the equality index (both directions)
@@ -1855,15 +1869,7 @@ pub async fn remove_from_edge_equality_index_scoped(
         )),
     }
     .to_bytes();
-    if let Some(data) = txn.get(&out_key).await? {
-        let mut bitmap = decode_roaring_treemap(&data)?;
-        bitmap.remove(edge_id);
-        if bitmap.is_empty() {
-            txn.delete(&out_key)?;
-        } else {
-            txn.put(&out_key, encode_roaring_treemap(&bitmap))?;
-        }
-    }
+    stage_shared_bitmap_membership(txn, &out_key, edge_id, false).await?;
 
     let in_key = DataKey::Data {
         scope: tenant_scope,
@@ -1877,15 +1883,7 @@ pub async fn remove_from_edge_equality_index_scoped(
         )),
     }
     .to_bytes();
-    if let Some(data) = txn.get(&in_key).await? {
-        let mut bitmap = decode_roaring_treemap(&data)?;
-        bitmap.remove(edge_id);
-        if bitmap.is_empty() {
-            txn.delete(&in_key)?;
-        } else {
-            txn.put(&in_key, encode_roaring_treemap(&bitmap))?;
-        }
-    }
+    stage_shared_bitmap_membership(txn, &in_key, edge_id, false).await?;
 
     let global_key = DataKey::Data {
         scope: tenant_scope,
@@ -1897,17 +1895,7 @@ pub async fn remove_from_edge_equality_index_scoped(
         )),
     }
     .to_bytes();
-    if let Some(data) = txn.get(&global_key).await? {
-        let mut bitmap = decode_roaring_treemap(&data)?;
-        bitmap.remove(edge_id);
-        if bitmap.is_empty() {
-            txn.delete(&global_key)?;
-        } else {
-            txn.put(&global_key, encode_roaring_treemap(&bitmap))?;
-        }
-    }
-
-    Ok(())
+    stage_shared_bitmap_membership(txn, &global_key, edge_id, false).await
 }
 
 /// Look up edges by equality (outgoing from source)
@@ -2026,8 +2014,7 @@ pub async fn add_to_global_edge_label_index_scoped(
         ))),
     }
     .to_bytes();
-    txn.merge_commutative(&key, crate::merge_operator::encode_bitmap_add(edge_id))?;
-    Ok(())
+    stage_shared_bitmap_membership(txn, &key, edge_id, true).await
 }
 
 /// Remove an edge from the global label -> edge IDs index.
@@ -2052,16 +2039,7 @@ pub async fn remove_from_global_edge_label_index_scoped(
         ))),
     }
     .to_bytes();
-    if let Some(data) = txn.get(&key).await? {
-        let mut bitmap = decode_roaring_treemap(&data)?;
-        bitmap.remove(edge_id);
-        if bitmap.is_empty() {
-            txn.delete(&key)?;
-        } else {
-            txn.put(&key, encode_roaring_treemap(&bitmap))?;
-        }
-    }
-    Ok(())
+    stage_shared_bitmap_membership(txn, &key, edge_id, false).await
 }
 
 /// Look up all edge IDs for a label from the global edge-label index.
@@ -2169,8 +2147,7 @@ pub async fn add_to_edge_pair_index_scoped(
         kind: DataKeyKind::EdgePairIndex(crate::encoding::keys::EdgePairIndexKey::new(from, to)),
     }
     .to_bytes();
-    txn.merge_commutative(&key, crate::merge_operator::encode_bitmap_add(edge_id))?;
-    Ok(())
+    stage_shared_bitmap_membership(txn, &key, edge_id, true).await
 }
 
 /// Remove an edge id from the exact `(from, to)` multigraph pair index.
@@ -2195,17 +2172,7 @@ pub async fn remove_from_edge_pair_index_scoped(
         kind: DataKeyKind::EdgePairIndex(crate::encoding::keys::EdgePairIndexKey::new(from, to)),
     }
     .to_bytes();
-    let Some(data) = txn.get(&key).await? else {
-        return Ok(());
-    };
-    let mut bitmap = decode_roaring_treemap(&data)?;
-    bitmap.remove(edge_id);
-    if bitmap.is_empty() {
-        txn.delete(&key)?;
-    } else {
-        txn.put(&key, encode_roaring_treemap(&bitmap))?;
-    }
-    Ok(())
+    stage_shared_bitmap_membership(txn, &key, edge_id, false).await
 }
 
 /// Delete all node `$label` equality-index entries before a full rebuild.
@@ -3736,6 +3703,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shared_bitmap_staging_rejects_corruption_in_every_write_mode() {
+        for mode in [
+            MembershipDeltaWriteMode::LegacyExclusive,
+            MembershipDeltaWriteMode::DisjointV2,
+        ] {
+            for present in [false, true] {
+                let db = crate::HelixDB::open(crate::HelixDbSource::InMemory {
+                    database: format!("search-corrupt-shared-bitmap-{mode:?}-{present}"),
+                })
+                .await
+                .expect("db opens");
+                if mode == MembershipDeltaWriteMode::DisjointV2 {
+                    db.activate_membership_delta_v2()
+                        .await
+                        .expect("corruption fixture activates V2 deltas");
+                }
+                let key = DataKey::Data {
+                    scope: DataScope::LegacyUnscoped,
+                    kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(
+                        EqualityIndexKey::new(
+                            hash_property_name("status"),
+                            hash_property_value("corrupt"),
+                        ),
+                    )),
+                }
+                .to_bytes();
+                let corrupt = Bytes::from_static(b"not-a-shared-bitmap");
+                db.inner_db().put(&key, corrupt.clone()).await.unwrap();
+
+                let txn = db
+                    .inner_db()
+                    .begin(IsolationLevel::SerializableSnapshot)
+                    .await
+                    .unwrap();
+                assert!(
+                    stage_shared_bitmap_membership(&txn, &key, 7, present)
+                        .await
+                        .is_err(),
+                    "{mode:?} present={present}"
+                );
+                txn.rollback();
+                assert_eq!(db.inner_db().get(&key).await.unwrap(), Some(corrupt));
+                db.close().await.unwrap();
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn concurrent_bitmap_inserts_cover_every_family_and_tenant_scope() {
         const INSERTS_PER_TENANT: u64 = 16;
 
@@ -3744,6 +3759,9 @@ mod tests {
         })
         .await
         .expect("db opens");
+        db.activate_membership_delta_v2()
+            .await
+            .expect("concurrent shared-bitmap fixture activates V2 deltas");
         let tenant_a =
             crate::encoding::keys::scope::TenantId::from_ulid_str("0000000000000000000000000A")
                 .expect("valid tenant");

--- a/crates/db/tests/encoding_only.rs
+++ b/crates/db/tests/encoding_only.rs
@@ -9,7 +9,7 @@
 // New typed encoding modules intentionally refer to their owning production
 // DTOs. Re-export those crate modules so this path-included test target keeps
 // exercising the real encoding sources without creating test-only DTO copies.
-pub use db::{config, error, search};
+pub use db::{config, error, search, MembershipDeltaWriteMode};
 
 #[path = "../src/index_lifecycle/model.rs"]
 mod index_lifecycle_model;

--- a/crates/db/tests/production_index_delete_regressions.rs
+++ b/crates/db/tests/production_index_delete_regressions.rs
@@ -5,7 +5,7 @@
 
 use std::{num::NonZeroUsize, time::Duration};
 
-use db::{HelixDB, HelixDbSource};
+use db::{HelixDB, HelixDbSource, MembershipDeltaWriteMode};
 use helix_ast::batch;
 use helix_ast::expr::Predicate;
 use helix_ast::graph::{EdgeRef, NodeRef};
@@ -607,6 +607,57 @@ async fn deletes_node_omitted_from_unique_equality_index() {
 #[tokio::test]
 async fn deletes_edge_omitted_from_equality_index() {
     run_direct_delete_case(DeleteCase::EdgeEquality).await;
+}
+
+#[tokio::test]
+async fn deletes_indexed_node_and_edge_equality_members_through_disjoint_deltas() {
+    for case in [
+        DeleteCase::NodeEquality { unique: false },
+        DeleteCase::EdgeEquality,
+    ] {
+        let db = HelixDB::open(HelixDbSource::InMemory {
+            database: format!("production-index-delete-disjoint-{}", case.name()),
+        })
+        .await
+        .unwrap_or_else(|error| panic!("{} database opens: {error}", case.name()));
+        assert_eq!(
+            db.membership_delta_write_mode().await.unwrap(),
+            MembershipDeltaWriteMode::LegacyExclusive
+        );
+        db.activate_membership_delta_v2()
+            .await
+            .unwrap_or_else(|error| panic!("{} activates disjoint deltas: {error}", case.name()));
+        assert_eq!(
+            db.membership_delta_write_mode().await.unwrap(),
+            MembershipDeltaWriteMode::DisjointV2
+        );
+
+        let seeded = seed_case(&db, case).await;
+        create_index(&db, case).await;
+        assert_eq!(control_ids(&db, case).await, vec![seeded.control_id]);
+
+        let delete = if case.is_node() {
+            traversal::g().n(NodeRef::id(seeded.control_id)).drop()
+        } else {
+            traversal::g().drop_edge_by_id(EdgeRef::id(seeded.control_id))
+        };
+        db.query(QueryRequest::write(
+            batch::write_batch()
+                .var_as("deleted", delete)
+                .returning(Vec::<String>::new()),
+        ))
+        .await
+        .unwrap_or_else(|error| panic!("{} indexed delete succeeds: {error}", case.name()));
+
+        assert!(control_ids(&db, case).await.is_empty());
+        assert_eq!(
+            entity_ids(&db, case, seeded.target_id).await,
+            vec![seeded.target_id]
+        );
+        db.close()
+            .await
+            .unwrap_or_else(|error| panic!("{} database closes: {error}", case.name()));
+    }
 }
 
 #[tokio::test]

--- a/crates/db/tests/production_support/index_lifecycle_typed_boundaries.rs
+++ b/crates/db/tests/production_support/index_lifecycle_typed_boundaries.rs
@@ -91,10 +91,10 @@ pub(crate) fn run() {
     );
     assert!(IndexStorageVersion::new(0).is_err());
     assert_eq!(
-        IndexStorageVersion::new(IndexStorageVersion::CURRENT.get() + 1)
+        IndexStorageVersion::new(IndexStorageVersion::MAX_SUPPORTED.get() + 1)
             .expect("non-zero future version remains representable")
             .get(),
-        IndexStorageVersion::CURRENT.get() + 1
+        IndexStorageVersion::MAX_SUPPORTED.get() + 1
     );
 
     let scope = DataScope::Tenant(TenantId::from_u128(u128::from_be_bytes([0xFE; 16])));

--- a/scripts/db-production-coverage-baselines.json
+++ b/scripts/db-production-coverage-baselines.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "uncovered_non_vector_source_lines": {
-    "count": 9962,
-    "sha256": "8d4b276efaa5704e5afdc7995a30e9623907514a48b0daf6bfcd855157415f7a",
+    "count": 10081,
+    "sha256": "7bac1f006af553ac0f87826de7042f9978cf75b428ba771b9677291f12c84822",
     "classification": "test-required",
     "reason": "Every uncovered production source line outside vector search and its stochastic vector key/value codecs remains in the explicit production-linked test backlog. The digest makes additions, removals, and newly covered lines require a reviewed baseline update; vector code remains enforced by the whole-DB and dedicated vector thresholds plus finer named-test, architecture, invariant, and platform classifications."
   },

--- a/scripts/run-migration-parity.sh
+++ b/scripts/run-migration-parity.sh
@@ -207,7 +207,7 @@ run_dev() {
         --scale-edges 4000 \
         --seed-batch-rows 1000 \
         --maximum-scenario-seconds 300 \
-        --maximum-suite-seconds 300 \
+        --maximum-suite-seconds 600 \
         --compaction-drain-seconds 5
 }
 

--- a/tools/hyperscale-migration-parity/Cargo.lock
+++ b/tools/hyperscale-migration-parity/Cargo.lock
@@ -3812,8 +3812,9 @@ dependencies = [
 [[package]]
 name = "slatedb"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2#1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2"
 dependencies = [
+ "ahash",
  "async-channel",
  "async-trait",
  "atomic",
@@ -3857,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2#1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2"
 dependencies = [
  "chrono",
  "log",
@@ -3872,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=30d9f28cfeb93cf95652aac2b7724811c5c49630#30d9f28cfeb93cf95652aac2b7724811c5c49630"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2#1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2"
 dependencies = [
  "async-trait",
  "bytes",

--- a/tools/hyperscale-migration-parity/Cargo.toml
+++ b/tools/hyperscale-migration-parity/Cargo.toml
@@ -16,8 +16,8 @@ futures = "0.3"
 baseline-helix-dsl = { package = "helix-db", version = "=2.0.5" }
 helix = { path = "../../../helix-hyperscale-migration-parity-source/enterprise/helix" }
 hyperscale-slatedb = { package = "slatedb", path = "../../../helix-hyperscale-migration-parity-source/enterprise/slatedb/slatedb" }
-target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "30d9f28cfeb93cf95652aac2b7724811c5c49630" }
-target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "30d9f28cfeb93cf95652aac2b7724811c5c49630" }
+target-slatedb = { package = "slatedb", git = "https://github.com/HelixDB/slatedb.git", rev = "1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2" }
+target-slatedb-common = { package = "slatedb-common", git = "https://github.com/HelixDB/slatedb.git", rev = "1cf0c4a317a5f7ce12126ab8549eb5d71d985ba2" }
 object_store = { version = "0.12", features = ["aws"] }
 object_store_014 = { package = "object_store", version = "0.14", features = ["aws"] }
 roaring = { version = "0.11", features = ["serde"] }

--- a/tools/hyperscale-migration-parity/README.md
+++ b/tools/hyperscale-migration-parity/README.md
@@ -25,7 +25,8 @@ Named profiles are:
 
 - `contracts`: production-linked DB migration contracts.
 - `dev`: all migration modes at 1k nodes/4k edges plus hash and corruption
-  contracts, with a hard 300-second aggregate limit.
+  contracts, with a hard 600-second aggregate limit and a 300-second limit for
+  each individual mode.
 - `full-correctness`: six distributions, batch sizes 1 and 1,024, every crash
   boundary, and the MinIO operation-fault matrix.
 - `scale-local`: the progressive 5k/20k through 2M/8M local ladder.


### PR DESCRIPTION
## Summary

Make concurrent graph deletes and inserts conflict by logical entity membership instead of by their shared physical label, adjacency, pair, and equality-index rows. This removes false conflicts for disjoint hot-row mutations while preserving conflicts for the same node or edge.

Depends on HelixDB/slatedb#11 and pins its reviewed head commit.

## Changes

- Add typed bitmap and adjacency membership deltas with deterministic last-mutation-wins composition.
- Batch topology removals by physical row and append fixed-width logical-member tokens directly into SlateDB transaction entries.
- Apply the same conflict contract to node labels, adjacency, edge pairs, edge labels, and node/edge equality-index bitmaps.
- Preserve conflicts for overlapping logical members, normal reads, exclusive writes, and mixed mutation types.
- Validate existing shared-row values before staging and fail closed on malformed bitmap or adjacency data.
- Add a durable, one-way V2 activation marker fenced with the storage version so legacy and V2 writers cannot mix.
- Keep activation and migration-parity capability reads snapshot consistent.
- Correct the contention and preparation benchmarks so every disjoint case activates V2.

## Correctness

- Cascade deletion observes nodes and incident edges before grouped topology/index removal and record deletion.
- Node and edge equality-index races are covered in both commit orders.
- Corrupt node/edge equality, label, pair, and adjacency rows fail before mutation in legacy and V2 modes.
- Activation conflicts with legacy transactions and survives reopen; readers cannot activate it.
- Migration parity tracks the validated membership mode from one snapshot.

## Performance

The corrected 100,000-node sweep benchmark with 10,000 concurrent inserts produced:

- Sweep conflict rate: 40/100 (40%) with exclusive shared-row writes, 0/100 with V2.
- Writer conflicts: 39/40 with exclusive writes, 0/40 with V2.
- Preparation medians: 44 ms exclusive, 93 ms unchecked V2, 98 ms checked V2.
- Checked validation overhead versus unchecked V2: 5.2%.
- Checked V2 preparation throughput: about 1.02 million memberships/second.

## Validation

- `cargo test --workspace`
- `cargo test -p db --features migration-parity migration_parity`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo llvm-cov -p db --lib --summary-only`

All non-ignored tests passed. The database crate coverage run reported 93.72% line coverage. Key files reported 91.16% for the activation gate, 93.85% for secondary indexes, and 96.14% for shared search bitmaps.

## Rollout

Merge and publish HelixDB/slatedb#11 first. Deploy this code in legacy mode, complete the required storage migration/readiness checks, and then call the explicit V2 activation API. Activation is durable and intentionally has no downgrade path.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces an opt-in, durable membership-delta write mode that conflicts graph mutations by logical node or edge membership rather than shared physical rows.
- Adds typed bitmap and adjacency deltas with deterministic composition and validation.
- Batches topology and secondary-index mutations with direction-aware logical-member conflict tokens.
- Adds activation/version fencing so legacy and V2 writers cannot commit across the mode transition.
- Updates equality-index, migration-parity, startup, and corruption-handling paths for the new representation.
- Pins the SlateDB revision providing checked disjoint-merge transaction APIs.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/membership_delta.rs | Adds durable mode decoding, snapshot-consistent reads, and atomic one-way activation fenced by the storage version. |
| crates/db/src/merge_operator.rs | Adds typed delta composition and checked base-value validation for bitmap and adjacency merge operators. |
| crates/db/src/execution/interpreter/mutation/topology.rs | Coalesces topology mutations by physical row and stages direction-aware logical-member tokens in checked batches. |
| crates/db/src/encoding/v2/values/adjacency.rs | Defines the adjacency membership-delta representation, composition, strict decoding, reset behavior, and directional member iteration. |
| crates/db/src/encoding/v2/values/indexes/equality.rs | Defines bitmap membership deltas with last-mutation-wins composition and token enumeration covering additions and removals. |
| crates/db/src/index_lifecycle/secondary.rs | Applies the selected write mode to grouped secondary equality-index bitmap mutations. |
| crates/db/src/search/mod.rs | Routes shared label and equality-index updates through mode-aware validated replacement or disjoint-delta writes. |
| crates/db/src/execution/interpreter/mutation/node.rs | Reorders and batches cascade deletion work so topology and index memberships are observed and removed consistently. |
| crates/db/src/migrations/startup/bootstrap.rs | Extends startup validation to accept the activated storage version while retaining writer-mode preflight checks. |
| crates/db/src/migration_parity.rs | Makes migration-parity capability selection snapshot-consistent and aware of validated membership mode. |
| crates/db/Cargo.toml | Pins the reviewed SlateDB revision that supplies the disjoint-member transaction APIs required by this change. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Open write transaction] --> B[Read activation marker and storage version]
    B -->|LegacyExclusive| C[Read and validate shared row]
    C --> D[Write complete replacement value]
    B -->|DisjointV2| E[Compose typed membership deltas]
    E --> F[Derive logical-member conflict tokens]
    F --> G[Validate base and operands]
    G --> H[Stage checked disjoint merge batch]
    D --> I[Commit transaction]
    H --> I
    J[Activate V2] --> K[Serializable snapshot reads marker and version]
    K --> L[Atomically write V2 marker and fenced version]
    L --> M[Conflicts with transactions that observed legacy mode]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["activate v2 in disjoint sweep benchmarks"](https://github.com/helixdb/helix-db/commit/c79276ca794eaf42e487fd1363d765a535b4301e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58365486)</sub>

<!-- /greptile_comment -->