### PR TITLE
fix(db): keep GetOperation on the open graph write

### DIFF
--- a/crates/db/src/execution/interpreter/ddl.rs
+++ b/crates/db/src/execution/interpreter/ddl.rs
@@ -13,7 +13,9 @@ impl<'db> ExecutionContext<'db> {
         _input: ExecutionValue,
         plan: &ir::IndexDdlPlan,
     ) -> Result<ExecutionValue> {
-        self.discard_pending_catalog_freshness();
+        if plan.requires_isolated_catalog_transaction() {
+            self.discard_pending_catalog_freshness();
+        }
         let operation_id = |operation_id: &ir::IndexOperationId| {
             let uuid = uuid::Uuid::parse_str(operation_id.as_str()).map_err(|error| {
                 HelixDbError::InvariantViolation(format!(

--- a/crates/db/src/execution/interpreter/dispatch.rs
+++ b/crates/db/src/execution/interpreter/dispatch.rs
@@ -93,14 +93,18 @@ impl<'db> ExecutionContext<'db> {
             )),
             exec::ExecOp::Mutation { plan } => self.execute_mutation(input, plan).await,
             exec::ExecOp::IndexDdl { plan } => {
-                let resume_request_scope = self.has_request_write_scope();
-                self.check_execution_deadline()?;
-                self.commit_request_write_scope().await?;
-                let result = self.execute_index_ddl(input, plan).await;
-                if resume_request_scope && result.is_ok() {
-                    self.enable_request_write_scope().await?;
+                if plan.requires_isolated_catalog_transaction() {
+                    let resume_request_scope = self.has_request_write_scope();
+                    self.check_execution_deadline()?;
+                    self.commit_request_write_scope().await?;
+                    let result = self.execute_index_ddl(input, plan).await;
+                    if resume_request_scope && result.is_ok() {
+                        self.enable_request_write_scope().await?;
+                    }
+                    result
+                } else {
+                    self.execute_index_ddl(input, plan).await
                 }
-                result
             }
             exec::ExecOp::Noop | exec::ExecOp::Barrier { .. } => Ok(input),
             exec::ExecOp::Reserved { op } => self.reserved(input, op).await,
@@ -519,5 +523,120 @@ mod tests {
         assert_eq!(persisted.len(), 3);
         assert_eq!(persisted[0].entity_id(), 3);
         db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn get_operation_does_not_commit_an_open_graph_write() {
+        let db = test_support::open_db("dispatch-get-op-does-not-commit").await;
+        let mut context = ExecutionContext::new(&db, context::ParamBindings::default());
+        let create = context
+            .execute_op(
+                &exec::ExecOp::IndexDdl {
+                    plan: ir::IndexDdlPlan::Create {
+                        spec: ir::IndexDdlCreateSpec::NodeEquality {
+                            key: helix_planner::catalog::ScopedPropertyKey::try_new(
+                                "User", "email",
+                            )
+                            .unwrap(),
+                            uniqueness: helix_planner::catalog::IndexUniqueness::NonUnique,
+                        },
+                        mode: ir::IndexCreateMode::ErrorIfExists,
+                    },
+                },
+                ExecutionValue::Stream(Vec::new()),
+            )
+            .await
+            .expect("create enqueues a durable operation");
+        let ExecutionValue::IndexDdlReceipt(crate::index_lifecycle::IndexDdlReceipt::Accepted {
+            operation_id,
+            ..
+        }) = create
+        else {
+            panic!("new index create must be accepted");
+        };
+        let operation_id = ir::IndexOperationId::try_new(operation_id.as_uuid().to_string())
+            .expect("receipt UUID is a canonical lowercase operation ID");
+
+        context.enable_request_write_scope().await.unwrap();
+        let added = context
+            .execute_op(
+                &exec::ExecOp::Mutation {
+                    plan: exec::ExecMutationPlan::AddNodeSource {
+                        label: test_support::name("User"),
+                        properties: test_support::assignments(vec![(
+                            "email",
+                            helix_ast::value::PropertyValue::from("uncommitted@example.com"),
+                        )]),
+                    },
+                },
+                ExecutionValue::Stream(Vec::new()),
+            )
+            .await
+            .expect("graph write stays on the request transaction");
+        let ExecutionValue::Stream(rows) = added else {
+            panic!("node write should return a stream");
+        };
+        let Some(ExecutionRow {
+            current: Some(ElementRef::Node(id)),
+            ..
+        }) = rows.first()
+        else {
+            panic!("node write should return a node row");
+        };
+        let node_key = crate::encoding::keys::DataKey::Data {
+            scope: crate::encoding::keys::scope::DataScope::LegacyUnscoped,
+            kind: crate::encoding::keys::DataKeyKind::NodeProperty(
+                crate::encoding::keys::NodePropertyKey::new(*id),
+            ),
+        }
+        .to_bytes();
+        assert!(
+            db.inner_db().get(&node_key).await.unwrap().is_none(),
+            "uncommitted graph write must not be visible on a snapshot"
+        );
+
+        let status = context
+            .execute_op(
+                &exec::ExecOp::IndexDdl {
+                    plan: ir::IndexDdlPlan::GetOperation { operation_id },
+                },
+                ExecutionValue::Stream(Vec::new()),
+            )
+            .await
+            .expect("status read stays on the open graph write");
+        assert!(matches!(status, ExecutionValue::IndexOperationStatus(_)));
+        assert!(
+            context.has_request_write_scope(),
+            "status read must not disable the request write"
+        );
+        assert!(
+            db.inner_db().get(&node_key).await.unwrap().is_none(),
+            "successful GetOperation must not publish the open graph write"
+        );
+
+        let missing = context
+            .execute_op(
+                &exec::ExecOp::IndexDdl {
+                    plan: ir::IndexDdlPlan::GetOperation {
+                        operation_id: ir::IndexOperationId::try_new(
+                            "07070707-0707-0707-0707-070707070707",
+                        )
+                        .unwrap(),
+                    },
+                },
+                ExecutionValue::Stream(Vec::new()),
+            )
+            .await
+            .expect_err("unknown operation ID is a status miss, not a commit");
+        assert!(matches!(
+            missing,
+            HelixDbError::IndexOperationNotFound { .. }
+        ));
+        assert!(context.has_request_write_scope());
+        assert!(db.inner_db().get(&node_key).await.unwrap().is_none());
+
+        context.commit_request_write_scope().await.unwrap();
+        assert!(db.inner_db().get(&node_key).await.unwrap().is_some());
+        db.close().await.expect("writer closes");
     }
 }

--- a/crates/db/src/execution/interpreter/mod.rs
+++ b/crates/db/src/execution/interpreter/mod.rs
@@ -220,16 +220,13 @@ impl RequestSideEffects {
     fn operation(operation: &exec::ExecOp) -> Self {
         match operation {
             exec::ExecOp::Mutation { .. } => Self::GraphMutation,
-            exec::ExecOp::IndexDdl {
-                plan: ir::IndexDdlPlan::GetOperation { .. },
-            } => Self::None,
-            exec::ExecOp::IndexDdl {
-                plan:
-                    ir::IndexDdlPlan::Create { .. }
-                    | ir::IndexDdlPlan::Drop { .. }
-                    | ir::IndexDdlPlan::RetryOperation { .. }
-                    | ir::IndexDdlPlan::AbortOperation { .. },
-            } => Self::IndexDdl,
+            exec::ExecOp::IndexDdl { plan } => {
+                if plan.requires_isolated_catalog_transaction() {
+                    Self::IndexDdl
+                } else {
+                    Self::None
+                }
+            }
             exec::ExecOp::Branch { plan } => match plan {
                 exec::ExecBranchPlan::Union(plans) => {
                     plans.iter().fold(Self::None, |effects, plan| {
@@ -418,6 +415,26 @@ mod request_execution_mode_tests {
         assert_eq!(
             RequestExecutionMode::try_from(&plan).unwrap(),
             RequestExecutionMode::Read
+        );
+    }
+
+    #[test]
+    fn graph_write_with_index_status_stays_one_write_transaction() {
+        let first = exec::ExecStepId::new(1).unwrap();
+        let second = exec::ExecStepId::new(2).unwrap();
+        let plan = test_support::executable(
+            ir::PlanKind::Write,
+            vec![
+                test_support::step(1, Vec::new(), mutation()),
+                test_support::step(2, vec![first], index_status()),
+                test_support::step(3, vec![second], mutation()),
+            ],
+            3,
+        );
+
+        assert_eq!(
+            RequestExecutionMode::try_from(&plan).unwrap(),
+            RequestExecutionMode::GraphWrite
         );
     }
 }

--- a/crates/planner/src/ir/index_ddl.rs
+++ b/crates/planner/src/ir/index_ddl.rs
@@ -148,6 +148,42 @@ pub enum IndexDdlPlan {
     },
 }
 
+impl IndexDdlPlan {
+    /// CREATE/DROP/RETRY/ABORT own a catalog transaction and must not share an
+    /// open graph write. [`Self::GetOperation`] is a status read and stays on
+    /// the request transaction already open.
+    ///
+    /// ```
+    /// use helix_planner::catalog::{IndexUniqueness, ScopedPropertyKey};
+    /// use helix_planner::ir::{IndexCreateMode, IndexDdlCreateSpec, IndexDdlPlan, IndexOperationId};
+    ///
+    /// let operation_id =
+    ///     IndexOperationId::try_new("07070707-0707-0707-0707-070707070707").unwrap();
+    /// assert!(!IndexDdlPlan::GetOperation {
+    ///     operation_id: operation_id.clone()
+    /// }
+    /// .requires_isolated_catalog_transaction());
+    /// assert!(IndexDdlPlan::RetryOperation { operation_id }.requires_isolated_catalog_transaction());
+    /// assert!(IndexDdlPlan::Create {
+    ///     spec: IndexDdlCreateSpec::NodeEquality {
+    ///         key: ScopedPropertyKey::try_new("User", "email").unwrap(),
+    ///         uniqueness: IndexUniqueness::NonUnique,
+    ///     },
+    ///     mode: IndexCreateMode::ErrorIfExists,
+    /// }
+    /// .requires_isolated_catalog_transaction());
+    /// ```
+    pub const fn requires_isolated_catalog_transaction(&self) -> bool {
+        match self {
+            Self::GetOperation { .. } => false,
+            Self::Create { .. }
+            | Self::Drop { .. }
+            | Self::RetryOperation { .. }
+            | Self::AbortOperation { .. } => true,
+        }
+    }
+}
+
 /// Index creation spec with validated labels, properties, and create-time
 /// attributes.
 ///


### PR DESCRIPTION
Fixes #1042.

## Summary
- `GetOperation` is a status read. dispatch used to commit the request write before every `IndexDdl` arm, so `add_n` + status + `add_n` published the first node early. a missing operation id did the same commit and left the write scope disabled.
- CREATE / DROP / RETRY / ABORT still isolate. the contract is `IndexDdlPlan::requires_isolated_catalog_transaction()`, used by dispatch, catalog-freshness discard, and request-mode classification so a new variant cannot pick the wrong txn.
- regression: a node written before `GetOperation` stays invisible on a snapshot until the request commits, including after a status miss.

## Test plan
- [ ] `cargo test -p db --lib get_operation_does_not_commit`
- [ ] `cargo test -p db --lib graph_write_with_index_status`
- [ ] `cargo test -p helix-planner --doc index_ddl`
- [ ] CI


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR keeps the read-only `GetOperation` on an open graph-write transaction while preserving isolated catalog transactions for CREATE, DROP, RETRY, and ABORT.
- Adds a centralized `requires_isolated_catalog_transaction()` contract to `IndexDdlPlan`.
- Uses that contract for dispatch isolation, catalog-freshness handling, and request-side-effect classification.
- Adds regression coverage for successful and missing operation-status reads without prematurely publishing graph writes.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/execution/interpreter/dispatch.rs | Gates request-write commit and resumption on whether the index operation requires an isolated catalog transaction, with regression coverage for status reads. |
| crates/db/src/execution/interpreter/ddl.rs | Restricts catalog-freshness discard to isolated lifecycle operations while leaving GetOperation as a status read. |
| crates/db/src/execution/interpreter/mod.rs | Reuses the isolation contract for request-side-effect classification and tests graph-write classification with an index-status step. |
| crates/planner/src/ir/index_ddl.rs | Centralizes the transaction-isolation classification for every current IndexDdlPlan variant and documents the contract. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant I as Interpreter
    participant W as Open graph write
    participant S as Operation snapshot
    I->>W: Stage graph mutation
    I->>S: GetOperation
    S-->>I: Status or not-found
    Note over W: Write remains open and unpublished
    I->>W: Continue request
    I->>W: Commit at request completion
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(db): keep index status reads off the..."](https://github.com/helixdb/helix-db/commit/3486443d2acf4a526e22ab5ac05d25aa8de7d251) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58412866)</sub>

<!-- /greptile_comment -->