### PR TITLE
docs: replace stale clippy script instructions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -253,10 +253,10 @@ QUERY addUser(name: String, age: I64) =>
 
 Run Clippy to check code quality:
 ```bash
-./clippy_check.sh
+cargo clippy --workspace -- -D warnings
 ```
 
-The `clippy_check.sh` script at the repository root runs `cargo clippy --workspace -- -D warnings`, treating all warnings as errors across every workspace crate.
+This treats all Clippy warnings as errors across every workspace crate.
 
 ### Testing
 
@@ -293,7 +293,7 @@ cd sdks/typescript && npm test
 cd sdks/go && go test ./...
 ```
 
-Format and lint before opening a PR: `cargo fmt` and `./clippy_check.sh`.
+Format and lint before opening a PR: `cargo fmt` and `cargo clippy --workspace -- -D warnings`.
 
 #### Testing Guidelines
 - Write tests for all new features


### PR DESCRIPTION
## What

Updates `CONTRIBUTORS.md` to use `cargo clippy --workspace -- -D warnings` instead of the nonexistent `./clippy_check.sh` script.

  ## Why

The contribution guide instructed new contributors to run a root script that is not tracked in the repository, causing the documented lint step to fail before Clippy runs.

  ## How

  Replaces both stale script references and removes the incorrect statement that the script exists.

  Closes #1046

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces references to the nonexistent `clippy_check.sh` script with the valid Cargo Clippy command.

- Documents `cargo clippy --workspace -- -D warnings` as the repository lint command.
- Clarifies that Clippy warnings are treated as errors across workspace crates.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CONTRIBUTORS.md | Correctly replaces two stale script references with the root workspace’s canonical Clippy command. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: replace stale clippy script instru..."](https://github.com/helixdb/helix-db/commit/24cec779fd3de4f63cf237c7972af0c6dc69d7f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58421284)</sub>

<!-- /greptile_comment -->