### PR TITLE
fix: use CanonicalNumber for planner proofs and GROUP BY

### DIFF
--- a/crates/db/src/execution/interpreter/stream/aggregate.rs
+++ b/crates/db/src/execution/interpreter/stream/aggregate.rs
@@ -9,8 +9,7 @@ use super::values::scalar_items;
 use super::*;
 
 /// Group identity is storage total order: CanonicalNumber for numerics, typed
-/// otherwise. Display strings are not an identity.
-#[derive(Clone)]
+/// otherwise. Display strings are not an identity. The key owns the emitted value.
 struct GroupKey(DbPropertyValue);
 
 impl PartialEq for GroupKey {
@@ -60,7 +59,7 @@ impl<'db> ExecutionContext<'db> {
         };
         match aggregate {
             ir::AggregatePlan::Group(property) => {
-                let mut groups = BTreeMap::<GroupKey, (Option<DbPropertyValue>, Vec<i64>)>::new();
+                let mut groups = BTreeMap::<GroupKey, Vec<i64>>::new();
                 for row in &rows {
                     self.check_execution_deadline()?;
                     let element_id = row
@@ -74,24 +73,18 @@ impl<'db> ExecutionContext<'db> {
                         .id()
                         .try_into()
                         .unwrap_or(i64::MAX);
-                    let value = self.row_property(row, property).await?;
-                    let entry = groups
-                        .entry(GroupKey(value.clone().unwrap_or(DbPropertyValue::Null)))
-                        .or_insert_with(|| (value.clone(), Vec::new()));
-                    if entry.0.is_none() {
-                        entry.0 = value;
-                    }
-                    entry.1.push(element_id);
+                    let value = self
+                        .row_property(row, property)
+                        .await?
+                        .unwrap_or(DbPropertyValue::Null);
+                    groups.entry(GroupKey(value)).or_default().push(element_id);
                 }
                 Ok(ExecutionValue::Scalars(
                     groups
                         .into_iter()
-                        .map(|(_, (value, ids))| {
+                        .map(|(GroupKey(value), ids)| {
                             ExecutionScalar::Object(BTreeMap::from([
-                                (
-                                    property.as_ref().to_string(),
-                                    value.unwrap_or(DbPropertyValue::Null),
-                                ),
+                                (property.as_ref().to_string(), value),
                                 ("count".to_string(), DbPropertyValue::I64(ids.len() as i64)),
                                 ("ids".to_string(), DbPropertyValue::I64Array(ids)),
                             ]))
@@ -100,7 +93,7 @@ impl<'db> ExecutionContext<'db> {
                 ))
             }
             ir::AggregatePlan::GroupCount(property) => {
-                let mut groups = BTreeMap::<GroupKey, (Option<DbPropertyValue>, i64)>::new();
+                let mut groups = BTreeMap::<GroupKey, i64>::new();
                 for row in &rows {
                     self.check_execution_deadline()?;
                     if row.current.is_none() {
@@ -108,24 +101,18 @@ impl<'db> ExecutionContext<'db> {
                             "groupCount expected element stream input, got empty row".to_string(),
                         ));
                     }
-                    let value = self.row_property(row, property).await?;
-                    let entry = groups
-                        .entry(GroupKey(value.clone().unwrap_or(DbPropertyValue::Null)))
-                        .or_insert_with(|| (value.clone(), 0));
-                    if entry.0.is_none() {
-                        entry.0 = value;
-                    }
-                    entry.1 += 1;
+                    let value = self
+                        .row_property(row, property)
+                        .await?
+                        .unwrap_or(DbPropertyValue::Null);
+                    *groups.entry(GroupKey(value)).or_default() += 1;
                 }
                 Ok(ExecutionValue::Scalars(
                     groups
                         .into_iter()
-                        .map(|(_, (value, count))| {
+                        .map(|(GroupKey(value), count)| {
                             ExecutionScalar::Object(BTreeMap::from([
-                                (
-                                    property.as_ref().to_string(),
-                                    value.unwrap_or(DbPropertyValue::Null),
-                                ),
+                                (property.as_ref().to_string(), value),
                                 ("count".to_string(), DbPropertyValue::I64(count)),
                             ]))
                         })

--- a/crates/db/src/execution/interpreter/stream/aggregate.rs
+++ b/crates/db/src/execution/interpreter/stream/aggregate.rs
@@ -1,11 +1,37 @@
 //! Runtime aggregate execution contracts.
 
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
 use helix_ast::traversal::AggregateFunction;
 
 use super::values::scalar_items;
 use super::*;
+
+/// Group identity is storage total order: CanonicalNumber for numerics, typed
+/// otherwise. Display strings are not an identity.
+#[derive(Clone)]
+struct GroupKey(DbPropertyValue);
+
+impl PartialEq for GroupKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.total_order(&other.0) == Ordering::Equal
+    }
+}
+
+impl Eq for GroupKey {}
+
+impl PartialOrd for GroupKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for GroupKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.total_order(&other.0)
+    }
+}
 
 impl<'db> ExecutionContext<'db> {
     pub(in crate::execution::interpreter) async fn aggregate(
@@ -34,7 +60,7 @@ impl<'db> ExecutionContext<'db> {
         };
         match aggregate {
             ir::AggregatePlan::Group(property) => {
-                let mut groups = BTreeMap::<String, (Option<DbPropertyValue>, Vec<i64>)>::new();
+                let mut groups = BTreeMap::<GroupKey, (Option<DbPropertyValue>, Vec<i64>)>::new();
                 for row in &rows {
                     self.check_execution_deadline()?;
                     let element_id = row
@@ -50,11 +76,7 @@ impl<'db> ExecutionContext<'db> {
                         .unwrap_or(i64::MAX);
                     let value = self.row_property(row, property).await?;
                     let entry = groups
-                        .entry(
-                            value
-                                .as_ref()
-                                .map_or_else(|| "null".to_string(), ToString::to_string),
-                        )
+                        .entry(GroupKey(value.clone().unwrap_or(DbPropertyValue::Null)))
                         .or_insert_with(|| (value.clone(), Vec::new()));
                     if entry.0.is_none() {
                         entry.0 = value;
@@ -78,7 +100,7 @@ impl<'db> ExecutionContext<'db> {
                 ))
             }
             ir::AggregatePlan::GroupCount(property) => {
-                let mut groups = BTreeMap::<String, (Option<DbPropertyValue>, i64)>::new();
+                let mut groups = BTreeMap::<GroupKey, (Option<DbPropertyValue>, i64)>::new();
                 for row in &rows {
                     self.check_execution_deadline()?;
                     if row.current.is_none() {
@@ -88,11 +110,7 @@ impl<'db> ExecutionContext<'db> {
                     }
                     let value = self.row_property(row, property).await?;
                     let entry = groups
-                        .entry(
-                            value
-                                .as_ref()
-                                .map_or_else(|| "null".to_string(), ToString::to_string),
-                        )
+                        .entry(GroupKey(value.clone().unwrap_or(DbPropertyValue::Null)))
                         .or_insert_with(|| (value.clone(), 0));
                     if entry.0.is_none() {
                         entry.0 = value;

--- a/crates/db/src/execution/interpreter/stream/tests/aggregate.rs
+++ b/crates/db/src/execution/interpreter/stream/tests/aggregate.rs
@@ -173,14 +173,14 @@ async fn group_and_group_count_return_property_rows() {
         result,
         ExecutionValue::Scalars(vec![
             ExecutionScalar::Object(BTreeMap::from([
+                ("status".to_string(), DbPropertyValue::Null,),
+                ("count".to_string(), DbPropertyValue::I64(1)),
+            ])),
+            ExecutionScalar::Object(BTreeMap::from([
                 (
                     "status".to_string(),
                     DbPropertyValue::String("closed".to_string()),
                 ),
-                ("count".to_string(), DbPropertyValue::I64(1)),
-            ])),
-            ExecutionScalar::Object(BTreeMap::from([
-                ("status".to_string(), DbPropertyValue::Null,),
                 ("count".to_string(), DbPropertyValue::I64(1)),
             ])),
             ExecutionScalar::Object(BTreeMap::from([
@@ -222,6 +222,14 @@ async fn group_and_group_count_return_property_rows() {
         result,
         ExecutionValue::Scalars(vec![
             ExecutionScalar::Object(BTreeMap::from([
+                ("status".to_string(), DbPropertyValue::Null),
+                ("count".to_string(), DbPropertyValue::I64(1)),
+                (
+                    "ids".to_string(),
+                    DbPropertyValue::I64Array(vec![missing as i64])
+                ),
+            ])),
+            ExecutionScalar::Object(BTreeMap::from([
                 (
                     "status".to_string(),
                     DbPropertyValue::String("closed".to_string()),
@@ -230,14 +238,6 @@ async fn group_and_group_count_return_property_rows() {
                 (
                     "ids".to_string(),
                     DbPropertyValue::I64Array(vec![closed as i64])
-                ),
-            ])),
-            ExecutionScalar::Object(BTreeMap::from([
-                ("status".to_string(), DbPropertyValue::Null),
-                ("count".to_string(), DbPropertyValue::I64(1)),
-                (
-                    "ids".to_string(),
-                    DbPropertyValue::I64Array(vec![missing as i64])
                 ),
             ])),
             ExecutionScalar::Object(BTreeMap::from([
@@ -250,6 +250,70 @@ async fn group_and_group_count_return_property_rows() {
                     "ids".to_string(),
                     DbPropertyValue::I64Array(vec![open_1 as i64, open_2 as i64])
                 ),
+            ])),
+        ])
+    );
+}
+
+#[tokio::test]
+async fn group_identity_is_canonical_and_typed() {
+    let db = test_support::open_db("stream-group-canonical-identity").await;
+    let as_i64 = test_support::add_node_with_properties(
+        &db,
+        "Ticket",
+        vec![("age", PropertyValue::I64(42))],
+    )
+    .await;
+    let as_f64 = test_support::add_node_with_properties(
+        &db,
+        "Ticket",
+        vec![("age", PropertyValue::F64(42.0))],
+    )
+    .await;
+    let as_string = test_support::add_node_with_properties(
+        &db,
+        "Ticket",
+        vec![("age", PropertyValue::from("42"))],
+    )
+    .await;
+    let ids = [as_i64, as_f64, as_string];
+    let ids_param = name("ids");
+    let access_id = exec::ExecStepId::new(1).expect("positive step id");
+    let plan = test_support::executable(
+        ir::PlanKind::Read,
+        vec![
+            node_access_step(1, ids_param.clone()),
+            test_support::step(
+                2,
+                vec![access_id],
+                exec::ExecOp::Aggregate {
+                    aggregate: ir::AggregatePlan::GroupCount(name("age")),
+                },
+            ),
+        ],
+        2,
+    );
+
+    let result = db
+        .execute(
+            &plan,
+            context::ParamBindings::default().with_value(ids_param, ids_value(&ids)),
+        )
+        .await
+        .expect("group count executes")
+        .last
+        .expect("aggregate step returns a value");
+
+    assert_eq!(
+        result,
+        ExecutionValue::Scalars(vec![
+            ExecutionScalar::Object(BTreeMap::from([
+                ("age".to_string(), DbPropertyValue::I64(42)),
+                ("count".to_string(), DbPropertyValue::I64(2)),
+            ])),
+            ExecutionScalar::Object(BTreeMap::from([
+                ("age".to_string(), DbPropertyValue::String("42".to_string())),
+                ("count".to_string(), DbPropertyValue::I64(1)),
             ])),
         ])
     );

--- a/crates/planner/src/analysis/scalar/constraints/property.rs
+++ b/crates/planner/src/analysis/scalar/constraints/property.rs
@@ -3,6 +3,7 @@
 use helix_ast::value::PropertyValue;
 
 use super::super::extract::{LiteralBound, NullabilityConstraint};
+use super::super::values::property_values_equal;
 use super::bounds::{
     lower_bound_allows_value, range_bounds_are_disjoint, upper_bound_allows_value,
 };
@@ -22,12 +23,16 @@ impl ScalarPropertyConstraint {
         if self
             .equality
             .as_ref()
-            .is_some_and(|existing| existing != &value)
-            || self.inequalities.iter().any(|excluded| excluded == &value)
+            .is_some_and(|existing| !property_values_equal(existing, &value))
             || self
-                .allowed_values
-                .as_ref()
-                .is_some_and(|values| !values.contains(&value))
+                .inequalities
+                .iter()
+                .any(|excluded| property_values_equal(excluded, &value))
+            || self.allowed_values.as_ref().is_some_and(|values| {
+                !values
+                    .iter()
+                    .any(|allowed| property_values_equal(allowed, &value))
+            })
             || self
                 .lower_bounds
                 .iter()
@@ -55,7 +60,7 @@ impl ScalarPropertyConstraint {
         if self
             .equality
             .as_ref()
-            .is_some_and(|existing| existing == &value)
+            .is_some_and(|existing| property_values_equal(existing, &value))
         {
             return true;
         }
@@ -142,8 +147,11 @@ impl ScalarPropertyConstraint {
     fn value_satisfies_constraints(&self, value: &PropertyValue) -> bool {
         self.equality
             .as_ref()
-            .is_none_or(|existing| existing == value)
-            && self.inequalities.iter().all(|excluded| excluded != value)
+            .is_none_or(|existing| property_values_equal(existing, value))
+            && self
+                .inequalities
+                .iter()
+                .all(|excluded| !property_values_equal(excluded, value))
             && self
                 .lower_bounds
                 .iter()
@@ -163,7 +171,11 @@ fn intersect_property_values(
     right: &[PropertyValue],
 ) -> Vec<PropertyValue> {
     left.iter()
-        .filter(|value| right.contains(value))
+        .filter(|value| {
+            right
+                .iter()
+                .any(|other| property_values_equal(value, other))
+        })
         .cloned()
         .collect()
 }

--- a/crates/planner/src/analysis/scalar/truth.rs
+++ b/crates/planner/src/analysis/scalar/truth.rs
@@ -7,6 +7,7 @@ use helix_ast::value::PropertyValue;
 
 use super::values::{
     literal_collection_values, property_value_has_reflexive_equality, property_value_ordering,
+    property_values_equal,
 };
 
 pub(super) fn static_predicate_value(predicate: &Predicate) -> Option<bool> {
@@ -88,7 +89,7 @@ fn static_eq_value(left: &Expr, right: &Expr) -> Option<bool> {
         return None;
     };
     (property_value_has_reflexive_equality(left) && property_value_has_reflexive_equality(right))
-        .then_some(left == right)
+        .then_some(property_values_equal(left, right))
 }
 
 fn static_order_value(
@@ -140,6 +141,9 @@ fn static_in_value(value: &Expr, values: &Expr) -> Option<bool> {
         return None;
     };
     property_value_has_reflexive_equality(value)
-        .then(|| literal_collection_values(values).map(|values| values.contains(value)))
+        .then(|| {
+            literal_collection_values(values)
+                .map(|values| values.iter().any(|item| property_values_equal(item, value)))
+        })
         .flatten()
 }

--- a/crates/planner/src/analysis/scalar/values.rs
+++ b/crates/planner/src/analysis/scalar/values.rs
@@ -1,8 +1,13 @@
 //! Property-value comparison and finite literal-collection contracts.
+//!
+//! Numeric identity is [`helix_value_semantics::CanonicalNumber`], the same
+//! kernel storage uses for `eq_value` and equality-index bytes. Strings,
+//! datetimes, and other domains stay typed: `"42"` is not `42`.
 
 use std::cmp::Ordering;
 
 use helix_ast::value::PropertyValue;
+use helix_value_semantics::CanonicalNumber;
 
 pub(super) fn literal_collection_is_empty(value: &PropertyValue) -> bool {
     match value {
@@ -85,23 +90,86 @@ pub(super) fn property_value_has_reflexive_equality(value: &PropertyValue) -> bo
     }
 }
 
+/// Exact identity used by planner proofs. Matches storage `eq_value`.
+pub(super) fn property_values_equal(left: &PropertyValue, right: &PropertyValue) -> bool {
+    match (left, right) {
+        (PropertyValue::Null, PropertyValue::Null) => true,
+        (PropertyValue::Bool(left), PropertyValue::Bool(right)) => left == right,
+        (
+            PropertyValue::I64(_) | PropertyValue::F64(_) | PropertyValue::F32(_),
+            PropertyValue::I64(_) | PropertyValue::F64(_) | PropertyValue::F32(_),
+        ) => canonical_number(left)
+            .zip(canonical_number(right))
+            .is_some_and(|(left, right)| left == right),
+        (PropertyValue::DateTime(left), PropertyValue::DateTime(right)) => left == right,
+        (PropertyValue::String(left), PropertyValue::String(right)) => left == right,
+        (PropertyValue::Bytes(left), PropertyValue::Bytes(right)) => left == right,
+        (PropertyValue::I64Array(left), PropertyValue::I64Array(right)) => left == right,
+        (PropertyValue::F64Array(left), PropertyValue::F64Array(right)) => {
+            left.len() == right.len()
+                && left.iter().zip(right).all(|(left, right)| {
+                    CanonicalNumber::from_f64(*left)
+                        .zip(CanonicalNumber::from_f64(*right))
+                        .is_some_and(|(left, right)| left == right)
+                })
+        }
+        (PropertyValue::F32Array(left), PropertyValue::F32Array(right)) => {
+            left.len() == right.len()
+                && left.iter().zip(right).all(|(left, right)| {
+                    CanonicalNumber::from_f32(*left)
+                        .zip(CanonicalNumber::from_f32(*right))
+                        .is_some_and(|(left, right)| left == right)
+                })
+        }
+        (PropertyValue::StringArray(left), PropertyValue::StringArray(right)) => left == right,
+        (PropertyValue::Array(left), PropertyValue::Array(right)) => left == right,
+        (PropertyValue::Object(left), PropertyValue::Object(right)) => left == right,
+        _ => false,
+    }
+}
+
 pub(super) fn property_value_ordering(
     left: &PropertyValue,
     right: &PropertyValue,
 ) -> Option<Ordering> {
     match (left, right) {
-        (PropertyValue::I64(left), PropertyValue::I64(right))
-        | (PropertyValue::DateTime(left), PropertyValue::DateTime(right)) => Some(left.cmp(right)),
-        (PropertyValue::F64(left), PropertyValue::F64(right)) => left.partial_cmp(right),
-        (PropertyValue::F32(left), PropertyValue::F32(right)) => left.partial_cmp(right),
+        (
+            PropertyValue::I64(_) | PropertyValue::F64(_) | PropertyValue::F32(_),
+            PropertyValue::I64(_) | PropertyValue::F64(_) | PropertyValue::F32(_),
+        ) => canonical_number(left)
+            .zip(canonical_number(right))
+            .map(|(left, right)| left.cmp(&right)),
+        (PropertyValue::DateTime(left), PropertyValue::DateTime(right)) => Some(left.cmp(right)),
         (PropertyValue::String(left), PropertyValue::String(right)) => Some(left.cmp(right)),
         _ => None,
     }
 }
 
+fn canonical_number(value: &PropertyValue) -> Option<CanonicalNumber> {
+    match value {
+        PropertyValue::I64(value) => Some(CanonicalNumber::from_i64(*value)),
+        PropertyValue::F64(value) => CanonicalNumber::from_f64(*value),
+        PropertyValue::F32(value) => CanonicalNumber::from_f32(*value),
+        PropertyValue::Null
+        | PropertyValue::Bool(_)
+        | PropertyValue::DateTime(_)
+        | PropertyValue::String(_)
+        | PropertyValue::Bytes(_)
+        | PropertyValue::I64Array(_)
+        | PropertyValue::F64Array(_)
+        | PropertyValue::F32Array(_)
+        | PropertyValue::StringArray(_)
+        | PropertyValue::Array(_)
+        | PropertyValue::Object(_) => None,
+    }
+}
+
 fn dedup_property_values(values: Vec<PropertyValue>) -> Vec<PropertyValue> {
     values.into_iter().fold(Vec::new(), |mut unique, value| {
-        if !unique.contains(&value) {
+        if !unique
+            .iter()
+            .any(|existing| property_values_equal(existing, &value))
+        {
             unique.push(value);
         }
         unique

--- a/crates/planner/src/analysis/tests/scalar/constraints.rs
+++ b/crates/planner/src/analysis/tests/scalar/constraints.rs
@@ -45,6 +45,17 @@ fn scalar_conjunction_detects_property_constraint_contradictions() {
             Predicate::eq("deleted_at", PropertyValue::Null),
         ]),
         Predicate::is_in("age", PropertyValue::I64Array(Vec::new())),
+        Predicate::and(vec![Predicate::eq("age", 42), Predicate::neq("age", 42.0)]),
+        Predicate::and(vec![Predicate::eq("age", 42), Predicate::eq("age", 43.0)]),
+        Predicate::and(vec![Predicate::eq("age", 42), Predicate::gt("age", 42.0)]),
+        Predicate::and(vec![Predicate::eq("age", 42), Predicate::eq("age", "42")]),
+        Predicate::and(vec![
+            Predicate::is_in(
+                "age",
+                PropertyValue::array([PropertyValue::from(20), PropertyValue::from(20.0)]),
+            ),
+            Predicate::neq("age", 20),
+        ]),
         Predicate::or(vec![
             Predicate::and(vec![Predicate::eq("age", 30), Predicate::neq("age", 30)]),
             Predicate::and(vec![
@@ -82,6 +93,15 @@ fn scalar_conjunction_keeps_feasible_property_constraints() {
         Predicate::and(vec![
             Predicate::eq("deleted_at", PropertyValue::Null),
             Predicate::is_null("deleted_at"),
+        ]),
+        Predicate::and(vec![Predicate::eq("age", 42), Predicate::eq("age", 42.0)]),
+        Predicate::and(vec![Predicate::eq("age", 42), Predicate::neq("age", "42")]),
+        Predicate::and(vec![
+            Predicate::is_in(
+                "age",
+                PropertyValue::array([PropertyValue::from(20), PropertyValue::from(20.0)]),
+            ),
+            Predicate::eq("age", 20.0),
         ]),
         Predicate::and(vec![
             Predicate::gt("age", 20),

--- a/crates/planner/src/analysis/tests/scalar/literals.rs
+++ b/crates/planner/src/analysis/tests/scalar/literals.rs
@@ -58,6 +58,30 @@ fn literal_in_values_dedupes_and_rejects_non_reflexive_collections() {
     );
     assert_eq!(
         literal_in_values(&Predicate::is_in(
+            "age",
+            PropertyValue::array([
+                PropertyValue::from(20),
+                PropertyValue::from(20.0),
+                PropertyValue::from(30),
+            ])
+        )),
+        Some((
+            "age".to_owned(),
+            vec![PropertyValue::from(20), PropertyValue::from(30)]
+        ))
+    );
+    assert_eq!(
+        literal_in_values(&Predicate::is_in(
+            "age",
+            PropertyValue::array([PropertyValue::from(20), PropertyValue::from("20")])
+        )),
+        Some((
+            "age".to_owned(),
+            vec![PropertyValue::from(20), PropertyValue::from("20")]
+        ))
+    );
+    assert_eq!(
+        literal_in_values(&Predicate::is_in(
             "score",
             PropertyValue::F64Array(vec![1.0, f64::NAN])
         )),

--- a/crates/planner/src/analysis/tests/scalar/truth.rs
+++ b/crates/planner/src/analysis/tests/scalar/truth.rs
@@ -34,6 +34,48 @@ fn static_predicate_values_cover_constant_boolean_contracts() {
         }),
         None
     );
+    assert_eq!(
+        static_predicate_value(&Predicate::Eq {
+            left: constant(42),
+            right: constant(42.0),
+        }),
+        Some(true)
+    );
+    assert_eq!(
+        static_predicate_value(&Predicate::Eq {
+            left: constant(42),
+            right: constant("42"),
+        }),
+        Some(false)
+    );
+    assert_eq!(
+        static_predicate_value(&Predicate::Lt {
+            left: constant(42),
+            right: constant(43.0),
+        }),
+        Some(true)
+    );
+    assert_eq!(
+        static_predicate_value(&Predicate::Gt {
+            left: constant(42),
+            right: constant("42"),
+        }),
+        None
+    );
+    assert_eq!(
+        static_predicate_value(&Predicate::IsIn {
+            value: constant(42.0),
+            values: Expr::Constant(PropertyValue::array([1, 42, 5])),
+        }),
+        Some(true)
+    );
+    assert_eq!(
+        static_predicate_value(&Predicate::IsIn {
+            value: constant("42"),
+            values: Expr::Constant(PropertyValue::array([1, 42, 5])),
+        }),
+        Some(false)
+    );
 
     assert_eq!(
         static_predicate_value(&Predicate::Gt {


### PR DESCRIPTION
Fixes #1048.

## Summary
- Storage already treats `42` and `42.0` as one `CanonicalNumber` and `"42"` as a string. planner proofs used AST `PartialEq`, so `age = 42 AND age != 42.0` looked feasible and `IN [20, 20.0]` did not collapse.
- `GROUP BY` keyed on `Display`, so those three values shared a bucket. group identity is now typed `total_order` (same numeric kernel, `Eq` consistent with `Ord`).
- scalar analysis matches storage `eq_value` / `compare` at the planner boundary. `"42"` stays distinct from `42`.

## Test plan
- [ ] `cargo test -p helix-planner --lib analysis::tests::scalar`
- [ ] `cargo test -p db --lib execution::interpreter::stream::tests::aggregate`
- [ ] CI


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns planner equality and ordering proofs with storage’s canonical numeric semantics and replaces display-based aggregate grouping with typed total-order keys.

- Canonicalizes mixed `I64`, `F32`, and `F64` comparisons during static predicate and constraint analysis.
- Deduplicates and intersects finite literal collections using storage-compatible equality.
- Keeps strings and other value domains distinct from numerically equivalent display values during grouping.
- Adds planner and aggregate regression coverage for canonical numeric identity.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/planner/src/analysis/scalar/values.rs | Introduces storage-aligned canonical numeric equality and ordering while retaining typed identity for nonnumeric values. |
| crates/planner/src/analysis/scalar/constraints/property.rs | Applies canonical equality consistently to equality, inequality, allowed-value, and intersection proofs. |
| crates/planner/src/analysis/scalar/truth.rs | Uses canonical equality for constant equality and membership proofs without proving non-reflexive values. |
| crates/db/src/execution/interpreter/stream/aggregate.rs | Replaces display-string grouping keys with typed total-order keys shared by Group and GroupCount. |
| crates/db/src/execution/interpreter/stream/tests/aggregate.rs | Adds regression coverage showing numeric representations merge while numeric-looking strings remain separate. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[AST property literals] --> B[CanonicalNumber equality and ordering]
    B --> C[Static predicate proofs]
    B --> D[Property constraints]
    C --> E[Planner simplification]
    D --> E
    F[Runtime property values] --> G[Typed total-order GroupKey]
    G --> H[GROUP BY and GROUP COUNT buckets]
    B -. aligned numeric identity .-> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use CanonicalNumber for planner pro..."](https://github.com/helixdb/helix-db/commit/1e299d77e40c52cc44abe87ecaea37e3449cbb09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58709588)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Query planning and execution](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/query-planning-and-execution.md)
- Knowledge Base — [Planner and optimizer](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/planner-optimizer.md)
- Knowledge Base — [Interpreter execution](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/interpreter-execution.md)
</details>


<!-- /greptile_comment -->