### PR TITLE
fix: only report a truncated cycle result when a cycle was left out

### DIFF
--- a/crates/graph-algorithms/src/algorithms/cycles.rs
+++ b/crates/graph-algorithms/src/algorithms/cycles.rs
@@ -30,7 +30,9 @@ pub struct Cycle {
 pub struct CycleResult {
     /// Cycles in canonical deterministic order.
     pub cycles: Vec<Cycle>,
-    /// True only when `max_cycles` stopped enumeration.
+    /// True only when a cycle was found and left out because `max_cycles` was
+    /// already full. A cap filled exactly still returns every cycle, so this
+    /// stays false.
     pub truncated: bool,
 }
 
@@ -113,19 +115,23 @@ impl Graph {
                 if cycle_len <= options.length_bound.get() {
                     path_edges.push(arc.edge);
                     let (nodes, edges) = self.canonical_cycle(path_nodes, path_edges);
+                    path_edges.pop();
                     match canonical.get_mut(&nodes) {
                         Some(existing) if edges < *existing => *existing = edges,
                         Some(_) => {}
                         None => {
+                            // Truncation means a cycle existed that we did not
+                            // return. Filling the cap exactly is a complete
+                            // answer, so only a *further* distinct cycle stops
+                            // enumeration, and that one is left out.
+                            if options
+                                .max_cycles
+                                .is_some_and(|limit| canonical.len() >= limit.get())
+                            {
+                                return true;
+                            }
                             canonical.insert(nodes, edges);
                         }
-                    }
-                    path_edges.pop();
-                    if options
-                        .max_cycles
-                        .is_some_and(|limit| canonical.len() >= limit.get())
-                    {
-                        return true;
                     }
                 }
                 continue;
@@ -343,6 +349,44 @@ mod tests {
         });
         assert_eq!(result.cycles.len(), 1);
         assert!(result.truncated);
+    }
+
+    /// A cap that is filled exactly has cut nothing off, so the result is
+    /// complete and `truncated` must stay false. Only a further cycle that the
+    /// cap refused counts as truncation.
+    #[test]
+    fn a_cap_filled_exactly_is_not_truncated() {
+        let graph = Graph::new(
+            GraphKind::DiGraph,
+            [Node::new("a"), Node::new("b")],
+            [Edge::new("aa", "a", "a"), Edge::new("bb", "b", "b")],
+        )
+        .unwrap();
+
+        let uncapped = graph.simple_cycles(CycleOptions {
+            length_bound: NonZeroUsize::new(1).unwrap(),
+            max_cycles: None,
+        });
+        assert_eq!(uncapped.cycles.len(), 2);
+        assert!(!uncapped.truncated);
+
+        let exact = graph.simple_cycles(CycleOptions {
+            length_bound: NonZeroUsize::new(1).unwrap(),
+            max_cycles: NonZeroUsize::new(2),
+        });
+        assert_eq!(exact.cycles, uncapped.cycles);
+        assert!(
+            !exact.truncated,
+            "a cap of two over exactly two cycles returned everything"
+        );
+
+        // One under the true count still truncates, and returns one fewer.
+        let capped = graph.simple_cycles(CycleOptions {
+            length_bound: NonZeroUsize::new(1).unwrap(),
+            max_cycles: NonZeroUsize::new(1),
+        });
+        assert_eq!(capped.cycles.len(), 1);
+        assert!(capped.truncated);
     }
 
     #[test]


### PR DESCRIPTION
simple_cycles stops as soon as canonical.len() reaches max_cycles and reports truncated: true. but a cap filled exactly has returned every cycle in the graph, so a complete result gets labelled incomplete.

two self loops, cap of two:

    max_cycles: Some(2)  ->  cycles=2, truncated=true
    max_cycles: None     ->  cycles=2, truncated=false

the uncapped run is the proof there were only ever two. the capped run returned both of them and still said it had cut something off.

that matters because the field is what a caller reads to decide whether to ask again. today it re-runs with a bigger cap and gets the same two cycles back, or it tells a user their results were trimmed when they were not.

the fix moves the check inside the None arm of the canonical lookup, so it fires on a further distinct cycle found while the cap is already full, and that one is left out. truncated now means what the doc says, a cycle existed that the result does not contain.

filling the cap exactly reports false. a cap below the true count still reports true and returns one fewer, which is what the existing cycle_limit_stops_enumeration test asserts and it still passes unchanged.

also moved the path_edges.pop() above the match. canonical_cycle only reads the path, so popping first keeps the early return from leaving a stale edge on it.

61 tests pass in the crate, clippy clean with -D warnings.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects `CycleResult::truncated` so reaching `max_cycles` exactly remains a complete result and truncation is reported only when a further distinct cycle is omitted.
- Moves the cycle-limit check into the new-canonical-cycle branch.
- Pops the closing path edge before the new early-return path.
- Adds regression coverage for exact-cap and below-cap behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/graph-algorithms/src/algorithms/cycles.rs | Correctly refines cycle-cap truncation semantics, preserves traversal cleanup, and adds focused regression coverage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: only report a truncated cycle resul..."](https://github.com/helixdb/helix-db/commit/636a6ebb5208ee8db69587f5d94d70506f06625f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59112090)</sub>

<!-- /greptile_comment -->