### PR TITLE
Fix lifecycle convergence across all index families

### DIFF
--- a/crates/db/src/encoding/v2/values/codec.rs
+++ b/crates/db/src/encoding/v2/values/codec.rs
@@ -224,6 +224,10 @@ impl<'a> ValueDecoder<'a> {
         }
     }
 
+    pub(super) const fn is_finished(&self) -> bool {
+        self.remaining.is_empty()
+    }
+
     pub(super) fn finish(self) -> Result<(), EncodingError> {
         if !self.remaining.is_empty() {
             return Err(EncodingError::Custom(format!(

--- a/crates/db/src/encoding/v2/values/lifecycle/entity_state.rs
+++ b/crates/db/src/encoding/v2/values/lifecycle/entity_state.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 
 use crate::encoding::error::EncodingError;
 use crate::index_lifecycle::work::{
-    AppliedEntityStateValue, AppliedFamilyState, CoalescedBuildDeltaValue,
+    AppliedEntityStateValue, AppliedFamilyState, CoalescedBuildDeltaState, CoalescedBuildDeltaValue,
 };
 
 use super::*;
@@ -17,6 +17,17 @@ pub(crate) fn encode_build_delta(value: &CoalescedBuildDeltaValue) -> Bytes {
     put_generation(&mut encoder, value.generation);
     put_element_kind(&mut encoder, value.entity_kind);
     encoder.put_u64(value.entity_id.get());
+    match &value.state {
+        CoalescedBuildDeltaState::Marker => {}
+        CoalescedBuildDeltaState::SecondaryBefore(previous) => {
+            encoder.put_u8(0x01);
+            put_option(&mut encoder, previous.as_ref(), put_secondary_value);
+        }
+        CoalescedBuildDeltaState::VectorBefore(previous) => {
+            encoder.put_u8(0x02);
+            put_option(&mut encoder, previous.as_ref(), put_partition);
+        }
+    }
     encoder.finish()
 }
 
@@ -28,11 +39,27 @@ pub(crate) fn decode_build_delta(value: &[u8]) -> Result<CoalescedBuildDeltaValu
             actual: decoder.kind(),
         });
     }
+    let index_id = take_index_id(&mut decoder)?;
+    let generation = take_generation(&mut decoder)?;
+    let entity_kind = take_element_kind(&mut decoder)?;
+    let entity_id = crate::index_lifecycle::IndexEntityId::new(decoder.take_u64()?);
+    let state = if decoder.is_finished() {
+        CoalescedBuildDeltaState::Marker
+    } else {
+        match decoder.take_u8()? {
+            0x01 => CoalescedBuildDeltaState::SecondaryBefore(
+                decoder.take_option(take_secondary_value)?,
+            ),
+            0x02 => CoalescedBuildDeltaState::VectorBefore(decoder.take_option(take_partition)?),
+            unknown => return Err(unknown_discriminant("build-delta family state", unknown)),
+        }
+    };
     let decoded = CoalescedBuildDeltaValue {
-        index_id: take_index_id(&mut decoder)?,
-        generation: take_generation(&mut decoder)?,
-        entity_kind: take_element_kind(&mut decoder)?,
-        entity_id: crate::index_lifecycle::IndexEntityId::new(decoder.take_u64()?),
+        index_id,
+        generation,
+        entity_kind,
+        entity_id,
+        state,
     };
     decoder.finish()?;
     Ok(decoded)

--- a/crates/db/src/encoding/v2/values/lifecycle/operation_record.rs
+++ b/crates/db/src/encoding/v2/values/lifecycle/operation_record.rs
@@ -18,7 +18,7 @@ use crate::index_lifecycle::{
 
 #[cfg(test)]
 use crate::index_lifecycle::work::{
-    AppliedEntityStateValue, AppliedFamilyState, CoalescedBuildDeltaValue,
+    AppliedEntityStateValue, AppliedFamilyState, CoalescedBuildDeltaState, CoalescedBuildDeltaValue,
 };
 #[cfg(test)]
 use crate::index_lifecycle::IndexRecordV2;
@@ -755,6 +755,21 @@ mod wire_fixtures {
             generation: generation(),
             entity_kind: IndexElementKind::Node,
             entity_id: crate::index_lifecycle::IndexEntityId::new(3),
+            state: CoalescedBuildDeltaState::Marker,
+        };
+        let secondary_delta = CoalescedBuildDeltaValue {
+            state: CoalescedBuildDeltaState::SecondaryBefore(Some(
+                CanonicalSecondaryValue::equality_string("shared"),
+            )),
+            ..delta.clone()
+        };
+        let tenant_partition = crate::index_lifecycle::work::TextPartition::try_tenant_value(
+            Bytes::from_static(b"tenant"),
+        )
+        .unwrap();
+        let vector_delta = CoalescedBuildDeltaValue {
+            state: CoalescedBuildDeltaState::VectorBefore(Some(tenant_partition.clone())),
+            ..delta.clone()
         };
         let applied = AppliedEntityStateValue {
             index_id: index_id(),
@@ -765,10 +780,6 @@ mod wire_fixtures {
                 "shared",
             ))),
         };
-        let tenant_partition = crate::index_lifecycle::work::TextPartition::try_tenant_value(
-            Bytes::from_static(b"tenant"),
-        )
-        .unwrap();
         let applied_vector = AppliedEntityStateValue {
             index_id: index_id(),
             generation: generation(),
@@ -787,11 +798,21 @@ mod wire_fixtures {
             ))),
         };
         let encoded_delta = encode_build_delta(&delta);
+        let encoded_secondary_delta = encode_build_delta(&secondary_delta);
+        let encoded_vector_delta = encode_build_delta(&vector_delta);
         let encoded_applied = encode_applied_state(&applied);
         let encoded_vector = encode_applied_state(&applied_vector);
         let encoded_text = encode_applied_state(&applied_text);
 
         assert_eq!(decode_build_delta(&encoded_delta).unwrap(), delta);
+        assert_eq!(
+            decode_build_delta(&encoded_secondary_delta).unwrap(),
+            secondary_delta
+        );
+        assert_eq!(
+            decode_build_delta(&encoded_vector_delta).unwrap(),
+            vector_delta
+        );
         assert_eq!(decode_applied_state(&encoded_applied).unwrap(), applied);
         assert_eq!(
             decode_applied_state(&encoded_vector).unwrap(),
@@ -800,14 +821,18 @@ mod wire_fixtures {
         assert_eq!(decode_applied_state(&encoded_text).unwrap(), applied_text);
         insta::assert_snapshot!(
             format!(
-                "build_delta={}\napplied_secondary={}\napplied_vector={}\napplied_text={}\n",
+                "build_delta={}\nbuild_delta_secondary={}\nbuild_delta_vector={}\napplied_secondary={}\napplied_vector={}\napplied_text={}\n",
                 hex(&encoded_delta),
+                hex(&encoded_secondary_delta),
+                hex(&encoded_vector_delta),
                 hex(&encoded_applied),
                 hex(&encoded_vector),
                 hex(&encoded_text),
             ),
             @"
 build_delta=010300000000000000010000000000000002010000000000000003
+build_delta_secondary=010300000000000000010000000000000002010000000000000003010101e9cf50951f33fb140000000b0400000006736861726564
+build_delta_vector=0103000000000000000100000000000000020100000000000000030201020000000674656e616e74
 applied_secondary=010400000000000000010000000000000002010000000000000003010101e9cf50951f33fb140000000b0400000006736861726564
 applied_vector=0104000000000000000100000000000000020100000000000000030201020000000674656e616e74
 applied_text=0104000000000000000100000000000000020100000000000000030301020000000674656e616e740000000000000004

--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -1338,10 +1338,12 @@ async fn catch_up(
         let plan = match reconciliation_plan(
             transaction,
             scope,
-            operation.index_id(),
-            operation.generation(),
+            IndexEntityStateKey {
+                index_id: operation.index_id(),
+                generation: operation.generation(),
+                entity,
+            },
             definition,
-            entity.id,
             &value.state,
             next_value,
         )
@@ -2293,17 +2295,21 @@ fn apply_active_change_from_overlay(
 async fn reconciliation_plan(
     transaction: &DbTransaction,
     scope: DataScope,
-    index_id: IndexId,
-    generation: IndexGenerationId,
+    state_key: IndexEntityStateKey,
     definition: &ValidatedSecondaryIndexDefinition,
-    entity_id: IndexEntityId,
     delta_state: &CoalescedBuildDeltaState,
     next_value: Option<CanonicalSecondaryValue>,
 ) -> Result<ReconciliationPlan> {
-    let entity = IndexEntity {
-        kind: definition.element_kind(),
-        id: entity_id,
-    };
+    let IndexEntityStateKey {
+        index_id,
+        generation,
+        entity,
+    } = state_key;
+    if entity.kind != definition.element_kind() {
+        return Err(corruption(
+            "secondary reconciliation entity kind disagrees with definition",
+        ));
+    }
     let applied_key = scoped_index_key(
         scope,
         ScopedKey::AppliedState(IndexEntityStateKey {
@@ -2334,7 +2340,7 @@ async fn reconciliation_plan(
                 generation,
                 definition,
                 value.clone(),
-                entity_id,
+                entity.id,
             )?;
             let observed = transaction.get(&key).await?;
             unique_entries.insert(key, observed);

--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -63,7 +63,8 @@ use crate::index_lifecycle::outbox::{
 };
 use crate::index_lifecycle::repository::ReaderStorageCompatibility;
 use crate::index_lifecycle::work::{
-    AppliedEntityStateValue, AppliedFamilyState, CoalescedBuildDeltaValue, SecondaryEntryValue,
+    AppliedEntityStateValue, AppliedFamilyState, CoalescedBuildDeltaState,
+    CoalescedBuildDeltaValue, SecondaryEntryValue,
 };
 #[cfg(any(
     test,
@@ -427,21 +428,14 @@ impl SecondaryMutationRuntime {
                 .ok_or_else(|| corruption("pending secondary mutation lost its catalog target"))?;
             match target.mode {
                 SecondaryMutationMode::RecordBuildDelta => {
-                    let key = scoped_index_key(
+                    stage_secondary_build_delta(
+                        transaction,
                         change.scope,
-                        ScopedKey::BuildDelta(IndexEntityStateKey {
-                            index_id: target.index_id,
-                            generation: target.generation,
-                            entity: change.entity,
-                        }),
-                    );
-                    let value = CoalescedBuildDeltaValue {
-                        index_id: target.index_id,
-                        generation: target.generation,
-                        entity_kind: change.entity.kind,
-                        entity_id: change.entity.id,
-                    };
-                    transaction.put(key, encode_build_delta(&value))?;
+                        target,
+                        change.entity,
+                        change.old_value,
+                    )
+                    .await?;
                 }
                 SecondaryMutationMode::MaintainActive => {
                     if definition_uses_equality_bitmap(&target.definition) {
@@ -669,24 +663,41 @@ pub(crate) async fn maintain_entity(
                     kind: entity_kind,
                     id: entity_id,
                 };
-                let key = scoped_index_key(
-                    scope,
-                    ScopedKey::BuildDelta(IndexEntityStateKey {
-                        index_id: target.index_id,
-                        generation: target.generation,
-                        entity,
-                    }),
-                );
-                let value = CoalescedBuildDeltaValue {
-                    index_id: target.index_id,
-                    generation: target.generation,
-                    entity_kind,
-                    entity_id,
-                };
-                transaction.put(key, encode_build_delta(&value))?;
+                stage_secondary_build_delta(transaction, scope, target, entity, old_value).await?;
             }
         }
     }
+    Ok(())
+}
+
+/// Preserves the original secondary value across repeated coalesced mutations.
+async fn stage_secondary_build_delta(
+    transaction: &DbTransaction,
+    scope: DataScope,
+    target: &SecondaryMutationTarget,
+    entity: IndexEntity,
+    initial_before: Option<CanonicalSecondaryValue>,
+) -> Result<()> {
+    let key = scoped_index_key(
+        scope,
+        ScopedKey::BuildDelta(IndexEntityStateKey {
+            index_id: target.index_id,
+            generation: target.generation,
+            entity,
+        }),
+    );
+    let state = match transaction.get(&key).await? {
+        Some(existing) => decode_delta(scope, &key, &existing)?.1.state,
+        None => CoalescedBuildDeltaState::SecondaryBefore(initial_before),
+    };
+    let value = CoalescedBuildDeltaValue {
+        index_id: target.index_id,
+        generation: target.generation,
+        entity_kind: entity.kind,
+        entity_id: entity.id,
+        state,
+    };
+    transaction.put(key, encode_build_delta(&value))?;
     Ok(())
 }
 
@@ -1331,6 +1342,7 @@ async fn catch_up(
             operation.generation(),
             definition,
             entity.id,
+            &value.state,
             next_value,
         )
         .await?
@@ -1434,17 +1446,18 @@ async fn catch_up_exact(
             delta_key,
             entity,
             u64::try_from(delta_value.len()).unwrap_or(u64::MAX),
+            value.state,
         ));
     }
 
     let property_keys = decoded
         .iter()
-        .map(|(_, entity, _)| authoritative_property_key(scope, *entity))
+        .map(|(_, entity, _, _)| authoritative_property_key(scope, *entity))
         .collect::<Vec<_>>();
     let property_values = transaction.multi_get(&property_keys).await?;
     let applied_keys = decoded
         .iter()
-        .map(|(_, entity, _)| {
+        .map(|(_, entity, _, _)| {
             scoped_index_key(
                 scope,
                 ScopedKey::AppliedState(IndexEntityStateKey {
@@ -1458,12 +1471,14 @@ async fn catch_up_exact(
     let applied_values = transaction.multi_get(&applied_keys).await?;
     let mut rows = Vec::with_capacity(decoded.len());
     let mut unique_keys = Vec::new();
-    for ((((delta_key, entity, delta_value_bytes), property_key), property_value), applied_pair) in
-        decoded
-            .into_iter()
-            .zip(property_keys)
-            .zip(property_values)
-            .zip(applied_keys.into_iter().zip(applied_values))
+    for (
+        (((delta_key, entity, delta_value_bytes, delta_state), property_key), property_value),
+        applied_pair,
+    ) in decoded
+        .into_iter()
+        .zip(property_keys)
+        .zip(property_values)
+        .zip(applied_keys.into_iter().zip(applied_values))
     {
         let next_value = match property_value.as_ref() {
             Some(properties) => {
@@ -1483,13 +1498,14 @@ async fn catch_up_exact(
             None => None,
         };
         let (applied_key, applied_value) = applied_pair;
-        let previous_value = decode_previous_applied(
+        let previous_value = reconciliation_previous_value(
             scope,
             operation.index_id(),
             operation.generation(),
             entity,
             &applied_key,
             applied_value.as_deref(),
+            &delta_state,
         )?;
         let mut unique_entry_keys = Vec::new();
         if definition.unique() && previous_value != next_value {
@@ -2281,6 +2297,7 @@ async fn reconciliation_plan(
     generation: IndexGenerationId,
     definition: &ValidatedSecondaryIndexDefinition,
     entity_id: IndexEntityId,
+    delta_state: &CoalescedBuildDeltaState,
     next_value: Option<CanonicalSecondaryValue>,
 ) -> Result<ReconciliationPlan> {
     let entity = IndexEntity {
@@ -2296,13 +2313,14 @@ async fn reconciliation_plan(
         }),
     );
     let applied_value = transaction.get(&applied_key).await?;
-    let previous = decode_previous_applied(
+    let previous = reconciliation_previous_value(
         scope,
         index_id,
         generation,
         entity,
         &applied_key,
         applied_value.as_deref(),
+        delta_state,
     )?;
     let mut unique_entries = BTreeMap::new();
     if definition.unique() && previous != next_value {
@@ -2333,6 +2351,36 @@ async fn reconciliation_plan(
         next_value,
         &unique_entries,
     )
+}
+
+fn reconciliation_previous_value(
+    scope: DataScope,
+    index_id: IndexId,
+    generation: IndexGenerationId,
+    entity: IndexEntity,
+    applied_key: &[u8],
+    applied_value: Option<&[u8]>,
+    delta_state: &CoalescedBuildDeltaState,
+) -> Result<Option<CanonicalSecondaryValue>> {
+    if applied_value.is_some() {
+        return decode_previous_applied(
+            scope,
+            index_id,
+            generation,
+            entity,
+            applied_key,
+            applied_value,
+        );
+    }
+    match delta_state {
+        CoalescedBuildDeltaState::SecondaryBefore(previous) => Ok(previous.clone()),
+        CoalescedBuildDeltaState::Marker => Err(corruption(
+            "secondary build delta has no original value after applied-state release",
+        )),
+        CoalescedBuildDeltaState::VectorBefore(_) => Err(corruption(
+            "secondary build delta contains vector recovery state",
+        )),
+    }
 }
 
 fn decode_previous_applied(

--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -85,7 +85,7 @@ use super::IndexScopeGates;
 mod exact;
 #[cfg(all(feature = "production-coverage", not(test)))]
 pub(crate) use exact::run_production_contracts as run_exact_production_contracts;
-#[cfg(test)]
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
 pub(crate) use exact::scan_active_range_generation_with_membership;
 pub(crate) use exact::{
     count_active_range_generation_with_membership,
@@ -2832,7 +2832,11 @@ fn property_value_type_name(value: &PropertyValue) -> &'static str {
 /// with `handle`. Unique entries and V4 non-unique bitmaps each use one point
 /// read. Authoritative-null lookup remains a graph scan because nulls are not
 /// physically indexed.
-#[cfg(any(test, feature = "production-coverage"))]
+#[cfg(any(
+    test,
+    feature = "production-coverage",
+    feature = "index-lifecycle-testing"
+))]
 pub(crate) async fn lookup_active_equality_generation(
     reader: &(impl DbReadOps + Sync),
     handle: &ActiveIndexHandle,
@@ -5775,6 +5779,125 @@ mod tests {
             }
         );
         db.close().await.expect("edge bitmap database closes");
+    }
+
+    #[tokio::test]
+    async fn bitmap_reconciliation_persists_physical_and_applied_state_together() {
+        let db = test_db("secondary-bitmap-reconciliation-state").await;
+        let scope = DataScope::LegacyUnscoped;
+        let definition = validated(
+            SecondaryIndexDefinition::node_equality("User", "status")
+                .expect("node equality definition validates"),
+        );
+        let ValidatedDynamicIndexDefinition::Secondary(definition) = definition else {
+            unreachable!("secondary fixture is type-checked")
+        };
+        let entity = IndexEntity {
+            kind: IndexElementKind::Node,
+            id: IndexEntityId::initial(),
+        };
+        let applied_key = scoped_index_key(
+            scope,
+            ScopedKey::AppliedState(IndexEntityStateKey {
+                index_id: IndexId::initial(),
+                generation: IndexGenerationId::initial(),
+                entity,
+            }),
+        );
+        let next = CanonicalSecondaryValue::equality_string("ready");
+        let ReconciliationPlan::Writes(plan) = reconciliation_plan_from_observations(
+            scope,
+            IndexId::initial(),
+            IndexGenerationId::initial(),
+            &definition,
+            entity,
+            applied_key.clone(),
+            None,
+            Some(next.clone()),
+            &BTreeMap::new(),
+        )
+        .expect("bitmap reconciliation plan validates") else {
+            panic!("fresh bitmap membership cannot be blocked")
+        };
+        let transaction = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .expect("bitmap reconciliation transaction begins");
+        plan.stage(&transaction)
+            .await
+            .expect("bitmap reconciliation stages");
+        transaction
+            .commit()
+            .await
+            .expect("bitmap reconciliation commits");
+
+        assert!(db
+            .get(&applied_key)
+            .await
+            .expect("applied state is readable")
+            .is_some());
+        let bitmap_key = secondary_entry_key(
+            scope,
+            IndexId::initial(),
+            IndexGenerationId::initial(),
+            &definition,
+            next,
+            entity.id,
+        )
+        .expect("bitmap key validates");
+        assert_eq!(
+            SecondaryEqualityBitmapValue::decode(
+                &db.get(bitmap_key)
+                    .await
+                    .expect("bitmap is readable")
+                    .expect("bitmap exists"),
+            )
+            .expect("bitmap decodes")
+            .ids()
+            .iter()
+            .collect::<Vec<_>>(),
+            vec![entity.id.get()]
+        );
+        db.close()
+            .await
+            .expect("bitmap reconciliation database closes");
+    }
+
+    #[tokio::test]
+    async fn bitmap_source_scan_retains_applied_state_for_catch_up() {
+        let db = test_db("secondary-bitmap-source-scan-state").await;
+        let scope = DataScope::LegacyUnscoped;
+        let definition = validated(
+            SecondaryIndexDefinition::node_equality("User", "status")
+                .expect("node equality definition validates"),
+        );
+        put_source(
+            &db,
+            scope,
+            IndexElementKind::Node,
+            0,
+            &[
+                Property::string("$label", "User"),
+                Property::string("status", "ready"),
+            ],
+        )
+        .await;
+        let (operation_id, index_id, generation) = create_build(&db, scope, &definition, 0).await;
+        let driver = SecondaryIndexDriver::new(Arc::new(IndexScopeGates::default()));
+        let mut claim_sequence = 1;
+        assert_eq!(
+            drive_one(&db, &driver, operation_id, &mut claim_sequence).await,
+            CommittedOperationStep::Progressed
+        );
+        assert_eq!(
+            generation_rows(&db, scope, RecordKind::AppliedState, index_id, generation,)
+                .await
+                .len(),
+            1
+        );
+        db.close()
+            .await
+            .expect("bitmap source scan database closes");
     }
 
     #[tokio::test]

--- a/crates/db/src/index_lifecycle/secondary/exact.rs
+++ b/crates/db/src/index_lifecycle/secondary/exact.rs
@@ -264,11 +264,19 @@ trait ExactRangeAccumulator {
     fn finish(self) -> Self::Output;
 }
 
-#[cfg(any(test, feature = "production-coverage"))]
+#[cfg(any(
+    test,
+    feature = "production-coverage",
+    feature = "index-lifecycle-testing"
+))]
 #[derive(Default)]
 struct ExactRangeOwners(Vec<u64>);
 
-#[cfg(any(test, feature = "production-coverage"))]
+#[cfg(any(
+    test,
+    feature = "production-coverage",
+    feature = "index-lifecycle-testing"
+))]
 impl ExactRangeAccumulator for ExactRangeOwners {
     type Output = Vec<u64>;
 
@@ -308,7 +316,11 @@ impl ExactRangeAccumulator for ExactRangeCount {
 ///
 /// Bitmap membership is evaluated in executable-plan order and `limit` is an
 /// accepted-owner threshold, not a storage-row limit.
-#[cfg(any(test, feature = "production-coverage"))]
+#[cfg(any(
+    test,
+    feature = "production-coverage",
+    feature = "index-lifecycle-testing"
+))]
 pub(crate) async fn scan_active_range_generation_with_membership(
     reader: &(impl DbReadOps + Sync),
     handle: &ActiveIndexHandle,

--- a/crates/db/src/index_lifecycle/text/driver.rs
+++ b/crates/db/src/index_lifecycle/text/driver.rs
@@ -511,6 +511,38 @@ impl PreparedTextOperationStep {
         scope: DataScope,
         operation: &IndexOperationRecord,
     ) -> Result<IndexOperationStepResult> {
+        let late_boundary_counters = match operation.progress() {
+            IndexOperationProgress::TextBuild(TextBuildProgress::Constructing(
+                TextBuildStage::Compact(progress) | TextBuildStage::PrepareManifests(progress),
+            )) => Some(progress.counters),
+            IndexOperationProgress::TextBuild(TextBuildProgress::Constructing(
+                TextBuildStage::ValidateManifests(progress),
+            )) => Some(progress.counters()),
+            IndexOperationProgress::TextBuild(
+                TextBuildProgress::Constructing(
+                    TextBuildStage::ScanSource(_)
+                    | TextBuildStage::ScanPartitions(_)
+                    | TextBuildStage::CatchUp(_)
+                    | TextBuildStage::Activate(_),
+                )
+                | TextBuildProgress::Aborting(_),
+            )
+            | IndexOperationProgress::SecondaryBuild(_)
+            | IndexOperationProgress::VectorBuild(_)
+            | IndexOperationProgress::SecondaryCleanup(_)
+            | IndexOperationProgress::VectorCleanup(_)
+            | IndexOperationProgress::TextCleanup(_) => None,
+        };
+        if let Some(counters) = late_boundary_counters
+            && generation_has_rows(transaction, scope, RecordKind::BuildDelta, operation).await?
+        {
+            return Ok(progressed_build(TextBuildStage::CatchUp(
+                PrefixScanProgress {
+                    cursor: None,
+                    counters,
+                },
+            )));
+        }
         match self {
             Self::Repository(prepared) => {
                 if operation != &prepared.source_operation {
@@ -3738,6 +3770,7 @@ mod tests {
                     generation: operation.generation(),
                     entity_kind: entity().kind,
                     entity_id: entity().id,
+                    state: work::CoalescedBuildDeltaState::Marker,
                 }),
             )
             .unwrap();
@@ -3820,6 +3853,7 @@ mod tests {
                     generation: operation.generation(),
                     entity_kind: entity().kind,
                     entity_id: entity().id,
+                    state: work::CoalescedBuildDeltaState::Marker,
                 }),
             )
             .unwrap();

--- a/crates/db/src/index_lifecycle/text/driver.rs
+++ b/crates/db/src/index_lifecycle/text/driver.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures::{stream, StreamExt};
 use slatedb::object_store::{ObjectStore, ObjectStoreExt};
 use slatedb::{Db, DbTransaction, IsolationLevel};
 
@@ -61,6 +62,17 @@ struct TextStorageRuntime {
     object_store: Arc<dyn ObjectStore>,
     db_path: String,
     compaction_limits: TextBackfillCompactionLimits,
+}
+
+/// Fixed upper bound for immutable manifest metadata requests.
+const MANIFEST_VALIDATION_HEAD_CONCURRENCY: usize = 8;
+
+/// Complete classification of one immutable manifest blob metadata proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ManifestBlobMetadataProof {
+    Valid,
+    InvariantViolation,
+    TransientFailure,
 }
 
 /// Family driver for durable text build checkpoints.
@@ -1570,23 +1582,45 @@ async fn prepare_validation_step(
         super::validation::ValidationSelection::Page(prepared) => prepared,
     };
 
-    let mut external_result = None;
-    for blob in prepared.blobs().iter().copied() {
-        let location = crate::search::text::blob_object_store_path(&runtime.db_path, *blob.hash());
-        match runtime.object_store.head(&location).await {
-            Ok(metadata) if metadata.size == blob.size() => {}
-            Ok(_) | Err(slatedb::object_store::Error::NotFound { .. }) => {
-                external_result = Some(IndexOperationStepResult::Blocked(
-                    IndexOperationBlocker::InvariantViolation,
-                ));
-                break;
+    let mut proofs = stream::iter(prepared.blobs().iter().copied())
+        .map(|blob| async move {
+            let location =
+                crate::search::text::blob_object_store_path(&runtime.db_path, *blob.hash());
+            match runtime.object_store.head(&location).await {
+                Ok(metadata) if metadata.size == blob.size() => ManifestBlobMetadataProof::Valid,
+                Ok(_) | Err(slatedb::object_store::Error::NotFound { .. }) => {
+                    ManifestBlobMetadataProof::InvariantViolation
+                }
+                Err(_) => ManifestBlobMetadataProof::TransientFailure,
             }
-            Err(_) => {
-                external_result = Some(IndexOperationStepResult::TransientFailure);
-                break;
+        })
+        .buffer_unordered(MANIFEST_VALIDATION_HEAD_CONCURRENCY);
+    let mut aggregate = ManifestBlobMetadataProof::Valid;
+    while let Some(proof) = proofs.next().await {
+        aggregate = match (aggregate, proof) {
+            (ManifestBlobMetadataProof::InvariantViolation, _)
+            | (_, ManifestBlobMetadataProof::InvariantViolation) => {
+                ManifestBlobMetadataProof::InvariantViolation
             }
-        }
+            (ManifestBlobMetadataProof::TransientFailure, _)
+            | (_, ManifestBlobMetadataProof::TransientFailure) => {
+                ManifestBlobMetadataProof::TransientFailure
+            }
+            (ManifestBlobMetadataProof::Valid, ManifestBlobMetadataProof::Valid) => {
+                ManifestBlobMetadataProof::Valid
+            }
+        };
     }
+    drop(proofs);
+    let external_result = match aggregate {
+        ManifestBlobMetadataProof::Valid => None,
+        ManifestBlobMetadataProof::InvariantViolation => Some(IndexOperationStepResult::Blocked(
+            IndexOperationBlocker::InvariantViolation,
+        )),
+        ManifestBlobMetadataProof::TransientFailure => {
+            Some(IndexOperationStepResult::TransientFailure)
+        }
+    };
     if let Some(result) = external_result {
         return Ok(PreparedTextOperationStep::Validation(Box::new(
             PreparedTextValidationStep::Database {

--- a/crates/db/src/index_lifecycle/text/mutation.rs
+++ b/crates/db/src/index_lifecycle/text/mutation.rs
@@ -25,7 +25,7 @@ use crate::encoding::v2::keys::{IndexEntity, IndexEntityStateKey, ScopedKey};
 use crate::encoding::v2::values::decode_index_record;
 use crate::encoding::v2::values::encode_build_delta;
 use crate::error::{HelixDbError, Result};
-use crate::index_lifecycle::work::CoalescedBuildDeltaValue;
+use crate::index_lifecycle::work::{CoalescedBuildDeltaState, CoalescedBuildDeltaValue};
 #[cfg(any(test, feature = "index-lifecycle-testing"))]
 use crate::index_lifecycle::IndexStateV2;
 use crate::index_lifecycle::{
@@ -511,6 +511,7 @@ async fn prepare_text_build_deltas_from(
             generation: target.generation,
             entity_kind: entity.entity_kind,
             entity_id: entity.entity_id,
+            state: CoalescedBuildDeltaState::Marker,
         };
         if !destination_keys.insert(key.clone()) {
             return Err(corruption(
@@ -935,6 +936,7 @@ mod tests {
             generation,
             entity_kind: entity.kind,
             entity_id: entity.id,
+            state: CoalescedBuildDeltaState::Marker,
         });
 
         let original = db

--- a/crates/db/src/index_lifecycle/text/mutation.rs
+++ b/crates/db/src/index_lifecycle/text/mutation.rs
@@ -18,15 +18,15 @@ use slatedb::DbTransaction;
 use crate::encoding::property::Property;
 use crate::encoding::v2::keys::scope::DataScope;
 use crate::encoding::v2::keys::ManagedIndexKey;
-#[cfg(test)]
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
 use crate::encoding::v2::keys::RecordKind;
 use crate::encoding::v2::keys::{IndexEntity, IndexEntityStateKey, ScopedKey};
-#[cfg(test)]
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
 use crate::encoding::v2::values::decode_index_record;
 use crate::encoding::v2::values::encode_build_delta;
 use crate::error::{HelixDbError, Result};
 use crate::index_lifecycle::work::CoalescedBuildDeltaValue;
-#[cfg(test)]
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
 use crate::index_lifecycle::IndexStateV2;
 use crate::index_lifecycle::{
     IndexElementKind, IndexEntityId, IndexGenerationId, IndexId, ValidatedDynamicIndexDefinition,
@@ -93,7 +93,7 @@ impl TextBuildDeltaMeasurements {
 /// Private rows ensure downstream code cannot substitute unmeasured deltas or
 /// stage them before request-level admission.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct PreparedTextBuildDeltas {
+pub(crate) struct PreparedTextBuildDeltas {
     rows: Vec<PreparedTextBuildDelta>,
     measurements: TextBuildDeltaMeasurements,
 }
@@ -131,8 +131,8 @@ impl PreparedTextBuildDeltas {
 
 /// Revalidated hidden-build rows ready for infallible staging.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg(test)]
-pub(super) struct ValidatedTextBuildDeltas {
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
+pub(crate) struct ValidatedTextBuildDeltas {
     rows: Vec<PreparedTextBuildDelta>,
 }
 
@@ -337,7 +337,7 @@ impl TextMutationSet {
 /// Building generations become coalesced-delta targets. Active generations
 /// become definition-bearing handles consumed only by the complete request
 /// orchestrator.
-#[cfg(test)]
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
 pub(crate) async fn load_mutation_set(
     transaction: &DbTransaction,
     scope: DataScope,
@@ -397,8 +397,8 @@ pub(crate) async fn load_mutation_set(
 /// property therefore creates no lifecycle work. Every source row is observed
 /// once here and once during validation, and every canonical replacement row is
 /// measured without staging.
-#[cfg(test)]
-pub(super) async fn prepare_text_build_deltas(
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
+pub(crate) async fn prepare_text_build_deltas(
     transaction: &DbTransaction,
     scope: DataScope,
     mutations: &TextMutationSet,
@@ -640,8 +640,8 @@ pub(super) fn stage_prepared_text_build_delta_rows(
 }
 
 /// Revalidates every hidden-build delta source without staging any write.
-#[cfg(test)]
-pub(super) async fn validate_text_build_deltas(
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
+pub(crate) async fn validate_text_build_deltas(
     transaction: &DbTransaction,
     prepared: &PreparedTextBuildDeltas,
 ) -> Result<ValidatedTextBuildDeltas> {
@@ -669,8 +669,8 @@ pub(super) async fn validate_text_build_deltas(
 }
 
 /// Stages hidden-build rows only after the complete request has validated.
-#[cfg(test)]
-pub(super) fn stage_validated_text_build_deltas(
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
+pub(crate) fn stage_validated_text_build_deltas(
     transaction: &DbTransaction,
     validated: ValidatedTextBuildDeltas,
 ) -> Result<()> {

--- a/crates/db/src/index_lifecycle/text/statistics.rs
+++ b/crates/db/src/index_lifecycle/text/statistics.rs
@@ -577,7 +577,7 @@ pub(crate) async fn load_entity_contribution(
 }
 
 /// Revalidates every observed row without buffering writes.
-#[cfg(test)]
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
 pub(crate) async fn validate(
     transaction: &DbTransaction,
     prepared: &PreparedTextStatisticsTransition,
@@ -593,7 +593,7 @@ pub(crate) async fn validate(
 }
 
 /// Buffers a transition after its complete request-level validation pass.
-#[cfg(test)]
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
 pub(crate) fn stage_validated(
     transaction: &DbTransaction,
     prepared: &PreparedTextStatisticsTransition,

--- a/crates/db/src/index_lifecycle/text/validation.rs
+++ b/crates/db/src/index_lifecycle/text/validation.rs
@@ -140,7 +140,19 @@ pub(super) async fn select(
     progress: &TextManifestValidationProgress,
     limits: SearchIndexBatchLimits,
 ) -> Result<ValidationSelection> {
-    match progress {
+    let delta_prefix = generation_prefix(scope, index_keys::RecordKind::BuildDelta, operation);
+    let (delta_range, delta) = select_one(transaction, delta_prefix, None).await?;
+    if delta.is_some() {
+        return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+            ranges: vec![delta_range],
+            observations: Vec::new(),
+            result: progressed(TextBuildStage::CatchUp(PrefixScanProgress {
+                cursor: None,
+                counters: progress.counters(),
+            })),
+        }));
+    }
+    let mut selection = match progress {
         TextManifestValidationProgress::Pages(progress) => {
             select_page(transaction, scope, operation, progress, limits).await
         }
@@ -150,7 +162,12 @@ pub(super) async fn select(
         TextManifestValidationProgress::EntityStates(progress) => {
             select_entity_state(transaction, scope, operation, progress, limits).await
         }
+    }?;
+    match &mut selection {
+        ValidationSelection::Database(prepared) => prepared.ranges.push(delta_range),
+        ValidationSelection::Page(prepared) => prepared.database.ranges.push(delta_range),
     }
+    Ok(selection)
 }
 
 /// Validates one immutable page and its exact root relationship.

--- a/crates/db/src/index_lifecycle/text/validation.rs
+++ b/crates/db/src/index_lifecycle/text/validation.rs
@@ -107,6 +107,37 @@ struct PreparedValidationRange {
     rows: Vec<(Bytes, Bytes)>,
 }
 
+/// One bounded prefix scan whose admitted prefix can become an exact fence.
+#[derive(Debug)]
+struct PreparedValidationScan {
+    prefix: Bytes,
+    start: Bound<Bytes>,
+    rows: Vec<(Bytes, Bytes)>,
+}
+
+impl PreparedValidationScan {
+    /// Retains exactly the first `count` rows, excluding every deferred row.
+    fn range_through(&self, count: usize) -> PreparedValidationRange {
+        assert!(
+            count <= self.rows.len(),
+            "validation range exceeds selected rows"
+        );
+        let selected = self.rows[..count].to_vec();
+        let end = selected.last().map_or(Bound::Unbounded, |(key, _)| {
+            let suffix = key
+                .strip_prefix(self.prefix.as_ref())
+                .expect("scan_prefix returns only keys with the requested prefix");
+            Bound::Included(Bytes::copy_from_slice(suffix))
+        });
+        PreparedValidationRange {
+            prefix: self.prefix.clone(),
+            start: self.start.clone(),
+            end,
+            rows: selected,
+        }
+    }
+}
+
 impl PreparedValidationRange {
     /// Replays one selected or exhausted interval inside the commit transaction.
     async fn is_current(&self, transaction: &DbTransaction) -> Result<bool> {
@@ -170,7 +201,7 @@ pub(super) async fn select(
     Ok(selection)
 }
 
-/// Validates one immutable page and its exact root relationship.
+/// Validates one bounded batch of immutable pages and exact root relationships.
 async fn select_page(
     transaction: &DbTransaction,
     scope: DataScope,
@@ -179,8 +210,15 @@ async fn select_page(
     limits: SearchIndexBatchLimits,
 ) -> Result<ValidationSelection> {
     let prefix = generation_prefix(scope, index_keys::RecordKind::TextManifestPage, operation);
-    let (range, row) = select_one(transaction, prefix, progress.cursor()).await?;
-    let Some((row_key, row_value)) = row else {
+    let scan = select_many(
+        transaction,
+        prefix,
+        progress.cursor(),
+        limits.max_entities().get(),
+        limits.max_input_bytes().get(),
+    )
+    .await?;
+    if scan.rows.is_empty() {
         let result = if progress.partition().is_some() {
             IndexOperationStepResult::Blocked(IndexOperationBlocker::InvariantViolation)
         } else {
@@ -192,129 +230,160 @@ async fn select_page(
             ))
         };
         return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
-            ranges: vec![range],
+            ranges: vec![scan.range_through(0)],
             observations: Vec::new(),
             result,
         }));
-    };
-
-    let page_key = match ManagedIndexKey::parse_from_slice(scope, &row_key) {
-        Ok(ManagedIndexKey::Data {
-            kind: index_keys::ScopedKey::TextManifestPage(key),
-            ..
-        }) => key,
-        Ok(ManagedIndexKey::Data { .. } | ManagedIndexKey::Global { .. }) | Err(_) => {
-            return Ok(blocked_database(vec![range], Vec::new()));
-        }
-    };
-    let Ok(page) = index_values::decode_manifest_page(&row_value) else {
-        return Ok(blocked_database(vec![range], Vec::new()));
-    };
-    let root_key = scoped_key(
-        scope,
-        index_keys::ScopedKey::TextManifestRoot(page_key.root),
-    );
-    let root_value = transaction.get(&root_key).await?;
-    let observations = vec![RowObservation {
-        key: root_key,
-        value: root_value.clone(),
-    }];
-    let Some(root_value) = root_value.as_ref() else {
-        return Ok(blocked_database(vec![range], observations));
-    };
-    let Ok(root) = index_values::decode_manifest_root(root_value) else {
-        return Ok(blocked_database(vec![range], observations));
-    };
-
-    let minimum_revision = u64::from(root.page_count()).saturating_add(1);
-    if page_key.root.index_id != operation.index_id()
-        || page_key.root.generation != operation.generation()
-        || page.index_id() != operation.index_id()
-        || page.generation() != operation.generation()
-        || page_key.root.partition != page.partition().fingerprint()
-        || page_key.page != page.page()
-        || root.index_id() != operation.index_id()
-        || root.generation() != operation.generation()
-        || page_key.root.partition != root.partition().fingerprint()
-        || root.partition() != page.partition()
-        || root.page_count() == 0
-        || root.split_count() == 0
-        || root.revision().get() < minimum_revision
-        || page_key.page >= root.page_count()
-    {
-        return Ok(blocked_database(vec![range], observations));
     }
 
-    let observed_before = match progress.partition() {
-        Some(partition)
-            if partition.partition_fingerprint() == page_key.root.partition.as_bytes()
-                && partition.root_revision() == root.revision()
-                && partition.page_count() == root.page_count()
-                && partition.split_count() == root.split_count()
-                && partition.next_page() == page_key.page =>
-        {
-            partition.observed_split_count()
-        }
-        None if page_key.page == 0 => 0,
-        Some(_) | None => return Ok(blocked_database(vec![range], observations)),
-    };
-    let page_split_count =
-        u64::try_from(page.entries().len()).expect("bounded manifest-page length fits u64");
-    // Both values are bounded by a valid root's page count times MAX_ENTRIES.
-    let observed_split_count = observed_before + page_split_count;
-    // `page < root.page_count <= u32::MAX` proves this addition cannot overflow.
-    let next_page = page_key.page + 1;
-    let next_partition = if next_page == root.page_count() {
-        if observed_split_count != root.split_count() {
-            return Ok(blocked_database(vec![range], observations));
-        }
-        None
-    } else {
-        let Ok(partition) = TextManifestPartitionValidation::try_new(
-            *page_key.root.partition.as_bytes(),
-            root.revision(),
-            root.page_count(),
-            root.split_count(),
-            next_page,
-            observed_split_count,
-        ) else {
-            return Ok(blocked_database(vec![range], observations));
+    let mut admitted_rows = 0;
+    let mut input_bytes = 0_u64;
+    let mut observations = Vec::new();
+    let mut blobs = Vec::new();
+    let mut distinct_blobs = HashSet::new();
+    let mut next_partition = progress.partition().cloned();
+    for (index, (row_key, row_value)) in scan.rows.iter().enumerate() {
+        let range = || vec![scan.range_through(index + 1)];
+        let page_key = match ManagedIndexKey::parse_from_slice(scope, row_key) {
+            Ok(ManagedIndexKey::Data {
+                kind: index_keys::ScopedKey::TextManifestPage(key),
+                ..
+            }) => key,
+            Ok(ManagedIndexKey::Data { .. } | ManagedIndexKey::Global { .. }) | Err(_) => {
+                return Ok(blocked_database(range(), observations));
+            }
         };
-        Some(partition)
-    };
+        let Ok(page) = index_values::decode_manifest_page(row_value) else {
+            return Ok(blocked_database(range(), observations));
+        };
+        let root_key = scoped_key(
+            scope,
+            index_keys::ScopedKey::TextManifestRoot(page_key.root),
+        );
+        let root_value = transaction.get(&root_key).await?;
+        let row_observations = vec![RowObservation {
+            key: root_key,
+            value: root_value.clone(),
+        }];
+        let Some(root_value) = root_value.as_ref() else {
+            observations.extend(row_observations);
+            return Ok(blocked_database(range(), observations));
+        };
+        let Ok(root) = index_values::decode_manifest_root(root_value) else {
+            observations.extend(row_observations);
+            return Ok(blocked_database(range(), observations));
+        };
 
-    let mut blobs = Vec::with_capacity(page.entries().len());
-    let mut distinct_blobs = HashSet::with_capacity(page.entries().len());
-    for split in page.entries().iter().copied() {
-        let blob = split.blob();
-        if !crate::search::text::split_reference_layout_is_exact(
-            split.footer_offset(),
-            split.footer_length(),
-            split.hot_cache_length(),
-            split.total_size(),
-        ) || !distinct_blobs.insert(blob)
+        let minimum_revision = u64::from(root.page_count()).saturating_add(1);
+        if page_key.root.index_id != operation.index_id()
+            || page_key.root.generation != operation.generation()
+            || page.index_id() != operation.index_id()
+            || page.generation() != operation.generation()
+            || page_key.root.partition != page.partition().fingerprint()
+            || page_key.page != page.page()
+            || root.index_id() != operation.index_id()
+            || root.generation() != operation.generation()
+            || page_key.root.partition != root.partition().fingerprint()
+            || root.partition() != page.partition()
+            || root.page_count() == 0
+            || root.split_count() == 0
+            || root.revision().get() < minimum_revision
+            || page_key.page >= root.page_count()
         {
-            return Ok(blocked_database(vec![range], observations));
+            observations.extend(row_observations);
+            return Ok(blocked_database(range(), observations));
         }
-        blobs.push(blob);
-    }
 
-    let input_bytes = row_bytes(&row_key, Some(&row_value)).saturating_add(
-        observations.iter().fold(0_u64, |bytes, observation| {
-            bytes.saturating_add(row_bytes(&observation.key, observation.value.as_ref()))
-        }),
-    );
-    if input_bytes > limits.max_input_bytes().get() {
-        return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
-            ranges: vec![range],
-            observations,
-            result: IndexOperationStepResult::Blocked(IndexOperationBlocker::ManifestLimit {
-                partition: page.partition().clone(),
-                observed: input_bytes,
-                limit: limits.max_input_bytes().get(),
+        let observed_before = match next_partition.as_ref() {
+            Some(partition)
+                if partition.partition_fingerprint() == page_key.root.partition.as_bytes()
+                    && partition.root_revision() == root.revision()
+                    && partition.page_count() == root.page_count()
+                    && partition.split_count() == root.split_count()
+                    && partition.next_page() == page_key.page =>
+            {
+                partition.observed_split_count()
+            }
+            None if page_key.page == 0 => 0,
+            Some(_) | None => {
+                observations.extend(row_observations);
+                return Ok(blocked_database(range(), observations));
+            }
+        };
+        let page_split_count =
+            u64::try_from(page.entries().len()).expect("bounded manifest-page length fits u64");
+        let observed_split_count = observed_before + page_split_count;
+        let next_page = page_key.page + 1;
+        let candidate_partition = if next_page == root.page_count() {
+            if observed_split_count != root.split_count() {
+                observations.extend(row_observations);
+                return Ok(blocked_database(range(), observations));
+            }
+            None
+        } else {
+            let Ok(partition) = TextManifestPartitionValidation::try_new(
+                *page_key.root.partition.as_bytes(),
+                root.revision(),
+                root.page_count(),
+                root.split_count(),
+                next_page,
+                observed_split_count,
+            ) else {
+                observations.extend(row_observations);
+                return Ok(blocked_database(range(), observations));
+            };
+            Some(partition)
+        };
+
+        let mut page_blobs = Vec::with_capacity(page.entries().len());
+        let mut page_distinct_blobs = HashSet::with_capacity(page.entries().len());
+        for split in page.entries().iter().copied() {
+            let blob = split.blob();
+            if !crate::search::text::split_reference_layout_is_exact(
+                split.footer_offset(),
+                split.footer_length(),
+                split.hot_cache_length(),
+                split.total_size(),
+            ) || !page_distinct_blobs.insert(blob)
+            {
+                observations.extend(row_observations);
+                return Ok(blocked_database(range(), observations));
+            }
+            page_blobs.push(blob);
+        }
+
+        let row_input_bytes = row_bytes(row_key, Some(row_value)).saturating_add(
+            row_observations.iter().fold(0_u64, |bytes, observation| {
+                bytes.saturating_add(row_bytes(&observation.key, observation.value.as_ref()))
             }),
-        }));
+        );
+        if admitted_rows == 0 && row_input_bytes > limits.max_input_bytes().get() {
+            observations.extend(row_observations);
+            return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+                ranges: range(),
+                observations,
+                result: IndexOperationStepResult::Blocked(IndexOperationBlocker::ManifestLimit {
+                    partition: page.partition().clone(),
+                    observed: row_input_bytes,
+                    limit: limits.max_input_bytes().get(),
+                }),
+            }));
+        }
+        if input_bytes.saturating_add(row_input_bytes) > limits.max_input_bytes().get() {
+            break;
+        }
+
+        input_bytes = input_bytes.saturating_add(row_input_bytes);
+        observations.extend(row_observations);
+        for blob in page_blobs {
+            if distinct_blobs.insert(blob) {
+                blobs.push(blob);
+            }
+        }
+        next_partition = candidate_partition;
+        admitted_rows += 1;
     }
+    assert!(admitted_rows != 0, "a non-empty page scan admits one row");
     let Some(input_bytes) = progress.counters().input_bytes.checked_add(input_bytes) else {
         return Err(corruption(
             "text manifest-validation input counter overflowed",
@@ -324,13 +393,13 @@ async fn select_page(
         input_bytes,
         ..progress.counters()
     };
-    let cursor = IndexCursor::try_new(row_key)
+    let cursor = IndexCursor::try_new(scan.rows[admitted_rows - 1].0.clone())
         .map_err(|error| HelixDbError::InvariantViolation(error.to_string()))?;
     let next = TextManifestPageValidationProgress::try_new(Some(cursor), next_partition, counters)
         .map_err(|error| HelixDbError::InvariantViolation(error.to_string()))?;
     Ok(ValidationSelection::Page(PreparedPageValidation {
         database: PreparedDatabaseValidation {
-            ranges: vec![range],
+            ranges: vec![scan.range_through(admitted_rows)],
             observations,
             result: progressed(TextBuildStage::ValidateManifests(
                 TextManifestValidationProgress::Pages(next),
@@ -340,7 +409,7 @@ async fn select_page(
     }))
 }
 
-/// Validates one manifest root, including the canonical empty representation.
+/// Validates one bounded batch of roots, including canonical empty roots.
 async fn select_root(
     transaction: &DbTransaction,
     scope: DataScope,
@@ -350,10 +419,17 @@ async fn select_root(
     limits: SearchIndexBatchLimits,
 ) -> Result<ValidationSelection> {
     let prefix = generation_prefix(scope, index_keys::RecordKind::TextManifestRoot, operation);
-    let (range, row) = select_one(transaction, prefix, progress.cursor.as_ref()).await?;
-    let Some((row_key, row_value)) = row else {
+    let scan = select_many(
+        transaction,
+        prefix,
+        progress.cursor.as_ref(),
+        limits.max_entities().get(),
+        limits.max_input_bytes().get(),
+    )
+    .await?;
+    if scan.rows.is_empty() {
         return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
-            ranges: vec![range],
+            ranges: vec![scan.range_through(0)],
             observations: Vec::new(),
             result: progressed(TextBuildStage::ValidateManifests(
                 TextManifestValidationProgress::EntityStates(PrefixScanProgress {
@@ -362,103 +438,122 @@ async fn select_root(
                 }),
             )),
         }));
-    };
-    let root_key = match ManagedIndexKey::parse_from_slice(scope, &row_key) {
-        Ok(ManagedIndexKey::Data {
-            kind: index_keys::ScopedKey::TextManifestRoot(key),
-            ..
-        }) => key,
-        Ok(ManagedIndexKey::Data { .. } | ManagedIndexKey::Global { .. }) | Err(_) => {
-            return Ok(blocked_database(vec![range], Vec::new()));
-        }
-    };
-    let Ok(root) = index_values::decode_manifest_root(&row_value) else {
-        return Ok(blocked_database(vec![range], Vec::new()));
-    };
-    let partition_mode_is_valid = match (definition.tenant_property(), root.partition()) {
-        (None, TextPartition::Unpartitioned) | (Some(_), TextPartition::TenantValue(_)) => true,
-        (None, TextPartition::TenantValue(_)) | (Some(_), TextPartition::Unpartitioned) => false,
-    };
-    let revision_is_valid = if root.page_count() == 0 {
-        root.split_count() == 0
-    } else {
-        root.revision().get() >= u64::from(root.page_count()).saturating_add(1)
-            && root.split_count() != 0
-    };
-    if root_key.index_id != operation.index_id()
-        || root_key.generation != operation.generation()
-        || root.index_id() != operation.index_id()
-        || root.generation() != operation.generation()
-        || root_key.partition != root.partition().fingerprint()
-        || !partition_mode_is_valid
-        || !revision_is_valid
-    {
-        return Ok(blocked_database(vec![range], Vec::new()));
     }
 
-    let corpus_key = super::statistics::corpus_key(
-        scope,
-        operation.index_id(),
-        operation.generation(),
-        root.partition(),
-    );
-    let corpus_value = transaction.get(&corpus_key).await?;
-    let mut observations = vec![RowObservation {
-        key: corpus_key,
-        value: corpus_value.clone(),
-    }];
-    if super::statistics::validate_manifest_corpus(
-        corpus_value.as_deref(),
-        operation.index_id(),
-        operation.generation(),
-        root.partition(),
-        root.split_count(),
-    )
-    .is_err()
-    {
-        return Ok(blocked_database(vec![range], observations));
-    }
-    if root.page_count() != 0 {
-        let page_key = scoped_key(
+    let mut admitted_rows = 0;
+    let mut input_bytes = 0_u64;
+    let mut observations = Vec::new();
+    for (index, (row_key, row_value)) in scan.rows.iter().enumerate() {
+        let range = || vec![scan.range_through(index + 1)];
+        let root_key = match ManagedIndexKey::parse_from_slice(scope, row_key) {
+            Ok(ManagedIndexKey::Data {
+                kind: index_keys::ScopedKey::TextManifestRoot(key),
+                ..
+            }) => key,
+            Ok(ManagedIndexKey::Data { .. } | ManagedIndexKey::Global { .. }) | Err(_) => {
+                return Ok(blocked_database(range(), observations));
+            }
+        };
+        let Ok(root) = index_values::decode_manifest_root(row_value) else {
+            return Ok(blocked_database(range(), observations));
+        };
+        let partition_mode_is_valid = match (definition.tenant_property(), root.partition()) {
+            (None, TextPartition::Unpartitioned) | (Some(_), TextPartition::TenantValue(_)) => true,
+            (None, TextPartition::TenantValue(_)) | (Some(_), TextPartition::Unpartitioned) => {
+                false
+            }
+        };
+        let revision_is_valid = if root.page_count() == 0 {
+            root.split_count() == 0
+        } else {
+            root.revision().get() >= u64::from(root.page_count()).saturating_add(1)
+                && root.split_count() != 0
+        };
+        if root_key.index_id != operation.index_id()
+            || root_key.generation != operation.generation()
+            || root.index_id() != operation.index_id()
+            || root.generation() != operation.generation()
+            || root_key.partition != root.partition().fingerprint()
+            || !partition_mode_is_valid
+            || !revision_is_valid
+        {
+            return Ok(blocked_database(range(), observations));
+        }
+
+        let corpus_key = super::statistics::corpus_key(
             scope,
-            index_keys::ScopedKey::TextManifestPage(index_keys::TextManifestPageKey {
-                root: root_key,
-                page: 0,
+            operation.index_id(),
+            operation.generation(),
+            root.partition(),
+        );
+        let corpus_value = transaction.get(&corpus_key).await?;
+        let mut row_observations = vec![RowObservation {
+            key: corpus_key,
+            value: corpus_value.clone(),
+        }];
+        if super::statistics::validate_manifest_corpus(
+            corpus_value.as_deref(),
+            operation.index_id(),
+            operation.generation(),
+            root.partition(),
+            root.split_count(),
+        )
+        .is_err()
+        {
+            observations.extend(row_observations);
+            return Ok(blocked_database(range(), observations));
+        }
+        if root.page_count() != 0 {
+            let page_key = scoped_key(
+                scope,
+                index_keys::ScopedKey::TextManifestPage(index_keys::TextManifestPageKey {
+                    root: root_key,
+                    page: 0,
+                }),
+            );
+            let page_value = transaction.get(&page_key).await?;
+            let exact_page_zero = page_value.as_ref().is_some_and(|value| {
+                index_values::decode_manifest_page(value).is_ok_and(|page| {
+                    page.index_id() == operation.index_id()
+                        && page.generation() == operation.generation()
+                        && page.partition() == root.partition()
+                        && page.page() == 0
+                })
+            });
+            row_observations.push(RowObservation {
+                key: page_key,
+                value: page_value,
+            });
+            if !exact_page_zero {
+                observations.extend(row_observations);
+                return Ok(blocked_database(range(), observations));
+            }
+        }
+        let row_input_bytes = row_bytes(row_key, Some(row_value)).saturating_add(
+            row_observations.iter().fold(0_u64, |bytes, observation| {
+                bytes.saturating_add(row_bytes(&observation.key, observation.value.as_ref()))
             }),
         );
-        let page_value = transaction.get(&page_key).await?;
-        let exact_page_zero = page_value.as_ref().is_some_and(|value| {
-            index_values::decode_manifest_page(value).is_ok_and(|page| {
-                page.index_id() == operation.index_id()
-                    && page.generation() == operation.generation()
-                    && page.partition() == root.partition()
-                    && page.page() == 0
-            })
-        });
-        observations.push(RowObservation {
-            key: page_key,
-            value: page_value,
-        });
-        if !exact_page_zero {
-            return Ok(blocked_database(vec![range], observations));
+        if admitted_rows == 0 && row_input_bytes > limits.max_input_bytes().get() {
+            observations.extend(row_observations);
+            return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+                ranges: range(),
+                observations,
+                result: IndexOperationStepResult::Blocked(IndexOperationBlocker::ManifestLimit {
+                    partition: root.partition().clone(),
+                    observed: row_input_bytes,
+                    limit: limits.max_input_bytes().get(),
+                }),
+            }));
         }
+        if input_bytes.saturating_add(row_input_bytes) > limits.max_input_bytes().get() {
+            break;
+        }
+        input_bytes = input_bytes.saturating_add(row_input_bytes);
+        observations.extend(row_observations);
+        admitted_rows += 1;
     }
-    let input_bytes = row_bytes(&row_key, Some(&row_value)).saturating_add(
-        observations.iter().fold(0_u64, |bytes, observation| {
-            bytes.saturating_add(row_bytes(&observation.key, observation.value.as_ref()))
-        }),
-    );
-    if input_bytes > limits.max_input_bytes().get() {
-        return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
-            ranges: vec![range],
-            observations,
-            result: IndexOperationStepResult::Blocked(IndexOperationBlocker::ManifestLimit {
-                partition: root.partition().clone(),
-                observed: input_bytes,
-                limit: limits.max_input_bytes().get(),
-            }),
-        }));
-    }
+    assert!(admitted_rows != 0, "a non-empty root scan admits one row");
     let Some(input_bytes) = progress.counters.input_bytes.checked_add(input_bytes) else {
         return Err(corruption("text root-validation input counter overflowed"));
     };
@@ -467,12 +562,12 @@ async fn select_root(
         ..progress.counters
     };
     Ok(ValidationSelection::Database(PreparedDatabaseValidation {
-        ranges: vec![range],
+        ranges: vec![scan.range_through(admitted_rows)],
         observations,
         result: progressed(TextBuildStage::ValidateManifests(
             TextManifestValidationProgress::Roots(PrefixScanProgress {
                 cursor: Some(
-                    IndexCursor::try_new(row_key)
+                    IndexCursor::try_new(scan.rows[admitted_rows - 1].0.clone())
                         .map_err(|error| HelixDbError::InvariantViolation(error.to_string()))?,
                 ),
                 counters,
@@ -481,7 +576,7 @@ async fn select_root(
     }))
 }
 
-/// Validates one entity-state row against its exact owning root revision.
+/// Validates one bounded entity-state batch against exact owning roots.
 async fn select_entity_state(
     transaction: &DbTransaction,
     scope: DataScope,
@@ -490,143 +585,175 @@ async fn select_entity_state(
     limits: SearchIndexBatchLimits,
 ) -> Result<ValidationSelection> {
     let prefix = generation_prefix(scope, index_keys::RecordKind::TextEntityState, operation);
-    let (range, row) = select_one(transaction, prefix, progress.cursor.as_ref()).await?;
-    let Some((row_key, row_value)) = row else {
+    let scan = select_many(
+        transaction,
+        prefix,
+        progress.cursor.as_ref(),
+        limits.max_entities().get(),
+        limits.max_input_bytes().get(),
+    )
+    .await?;
+    if scan.rows.is_empty() {
         return select_activation_prerequisites(
             transaction,
             scope,
             operation,
             progress.counters,
-            range,
+            scan.range_through(0),
         )
         .await;
-    };
-    let state_key = match ManagedIndexKey::parse_from_slice(scope, &row_key) {
-        Ok(ManagedIndexKey::Data {
-            kind: index_keys::ScopedKey::TextEntityState(key),
-            ..
-        }) => key,
-        Ok(ManagedIndexKey::Data { .. } | ManagedIndexKey::Global { .. }) | Err(_) => {
-            return Ok(blocked_database(vec![range], Vec::new()));
-        }
-    };
-    let Ok(state) = index_values::decode_text_entity_state(&row_value) else {
-        return Ok(blocked_database(vec![range], Vec::new()));
-    };
-    let root_key = scoped_key(
-        scope,
-        index_keys::ScopedKey::TextManifestRoot(state_key.root),
-    );
-    let root_value = transaction.get(&root_key).await?;
-    let mut observations = vec![RowObservation {
-        key: root_key,
-        value: root_value.clone(),
-    }];
-    let Some(root_value) = root_value.as_ref() else {
-        return Ok(blocked_database(vec![range], observations));
-    };
-    let Ok(root) = index_values::decode_manifest_root(root_value) else {
-        return Ok(blocked_database(vec![range], observations));
-    };
-    if state_key.root.index_id != operation.index_id()
-        || state_key.root.generation != operation.generation()
-        || state.index_id != operation.index_id()
-        || state.generation != operation.generation()
-        || state_key.root.partition != state.partition.fingerprint()
-        || state_key.entity.kind != state.entity_kind
-        || state_key.entity.id != state.entity_id
-        || root.index_id() != operation.index_id()
-        || root.generation() != operation.generation()
-        || root.partition() != &state.partition
-        || state.logical_version.get() > root.revision().get()
-        || (state.live && root.page_count() == 0)
-    {
-        return Ok(blocked_database(vec![range], observations));
     }
-    let marker_key = scoped_key(
-        scope,
-        index_keys::ScopedKey::TextStatisticsEntity(index_keys::TextStatisticsEntityKey {
-            index_id: operation.index_id(),
-            generation: operation.generation(),
-            entity: state_key.entity,
-        }),
-    );
-    let marker_value = transaction.get(&marker_key).await?;
-    observations.push(RowObservation {
-        key: marker_key,
-        value: marker_value.clone(),
-    });
-    let Some(marker_value) = marker_value.as_ref() else {
-        return Ok(blocked_database(vec![range], observations));
-    };
-    let Ok(marker) = index_values::decode_statistics_entity(marker_value) else {
-        return Ok(blocked_database(vec![range], observations));
-    };
-    if marker.index_id != operation.index_id()
-        || marker.generation != operation.generation()
-        || marker.entity_kind != state_key.entity.kind
-        || marker.entity_id != state_key.entity.id
-    {
-        return Ok(blocked_database(vec![range], observations));
-    }
-    let marker_matches = match (&marker.contribution, state.live) {
-        (work::TextStatisticsContribution::Present { partition, .. }, true) => {
-            partition == &state.partition
-        }
-        (work::TextStatisticsContribution::Absent, false) => true,
-        (work::TextStatisticsContribution::Present { partition, .. }, false)
-            if partition != &state.partition =>
+
+    let mut admitted_rows = 0;
+    let mut input_bytes = 0_u64;
+    let mut observations = Vec::new();
+    for (index, (row_key, row_value)) in scan.rows.iter().enumerate() {
+        let range = || vec![scan.range_through(index + 1)];
+        let state_key = match ManagedIndexKey::parse_from_slice(scope, row_key) {
+            Ok(ManagedIndexKey::Data {
+                kind: index_keys::ScopedKey::TextEntityState(key),
+                ..
+            }) => key,
+            Ok(ManagedIndexKey::Data { .. } | ManagedIndexKey::Global { .. }) | Err(_) => {
+                return Ok(blocked_database(range(), observations));
+            }
+        };
+        let Ok(state) = index_values::decode_text_entity_state(row_value) else {
+            return Ok(blocked_database(range(), observations));
+        };
+        let root_key = scoped_key(
+            scope,
+            index_keys::ScopedKey::TextManifestRoot(state_key.root),
+        );
+        let root_value = transaction.get(&root_key).await?;
+        let mut row_observations = vec![RowObservation {
+            key: root_key,
+            value: root_value.clone(),
+        }];
+        let Some(root_value) = root_value.as_ref() else {
+            observations.extend(row_observations);
+            return Ok(blocked_database(range(), observations));
+        };
+        let Ok(root) = index_values::decode_manifest_root(root_value) else {
+            observations.extend(row_observations);
+            return Ok(blocked_database(range(), observations));
+        };
+        if state_key.root.index_id != operation.index_id()
+            || state_key.root.generation != operation.generation()
+            || state.index_id != operation.index_id()
+            || state.generation != operation.generation()
+            || state_key.root.partition != state.partition.fingerprint()
+            || state_key.entity.kind != state.entity_kind
+            || state_key.entity.id != state.entity_id
+            || root.index_id() != operation.index_id()
+            || root.generation() != operation.generation()
+            || root.partition() != &state.partition
+            || state.logical_version.get() > root.revision().get()
+            || (state.live && root.page_count() == 0)
         {
-            let live_key = scoped_key(
-                scope,
-                index_keys::ScopedKey::TextEntityState(index_keys::TextEntityStateKey {
-                    root: index_keys::TextManifestRootKey {
-                        index_id: operation.index_id(),
-                        generation: operation.generation(),
-                        partition: partition.fingerprint(),
-                    },
-                    entity: state_key.entity,
-                }),
-            );
-            let live_value = transaction.get(&live_key).await?;
-            let exact_live_state = live_value.as_ref().is_some_and(|value| {
-                index_values::decode_text_entity_state(value).is_ok_and(|live| {
-                    live.index_id == operation.index_id()
-                        && live.generation == operation.generation()
-                        && live.partition == *partition
-                        && live.entity_kind == state_key.entity.kind
-                        && live.entity_id == state_key.entity.id
-                        && live.live
-                })
-            });
-            observations.push(RowObservation {
-                key: live_key,
-                value: live_value,
-            });
-            exact_live_state
+            observations.extend(row_observations);
+            return Ok(blocked_database(range(), observations));
         }
-        (work::TextStatisticsContribution::Absent, true)
-        | (work::TextStatisticsContribution::Present { .. }, false) => false,
-    };
-    if !marker_matches {
-        return Ok(blocked_database(vec![range], observations));
-    }
-    let input_bytes = row_bytes(&row_key, Some(&row_value)).saturating_add(
-        observations.iter().fold(0_u64, |bytes, observation| {
-            bytes.saturating_add(row_bytes(&observation.key, observation.value.as_ref()))
-        }),
-    );
-    if input_bytes > limits.max_input_bytes().get() {
-        return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
-            ranges: vec![range],
-            observations,
-            result: IndexOperationStepResult::Blocked(IndexOperationBlocker::ManifestLimit {
-                partition: state.partition,
-                observed: input_bytes,
-                limit: limits.max_input_bytes().get(),
+        let marker_key = scoped_key(
+            scope,
+            index_keys::ScopedKey::TextStatisticsEntity(index_keys::TextStatisticsEntityKey {
+                index_id: operation.index_id(),
+                generation: operation.generation(),
+                entity: state_key.entity,
             }),
-        }));
+        );
+        let marker_value = transaction.get(&marker_key).await?;
+        row_observations.push(RowObservation {
+            key: marker_key,
+            value: marker_value.clone(),
+        });
+        let Some(marker_value) = marker_value.as_ref() else {
+            observations.extend(row_observations);
+            return Ok(blocked_database(range(), observations));
+        };
+        let Ok(marker) = index_values::decode_statistics_entity(marker_value) else {
+            observations.extend(row_observations);
+            return Ok(blocked_database(range(), observations));
+        };
+        if marker.index_id != operation.index_id()
+            || marker.generation != operation.generation()
+            || marker.entity_kind != state_key.entity.kind
+            || marker.entity_id != state_key.entity.id
+        {
+            observations.extend(row_observations);
+            return Ok(blocked_database(range(), observations));
+        }
+        let marker_matches = match (&marker.contribution, state.live) {
+            (work::TextStatisticsContribution::Present { partition, .. }, true) => {
+                partition == &state.partition
+            }
+            (work::TextStatisticsContribution::Absent, false) => true,
+            (work::TextStatisticsContribution::Present { partition, .. }, false)
+                if partition != &state.partition =>
+            {
+                let live_key = scoped_key(
+                    scope,
+                    index_keys::ScopedKey::TextEntityState(index_keys::TextEntityStateKey {
+                        root: index_keys::TextManifestRootKey {
+                            index_id: operation.index_id(),
+                            generation: operation.generation(),
+                            partition: partition.fingerprint(),
+                        },
+                        entity: state_key.entity,
+                    }),
+                );
+                let live_value = transaction.get(&live_key).await?;
+                let exact_live_state = live_value.as_ref().is_some_and(|value| {
+                    index_values::decode_text_entity_state(value).is_ok_and(|live| {
+                        live.index_id == operation.index_id()
+                            && live.generation == operation.generation()
+                            && live.partition == *partition
+                            && live.entity_kind == state_key.entity.kind
+                            && live.entity_id == state_key.entity.id
+                            && live.live
+                    })
+                });
+                row_observations.push(RowObservation {
+                    key: live_key,
+                    value: live_value,
+                });
+                exact_live_state
+            }
+            (work::TextStatisticsContribution::Absent, true)
+            | (work::TextStatisticsContribution::Present { .. }, false) => false,
+        };
+        if !marker_matches {
+            observations.extend(row_observations);
+            return Ok(blocked_database(range(), observations));
+        }
+        let row_input_bytes = row_bytes(row_key, Some(row_value)).saturating_add(
+            row_observations.iter().fold(0_u64, |bytes, observation| {
+                bytes.saturating_add(row_bytes(&observation.key, observation.value.as_ref()))
+            }),
+        );
+        if admitted_rows == 0 && row_input_bytes > limits.max_input_bytes().get() {
+            observations.extend(row_observations);
+            return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+                ranges: range(),
+                observations,
+                result: IndexOperationStepResult::Blocked(IndexOperationBlocker::ManifestLimit {
+                    partition: state.partition,
+                    observed: row_input_bytes,
+                    limit: limits.max_input_bytes().get(),
+                }),
+            }));
+        }
+        if input_bytes.saturating_add(row_input_bytes) > limits.max_input_bytes().get() {
+            break;
+        }
+        input_bytes = input_bytes.saturating_add(row_input_bytes);
+        observations.extend(row_observations);
+        admitted_rows += 1;
     }
+    assert!(
+        admitted_rows != 0,
+        "a non-empty entity-state scan admits one row"
+    );
     let Some(input_bytes) = progress.counters.input_bytes.checked_add(input_bytes) else {
         return Err(corruption(
             "text entity-state validation input counter overflowed",
@@ -637,12 +764,12 @@ async fn select_entity_state(
         ..progress.counters
     };
     Ok(ValidationSelection::Database(PreparedDatabaseValidation {
-        ranges: vec![range],
+        ranges: vec![scan.range_through(admitted_rows)],
         observations,
         result: progressed(TextBuildStage::ValidateManifests(
             TextManifestValidationProgress::EntityStates(PrefixScanProgress {
                 cursor: Some(
-                    IndexCursor::try_new(row_key)
+                    IndexCursor::try_new(scan.rows[admitted_rows - 1].0.clone())
                         .map_err(|error| HelixDbError::InvariantViolation(error.to_string()))?,
                 ),
                 counters,
@@ -683,23 +810,44 @@ async fn select_activation_prerequisites(
     }))
 }
 
+/// Selects at most `max_rows` exact rows from one typed prefix.
+async fn select_many(
+    transaction: &DbTransaction,
+    prefix: Bytes,
+    cursor: Option<&IndexCursor>,
+    max_rows: usize,
+    max_input_bytes: u64,
+) -> Result<PreparedValidationScan> {
+    let start = validation_start(&prefix, cursor)?;
+    let bounds = (start.clone(), Bound::<Bytes>::Unbounded);
+    let mut source = transaction.scan_prefix(&prefix, bounds).await?;
+    let mut rows = Vec::new();
+    let mut input_bytes = 0_u64;
+    while rows.len() < max_rows {
+        let Some(row) = source.next().await? else {
+            break;
+        };
+        let row_input_bytes = row_bytes(&row.key, Some(&row.value));
+        if !rows.is_empty() && input_bytes.saturating_add(row_input_bytes) > max_input_bytes {
+            break;
+        }
+        input_bytes = input_bytes.saturating_add(row_input_bytes);
+        rows.push((row.key, row.value));
+    }
+    Ok(PreparedValidationScan {
+        prefix,
+        start,
+        rows,
+    })
+}
+
 /// Selects one exact row or one exact exhausted suffix from a typed prefix.
 async fn select_one(
     transaction: &DbTransaction,
     prefix: Bytes,
     cursor: Option<&IndexCursor>,
 ) -> Result<(PreparedValidationRange, Option<(Bytes, Bytes)>)> {
-    let start = match cursor {
-        Some(cursor) => {
-            let Some(suffix) = cursor.as_bytes().strip_prefix(prefix.as_ref()) else {
-                return Err(corruption(
-                    "text manifest-validation cursor is outside its exact prefix",
-                ));
-            };
-            Bound::Excluded(Bytes::copy_from_slice(suffix))
-        }
-        None => Bound::Unbounded,
-    };
+    let start = validation_start(&prefix, cursor)?;
     let bounds = (start.clone(), Bound::<Bytes>::Unbounded);
     let mut rows = transaction.scan_prefix(&prefix, bounds).await?;
     let Some(row) = rows.next().await? else {
@@ -728,6 +876,21 @@ async fn select_one(
         },
         Some(selected),
     ))
+}
+
+/// Derives the exact suffix boundary represented by one optional cursor.
+fn validation_start(prefix: &Bytes, cursor: Option<&IndexCursor>) -> Result<Bound<Bytes>> {
+    Ok(match cursor {
+        Some(cursor) => {
+            let Some(suffix) = cursor.as_bytes().strip_prefix(prefix.as_ref()) else {
+                return Err(corruption(
+                    "text manifest-validation cursor is outside its exact prefix",
+                ));
+            };
+            Bound::Excluded(Bytes::copy_from_slice(suffix))
+        }
+        None => Bound::Unbounded,
+    })
 }
 
 /// Constructs a range-fenced durable invariant blocker.

--- a/crates/db/src/index_lifecycle/vector.rs
+++ b/crates/db/src/index_lifecycle/vector.rs
@@ -1251,6 +1251,37 @@ mod tests {
         );
         assert!(matches!(zero, Err(HelixDbError::ZeroNormCosineVector)));
 
+        for (vector, invalid_index) in [
+            (vec![f32::NAN, 2.0, 3.0], 0),
+            (vec![1.0, f32::INFINITY, 3.0], 1),
+            (vec![1.0, 2.0, f32::NEG_INFINITY], 2),
+        ] {
+            assert!(matches!(
+                vector_document(
+                    &validated_definition(None, VectorDistanceMetric::Euclidean),
+                    &[
+                        property("$label", PropertyValue::String("Document".to_string())),
+                        property("embedding", PropertyValue::F32Array(vector)),
+                    ],
+                ),
+                Err(HelixDbError::InvalidVectorComponent { index }) if index == invalid_index
+            ));
+        }
+
+        for vector in [vec![1.0, 2.0], vec![1.0, 2.0, 3.0, 4.0]] {
+            let actual = vector.len();
+            assert!(matches!(
+                vector_document(
+                    &validated_definition(None, VectorDistanceMetric::Euclidean),
+                    &[
+                        property("$label", PropertyValue::String("Document".to_string())),
+                        property("embedding", PropertyValue::F32Array(vector)),
+                    ],
+                ),
+                Err(HelixDbError::InvalidDimension { expected: 3, got }) if got == actual
+            ));
+        }
+
         let overflow = vector_document(
             &validated_definition(None, VectorDistanceMetric::Euclidean),
             &[

--- a/crates/db/src/index_lifecycle/vector.rs
+++ b/crates/db/src/index_lifecycle/vector.rs
@@ -29,8 +29,8 @@ use crate::encoding::v2::legacy::vector::transaction_guard::{
 };
 #[cfg(any(test, feature = "index-lifecycle-testing"))]
 use crate::encoding::v2::values::decode_index_record;
-use crate::encoding::v2::values::encode_build_delta;
 use crate::encoding::v2::values::property::encode_index_partition_value;
+use crate::encoding::v2::values::{decode_build_delta, encode_build_delta};
 use crate::error::{HelixDbError, Result};
 use crate::search;
 use crate::search::vector::{
@@ -39,7 +39,7 @@ use crate::search::vector::{
 };
 
 use super::repository;
-use super::work::{CoalescedBuildDeltaValue, VectorTenantPartition};
+use super::work::{CoalescedBuildDeltaState, CoalescedBuildDeltaValue, VectorTenantPartition};
 #[cfg(any(test, feature = "index-lifecycle-testing"))]
 use super::IndexStateV2;
 use super::{
@@ -289,21 +289,14 @@ async fn maintain_target(
                 kind: entity.entity_kind,
                 id: entity.entity_id,
             };
-            let key = scoped_index_key(
+            stage_vector_build_delta(
+                transaction,
                 scope,
-                ScopedKey::BuildDelta(IndexEntityStateKey {
-                    index_id: target.index_id,
-                    generation: target.generation,
-                    entity: index_entity,
-                }),
-            );
-            let value = CoalescedBuildDeltaValue {
-                index_id: target.index_id,
-                generation: target.generation,
-                entity_kind: entity.entity_kind,
-                entity_id: entity.entity_id,
-            };
-            transaction.put(key, encode_build_delta(&value))?;
+                target,
+                index_entity,
+                old_document.map(|document| document.partition),
+            )
+            .await?;
         }
         VectorMutationMode::MaintainActive(handle) => {
             maintain_active(
@@ -320,6 +313,61 @@ async fn maintain_target(
             .await?;
         }
     }
+    Ok(())
+}
+
+/// Preserves the original partition across repeated coalesced mutations.
+async fn stage_vector_build_delta(
+    transaction: &DbTransaction,
+    scope: DataScope,
+    target: &VectorMutationTarget,
+    entity: IndexEntity,
+    initial_before: Option<TextPartition>,
+) -> Result<()> {
+    let key = scoped_index_key(
+        scope,
+        ScopedKey::BuildDelta(IndexEntityStateKey {
+            index_id: target.index_id,
+            generation: target.generation,
+            entity,
+        }),
+    );
+    let state = match transaction.get(&key).await? {
+        Some(existing) => {
+            let value = crate::index_lifecycle::expect_typed_value(
+                decode_build_delta(&existing),
+                "vector build-delta key contains another value kind",
+            )?;
+            if value.index_id != target.index_id
+                || value.generation != target.generation
+                || value.entity_kind != entity.kind
+                || value.entity_id != entity.id
+            {
+                return Err(corruption("vector build-delta key/value mismatch"));
+            }
+            match value.state {
+                CoalescedBuildDeltaState::Marker | CoalescedBuildDeltaState::VectorBefore(_) => {
+                    value.state
+                }
+                CoalescedBuildDeltaState::SecondaryBefore(_) => {
+                    return Err(corruption(
+                        "vector build delta contains secondary recovery state",
+                    ));
+                }
+            }
+        }
+        None => CoalescedBuildDeltaState::VectorBefore(initial_before),
+    };
+    transaction.put(
+        key,
+        encode_build_delta(&CoalescedBuildDeltaValue {
+            index_id: target.index_id,
+            generation: target.generation,
+            entity_kind: entity.kind,
+            entity_id: entity.id,
+            state,
+        }),
+    )?;
     Ok(())
 }
 
@@ -1039,6 +1087,60 @@ mod tests {
         )
     }
 
+    #[tokio::test]
+    async fn repeated_build_deltas_preserve_the_first_vector_partition() {
+        let db = test_db("vector-build-delta-first-partition").await;
+        let scope = DataScope::LegacyUnscoped;
+        let target = VectorMutationTarget {
+            index_id: IndexId::new(31).unwrap(),
+            generation: IndexGenerationId::new(7).unwrap(),
+            definition: validated_definition(Some("account_id"), VectorDistanceMetric::Euclidean),
+            mode: VectorMutationMode::RecordBuildDelta,
+        };
+        let first_partition =
+            TextPartition::try_tenant_value(Bytes::from_static(b"first")).unwrap();
+        let second_partition =
+            TextPartition::try_tenant_value(Bytes::from_static(b"second")).unwrap();
+        let transaction = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .unwrap();
+
+        for (entity_id, first, second) in [
+            (
+                IndexEntityId::new(7),
+                Some(first_partition.clone()),
+                Some(second_partition.clone()),
+            ),
+            (IndexEntityId::new(8), None, Some(second_partition.clone())),
+        ] {
+            let entity = IndexEntity {
+                kind: IndexElementKind::Node,
+                id: entity_id,
+            };
+            stage_vector_build_delta(&transaction, scope, &target, entity, first.clone())
+                .await
+                .unwrap();
+            stage_vector_build_delta(&transaction, scope, &target, entity, second)
+                .await
+                .unwrap();
+
+            let key = scoped_index_key(
+                scope,
+                ScopedKey::BuildDelta(IndexEntityStateKey {
+                    index_id: target.index_id,
+                    generation: target.generation,
+                    entity,
+                }),
+            );
+            let delta = decode_build_delta(&transaction.get(&key).await.unwrap().unwrap()).unwrap();
+            assert_eq!(delta.state, CoalescedBuildDeltaState::VectorBefore(first));
+        }
+
+        transaction.rollback();
+        db.close().await.unwrap();
+    }
+
     /// Exercises one unpartitioned active generation through insert and removal.
     async fn exercise_active_unpartitioned_metric<D: Distance>(
         db_name: &str,
@@ -1665,6 +1767,7 @@ mod tests {
                 generation: target.generation,
                 entity_kind: IndexElementKind::Node,
                 entity_id: IndexEntityId::new(9),
+                state: CoalescedBuildDeltaState::Marker,
             }),
         )
         .await

--- a/crates/db/src/index_lifecycle/vector.rs
+++ b/crates/db/src/index_lifecycle/vector.rs
@@ -27,7 +27,7 @@ use crate::encoding::v2::keys::{IndexEntity, IndexEntityStateKey, ScopedKey};
 use crate::encoding::v2::legacy::vector::transaction_guard::{
     decode_active_txn_guard, LegacyVectorTxnGuardKey,
 };
-#[cfg(test)]
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
 use crate::encoding::v2::values::decode_index_record;
 use crate::encoding::v2::values::encode_build_delta;
 use crate::encoding::v2::values::property::encode_index_partition_value;
@@ -40,7 +40,7 @@ use crate::search::vector::{
 
 use super::repository;
 use super::work::{CoalescedBuildDeltaValue, VectorTenantPartition};
-#[cfg(test)]
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
 use super::IndexStateV2;
 use super::{
     ActiveIndexHandle, IndexElementKind, IndexEntityId, IndexGenerationId, IndexId, TextPartition,
@@ -103,7 +103,11 @@ pub(crate) struct VectorEntityMutation<'a> {
 
 impl<'a> VectorEntityMutation<'a> {
     /// Binds one entity to its complete before/after property snapshots.
-    #[cfg(any(test, feature = "production-coverage"))]
+    #[cfg(any(
+        test,
+        feature = "production-coverage",
+        feature = "index-lifecycle-testing"
+    ))]
     pub(crate) const fn new(
         entity_kind: IndexElementKind,
         entity_id: u64,
@@ -173,7 +177,7 @@ impl VectorMutationSet {
 /// The canonical record scan is part of the caller's serializable graph
 /// transaction. Activation/drop revisions therefore conflict with the graph
 /// commit rather than allowing writes to cross a lifecycle boundary.
-#[cfg(test)]
+#[cfg(any(test, feature = "index-lifecycle-testing"))]
 pub(crate) async fn load_mutation_set(
     transaction: &DbTransaction,
     scope: DataScope,
@@ -231,7 +235,11 @@ pub(crate) async fn load_mutation_set(
 /// `before` and `after` are complete authoritative property sets. Partition
 /// moves therefore become a typed remove-plus-upsert, and hidden builds receive
 /// one coalesced reconciliation marker for any semantic document change.
-#[cfg(any(test, feature = "production-coverage"))]
+#[cfg(any(
+    test,
+    feature = "production-coverage",
+    feature = "index-lifecycle-testing"
+))]
 pub(crate) async fn maintain_entity_with_runtime(
     transaction: &DbTransaction,
     scope: DataScope,
@@ -355,7 +363,11 @@ pub(crate) async fn maintain_routed_entity_with_runtime(
 }
 
 /// Preserves the isolated per-entity contract as a differential-test oracle.
-#[cfg(any(test, feature = "production-coverage"))]
+#[cfg(any(
+    test,
+    feature = "production-coverage",
+    feature = "index-lifecycle-testing"
+))]
 pub(crate) async fn maintain_entity(
     transaction: &DbTransaction,
     scope: DataScope,

--- a/crates/db/src/index_lifecycle/vector/driver.rs
+++ b/crates/db/src/index_lifecycle/vector/driver.rs
@@ -1954,7 +1954,7 @@ async fn catch_up<D: Distance>(
             }
             break;
         }
-        let previous = load_applied(
+        let mut previous = load_applied(
             transaction,
             scope,
             operation.index_id(),
@@ -1963,6 +1963,23 @@ async fn catch_up<D: Distance>(
             entity.id,
         )
         .await?;
+        if previous.is_none() {
+            previous = match &delta.state {
+                crate::index_lifecycle::work::CoalescedBuildDeltaState::VectorBefore(previous) => {
+                    previous.clone()
+                }
+                crate::index_lifecycle::work::CoalescedBuildDeltaState::Marker => {
+                    return Err(corruption(
+                        "vector build delta has no original partition after applied-state release",
+                    ));
+                }
+                crate::index_lifecycle::work::CoalescedBuildDeltaState::SecondaryBefore(_) => {
+                    return Err(corruption(
+                        "vector build delta contains secondary recovery state",
+                    ));
+                }
+            };
+        }
         let properties = read_authoritative_properties(transaction, scope, entity).await?;
         let next = match properties {
             Some(properties) => match vector_document(definition, &properties) {
@@ -2096,10 +2113,8 @@ async fn plan_and_apply<D: Distance>(
         Some(partition)
             if Some(partition) != next_document.map(VectorIndexedDocument::partition) =>
         {
-            Some(
-                resolve_build_physical(transaction, scope, operation, record, partition, false)
-                    .await?,
-            )
+            resolve_existing_build_physical(transaction, scope, operation, record, partition)
+                .await?
         }
         Some(_) | None => None,
     };
@@ -2347,6 +2362,52 @@ async fn resolve_build_physical(
         (VectorPhysicalLayout::Unpartitioned { .. }, TextPartition::TenantValue(_))
         | (VectorPhysicalLayout::Partitioned, TextPartition::Unpartitioned) => Err(corruption(
             "vector build document partition disagrees with physical layout",
+        )),
+    }
+}
+
+async fn resolve_existing_build_physical(
+    transaction: &DbTransaction,
+    scope: DataScope,
+    operation: &IndexOperationRecord,
+    record: &IndexRecordV2,
+    partition: &TextPartition,
+) -> Result<Option<BuildPhysicalResolution>> {
+    let IndexStateVectorPhysical { layout } = IndexStateVectorPhysical::from_record(record)?;
+    match (layout, partition) {
+        (
+            VectorPhysicalLayout::Unpartitioned { physical_index_id },
+            TextPartition::Unpartitioned,
+        ) => Ok(Some(BuildPhysicalResolution {
+            scope,
+            layout,
+            physical_index_id,
+            mapping_is_new: false,
+        })),
+        (VectorPhysicalLayout::Partitioned, TextPartition::TenantValue(_)) => {
+            let tenant = VectorTenantPartition::try_from_partition(partition.clone())
+                .map_err(|error| corruption(error.to_string()))?;
+            Ok(
+                crate::index_lifecycle::repository::load_vector_partition_mapping(
+                    transaction,
+                    scope,
+                    operation.index_id(),
+                    operation.generation(),
+                    layout,
+                    &tenant,
+                )
+                .await?
+                .map(|physical_index_id| BuildPhysicalResolution {
+                    scope,
+                    layout,
+                    physical_index_id,
+                    mapping_is_new: false,
+                }),
+            )
+        }
+        (VectorPhysicalLayout::Unpartitioned { .. }, TextPartition::TenantValue(_))
+        | (VectorPhysicalLayout::Partitioned, TextPartition::Unpartitioned) => Err(corruption(
+            "vector build recovery partition disagrees with physical layout",
         )),
     }
 }
@@ -4772,6 +4833,7 @@ mod tests {
             generation,
             entity_kind: entity.kind,
             entity_id: entity.id,
+            state: crate::index_lifecycle::work::CoalescedBuildDeltaState::Marker,
         };
         let applied_value = AppliedEntityStateValue {
             index_id,

--- a/crates/db/src/index_lifecycle/work.rs
+++ b/crates/db/src/index_lifecycle/work.rs
@@ -293,13 +293,25 @@ impl SplitRef {
     }
 }
 
+/// Family-specific recovery state carried by one coalesced build delta.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum CoalescedBuildDeltaState {
+    /// The owning family reconciles from durable builder state or authoritative data.
+    Marker,
+    /// Original secondary value before the first still-pending mutation.
+    SecondaryBefore(Option<CanonicalSecondaryValue>),
+    /// Original vector partition before the first still-pending mutation.
+    VectorBefore(Option<TextPartition>),
+}
+
 /// Coalesced build delta body.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct CoalescedBuildDeltaValue {
     pub(crate) index_id: IndexId,
     pub(crate) generation: IndexGenerationId,
     pub(crate) entity_kind: IndexElementKind,
     pub(crate) entity_id: IndexEntityId,
+    pub(crate) state: CoalescedBuildDeltaState,
 }
 
 /// Family-specific authoritative state last applied by a builder.

--- a/crates/db/src/index_lifecycle_testing.rs
+++ b/crates/db/src/index_lifecycle_testing.rs
@@ -162,6 +162,12 @@ pub async fn run_deterministic_all_index_validation_contracts() {
     contracts::run_all_index_validation_mutations().await;
 }
 
+/// Runs public secondary/vector writes at every exact build boundary.
+pub async fn run_secondary_vector_public_boundary_contracts() {
+    let _guard = LIFECYCLE_CONTRACT_LOCK.lock().await;
+    contracts::run_secondary_vector_public_boundaries().await;
+}
+
 /// Runs retry-safe concurrent CREATE convergence for every family.
 pub async fn run_deterministic_lifecycle_race_contracts() {
     let _guard = LIFECYCLE_CONTRACT_LOCK.lock().await;

--- a/crates/db/src/index_lifecycle_testing.rs
+++ b/crates/db/src/index_lifecycle_testing.rs
@@ -156,6 +156,12 @@ pub async fn run_deterministic_lifecycle_mutation_contracts() {
     contracts::run_mutations().await;
 }
 
+/// Runs late-mutation convergence for every supported managed index shape.
+pub async fn run_deterministic_all_index_validation_contracts() {
+    let _guard = LIFECYCLE_CONTRACT_LOCK.lock().await;
+    contracts::run_all_index_validation_mutations().await;
+}
+
 /// Runs retry-safe concurrent CREATE convergence for every family.
 pub async fn run_deterministic_lifecycle_race_contracts() {
     let _guard = LIFECYCLE_CONTRACT_LOCK.lock().await;

--- a/crates/db/src/index_lifecycle_testing/contracts.rs
+++ b/crates/db/src/index_lifecycle_testing/contracts.rs
@@ -182,6 +182,107 @@ pub(super) async fn run_tenant_reopen_recovery() {
     }
 }
 
+/// Runs public secondary/vector writes at every exact build boundary.
+pub(super) async fn run_secondary_vector_public_boundaries() {
+    for (family_ordinal, family) in [
+        PublicMutationFamily::Secondary,
+        PublicMutationFamily::Vector,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        for (boundary_ordinal, boundary) in PublicMutationBoundary::ALL.into_iter().enumerate() {
+            let ordinal = family_ordinal * PublicMutationBoundary::ALL.len() + boundary_ordinal;
+            let db = HelixDB::open_for_index_lifecycle_testing(
+                HelixDbSource::InMemory {
+                    database: format!("index-lifecycle-public-boundary-{ordinal}"),
+                },
+                DbConfig::new(),
+                LifecycleTestScheduling::Explicit,
+            )
+            .await
+            .expect("public-boundary writer opens");
+            let controller = LifecycleTestController::new();
+            let scope = DataScope::LegacyUnscoped;
+            controller
+                .seed_node_property_rows(
+                    &db,
+                    scope,
+                    NonZeroU64::new(3).expect("public-boundary seed count is positive"),
+                    NonZeroUsize::MIN,
+                    |entity_id| family.source_properties(entity_id),
+                )
+                .await
+                .expect("public-boundary source rows seed");
+            let definition = family.definition();
+            let IndexDdlReceipt::Accepted { operation_id, .. } = controller
+                .create_index(
+                    &db,
+                    scope,
+                    definition.clone(),
+                    ir::IndexCreateMode::ErrorIfExists,
+                )
+                .await
+                .expect("public-boundary build is accepted")
+            else {
+                panic!("fresh public-boundary build must enqueue");
+            };
+            let stage = boundary.stage(family);
+            drive_until_stage(&db, &controller, scope, operation_id, stage).await;
+
+            let first_ordinal =
+                u64::try_from(ordinal * 2).expect("public-boundary first ordinal fits u64");
+            let second_ordinal = first_ordinal + 1;
+            let first_plan = public_add_node_plan(family, first_ordinal);
+            let second_plan = public_add_node_plan(family, second_ordinal);
+            let (first, second) = tokio::join!(
+                execute_write_with_retry(&db, &first_plan),
+                execute_write_with_retry(&db, &second_plan),
+            );
+            first.expect("first exact-boundary public write commits");
+            second.expect("second exact-boundary public write commits");
+            assert_build_delta_count_at_least(&db, scope, &definition, 2).await;
+
+            let evidence = controller
+                .advance(
+                    &db,
+                    LifecycleWorkTarget::Operation {
+                        scope,
+                        operation_id,
+                    },
+                )
+                .await
+                .expect("public-boundary operation resumes after writes");
+            assert_monotonic_step(&evidence);
+            if matches!(
+                stage,
+                IndexOperationStage::Validate
+                    | IndexOperationStage::ValidateDescriptor
+                    | IndexOperationStage::Activate
+            ) {
+                assert_eq!(
+                    db.get_index_operation(scope, operation_id)
+                        .await
+                        .expect("public-boundary operation remains readable")
+                        .common()
+                        .stage,
+                    IndexOperationStage::CatchUp,
+                    "{family:?} must re-enter CatchUp after a public write at {stage:?}"
+                );
+            }
+            assert!(matches!(
+                drive_to_terminal(&db, &controller, scope, operation_id).await,
+                IndexOperationStatus::Succeeded { .. }
+            ));
+            assert_identity_active(&db, scope, &definition).await;
+            assert_build_deltas_empty(&db, scope, &definition).await;
+            assert_public_indexed_read(&db, family, first_ordinal).await;
+            assert_public_indexed_read(&db, family, second_ordinal).await;
+            db.close().await.expect("public-boundary writer closes");
+        }
+    }
+}
+
 fn one_row_lifecycle_config() -> DbConfig {
     let defaults = SearchIndexBackfillLimits::default();
     let batch = defaults.batch();
@@ -1214,9 +1315,121 @@ async fn wait_for_automatic_terminal(
 /// Runs data-bearing backfill/mutation and uniqueness contracts.
 pub(super) async fn run_mutations() {
     run_secondary_mutation_interleaving().await;
+    run_unique_activation_conflict_repair().await;
     run_secondary_edge_mutation_interleaving().await;
     run_every_family_public_mutation_interleaving().await;
     run_partitioned_search_edge_tenant_moves().await;
+}
+
+/// Proves an activation-boundary unique conflict blocks, repairs, and retries.
+async fn run_unique_activation_conflict_repair() {
+    let db = HelixDB::open_for_index_lifecycle_testing(
+        HelixDbSource::InMemory {
+            database: "index-lifecycle-unique-activation-conflict".to_string(),
+        },
+        DbConfig::new(),
+        LifecycleTestScheduling::Explicit,
+    )
+    .await
+    .expect("unique activation-conflict writer opens");
+    let controller = LifecycleTestController::new();
+    let scope = DataScope::LegacyUnscoped;
+    let entity_ids = allocate_node_ids(&db, 2).await;
+    let duplicate = "activation-duplicate";
+    let first = vec![
+        Property::string("$label", "ActivationUnique"),
+        Property::string("value", duplicate),
+    ];
+    let second = vec![
+        Property::string("$label", "ActivationUnique"),
+        Property::string("value", "activation-distinct"),
+    ];
+    put_source(&db, scope, entity_ids.start, &first).await;
+    put_source(&db, scope, entity_ids.start + 1, &second).await;
+    let definition: ValidatedDynamicIndexDefinition =
+        SecondaryIndexDefinition::node_unique_equality("ActivationUnique", "value")
+            .expect("activation unique definition validates")
+            .try_into()
+            .expect("activation unique definition converts");
+    let IndexDdlReceipt::Accepted { operation_id, .. } = controller
+        .create_index(
+            &db,
+            scope,
+            definition.clone(),
+            ir::IndexCreateMode::ErrorIfExists,
+        )
+        .await
+        .expect("activation unique build is accepted")
+    else {
+        panic!("fresh activation unique build must enqueue");
+    };
+    drive_until_stage(
+        &db,
+        &controller,
+        scope,
+        operation_id,
+        IndexOperationStage::Activate,
+    )
+    .await;
+
+    let conflicting = vec![
+        Property::string("$label", "ActivationUnique"),
+        Property::string("value", duplicate),
+    ];
+    mutate_source(&db, scope, entity_ids.start + 1, &second, &conflicting)
+        .await
+        .expect("activation-boundary duplicate records one build delta");
+    let evidence = controller
+        .advance(
+            &db,
+            LifecycleWorkTarget::Operation {
+                scope,
+                operation_id,
+            },
+        )
+        .await
+        .expect("activation-boundary duplicate returns to catch-up");
+    assert_monotonic_step(&evidence);
+    assert_eq!(
+        db.get_index_operation(scope, operation_id)
+            .await
+            .expect("activation unique operation remains readable")
+            .common()
+            .stage,
+        IndexOperationStage::CatchUp
+    );
+    let blocked = drive_to_terminal(&db, &controller, scope, operation_id).await;
+    assert!(matches!(blocked, IndexOperationStatus::Blocked { .. }));
+
+    let repaired = vec![
+        Property::string("$label", "ActivationUnique"),
+        Property::string("value", "activation-repaired"),
+    ];
+    mutate_source(&db, scope, entity_ids.start + 1, &conflicting, &repaired)
+        .await
+        .expect("blocked activation unique source repairs");
+    let retried = db
+        .retry_index_operation(scope, operation_id)
+        .await
+        .expect("activation unique operation retries");
+    assert_eq!(retried.common().stage, blocked.common().stage);
+    assert!(matches!(
+        drive_to_terminal(&db, &controller, scope, operation_id).await,
+        IndexOperationStatus::Succeeded { .. }
+    ));
+    assert_equality(&db, scope, &definition, duplicate, [entity_ids.start]).await;
+    assert_equality(
+        &db,
+        scope,
+        &definition,
+        "activation-repaired",
+        [entity_ids.start + 1],
+    )
+    .await;
+    assert_build_deltas_empty(&db, scope, &definition).await;
+    db.close()
+        .await
+        .expect("unique activation-conflict writer closes");
 }
 
 /// Runs late insert, update, and delete races at every family validation boundary.
@@ -1879,6 +2092,34 @@ enum PublicMutationFamily {
     Secondary,
     Vector,
     Text,
+}
+
+/// Exact durable stages where public writes can race one secondary/vector build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublicMutationBoundary {
+    Scan,
+    CatchUp,
+    Validate,
+    Activate,
+}
+
+impl PublicMutationBoundary {
+    const ALL: [Self; 4] = [Self::Scan, Self::CatchUp, Self::Validate, Self::Activate];
+
+    fn stage(self, family: PublicMutationFamily) -> IndexOperationStage {
+        match (self, family) {
+            (Self::Scan, _) => IndexOperationStage::Scan,
+            (Self::CatchUp, _) => IndexOperationStage::CatchUp,
+            (Self::Validate, PublicMutationFamily::Secondary) => IndexOperationStage::Validate,
+            (Self::Validate, PublicMutationFamily::Vector) => {
+                IndexOperationStage::ValidateDescriptor
+            }
+            (Self::Activate, _) => IndexOperationStage::Activate,
+            (Self::Validate, PublicMutationFamily::Text) => {
+                unreachable!("text uses its manifest validation matrix")
+            }
+        }
+    }
 }
 
 impl PublicMutationFamily {

--- a/crates/db/src/index_lifecycle_testing/contracts.rs
+++ b/crates/db/src/index_lifecycle_testing/contracts.rs
@@ -11,6 +11,7 @@ use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use helix_ast::index::RangeIndexDirection as AstRangeIndexDirection;
 use helix_ast::value::PropertyValue as AstPropertyValue;
 use helix_planner::{catalog, context, cost, exec, ir, properties, trace};
 use slatedb::object_store::memory::InMemory;
@@ -35,7 +36,8 @@ use crate::execution::interpreter::{
 use crate::index_lifecycle::{
     ActiveIndexHandle, IndexDdlReceipt, IndexDefinitionFamily, IndexElementKind,
     IndexOperationStage, IndexOperationStatus, IndexStateV2, PhysicalGeneration,
-    ValidatedDynamicIndexDefinition, VectorPhysicalLayout,
+    ValidatedDynamicIndexDefinition, ValidatedSecondaryIndexDefinition,
+    ValidatedVectorIndexDefinition, VectorPhysicalLayout,
 };
 use crate::search::vector::distance::Cosine;
 use crate::search::vector::{ValidatedVectorGenerationHandle, VectorDistanceMetric, VectorIndex};
@@ -184,15 +186,31 @@ pub(super) async fn run_tenant_reopen_recovery() {
 
 /// Runs public secondary/vector writes at every exact build boundary.
 pub(super) async fn run_secondary_vector_public_boundaries() {
-    for (family_ordinal, family) in [
-        PublicMutationFamily::Secondary,
-        PublicMutationFamily::Vector,
-    ]
-    .into_iter()
-    .enumerate()
-    {
+    let shapes = family_shapes()
+        .into_iter()
+        .filter_map(PublicBoundaryShape::from_definition)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        shapes
+            .iter()
+            .filter(|shape| shape.family() == PublicMutationFamily::Secondary)
+            .count(),
+        7,
+        "every secondary shape uses the public write boundary"
+    );
+    assert_eq!(
+        shapes
+            .iter()
+            .filter(|shape| shape.family() == PublicMutationFamily::Vector)
+            .count(),
+        12,
+        "every vector shape uses the public write boundary"
+    );
+
+    let mut case_count = 0usize;
+    for (shape_ordinal, shape) in shapes.into_iter().enumerate() {
         for (boundary_ordinal, boundary) in PublicMutationBoundary::ALL.into_iter().enumerate() {
-            let ordinal = family_ordinal * PublicMutationBoundary::ALL.len() + boundary_ordinal;
+            let ordinal = shape_ordinal * PublicMutationBoundary::ALL.len() + boundary_ordinal;
             let db = HelixDB::open_for_index_lifecycle_testing(
                 HelixDbSource::InMemory {
                     database: format!("index-lifecycle-public-boundary-{ordinal}"),
@@ -204,17 +222,37 @@ pub(super) async fn run_secondary_vector_public_boundaries() {
             .expect("public-boundary writer opens");
             let controller = LifecycleTestController::new();
             let scope = DataScope::LegacyUnscoped;
-            controller
-                .seed_node_property_rows(
-                    &db,
-                    scope,
-                    NonZeroU64::new(3).expect("public-boundary seed count is positive"),
-                    NonZeroUsize::MIN,
-                    |entity_id| family.source_properties(entity_id),
-                )
-                .await
-                .expect("public-boundary source rows seed");
-            let definition = family.definition();
+            let edge_endpoints = match shape.element_kind() {
+                IndexElementKind::Node => None,
+                IndexElementKind::Edge => {
+                    let endpoints = controller
+                        .seed_node_property_rows(
+                            &db,
+                            scope,
+                            NonZeroU64::new(2).expect("public-boundary endpoint count is positive"),
+                            NonZeroUsize::MIN,
+                            |_| vec![Property::string("$label", "PublicBoundaryEndpoint")],
+                        )
+                        .await
+                        .expect("public-boundary endpoint rows seed");
+                    Some((endpoints.start, endpoints.end - 1))
+                }
+            };
+            let mut seeded = Vec::new();
+            for seed_ordinal in 0..3 {
+                let seed_ordinal =
+                    u64::try_from(seed_ordinal).expect("public-boundary seed ordinal fits u64");
+                let (plan, bindings) =
+                    public_boundary_add_plan(&shape, seed_ordinal, edge_endpoints);
+                let result = execute_write_with_bindings_retry(&db, &plan, bindings)
+                    .await
+                    .expect("public-boundary source row seeds through the interpreter");
+                seeded.push((
+                    seed_ordinal,
+                    public_created_entity_id(result, shape.element_kind()),
+                ));
+            }
+            let definition = shape.definition();
             let IndexDdlReceipt::Accepted { operation_id, .. } = controller
                 .create_index(
                     &db,
@@ -227,20 +265,40 @@ pub(super) async fn run_secondary_vector_public_boundaries() {
             else {
                 panic!("fresh public-boundary build must enqueue");
             };
-            let stage = boundary.stage(family);
+            let stage = boundary.stage(shape.family());
             drive_until_stage(&db, &controller, scope, operation_id, stage).await;
 
-            let first_ordinal =
-                u64::try_from(ordinal * 2).expect("public-boundary first ordinal fits u64");
+            let first_ordinal = 3;
             let second_ordinal = first_ordinal + 1;
-            let first_plan = public_add_node_plan(family, first_ordinal);
-            let second_plan = public_add_node_plan(family, second_ordinal);
+            let (first_plan, first_bindings) =
+                public_boundary_add_plan(&shape, first_ordinal, edge_endpoints);
+            let (second_plan, second_bindings) =
+                public_boundary_add_plan(&shape, second_ordinal, edge_endpoints);
             let (first, second) = tokio::join!(
-                execute_write_with_retry(&db, &first_plan),
-                execute_write_with_retry(&db, &second_plan),
+                execute_write_with_bindings_retry(&db, &first_plan, first_bindings),
+                execute_write_with_bindings_retry(&db, &second_plan, second_bindings),
             );
-            first.expect("first exact-boundary public write commits");
-            second.expect("second exact-boundary public write commits");
+            let first_id = public_created_entity_id(
+                first.expect("first exact-boundary public write commits"),
+                shape.element_kind(),
+            );
+            let second_id = public_created_entity_id(
+                second.expect("second exact-boundary public write commits"),
+                shape.element_kind(),
+            );
+            if let Some(tenant_property) = shape.tenant_property() {
+                execute_write_with_bindings_retry(
+                    &db,
+                    &public_boundary_set_tenant_plan(
+                        shape.element_kind(),
+                        tenant_property,
+                        "tenant-moved",
+                    ),
+                    public_boundary_entity_binding(shape.element_kind(), first_id),
+                )
+                .await
+                .expect("partitioned vector moves through the public mutation boundary");
+            }
             assert_build_delta_count_at_least(&db, scope, &definition, 2).await;
 
             let evidence = controller
@@ -267,7 +325,7 @@ pub(super) async fn run_secondary_vector_public_boundaries() {
                         .common()
                         .stage,
                     IndexOperationStage::CatchUp,
-                    "{family:?} must re-enter CatchUp after a public write at {stage:?}"
+                    "{shape:?} must re-enter CatchUp after a public write at {stage:?}"
                 );
             }
             assert!(matches!(
@@ -276,11 +334,22 @@ pub(super) async fn run_secondary_vector_public_boundaries() {
             ));
             assert_identity_active(&db, scope, &definition).await;
             assert_build_deltas_empty(&db, scope, &definition).await;
-            assert_public_indexed_read(&db, family, first_ordinal).await;
-            assert_public_indexed_read(&db, family, second_ordinal).await;
+            assert_public_boundary_results(
+                &db,
+                &shape,
+                &seeded,
+                (first_ordinal, first_id),
+                (second_ordinal, second_id),
+            )
+            .await;
             db.close().await.expect("public-boundary writer closes");
+            case_count += 1;
         }
     }
+    assert_eq!(
+        case_count, 76,
+        "nineteen public shapes run at four exact lifecycle boundaries"
+    );
 }
 
 fn one_row_lifecycle_config() -> DbConfig {
@@ -2086,6 +2155,82 @@ const PUBLIC_MUTATION_LABEL: &str = "LifecycleMutation";
 const PUBLIC_MUTATION_PROPERTY: &str = "value";
 const PUBLIC_MUTATION_TENANT: &str = "tenant";
 
+/// Secondary/vector shape whose public mutation path must cross every build boundary.
+#[derive(Debug, Clone, PartialEq)]
+enum PublicBoundaryShape {
+    Secondary(ValidatedSecondaryIndexDefinition),
+    Vector(ValidatedVectorIndexDefinition),
+}
+
+impl PublicBoundaryShape {
+    /// Retains only the two families covered by the public boundary matrix.
+    fn from_definition(definition: ValidatedDynamicIndexDefinition) -> Option<Self> {
+        match definition {
+            ValidatedDynamicIndexDefinition::Secondary(definition) => {
+                Some(Self::Secondary(definition))
+            }
+            ValidatedDynamicIndexDefinition::Vector(definition) => Some(Self::Vector(definition)),
+            ValidatedDynamicIndexDefinition::Text(_) => None,
+        }
+    }
+
+    const fn family(&self) -> PublicMutationFamily {
+        match self {
+            Self::Secondary(_) => PublicMutationFamily::Secondary,
+            Self::Vector(_) => PublicMutationFamily::Vector,
+        }
+    }
+
+    fn definition(&self) -> ValidatedDynamicIndexDefinition {
+        match self {
+            Self::Secondary(definition) => {
+                ValidatedDynamicIndexDefinition::Secondary(definition.clone())
+            }
+            Self::Vector(definition) => ValidatedDynamicIndexDefinition::Vector(definition.clone()),
+        }
+    }
+
+    const fn element_kind(&self) -> IndexElementKind {
+        match self {
+            Self::Secondary(definition) => definition.element_kind(),
+            Self::Vector(definition) => definition.element_kind(),
+        }
+    }
+
+    fn label(&self) -> &str {
+        match self {
+            Self::Secondary(definition) => definition.label().as_str(),
+            Self::Vector(definition) => definition.label().as_str(),
+        }
+    }
+
+    fn property(&self) -> &str {
+        match self {
+            Self::Secondary(definition) => definition.property().as_str(),
+            Self::Vector(definition) => definition.property().as_str(),
+        }
+    }
+
+    fn tenant_property(&self) -> Option<&str> {
+        match self {
+            Self::Secondary(_) => None,
+            Self::Vector(definition) => definition
+                .tenant_property()
+                .map(crate::index_lifecycle::IndexComponent::as_str),
+        }
+    }
+
+    fn value(&self, ordinal: u64) -> AstPropertyValue {
+        match self {
+            Self::Secondary(_) => AstPropertyValue::String(format!("public-boundary-{ordinal:03}")),
+            Self::Vector(_) => {
+                let ordinal = ordinal as f32;
+                AstPropertyValue::F32Array(vec![1.0, ordinal + 1.0, ordinal.mul_add(ordinal, 1.0)])
+            }
+        }
+    }
+}
+
 /// Family-refined public write/read fixture used by the mutation matrix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PublicMutationFamily {
@@ -2537,6 +2682,106 @@ async fn assert_build_delta_count_at_least(
         count >= minimum,
         "Building public writes must retain at least {minimum} coalesced deltas, observed {count}"
     );
+}
+
+/// Verifies every public-boundary shape through its production indexed-read path.
+async fn assert_public_boundary_results(
+    db: &HelixDB,
+    shape: &PublicBoundaryShape,
+    seeded: &[(u64, u64)],
+    first: (u64, u64),
+    second: (u64, u64),
+) {
+    match shape {
+        PublicBoundaryShape::Secondary(
+            ValidatedSecondaryIndexDefinition::NodeEquality { .. }
+            | ValidatedSecondaryIndexDefinition::EdgeEquality { .. },
+        ) => {
+            assert_eq!(
+                public_boundary_indexed_ids(db, shape, first.0, "tenant-initial").await,
+                vec![first.1],
+                "public equality lookup returns the first late entity"
+            );
+            assert_eq!(
+                public_boundary_indexed_ids(db, shape, second.0, "tenant-initial").await,
+                vec![second.1],
+                "public equality lookup returns the second late entity"
+            );
+        }
+        PublicBoundaryShape::Secondary(
+            ValidatedSecondaryIndexDefinition::NodeRange { direction, .. }
+            | ValidatedSecondaryIndexDefinition::EdgeRange { direction, .. },
+        ) => {
+            let mut expected = seeded.to_vec();
+            expected.extend([first, second]);
+            expected.sort_unstable_by_key(|(ordinal, _)| *ordinal);
+            if *direction == crate::config::RangeIndexDirection::Desc {
+                expected.reverse();
+            }
+            assert_eq!(
+                public_boundary_indexed_ids(db, shape, first.0, "tenant-initial").await,
+                expected
+                    .into_iter()
+                    .map(|(_, entity_id)| entity_id)
+                    .collect::<Vec<_>>(),
+                "public range scan preserves {direction:?} value order"
+            );
+        }
+        PublicBoundaryShape::Vector(definition) => {
+            let first_tenant = if definition.tenant_property().is_some() {
+                "tenant-moved"
+            } else {
+                "tenant-initial"
+            };
+            let first_results = public_boundary_indexed_ids(db, shape, first.0, first_tenant).await;
+            assert_eq!(
+                first_results.first(),
+                Some(&first.1),
+                "public vector search returns the exact first late vector"
+            );
+            let second_results =
+                public_boundary_indexed_ids(db, shape, second.0, "tenant-initial").await;
+            assert_eq!(
+                second_results.first(),
+                Some(&second.1),
+                "public vector search returns the exact second late vector"
+            );
+            if definition.tenant_property().is_some() {
+                assert!(
+                    !public_boundary_indexed_ids(db, shape, first.0, "tenant-initial")
+                        .await
+                        .contains(&first.1),
+                    "public partition move removes the vector from its previous tenant"
+                );
+            }
+        }
+    }
+}
+
+async fn public_boundary_indexed_ids(
+    db: &HelixDB,
+    shape: &PublicBoundaryShape,
+    ordinal: u64,
+    tenant: &str,
+) -> Vec<u64> {
+    let result = db
+        .execute(
+            &public_boundary_read_plan(shape, ordinal, tenant),
+            context::ParamBindings::default(),
+        )
+        .await
+        .expect("public-boundary indexed read succeeds");
+    let Some(ExecutionValue::Scalars(values)) = result.last else {
+        panic!("public-boundary indexed read returns projected IDs");
+    };
+    values
+        .into_iter()
+        .map(|value| match (shape.element_kind(), value) {
+            (IndexElementKind::Node, ExecutionScalar::NodeId(entity_id))
+            | (IndexElementKind::Edge, ExecutionScalar::EdgeId(entity_id)) => entity_id,
+            _ => panic!("public-boundary indexed read returns the expected entity kind"),
+        })
+        .collect()
 }
 
 /// Verifies one Building/Active mutation through the public indexed read path.
@@ -3958,6 +4203,334 @@ fn public_executable(
         exec::PlannerMetrics::default(),
     )
     .expect("public lifecycle fixture dependencies form an executable plan")
+}
+
+/// Builds one shape-specific entity insert through the production interpreter boundary.
+fn public_boundary_add_plan(
+    shape: &PublicBoundaryShape,
+    ordinal: u64,
+    edge_endpoints: Option<(u64, u64)>,
+) -> (exec::ExecutablePlan, context::ParamBindings) {
+    let mut properties = vec![(
+        public_name(shape.property()),
+        ir::PropertyInputPlan::Value(shape.value(ordinal)),
+    )];
+    if let Some(tenant_property) = shape.tenant_property() {
+        properties.push((
+            public_name(tenant_property),
+            ir::PropertyInputPlan::Value(AstPropertyValue::String("tenant-initial".to_string())),
+        ));
+    }
+    let properties = ir::PropertyAssignments::try_from_vec(properties)
+        .expect("public-boundary properties are unique");
+    match shape.element_kind() {
+        IndexElementKind::Node => (
+            public_executable(
+                ir::PlanKind::Write,
+                vec![public_step(
+                    1,
+                    Vec::new(),
+                    exec::ExecOp::Mutation {
+                        plan: exec::ExecMutationPlan::AddNodeSource {
+                            label: public_name(shape.label()),
+                            properties,
+                        },
+                    },
+                )],
+                1,
+            ),
+            context::ParamBindings::default(),
+        ),
+        IndexElementKind::Edge => {
+            let Some((from, to)) = edge_endpoints else {
+                panic!("public edge boundary fixture requires two endpoints");
+            };
+            let access_id =
+                exec::ExecStepId::new(1).expect("public-boundary edge access ID is positive");
+            (
+                public_executable(
+                    ir::PlanKind::Write,
+                    vec![
+                        public_step(
+                            1,
+                            Vec::new(),
+                            exec::ExecOp::Access {
+                                plan: Box::new(exec::ExecAccessPlan::Node(
+                                    exec::ExecNodeAccessPlan::FromParam {
+                                        param: public_name("from"),
+                                    },
+                                )),
+                            },
+                        ),
+                        public_step(
+                            2,
+                            vec![access_id],
+                            exec::ExecOp::Mutation {
+                                plan: exec::ExecMutationPlan::AddEdge {
+                                    label: public_name(shape.label()),
+                                    to: ir::NodeTargetPlan::PointIds {
+                                        ids: ir::ElementIds::new(ir::AtLeast::<_, 1>::from_one(to))
+                                            .expect("public-boundary edge target is non-empty"),
+                                    },
+                                    properties,
+                                },
+                            },
+                        ),
+                    ],
+                    2,
+                ),
+                context::ParamBindings::default().with_value(
+                    public_name("from"),
+                    AstPropertyValue::I64(
+                        i64::try_from(from).expect("public-boundary endpoint ID fits i64"),
+                    ),
+                ),
+            )
+        }
+    }
+}
+
+/// Builds one public tenant-partition move for a node or edge.
+fn public_boundary_set_tenant_plan(
+    element_kind: IndexElementKind,
+    tenant_property: &str,
+    tenant: &str,
+) -> exec::ExecutablePlan {
+    let access_id = exec::ExecStepId::new(1).expect("public-boundary tenant access ID is positive");
+    let access = match element_kind {
+        IndexElementKind::Node => exec::ExecAccessPlan::Node(exec::ExecNodeAccessPlan::FromParam {
+            param: public_name("entity"),
+        }),
+        IndexElementKind::Edge => exec::ExecAccessPlan::Edge(exec::ExecEdgeAccessPlan::FromParam {
+            param: public_name("entity"),
+        }),
+    };
+    public_executable(
+        ir::PlanKind::Write,
+        vec![
+            public_step(
+                1,
+                Vec::new(),
+                exec::ExecOp::Access {
+                    plan: Box::new(access),
+                },
+            ),
+            public_step(
+                2,
+                vec![access_id],
+                exec::ExecOp::Mutation {
+                    plan: exec::ExecMutationPlan::SetProperty {
+                        name: public_name(tenant_property),
+                        value: ir::PropertyInputPlan::Value(AstPropertyValue::String(
+                            tenant.to_string(),
+                        )),
+                    },
+                },
+            ),
+        ],
+        2,
+    )
+}
+
+fn public_boundary_entity_binding(
+    element_kind: IndexElementKind,
+    entity_id: u64,
+) -> context::ParamBindings {
+    let value = match element_kind {
+        IndexElementKind::Node | IndexElementKind::Edge => AstPropertyValue::I64(
+            i64::try_from(entity_id).expect("public-boundary entity ID fits i64"),
+        ),
+    };
+    context::ParamBindings::default().with_value(public_name("entity"), value)
+}
+
+fn public_created_entity_id(result: ExecutionResult, element_kind: IndexElementKind) -> u64 {
+    let Some(ExecutionValue::Stream(rows)) = result.last else {
+        panic!("public-boundary insert returns its created row");
+    };
+    let Some(row) = rows.first() else {
+        panic!("public-boundary insert returns one created row");
+    };
+    match (element_kind, row.current.as_ref()) {
+        (IndexElementKind::Node, Some(ElementRef::Node(entity_id)))
+        | (IndexElementKind::Edge, Some(ElementRef::Edge(entity_id))) => *entity_id,
+        _ => panic!("public-boundary insert returns the expected entity kind"),
+    }
+}
+
+const fn public_ast_range_direction(
+    direction: crate::config::RangeIndexDirection,
+) -> AstRangeIndexDirection {
+    match direction {
+        crate::config::RangeIndexDirection::Asc => AstRangeIndexDirection::Asc,
+        crate::config::RangeIndexDirection::Desc => AstRangeIndexDirection::Desc,
+    }
+}
+
+fn public_boundary_read_plan(
+    shape: &PublicBoundaryShape,
+    ordinal: u64,
+    tenant: &str,
+) -> exec::ExecutablePlan {
+    match shape {
+        PublicBoundaryShape::Secondary(definition) => match definition {
+            ValidatedSecondaryIndexDefinition::NodeEquality { unique, .. } => {
+                let index = catalog::NodeEqualityIndexMeta::new(public_name(&format!(
+                    "node_eq:{}:{}",
+                    shape.label(),
+                    shape.property()
+                )))
+                .with_uniqueness(if *unique {
+                    catalog::IndexUniqueness::Unique
+                } else {
+                    catalog::IndexUniqueness::NonUnique
+                });
+                public_boundary_node_read_plan(exec::ExecNodeAccessPlan::exact_equality(
+                    index,
+                    catalog::ScopedPropertyKey::try_new(shape.label(), shape.property())
+                        .expect("public-boundary node equality key validates"),
+                    ir::IndexValue::Literal(
+                        ir::SecondaryIndexLiteral::new(shape.value(ordinal))
+                            .expect("public-boundary equality value is indexable"),
+                    ),
+                ))
+            }
+            ValidatedSecondaryIndexDefinition::EdgeEquality { .. } => {
+                public_boundary_edge_read_plan(exec::ExecEdgeAccessPlan::exact_equality(
+                    catalog::EdgeEqualityIndexMeta::new(public_name(&format!(
+                        "edge_eq:{}:{}",
+                        shape.label(),
+                        shape.property()
+                    ))),
+                    catalog::ScopedPropertyKey::try_new(shape.label(), shape.property())
+                        .expect("public-boundary edge equality key validates"),
+                    ir::IndexValue::Literal(
+                        ir::SecondaryIndexLiteral::new(shape.value(ordinal))
+                            .expect("public-boundary equality value is indexable"),
+                    ),
+                ))
+            }
+            ValidatedSecondaryIndexDefinition::NodeRange { direction, .. } => {
+                let key = catalog::ScopedPropertyDirectionKey::try_new(
+                    shape.label(),
+                    shape.property(),
+                    public_ast_range_direction(*direction),
+                )
+                .expect("public-boundary node range key validates");
+                public_boundary_node_read_plan(exec::ExecNodeAccessPlan::RangeIndex {
+                    index: catalog::NodeRangeIndexMeta::new(public_name(&format!(
+                        "node_range:{key}"
+                    ))),
+                    key,
+                    range: ir::IndexRange::All,
+                })
+            }
+            ValidatedSecondaryIndexDefinition::EdgeRange { direction, .. } => {
+                let key = catalog::ScopedPropertyDirectionKey::try_new(
+                    shape.label(),
+                    shape.property(),
+                    public_ast_range_direction(*direction),
+                )
+                .expect("public-boundary edge range key validates");
+                public_boundary_edge_read_plan(exec::ExecEdgeAccessPlan::RangeIndex {
+                    index: catalog::EdgeRangeIndexMeta::new(public_name(&format!(
+                        "edge_range:{key}"
+                    ))),
+                    key,
+                    range: ir::IndexRange::All,
+                })
+            }
+        },
+        PublicBoundaryShape::Vector(definition) => {
+            let AstPropertyValue::F32Array(query) = shape.value(ordinal) else {
+                unreachable!("public-boundary vector shape returns a vector");
+            };
+            let tenant = match definition.tenant_property() {
+                Some(property) => ir::SearchTenantPlan::ScopedValue {
+                    property: public_name(property.as_str()),
+                    value: ir::SearchTenantValuePlan::new(ir::PropertyInputPlan::Value(
+                        AstPropertyValue::String(tenant.to_string()),
+                    ))
+                    .expect("public-boundary tenant is non-null"),
+                },
+                None => ir::SearchTenantPlan::Unscoped,
+            };
+            let query_vector = ir::VectorQueryInputPlan::Vector(
+                ir::SearchVector::new(query)
+                    .expect("public-boundary vector query is finite and non-empty"),
+            );
+            let k = ir::SearchLimitPlan::Literal(
+                NonZeroUsize::new(10).expect("public-boundary vector limit is positive"),
+            );
+            match definition.element_kind() {
+                IndexElementKind::Node => {
+                    public_boundary_node_read_plan(exec::ExecNodeAccessPlan::VectorSearch {
+                        key: catalog::NodeSearchIndexKey::try_new(shape.label(), shape.property())
+                            .expect("public-boundary node vector key validates"),
+                        index: ir::SearchIndexPlan {
+                            index_id: public_name(&vector_index_name(
+                                VectorElementType::Node,
+                                shape.label(),
+                                shape.property(),
+                            )),
+                            tenant,
+                        },
+                        query_vector,
+                        k,
+                    })
+                }
+                IndexElementKind::Edge => {
+                    public_boundary_edge_read_plan(exec::ExecEdgeAccessPlan::VectorSearch {
+                        key: catalog::EdgeSearchIndexKey::try_new(shape.label(), shape.property())
+                            .expect("public-boundary edge vector key validates"),
+                        index: ir::SearchIndexPlan {
+                            index_id: public_name(&vector_index_name(
+                                VectorElementType::Edge,
+                                shape.label(),
+                                shape.property(),
+                            )),
+                            tenant,
+                        },
+                        query_vector,
+                        k,
+                    })
+                }
+            }
+        }
+    }
+}
+
+fn public_boundary_node_read_plan(access: exec::ExecNodeAccessPlan) -> exec::ExecutablePlan {
+    public_boundary_projected_read_plan(exec::ExecAccessPlan::Node(access))
+}
+
+fn public_boundary_edge_read_plan(access: exec::ExecEdgeAccessPlan) -> exec::ExecutablePlan {
+    public_boundary_projected_read_plan(exec::ExecAccessPlan::Edge(access))
+}
+
+fn public_boundary_projected_read_plan(access: exec::ExecAccessPlan) -> exec::ExecutablePlan {
+    let access_id =
+        exec::ExecStepId::new(1).expect("public-boundary indexed access ID is positive");
+    public_executable(
+        ir::PlanKind::Read,
+        vec![
+            public_step(
+                1,
+                Vec::new(),
+                exec::ExecOp::Access {
+                    plan: Box::new(access),
+                },
+            ),
+            public_step(
+                2,
+                vec![access_id],
+                exec::ExecOp::Project {
+                    projection: ir::ProjectionPlan::Id,
+                },
+            ),
+        ],
+        2,
+    )
 }
 
 /// Builds one public node insert for the selected physical family.

--- a/crates/db/src/index_lifecycle_testing/contracts.rs
+++ b/crates/db/src/index_lifecycle_testing/contracts.rs
@@ -47,6 +47,8 @@ use super::{
     LifecycleTestScheduling, LifecycleWorkTarget,
 };
 
+mod all_index_validation;
+
 const MAXIMUM_CONTROLLER_TURNS: usize = 4_096;
 
 /// Runs all deterministic DDL shape and convergence contracts.
@@ -1215,6 +1217,11 @@ pub(super) async fn run_mutations() {
     run_secondary_edge_mutation_interleaving().await;
     run_every_family_public_mutation_interleaving().await;
     run_partitioned_search_edge_tenant_moves().await;
+}
+
+/// Runs late insert, update, and delete races at every family validation boundary.
+pub(super) async fn run_all_index_validation_mutations() {
+    all_index_validation::run().await;
 }
 
 /// Interleaves source changes with two builds and proves unique repair/retry.

--- a/crates/db/src/index_lifecycle_testing/contracts/all_index_validation.rs
+++ b/crates/db/src/index_lifecycle_testing/contracts/all_index_validation.rs
@@ -13,8 +13,10 @@ use crate::encoding::property::property_value::PropertyValue;
 use crate::encoding::property::{decode_properties, encode_properties, Property};
 use crate::encoding::v2::keys::scope::{DataScope, TenantId};
 use crate::encoding::v2::keys::{
-    IndexEntity, IndexEntityStateKey, ManagedIndexKey, RecordKind, ScopedKey,
+    DataKey, DataKeyKind, EdgeEndpointsKey, IndexEntity, IndexEntityStateKey, ManagedIndexKey,
+    RecordKind, ScopedKey,
 };
+use crate::encoding::v2::values::edge_endpoints::EdgeEndpointsValue;
 use crate::execution::interpreter::{ExecutionScalar, ExecutionValue};
 use crate::index_lifecycle::{
     ActiveIndexHandle, IndexDefinitionFamily, IndexElementKind, IndexOperationId,
@@ -194,7 +196,10 @@ async fn run_case(
         );
         match element_kind {
             IndexElementKind::Node => put_source(&db, scope, entity_id, &properties).await,
-            IndexElementKind::Edge => put_edge_source(&db, scope, entity_id, &properties).await,
+            IndexElementKind::Edge => {
+                put_edge_source(&db, scope, entity_id, &properties).await;
+                put_edge_endpoints(&db, scope, entity_id).await;
+            }
         }
     }
     let crate::index_lifecycle::IndexDdlReceipt::Accepted { operation_id, .. } = controller
@@ -256,6 +261,9 @@ async fn run_case(
         IndexElementKind::Node => allocate_node_ids(&db, 1).await.start,
         IndexElementKind::Edge => allocate_edge_ids(&db, 1).await.start,
     };
+    if element_kind == IndexElementKind::Edge {
+        put_edge_endpoints(&db, scope, inserted_id).await;
+    }
     mutate_entity(
         &db,
         scope,
@@ -583,6 +591,21 @@ fn fixture_properties(
         properties.push(Property::string(TENANT_PROPERTY, TENANT_VALUE));
     }
     properties
+}
+
+async fn put_edge_endpoints(db: &HelixDB, scope: DataScope, entity_id: u64) {
+    db.lifecycle_test_writer_db()
+        .expect("edge endpoint fixture has writer storage")
+        .put(
+            DataKey::Data {
+                scope,
+                kind: DataKeyKind::EdgeEndpoints(EdgeEndpointsKey::new(entity_id)),
+            }
+            .to_bytes(),
+            EdgeEndpointsValue::new(0, 1).encode(),
+        )
+        .await
+        .expect("edge endpoint fixture commits");
 }
 
 async fn mutate_entity(
@@ -916,7 +939,11 @@ async fn assert_search_results<const N: usize>(
             },
         )
         .collect::<BTreeSet<_>>();
-    assert_eq!(actual, expected.into_iter().collect());
+    assert_eq!(
+        actual,
+        expected.into_iter().collect(),
+        "search result differs for {definition:?} fixture {fixture:?}"
+    );
 }
 
 fn search_plan(

--- a/crates/db/src/index_lifecycle_testing/contracts/all_index_validation.rs
+++ b/crates/db/src/index_lifecycle_testing/contracts/all_index_validation.rs
@@ -1,0 +1,1087 @@
+//! Late-mutation convergence across every supported managed index shape.
+
+use std::collections::BTreeSet;
+use std::num::NonZeroUsize;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use helix_ast::value::PropertyValue as AstPropertyValue;
+use helix_planner::{catalog, context, exec, ir};
+use slatedb::IsolationLevel;
+
+use crate::config::{TextElementType, VectorElementType};
+use crate::encoding::property::property_value::PropertyValue;
+use crate::encoding::property::{decode_properties, encode_properties, Property};
+use crate::encoding::v2::keys::scope::{DataScope, TenantId};
+use crate::encoding::v2::keys::{
+    IndexEntity, IndexEntityStateKey, ManagedIndexKey, RecordKind, ScopedKey,
+};
+use crate::execution::interpreter::{ExecutionScalar, ExecutionValue};
+use crate::index_lifecycle::{
+    ActiveIndexHandle, IndexDefinitionFamily, IndexElementKind, IndexOperationId,
+    IndexOperationStage, IndexOperationStatus, ValidatedDynamicIndexDefinition,
+    ValidatedSecondaryIndexDefinition,
+};
+use crate::index_lifecycle_testing::{
+    LifecycleCheckpoint, LifecycleStage, LifecycleTestController, LifecycleWorkTarget,
+    TextManifestValidationLane,
+};
+use crate::search::{text_index_name, vector_index_name};
+use crate::{HelixDB, HelixDbSource};
+
+use super::{
+    allocate_edge_ids, allocate_node_ids, assert_build_delta_count_at_least,
+    assert_build_deltas_empty, assert_identity_active, assert_monotonic_step, drive_to_terminal,
+    edge_source_key, family_shapes, mutate_edge_source, mutate_source, public_executable,
+    public_name, public_step, put_edge_source, put_source, source_key, MAXIMUM_CONTROLLER_TURNS,
+};
+
+const INDEX_PROPERTY: &str = "value";
+const TENANT_PROPERTY: &str = "tenant";
+const TENANT_VALUE: &str = "tenant-a";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SecondaryLatePoint {
+    Validate,
+    Activate,
+}
+
+impl SecondaryLatePoint {
+    const ALL: [Self; 2] = [Self::Validate, Self::Activate];
+
+    const fn stage(self) -> IndexOperationStage {
+        match self {
+            Self::Validate => IndexOperationStage::Validate,
+            Self::Activate => IndexOperationStage::Activate,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VectorLatePoint {
+    ValidateDescriptor,
+    Activate,
+}
+
+impl VectorLatePoint {
+    const ALL: [Self; 2] = [Self::ValidateDescriptor, Self::Activate];
+
+    const fn stage(self) -> IndexOperationStage {
+        match self {
+            Self::ValidateDescriptor => IndexOperationStage::ValidateDescriptor,
+            Self::Activate => IndexOperationStage::Activate,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TextLatePoint {
+    Compact,
+    PrepareManifests,
+    ValidatePages,
+    ValidateRoots,
+    ValidateEntityStates,
+    Activate,
+}
+
+impl TextLatePoint {
+    const ALL: [Self; 6] = [
+        Self::Compact,
+        Self::PrepareManifests,
+        Self::ValidatePages,
+        Self::ValidateRoots,
+        Self::ValidateEntityStates,
+        Self::Activate,
+    ];
+
+    const fn stage(self) -> IndexOperationStage {
+        match self {
+            Self::Compact => IndexOperationStage::Compact,
+            Self::PrepareManifests => IndexOperationStage::PrepareManifests,
+            Self::ValidatePages | Self::ValidateRoots | Self::ValidateEntityStates => {
+                IndexOperationStage::ValidateManifests
+            }
+            Self::Activate => IndexOperationStage::Activate,
+        }
+    }
+
+    const fn lane(self) -> Option<TextManifestValidationLane> {
+        match self {
+            Self::ValidatePages => Some(TextManifestValidationLane::Pages),
+            Self::ValidateRoots => Some(TextManifestValidationLane::Roots),
+            Self::ValidateEntityStates => Some(TextManifestValidationLane::EntityStates),
+            Self::Compact | Self::PrepareManifests | Self::Activate => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FixtureValue {
+    Initial(u8),
+    Updated,
+    Inserted,
+}
+
+/// Runs 182 exact tenant-scope races: 14 secondary, 24 vector, and 144 text.
+pub(super) async fn run() {
+    let mut ordinal = 0usize;
+    let mut secondary_cases = 0usize;
+    let mut vector_cases = 0usize;
+    let mut text_cases = 0usize;
+    for definition in family_shapes() {
+        match definition.family() {
+            IndexDefinitionFamily::Secondary => {
+                for point in SecondaryLatePoint::ALL {
+                    run_case(ordinal, definition.clone(), point.stage(), None).await;
+                    ordinal += 1;
+                    secondary_cases += 1;
+                }
+            }
+            IndexDefinitionFamily::Vector => {
+                for point in VectorLatePoint::ALL {
+                    run_case(ordinal, definition.clone(), point.stage(), None).await;
+                    ordinal += 1;
+                    vector_cases += 1;
+                }
+            }
+            IndexDefinitionFamily::Text => {
+                for point in TextLatePoint::ALL {
+                    run_case(ordinal, definition.clone(), point.stage(), point.lane()).await;
+                    ordinal += 1;
+                    text_cases += 1;
+                }
+            }
+        }
+    }
+    assert_eq!(
+        secondary_cases, 14,
+        "every secondary shape and late stage runs"
+    );
+    assert_eq!(vector_cases, 24, "every vector shape and late stage runs");
+    assert_eq!(text_cases, 144, "every text shape and late stage runs");
+    assert_eq!(ordinal, 182, "the complete all-index race matrix runs");
+}
+
+async fn run_case(
+    ordinal: usize,
+    definition: ValidatedDynamicIndexDefinition,
+    stage: IndexOperationStage,
+    text_lane: Option<TextManifestValidationLane>,
+) {
+    let scope = DataScope::Tenant(TenantId::from_u128(
+        0xFD00_0000_0000_0000_0000_0000_1000_0000 + ordinal as u128,
+    ));
+    let db = HelixDB::open_for_index_lifecycle_testing(
+        HelixDbSource::InMemory {
+            database: format!("index-lifecycle-all-index-validation-{ordinal}"),
+        },
+        crate::DbConfig::new(),
+        crate::index_lifecycle_testing::LifecycleTestScheduling::Explicit,
+    )
+    .await
+    .expect("all-index validation writer opens");
+    let controller = LifecycleTestController::new();
+    let element_kind = definition.identity().element_kind();
+    let initial_ids = match element_kind {
+        IndexElementKind::Node => allocate_node_ids(&db, 3).await,
+        IndexElementKind::Edge => allocate_edge_ids(&db, 3).await,
+    };
+    for (source_ordinal, entity_id) in initial_ids.clone().enumerate() {
+        let properties = fixture_properties(
+            &definition,
+            FixtureValue::Initial(
+                u8::try_from(source_ordinal).expect("three source rows fit one fixture ordinal"),
+            ),
+        );
+        match element_kind {
+            IndexElementKind::Node => put_source(&db, scope, entity_id, &properties).await,
+            IndexElementKind::Edge => put_edge_source(&db, scope, entity_id, &properties).await,
+        }
+    }
+    let crate::index_lifecycle::IndexDdlReceipt::Accepted { operation_id, .. } = controller
+        .create_index(
+            &db,
+            scope,
+            definition.clone(),
+            ir::IndexCreateMode::ErrorIfExists,
+        )
+        .await
+        .expect("all-index validation build is accepted")
+    else {
+        panic!("fresh all-index validation build must enqueue");
+    };
+
+    if matches!(definition, ValidatedDynamicIndexDefinition::Secondary(_)) {
+        drive_until_exact_stage(
+            &db,
+            &controller,
+            scope,
+            operation_id,
+            IndexOperationStage::CatchUp,
+        )
+        .await;
+        assert_secondary_applied_state_present(
+            &db,
+            scope,
+            operation_id,
+            &definition,
+            [
+                initial_ids.start,
+                initial_ids.start + 1,
+                initial_ids.start + 2,
+            ],
+        )
+        .await;
+    }
+    drive_until_exact_stage(&db, &controller, scope, operation_id, stage).await;
+    if let Some(lane) = text_lane {
+        drive_until_text_validation_lane(&db, &controller, scope, operation_id, lane).await;
+    }
+
+    let updated_id = initial_ids.start;
+    let deleted_id = initial_ids.start + 1;
+    let stable_id = initial_ids.start + 2;
+    if matches!(definition, ValidatedDynamicIndexDefinition::Secondary(_))
+        && stage == IndexOperationStage::Validate
+    {
+        assert_secondary_applied_state_present(
+            &db,
+            scope,
+            operation_id,
+            &definition,
+            [updated_id, deleted_id, stable_id],
+        )
+        .await;
+    }
+    let inserted_id = match element_kind {
+        IndexElementKind::Node => allocate_node_ids(&db, 1).await.start,
+        IndexElementKind::Edge => allocate_edge_ids(&db, 1).await.start,
+    };
+    mutate_entity(
+        &db,
+        scope,
+        &definition,
+        updated_id,
+        &fixture_properties(&definition, FixtureValue::Initial(0)),
+        &fixture_properties(&definition, FixtureValue::Updated),
+    )
+    .await;
+    mutate_entity(
+        &db,
+        scope,
+        &definition,
+        deleted_id,
+        &fixture_properties(&definition, FixtureValue::Initial(1)),
+        &[],
+    )
+    .await;
+    mutate_entity(
+        &db,
+        scope,
+        &definition,
+        inserted_id,
+        &[],
+        &fixture_properties(&definition, FixtureValue::Inserted),
+    )
+    .await;
+    assert_build_delta_count_at_least(&db, scope, &definition, 3).await;
+
+    let evidence = controller
+        .advance(
+            &db,
+            LifecycleWorkTarget::Operation {
+                scope,
+                operation_id,
+            },
+        )
+        .await
+        .expect("late validation mutation re-entry step succeeds");
+    assert_monotonic_step(&evidence);
+    let reentered = db
+        .get_index_operation(scope, operation_id)
+        .await
+        .expect("re-entered operation remains readable");
+    assert_eq!(
+        reentered.common().stage,
+        IndexOperationStage::CatchUp,
+        "{definition:?} must leave {stage:?} for catch-up after late mutations"
+    );
+
+    let terminal = drive_to_terminal(&db, &controller, scope, operation_id).await;
+    assert!(
+        matches!(terminal, IndexOperationStatus::Succeeded { .. }),
+        "{definition:?} did not activate after a late mutation at {stage:?}: {terminal:?}"
+    );
+    assert_identity_active(&db, scope, &definition).await;
+    assert_build_deltas_empty(&db, scope, &definition).await;
+    assert_source_rows(
+        &db,
+        scope,
+        &definition,
+        updated_id,
+        deleted_id,
+        stable_id,
+        inserted_id,
+    )
+    .await;
+    assert_active_results(&db, scope, &definition, updated_id, stable_id, inserted_id).await;
+    db.close()
+        .await
+        .expect("all-index validation writer closes");
+}
+
+async fn assert_secondary_applied_state_present<const N: usize>(
+    db: &HelixDB,
+    scope: DataScope,
+    operation_id: IndexOperationId,
+    definition: &ValidatedDynamicIndexDefinition,
+    entity_ids: [u64; N],
+) {
+    let writer = db
+        .lifecycle_test_writer_db()
+        .expect("secondary applied-state assertion has writer storage");
+    let record = crate::index_lifecycle::repository::load_index_record(
+        writer,
+        scope,
+        &definition.identity(),
+    )
+    .await
+    .expect("building secondary record decodes")
+    .expect("building secondary record exists");
+    for entity_id in entity_ids {
+        let key = ManagedIndexKey::Data {
+            scope,
+            kind: ScopedKey::AppliedState(IndexEntityStateKey {
+                index_id: record.index_id(),
+                generation: record.state().generation(),
+                entity: IndexEntity {
+                    kind: definition.identity().element_kind(),
+                    id: crate::index_lifecycle::IndexEntityId::new(entity_id),
+                },
+            }),
+        }
+        .to_bytes();
+        if writer
+            .get(key)
+            .await
+            .expect("secondary applied-state row is readable")
+            .is_none()
+        {
+            let prefix = ManagedIndexKey::data_prefix(
+                scope,
+                ScopedKey::generation_prefix(
+                    RecordKind::AppliedState,
+                    record.index_id(),
+                    record.state().generation(),
+                ),
+            );
+            let mut rows = writer
+                .scan_prefix(&prefix, ..)
+                .await
+                .expect("secondary applied-state prefix is readable");
+            let mut count = 0usize;
+            while rows
+                .next()
+                .await
+                .expect("secondary applied-state prefix scan succeeds")
+                .is_some()
+            {
+                count += 1;
+            }
+            let operation =
+                crate::index_lifecycle::outbox::read_queued_operation(writer, operation_id)
+                    .await
+                    .expect("secondary operation is readable")
+                    .expect("secondary operation remains queued")
+                    .1;
+            panic!(
+                "{definition:?} lost applied state for entity {entity_id} before late mutation; index {} generation {} retains {count} applied rows; progress {:?}",
+                record.index_id().get(),
+                record.state().generation().get(),
+                operation.progress(),
+            );
+        }
+    }
+}
+
+async fn drive_until_text_validation_lane(
+    db: &HelixDB,
+    controller: &LifecycleTestController,
+    scope: DataScope,
+    operation_id: IndexOperationId,
+    expected: TextManifestValidationLane,
+) {
+    let target = LifecycleWorkTarget::Operation {
+        scope,
+        operation_id,
+    };
+    let logical_start = u64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("all-index validation clock is after the Unix epoch")
+            .as_millis(),
+    )
+    .expect("all-index validation time fits u64 milliseconds");
+    for turn in 0..MAXIMUM_CONTROLLER_TURNS {
+        if controller
+            .text_manifest_validation_lane(db, scope, operation_id)
+            .await
+            .expect("text validation lane is readable")
+            == Some(expected)
+        {
+            return;
+        }
+        let logical_now = logical_start.saturating_add(
+            u64::try_from(turn)
+                .expect("all-index validation turn fits u64")
+                .saturating_mul(60_000),
+        );
+        let evidence = controller
+            .advance_at_unix_millis(db, target, logical_now)
+            .await
+            .expect("text validation lane operation step succeeds");
+        assert_monotonic_step(&evidence);
+        let page = controller
+            .discover(
+                db,
+                NonZeroUsize::new(1_024).expect("all-index discovery bound is positive"),
+            )
+            .await
+            .expect("text validation child work remains discoverable");
+        for child in page.targets {
+            if child == target {
+                continue;
+            }
+            let evidence = controller
+                .advance_at_unix_millis(db, child, logical_now)
+                .await
+                .expect("text validation child step succeeds");
+            assert_monotonic_step(&evidence);
+        }
+    }
+    panic!("text validation lane {expected:?} was not reached");
+}
+
+async fn drive_until_exact_stage(
+    db: &HelixDB,
+    controller: &LifecycleTestController,
+    scope: DataScope,
+    operation_id: IndexOperationId,
+    expected: IndexOperationStage,
+) {
+    let target = LifecycleWorkTarget::Operation {
+        scope,
+        operation_id,
+    };
+    let logical_start = u64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("all-index validation clock is after the Unix epoch")
+            .as_millis(),
+    )
+    .expect("all-index validation time fits u64 milliseconds");
+    for turn in 0..MAXIMUM_CONTROLLER_TURNS {
+        if matches!(
+            controller
+                .inspect(db, target)
+                .await
+                .expect("all-index validation checkpoint is readable"),
+            LifecycleCheckpoint::Present {
+                stage: LifecycleStage::Operation(actual),
+                ..
+            } if actual == expected
+        ) {
+            return;
+        }
+        let logical_now = logical_start.saturating_add(
+            u64::try_from(turn)
+                .expect("controller turn fits u64")
+                .saturating_mul(60_000),
+        );
+        let evidence = controller
+            .advance_at_unix_millis(db, target, logical_now)
+            .await
+            .expect("all-index validation operation step succeeds");
+        assert_monotonic_step(&evidence);
+        if matches!(
+            evidence.after,
+            LifecycleCheckpoint::Present {
+                stage: LifecycleStage::Operation(actual),
+                ..
+            } if actual == expected
+        ) {
+            return;
+        }
+        let page = controller
+            .discover(
+                db,
+                NonZeroUsize::new(1_024).expect("all-index discovery bound is positive"),
+            )
+            .await
+            .expect("all-index validation child work is discoverable");
+        assert!(page.exhausted, "small all-index contract fits one page");
+        for child in page.targets {
+            if child == target {
+                continue;
+            }
+            let evidence = controller
+                .advance_at_unix_millis(db, child, logical_now)
+                .await
+                .expect("all-index validation child step succeeds");
+            assert_monotonic_step(&evidence);
+        }
+    }
+    panic!("operation did not reach exact live stage {expected:?}");
+}
+
+fn fixture_properties(
+    definition: &ValidatedDynamicIndexDefinition,
+    value: FixtureValue,
+) -> Vec<Property> {
+    let mut properties = vec![Property::string(
+        "$label",
+        definition.identity().label().as_str(),
+    )];
+    let property = match definition {
+        ValidatedDynamicIndexDefinition::Secondary(_) => Property::string(
+            INDEX_PROPERTY,
+            match value {
+                FixtureValue::Initial(ordinal) => format!("initial-{ordinal}"),
+                FixtureValue::Updated => "updated".to_string(),
+                FixtureValue::Inserted => "inserted".to_string(),
+            },
+        ),
+        ValidatedDynamicIndexDefinition::Vector(_) => Property::f32_array(
+            INDEX_PROPERTY,
+            match value {
+                FixtureValue::Initial(0) => vec![1.0, 0.1, 0.1],
+                FixtureValue::Initial(1) => vec![0.1, 1.0, 0.1],
+                FixtureValue::Initial(_) => vec![0.1, 0.1, 1.0],
+                FixtureValue::Updated => vec![-1.0, 0.2, 0.1],
+                FixtureValue::Inserted => vec![0.2, -1.0, 0.1],
+            },
+        ),
+        ValidatedDynamicIndexDefinition::Text(_) => Property::string(
+            INDEX_PROPERTY,
+            match value {
+                FixtureValue::Initial(ordinal) => {
+                    format!("initialvalidationtoken{ordinal}")
+                }
+                FixtureValue::Updated => "updatedvalidationtoken".to_string(),
+                FixtureValue::Inserted => "insertedvalidationtoken".to_string(),
+            },
+        ),
+    };
+    properties.push(property);
+    let partitioned = match definition {
+        ValidatedDynamicIndexDefinition::Secondary(_) => false,
+        ValidatedDynamicIndexDefinition::Vector(definition) => {
+            definition.tenant_property().is_some()
+        }
+        ValidatedDynamicIndexDefinition::Text(definition) => definition.tenant_property().is_some(),
+    };
+    if partitioned {
+        properties.push(Property::string(TENANT_PROPERTY, TENANT_VALUE));
+    }
+    properties
+}
+
+async fn mutate_entity(
+    db: &HelixDB,
+    scope: DataScope,
+    definition: &ValidatedDynamicIndexDefinition,
+    entity_id: u64,
+    before: &[Property],
+    after: &[Property],
+) {
+    let element_kind = definition.identity().element_kind();
+    match definition {
+        ValidatedDynamicIndexDefinition::Secondary(_) => match element_kind {
+            IndexElementKind::Node => mutate_source(db, scope, entity_id, before, after).await,
+            IndexElementKind::Edge => mutate_edge_source(db, scope, entity_id, before, after).await,
+        }
+        .expect("late secondary mutation commits"),
+        ValidatedDynamicIndexDefinition::Vector(_) => {
+            let writer = db
+                .lifecycle_test_writer_db()
+                .expect("late vector mutation has writer storage");
+            let transaction = writer
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("late vector mutation transaction begins");
+            let mutations = crate::index_lifecycle::vector::load_mutation_set(&transaction, scope)
+                .await
+                .expect("late vector mutation loads its building generation");
+            let cache_writes = crate::search::vector::VectorCacheWriteSet::default();
+            crate::index_lifecycle::vector::maintain_entity(
+                &transaction,
+                scope,
+                &mutations,
+                &cache_writes,
+                crate::index_lifecycle::vector::VectorEntityMutation::new(
+                    element_kind,
+                    entity_id,
+                    before,
+                    after,
+                ),
+            )
+            .await
+            .expect("late vector mutation records its build delta");
+            stage_source_row(&transaction, scope, element_kind, entity_id, after);
+            transaction
+                .commit()
+                .await
+                .expect("late vector source and build delta commit atomically");
+        }
+        ValidatedDynamicIndexDefinition::Text(_) => {
+            let writer = db
+                .lifecycle_test_writer_db()
+                .expect("late text mutation has writer storage");
+            let transaction = writer
+                .begin(IsolationLevel::SerializableSnapshot)
+                .await
+                .expect("late text mutation transaction begins");
+            let mutations =
+                crate::index_lifecycle::text::mutation::load_mutation_set(&transaction, scope)
+                    .await
+                    .expect("late text mutation loads its building generation");
+            let prepared = crate::index_lifecycle::text::mutation::prepare_text_build_deltas(
+                &transaction,
+                scope,
+                &mutations,
+                crate::index_lifecycle::text::mutation::TextEntityMutation::new(
+                    element_kind,
+                    entity_id,
+                    before,
+                    after,
+                ),
+            )
+            .await
+            .expect("late text mutation prepares its build delta");
+            let validated = crate::index_lifecycle::text::mutation::validate_text_build_deltas(
+                &transaction,
+                &prepared,
+            )
+            .await
+            .expect("late text mutation revalidates its build delta");
+            crate::index_lifecycle::text::mutation::stage_validated_text_build_deltas(
+                &transaction,
+                validated,
+            )
+            .expect("late text mutation stages its validated build delta");
+            stage_source_row(&transaction, scope, element_kind, entity_id, after);
+            transaction
+                .commit()
+                .await
+                .expect("late text source, statistics, and build delta commit atomically");
+        }
+    }
+}
+
+fn stage_source_row(
+    transaction: &slatedb::DbTransaction,
+    scope: DataScope,
+    element_kind: IndexElementKind,
+    entity_id: u64,
+    after: &[Property],
+) {
+    let key = match element_kind {
+        IndexElementKind::Node => source_key(scope, entity_id),
+        IndexElementKind::Edge => edge_source_key(scope, entity_id),
+    };
+    if after.is_empty() {
+        transaction.delete(key).expect("late source delete stages");
+    } else {
+        transaction
+            .put(key, encode_properties(after))
+            .expect("late source replacement stages");
+    }
+}
+
+async fn assert_source_rows(
+    db: &HelixDB,
+    scope: DataScope,
+    definition: &ValidatedDynamicIndexDefinition,
+    updated_id: u64,
+    deleted_id: u64,
+    stable_id: u64,
+    inserted_id: u64,
+) {
+    let writer = db
+        .lifecycle_test_writer_db()
+        .expect("all-index source assertion has writer storage");
+    let key = |entity_id| match definition.identity().element_kind() {
+        IndexElementKind::Node => source_key(scope, entity_id),
+        IndexElementKind::Edge => edge_source_key(scope, entity_id),
+    };
+    for (entity_id, expected) in [
+        (updated_id, FixtureValue::Updated),
+        (stable_id, FixtureValue::Initial(2)),
+        (inserted_id, FixtureValue::Inserted),
+    ] {
+        let stored = writer
+            .get(key(entity_id))
+            .await
+            .expect("authoritative source read succeeds")
+            .expect("authoritative source row remains present");
+        assert_eq!(
+            decode_properties(&stored).expect("authoritative source properties decode"),
+            fixture_properties(definition, expected)
+        );
+    }
+    assert!(
+        writer
+            .get(key(deleted_id))
+            .await
+            .expect("deleted authoritative source read succeeds")
+            .is_none(),
+        "deleted source row must remain absent"
+    );
+}
+
+async fn assert_active_results(
+    db: &HelixDB,
+    scope: DataScope,
+    definition: &ValidatedDynamicIndexDefinition,
+    updated_id: u64,
+    stable_id: u64,
+    inserted_id: u64,
+) {
+    match definition {
+        ValidatedDynamicIndexDefinition::Secondary(definition) => {
+            assert_secondary_results(db, scope, definition, updated_id, stable_id, inserted_id)
+                .await;
+        }
+        ValidatedDynamicIndexDefinition::Vector(_) => {
+            assert_search_results(
+                db,
+                scope,
+                definition,
+                SearchFixture::Vector(FixtureValue::Updated),
+                [updated_id],
+            )
+            .await;
+            assert_search_results(
+                db,
+                scope,
+                definition,
+                SearchFixture::Vector(FixtureValue::Inserted),
+                [inserted_id],
+            )
+            .await;
+            assert_search_results(
+                db,
+                scope,
+                definition,
+                SearchFixture::VectorAll,
+                [updated_id, stable_id, inserted_id],
+            )
+            .await;
+        }
+        ValidatedDynamicIndexDefinition::Text(_) => {
+            assert_search_results(
+                db,
+                scope,
+                definition,
+                SearchFixture::Text("updatedvalidationtoken"),
+                [updated_id],
+            )
+            .await;
+            assert_search_results(
+                db,
+                scope,
+                definition,
+                SearchFixture::Text("insertedvalidationtoken"),
+                [inserted_id],
+            )
+            .await;
+            assert_search_results(
+                db,
+                scope,
+                definition,
+                SearchFixture::Text("initialvalidationtoken1"),
+                [],
+            )
+            .await;
+            assert_search_results(
+                db,
+                scope,
+                definition,
+                SearchFixture::Text("initialvalidationtoken2"),
+                [stable_id],
+            )
+            .await;
+        }
+    }
+}
+
+async fn assert_secondary_results(
+    db: &HelixDB,
+    scope: DataScope,
+    definition: &ValidatedSecondaryIndexDefinition,
+    updated_id: u64,
+    stable_id: u64,
+    inserted_id: u64,
+) {
+    let dynamic = ValidatedDynamicIndexDefinition::Secondary(definition.clone());
+    let record = crate::index_lifecycle::repository::load_index_record(
+        db.lifecycle_test_writer_db()
+            .expect("secondary result assertion has writer storage"),
+        scope,
+        &dynamic.identity(),
+    )
+    .await
+    .expect("active secondary record decodes")
+    .expect("active secondary record exists");
+    let handle = ActiveIndexHandle::try_from_record(scope, &record)
+        .expect("active secondary record projects one handle");
+    match definition {
+        ValidatedSecondaryIndexDefinition::NodeEquality { .. }
+        | ValidatedSecondaryIndexDefinition::EdgeEquality { .. } => {
+            for (value, expected) in [
+                ("updated", BTreeSet::from([updated_id])),
+                ("initial-1", BTreeSet::new()),
+                ("initial-2", BTreeSet::from([stable_id])),
+                ("inserted", BTreeSet::from([inserted_id])),
+            ] {
+                let actual = crate::index_lifecycle::secondary::lookup_active_equality_generation(
+                    db.lifecycle_test_writer_db()
+                        .expect("secondary equality result has writer storage"),
+                    &handle,
+                    &PropertyValue::String(value.to_string()),
+                )
+                .await
+                .expect("secondary equality result remains readable")
+                .iter()
+                .collect::<BTreeSet<_>>();
+                assert_eq!(
+                    actual, expected,
+                    "secondary equality result differs for {definition:?} value {value}"
+                );
+            }
+        }
+        ValidatedSecondaryIndexDefinition::NodeRange { .. }
+        | ValidatedSecondaryIndexDefinition::EdgeRange { .. } => {
+            let actual =
+                crate::index_lifecycle::secondary::scan_active_range_generation_with_membership(
+                    db.lifecycle_test_writer_db()
+                        .expect("secondary range result has writer storage"),
+                    &handle,
+                    None,
+                    None,
+                    &[],
+                )
+                .await
+                .expect("secondary range result remains readable")
+                .into_iter()
+                .collect::<BTreeSet<_>>();
+            assert_eq!(actual, BTreeSet::from([updated_id, stable_id, inserted_id]));
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum SearchFixture {
+    Vector(FixtureValue),
+    VectorAll,
+    Text(&'static str),
+}
+
+async fn assert_search_results<const N: usize>(
+    db: &HelixDB,
+    scope: DataScope,
+    definition: &ValidatedDynamicIndexDefinition,
+    fixture: SearchFixture,
+    expected: [u64; N],
+) {
+    let result = db
+        .execute_scoped(
+            &search_plan(definition, fixture),
+            context::ParamBindings::default(),
+            scope,
+        )
+        .await
+        .expect("active search result remains readable");
+    let Some(ExecutionValue::Scalars(values)) = result.last else {
+        panic!("active search result returns projected IDs");
+    };
+    let actual = values
+        .into_iter()
+        .map(
+            |value| match (definition.identity().element_kind(), value) {
+                (IndexElementKind::Node, ExecutionScalar::NodeId(entity_id))
+                | (IndexElementKind::Edge, ExecutionScalar::EdgeId(entity_id)) => entity_id,
+                (element_kind, value) => {
+                    panic!("{element_kind:?} search returned another scalar: {value:?}")
+                }
+            },
+        )
+        .collect::<BTreeSet<_>>();
+    assert_eq!(actual, expected.into_iter().collect());
+}
+
+fn search_plan(
+    definition: &ValidatedDynamicIndexDefinition,
+    fixture: SearchFixture,
+) -> exec::ExecutablePlan {
+    let index = search_index_plan(definition);
+    let access = match (definition, fixture) {
+        (ValidatedDynamicIndexDefinition::Vector(definition), SearchFixture::Vector(value)) => {
+            search_access_vector(definition, index, vector_value(value), NonZeroUsize::MIN)
+        }
+        (ValidatedDynamicIndexDefinition::Vector(definition), SearchFixture::VectorAll) => {
+            search_access_vector(
+                definition,
+                index,
+                vector_value(FixtureValue::Updated),
+                NonZeroUsize::new(10).expect("all-vector search limit is positive"),
+            )
+        }
+        (ValidatedDynamicIndexDefinition::Text(definition), SearchFixture::Text(query)) => {
+            match definition.element_kind() {
+                IndexElementKind::Node => {
+                    exec::ExecAccessPlan::Node(exec::ExecNodeAccessPlan::TextSearch {
+                        key: catalog::NodeSearchIndexKey::try_new(
+                            definition.label().as_str(),
+                            definition.property().as_str(),
+                        )
+                        .expect("node text validation key is valid"),
+                        index,
+                        query_text: ir::TextQueryInputPlan::Text(public_name(query)),
+                        k: ir::SearchLimitPlan::Literal(
+                            NonZeroUsize::new(10).expect("text validation limit is positive"),
+                        ),
+                    })
+                }
+                IndexElementKind::Edge => {
+                    let key = catalog::EdgeSearchIndexKey::try_new(
+                        definition.label().as_str(),
+                        definition.property().as_str(),
+                    )
+                    .expect("edge text validation key is valid");
+                    exec::ExecAccessPlan::Edge(exec::ExecEdgeAccessPlan::TextSearch {
+                        key,
+                        index,
+                        query_text: ir::TextQueryInputPlan::Text(public_name(query)),
+                        k: ir::SearchLimitPlan::Literal(
+                            NonZeroUsize::new(10).expect("text validation limit is positive"),
+                        ),
+                    })
+                }
+            }
+        }
+        (definition, fixture) => {
+            panic!("invalid search fixture {fixture:?} for {definition:?}")
+        }
+    };
+    let access_id = exec::ExecStepId::new(1).expect("validation access ID is positive");
+    public_executable(
+        ir::PlanKind::Read,
+        vec![
+            public_step(
+                1,
+                Vec::new(),
+                exec::ExecOp::Access {
+                    plan: Box::new(access),
+                },
+            ),
+            public_step(
+                2,
+                vec![access_id],
+                exec::ExecOp::Project {
+                    projection: ir::ProjectionPlan::Id,
+                },
+            ),
+        ],
+        2,
+    )
+}
+
+fn search_access_vector(
+    definition: &crate::index_lifecycle::ValidatedVectorIndexDefinition,
+    index: ir::SearchIndexPlan,
+    query: Vec<f32>,
+    k: NonZeroUsize,
+) -> exec::ExecAccessPlan {
+    let query_vector = ir::VectorQueryInputPlan::Vector(
+        ir::SearchVector::new(query).expect("validation vector query is finite and non-empty"),
+    );
+    match definition.element_kind() {
+        IndexElementKind::Node => {
+            exec::ExecAccessPlan::Node(exec::ExecNodeAccessPlan::VectorSearch {
+                key: catalog::NodeSearchIndexKey::try_new(
+                    definition.label().as_str(),
+                    definition.property().as_str(),
+                )
+                .expect("node vector validation key is valid"),
+                index,
+                query_vector,
+                k: ir::SearchLimitPlan::Literal(k),
+            })
+        }
+        IndexElementKind::Edge => {
+            exec::ExecAccessPlan::Edge(exec::ExecEdgeAccessPlan::VectorSearch {
+                key: catalog::EdgeSearchIndexKey::try_new(
+                    definition.label().as_str(),
+                    definition.property().as_str(),
+                )
+                .expect("edge vector validation key is valid"),
+                index,
+                query_vector,
+                k: ir::SearchLimitPlan::Literal(k),
+            })
+        }
+    }
+}
+
+fn search_index_plan(definition: &ValidatedDynamicIndexDefinition) -> ir::SearchIndexPlan {
+    let (index_id, tenant_property) = match definition {
+        ValidatedDynamicIndexDefinition::Vector(definition) => (
+            vector_index_name(
+                match definition.element_kind() {
+                    IndexElementKind::Node => VectorElementType::Node,
+                    IndexElementKind::Edge => VectorElementType::Edge,
+                },
+                definition.label().as_str(),
+                definition.property().as_str(),
+            ),
+            definition.tenant_property(),
+        ),
+        ValidatedDynamicIndexDefinition::Text(definition) => (
+            text_index_name(
+                match definition.element_kind() {
+                    IndexElementKind::Node => TextElementType::Node,
+                    IndexElementKind::Edge => TextElementType::Edge,
+                },
+                definition.label().as_str(),
+                definition.property().as_str(),
+            ),
+            definition.tenant_property(),
+        ),
+        ValidatedDynamicIndexDefinition::Secondary(_) => {
+            panic!("secondary validation uses exact physical reads")
+        }
+    };
+    let tenant = tenant_property.map_or(ir::SearchTenantPlan::Unscoped, |property| {
+        ir::SearchTenantPlan::ScopedValue {
+            property: public_name(property.as_str()),
+            value: ir::SearchTenantValuePlan::new(ir::PropertyInputPlan::Value(
+                AstPropertyValue::String(TENANT_VALUE.to_string()),
+            ))
+            .expect("validation tenant value is non-null"),
+        }
+    });
+    ir::SearchIndexPlan {
+        index_id: public_name(&index_id),
+        tenant,
+    }
+}
+
+fn vector_value(value: FixtureValue) -> Vec<f32> {
+    match value {
+        FixtureValue::Initial(0) => vec![1.0, 0.1, 0.1],
+        FixtureValue::Initial(1) => vec![0.1, 1.0, 0.1],
+        FixtureValue::Initial(_) => vec![0.1, 0.1, 1.0],
+        FixtureValue::Updated => vec![-1.0, 0.2, 0.1],
+        FixtureValue::Inserted => vec![0.2, -1.0, 0.1],
+    }
+}

--- a/crates/db/src/index_lifecycle_testing/contracts/all_index_validation.rs
+++ b/crates/db/src/index_lifecycle_testing/contracts/all_index_validation.rs
@@ -2,10 +2,13 @@
 
 use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use helix_ast::value::PropertyValue as AstPropertyValue;
 use helix_planner::{catalog, context, exec, ir};
+use slatedb::object_store::memory::InMemory;
+use slatedb::object_store::ObjectStore;
 use slatedb::IsolationLevel;
 
 use crate::config::{TextElementType, VectorElementType};
@@ -28,7 +31,7 @@ use crate::index_lifecycle_testing::{
     TextManifestValidationLane,
 };
 use crate::search::{text_index_name, vector_index_name};
-use crate::{HelixDB, HelixDbSource};
+use crate::HelixDB;
 
 use super::{
     allocate_edge_ids, allocate_node_ids, assert_build_delta_count_at_least,
@@ -39,19 +42,25 @@ use super::{
 
 const INDEX_PROPERTY: &str = "value";
 const TENANT_PROPERTY: &str = "tenant";
-const TENANT_VALUE: &str = "tenant-a";
+const TENANT_A: &str = "tenant-a";
+const TENANT_B: &str = "tenant-b";
+const TENANT_C: &str = "tenant-c";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SecondaryLatePoint {
+    Scan,
+    CatchUp,
     Validate,
     Activate,
 }
 
 impl SecondaryLatePoint {
-    const ALL: [Self; 2] = [Self::Validate, Self::Activate];
+    const ALL: [Self; 4] = [Self::Scan, Self::CatchUp, Self::Validate, Self::Activate];
 
     const fn stage(self) -> IndexOperationStage {
         match self {
+            Self::Scan => IndexOperationStage::Scan,
+            Self::CatchUp => IndexOperationStage::CatchUp,
             Self::Validate => IndexOperationStage::Validate,
             Self::Activate => IndexOperationStage::Activate,
         }
@@ -60,15 +69,24 @@ impl SecondaryLatePoint {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum VectorLatePoint {
+    Scan,
+    CatchUp,
     ValidateDescriptor,
     Activate,
 }
 
 impl VectorLatePoint {
-    const ALL: [Self; 2] = [Self::ValidateDescriptor, Self::Activate];
+    const ALL: [Self; 4] = [
+        Self::Scan,
+        Self::CatchUp,
+        Self::ValidateDescriptor,
+        Self::Activate,
+    ];
 
     const fn stage(self) -> IndexOperationStage {
         match self {
+            Self::Scan => IndexOperationStage::Scan,
+            Self::CatchUp => IndexOperationStage::CatchUp,
             Self::ValidateDescriptor => IndexOperationStage::ValidateDescriptor,
             Self::Activate => IndexOperationStage::Activate,
         }
@@ -119,11 +137,12 @@ impl TextLatePoint {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FixtureValue {
     Initial(u8),
+    Intermediate,
     Updated,
     Inserted,
 }
 
-/// Runs 182 exact tenant-scope races: 14 secondary, 24 vector, and 144 text.
+/// Runs 220 exact tenant-scope races: 28 secondary, 48 vector, and 144 text.
 pub(super) async fn run() {
     let mut ordinal = 0usize;
     let mut secondary_cases = 0usize;
@@ -155,12 +174,15 @@ pub(super) async fn run() {
         }
     }
     assert_eq!(
-        secondary_cases, 14,
-        "every secondary shape and late stage runs"
+        secondary_cases, 28,
+        "every secondary shape and lifecycle stage runs"
     );
-    assert_eq!(vector_cases, 24, "every vector shape and late stage runs");
+    assert_eq!(
+        vector_cases, 48,
+        "every vector shape and lifecycle stage runs"
+    );
     assert_eq!(text_cases, 144, "every text shape and late stage runs");
-    assert_eq!(ordinal, 182, "the complete all-index race matrix runs");
+    assert_eq!(ordinal, 220, "the complete all-index race matrix runs");
 }
 
 async fn run_case(
@@ -172,10 +194,11 @@ async fn run_case(
     let scope = DataScope::Tenant(TenantId::from_u128(
         0xFD00_0000_0000_0000_0000_0000_1000_0000 + ordinal as u128,
     ));
-    let db = HelixDB::open_for_index_lifecycle_testing(
-        HelixDbSource::InMemory {
-            database: format!("index-lifecycle-all-index-validation-{ordinal}"),
-        },
+    let database = format!("index-lifecycle-all-index-validation-{ordinal}");
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let mut db = HelixDB::open_with_object_store_for_index_lifecycle_testing(
+        &database,
+        Arc::clone(&object_store),
         crate::DbConfig::new(),
         crate::index_lifecycle_testing::LifecycleTestScheduling::Explicit,
     )
@@ -215,7 +238,9 @@ async fn run_case(
         panic!("fresh all-index validation build must enqueue");
     };
 
-    if matches!(definition, ValidatedDynamicIndexDefinition::Secondary(_)) {
+    if matches!(definition, ValidatedDynamicIndexDefinition::Secondary(_))
+        && stage != IndexOperationStage::Scan
+    {
         drive_until_exact_stage(
             &db,
             &controller,
@@ -264,13 +289,37 @@ async fn run_case(
     if element_kind == IndexElementKind::Edge {
         put_edge_endpoints(&db, scope, inserted_id).await;
     }
+    let partitioned_vector = matches!(
+        &definition,
+        ValidatedDynamicIndexDefinition::Vector(definition)
+            if definition.tenant_property().is_some()
+    );
+    let intermediate_tenant = partitioned_vector.then_some(TENANT_B);
+    let final_tenant = partitioned_vector.then_some(TENANT_C);
     mutate_entity(
         &db,
         scope,
         &definition,
         updated_id,
         &fixture_properties(&definition, FixtureValue::Initial(0)),
-        &fixture_properties(&definition, FixtureValue::Updated),
+        &fixture_properties_with_tenant(
+            &definition,
+            FixtureValue::Intermediate,
+            intermediate_tenant,
+        ),
+    )
+    .await;
+    mutate_entity(
+        &db,
+        scope,
+        &definition,
+        updated_id,
+        &fixture_properties_with_tenant(
+            &definition,
+            FixtureValue::Intermediate,
+            intermediate_tenant,
+        ),
+        &fixture_properties_with_tenant(&definition, FixtureValue::Updated, final_tenant),
     )
     .await;
     mutate_entity(
@@ -279,6 +328,23 @@ async fn run_case(
         &definition,
         deleted_id,
         &fixture_properties(&definition, FixtureValue::Initial(1)),
+        &fixture_properties_with_tenant(
+            &definition,
+            FixtureValue::Intermediate,
+            intermediate_tenant,
+        ),
+    )
+    .await;
+    mutate_entity(
+        &db,
+        scope,
+        &definition,
+        deleted_id,
+        &fixture_properties_with_tenant(
+            &definition,
+            FixtureValue::Intermediate,
+            intermediate_tenant,
+        ),
         &[],
     )
     .await;
@@ -288,10 +354,51 @@ async fn run_case(
         &definition,
         inserted_id,
         &[],
-        &fixture_properties(&definition, FixtureValue::Inserted),
+        &fixture_properties_with_tenant(
+            &definition,
+            FixtureValue::Intermediate,
+            intermediate_tenant,
+        ),
+    )
+    .await;
+    mutate_entity(
+        &db,
+        scope,
+        &definition,
+        inserted_id,
+        &fixture_properties_with_tenant(
+            &definition,
+            FixtureValue::Intermediate,
+            intermediate_tenant,
+        ),
+        &fixture_properties_with_tenant(&definition, FixtureValue::Inserted, final_tenant),
     )
     .await;
     assert_build_delta_count_at_least(&db, scope, &definition, 3).await;
+
+    if !matches!(definition, ValidatedDynamicIndexDefinition::Text(_)) {
+        db.close()
+            .await
+            .expect("secondary/vector writer closes with pending deltas");
+        db = HelixDB::open_with_object_store_for_index_lifecycle_testing(
+            &database,
+            Arc::clone(&object_store),
+            crate::DbConfig::new(),
+            crate::index_lifecycle_testing::LifecycleTestScheduling::Explicit,
+        )
+        .await
+        .expect("secondary/vector writer reopens with pending deltas");
+        assert_build_delta_count_at_least(&db, scope, &definition, 3).await;
+        assert_eq!(
+            db.get_index_operation(scope, operation_id)
+                .await
+                .expect("reopened operation remains readable")
+                .common()
+                .stage,
+            stage,
+            "{definition:?} must preserve {stage:?} while pending deltas survive a cold reopen"
+        );
+    }
 
     let evidence = controller
         .advance(
@@ -304,15 +411,20 @@ async fn run_case(
         .await
         .expect("late validation mutation re-entry step succeeds");
     assert_monotonic_step(&evidence);
-    let reentered = db
-        .get_index_operation(scope, operation_id)
-        .await
-        .expect("re-entered operation remains readable");
-    assert_eq!(
-        reentered.common().stage,
-        IndexOperationStage::CatchUp,
-        "{definition:?} must leave {stage:?} for catch-up after late mutations"
-    );
+    if !matches!(
+        stage,
+        IndexOperationStage::Scan | IndexOperationStage::CatchUp
+    ) {
+        let reentered = db
+            .get_index_operation(scope, operation_id)
+            .await
+            .expect("re-entered operation remains readable");
+        assert_eq!(
+            reentered.common().stage,
+            IndexOperationStage::CatchUp,
+            "{definition:?} must leave {stage:?} for catch-up after late mutations"
+        );
+    }
 
     let terminal = drive_to_terminal(&db, &controller, scope, operation_id).await;
     assert!(
@@ -545,6 +657,14 @@ fn fixture_properties(
     definition: &ValidatedDynamicIndexDefinition,
     value: FixtureValue,
 ) -> Vec<Property> {
+    fixture_properties_with_tenant(definition, value, None)
+}
+
+fn fixture_properties_with_tenant(
+    definition: &ValidatedDynamicIndexDefinition,
+    value: FixtureValue,
+    tenant: Option<&str>,
+) -> Vec<Property> {
     let mut properties = vec![Property::string(
         "$label",
         definition.identity().label().as_str(),
@@ -554,6 +674,7 @@ fn fixture_properties(
             INDEX_PROPERTY,
             match value {
                 FixtureValue::Initial(ordinal) => format!("initial-{ordinal}"),
+                FixtureValue::Intermediate => "intermediate".to_string(),
                 FixtureValue::Updated => "updated".to_string(),
                 FixtureValue::Inserted => "inserted".to_string(),
             },
@@ -564,6 +685,7 @@ fn fixture_properties(
                 FixtureValue::Initial(0) => vec![1.0, 0.1, 0.1],
                 FixtureValue::Initial(1) => vec![0.1, 1.0, 0.1],
                 FixtureValue::Initial(_) => vec![0.1, 0.1, 1.0],
+                FixtureValue::Intermediate => vec![-0.2, 0.1, 1.0],
                 FixtureValue::Updated => vec![-1.0, 0.2, 0.1],
                 FixtureValue::Inserted => vec![0.2, -1.0, 0.1],
             },
@@ -574,6 +696,7 @@ fn fixture_properties(
                 FixtureValue::Initial(ordinal) => {
                     format!("initialvalidationtoken{ordinal}")
                 }
+                FixtureValue::Intermediate => "intermediatevalidationtoken".to_string(),
                 FixtureValue::Updated => "updatedvalidationtoken".to_string(),
                 FixtureValue::Inserted => "insertedvalidationtoken".to_string(),
             },
@@ -588,7 +711,10 @@ fn fixture_properties(
         ValidatedDynamicIndexDefinition::Text(definition) => definition.tenant_property().is_some(),
     };
     if partitioned {
-        properties.push(Property::string(TENANT_PROPERTY, TENANT_VALUE));
+        properties.push(Property::string(
+            TENANT_PROPERTY,
+            tenant.unwrap_or(TENANT_A),
+        ));
     }
     properties
 }
@@ -748,7 +874,17 @@ async fn assert_source_rows(
             .expect("authoritative source row remains present");
         assert_eq!(
             decode_properties(&stored).expect("authoritative source properties decode"),
-            fixture_properties(definition, expected)
+            fixture_properties_with_tenant(
+                definition,
+                expected,
+                matches!(
+                    definition,
+                    ValidatedDynamicIndexDefinition::Vector(definition)
+                        if definition.tenant_property().is_some()
+                            && matches!(expected, FixtureValue::Updated | FixtureValue::Inserted)
+                )
+                .then_some(TENANT_C),
+            )
         );
     }
     assert!(
@@ -775,11 +911,17 @@ async fn assert_active_results(
                 .await;
         }
         ValidatedDynamicIndexDefinition::Vector(_) => {
+            let partitioned = matches!(
+                definition,
+                ValidatedDynamicIndexDefinition::Vector(definition)
+                    if definition.tenant_property().is_some()
+            );
+            let final_tenant = if partitioned { TENANT_C } else { TENANT_A };
             assert_search_results(
                 db,
                 scope,
                 definition,
-                SearchFixture::Vector(FixtureValue::Updated),
+                SearchFixture::Vector(FixtureValue::Updated, final_tenant),
                 [updated_id],
             )
             .await;
@@ -787,18 +929,45 @@ async fn assert_active_results(
                 db,
                 scope,
                 definition,
-                SearchFixture::Vector(FixtureValue::Inserted),
+                SearchFixture::Vector(FixtureValue::Inserted, final_tenant),
                 [inserted_id],
             )
             .await;
-            assert_search_results(
-                db,
-                scope,
-                definition,
-                SearchFixture::VectorAll,
-                [updated_id, stable_id, inserted_id],
-            )
-            .await;
+            if partitioned {
+                assert_search_results(
+                    db,
+                    scope,
+                    definition,
+                    SearchFixture::VectorAll(TENANT_A),
+                    [stable_id],
+                )
+                .await;
+                assert_search_results(
+                    db,
+                    scope,
+                    definition,
+                    SearchFixture::VectorAll(TENANT_B),
+                    [],
+                )
+                .await;
+                assert_search_results(
+                    db,
+                    scope,
+                    definition,
+                    SearchFixture::VectorAll(TENANT_C),
+                    [updated_id, inserted_id],
+                )
+                .await;
+            } else {
+                assert_search_results(
+                    db,
+                    scope,
+                    definition,
+                    SearchFixture::VectorAll(TENANT_A),
+                    [updated_id, stable_id, inserted_id],
+                )
+                .await;
+            }
         }
         ValidatedDynamicIndexDefinition::Text(_) => {
             assert_search_results(
@@ -904,9 +1073,18 @@ async fn assert_secondary_results(
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum SearchFixture {
-    Vector(FixtureValue),
-    VectorAll,
+    Vector(FixtureValue, &'static str),
+    VectorAll(&'static str),
     Text(&'static str),
+}
+
+impl SearchFixture {
+    const fn tenant(self) -> &'static str {
+        match self {
+            Self::Vector(_, tenant) | Self::VectorAll(tenant) => tenant,
+            Self::Text(_) => TENANT_A,
+        }
+    }
 }
 
 async fn assert_search_results<const N: usize>(
@@ -950,12 +1128,12 @@ fn search_plan(
     definition: &ValidatedDynamicIndexDefinition,
     fixture: SearchFixture,
 ) -> exec::ExecutablePlan {
-    let index = search_index_plan(definition);
+    let index = search_index_plan(definition, fixture.tenant());
     let access = match (definition, fixture) {
-        (ValidatedDynamicIndexDefinition::Vector(definition), SearchFixture::Vector(value)) => {
+        (ValidatedDynamicIndexDefinition::Vector(definition), SearchFixture::Vector(value, _)) => {
             search_access_vector(definition, index, vector_value(value), NonZeroUsize::MIN)
         }
-        (ValidatedDynamicIndexDefinition::Vector(definition), SearchFixture::VectorAll) => {
+        (ValidatedDynamicIndexDefinition::Vector(definition), SearchFixture::VectorAll(_)) => {
             search_access_vector(
                 definition,
                 index,
@@ -1060,7 +1238,10 @@ fn search_access_vector(
     }
 }
 
-fn search_index_plan(definition: &ValidatedDynamicIndexDefinition) -> ir::SearchIndexPlan {
+fn search_index_plan(
+    definition: &ValidatedDynamicIndexDefinition,
+    tenant_value: &str,
+) -> ir::SearchIndexPlan {
     let (index_id, tenant_property) = match definition {
         ValidatedDynamicIndexDefinition::Vector(definition) => (
             vector_index_name(
@@ -1092,7 +1273,7 @@ fn search_index_plan(definition: &ValidatedDynamicIndexDefinition) -> ir::Search
         ir::SearchTenantPlan::ScopedValue {
             property: public_name(property.as_str()),
             value: ir::SearchTenantValuePlan::new(ir::PropertyInputPlan::Value(
-                AstPropertyValue::String(TENANT_VALUE.to_string()),
+                AstPropertyValue::String(tenant_value.to_string()),
             ))
             .expect("validation tenant value is non-null"),
         }
@@ -1108,6 +1289,7 @@ fn vector_value(value: FixtureValue) -> Vec<f32> {
         FixtureValue::Initial(0) => vec![1.0, 0.1, 0.1],
         FixtureValue::Initial(1) => vec![0.1, 1.0, 0.1],
         FixtureValue::Initial(_) => vec![0.1, 0.1, 1.0],
+        FixtureValue::Intermediate => vec![-0.2, 0.1, 1.0],
         FixtureValue::Updated => vec![-1.0, 0.2, 0.1],
         FixtureValue::Inserted => vec![0.2, -1.0, 0.1],
     }

--- a/crates/db/src/migrations/tenant/envelope.rs
+++ b/crates/db/src/migrations/tenant/envelope.rs
@@ -617,6 +617,7 @@ mod tests {
             generation: generation(),
             entity_kind: entity.kind,
             entity_id: entity.id,
+            state: crate::index_lifecycle::work::CoalescedBuildDeltaState::Marker,
         });
         let encoded_pointer = encoded.as_ptr();
         let migrated =

--- a/crates/db/tests/index_lifecycle_contracts.rs
+++ b/crates/db/tests/index_lifecycle_contracts.rs
@@ -47,6 +47,32 @@ fn index_lifecycle_backfill_mutations_and_unique_retry_converge() {
         .expect("lifecycle mutation test thread should not panic");
 }
 
+/// Proves every managed index shape catches up after late validation mutations.
+#[test]
+fn index_lifecycle_all_index_shapes_reenter_catch_up_before_activation() {
+    std::thread::Builder::new()
+        .name("index-lifecycle-all-index-validation".to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .thread_stack_size(16 * 1024 * 1024)
+                .build()
+                .expect("all-index validation test runtime should build")
+                .block_on(async {
+                    let _permit = CONTRACT_SUITE
+                        .acquire()
+                        .await
+                        .expect("lifecycle contract semaphore remains open");
+                    db::index_lifecycle_testing::run_deterministic_all_index_validation_contracts()
+                        .await;
+                });
+        })
+        .expect("all-index validation test thread should spawn")
+        .join()
+        .expect("all-index validation test thread should not panic");
+}
+
 /// Proves simultaneous CREATE requests converge after retryable serialization.
 #[tokio::test(flavor = "multi_thread")]
 async fn index_lifecycle_concurrent_create_converges_for_every_family() {

--- a/crates/db/tests/index_lifecycle_contracts.rs
+++ b/crates/db/tests/index_lifecycle_contracts.rs
@@ -47,7 +47,7 @@ fn index_lifecycle_backfill_mutations_and_unique_retry_converge() {
         .expect("lifecycle mutation test thread should not panic");
 }
 
-/// Proves every managed index shape catches up after late validation mutations.
+/// Proves every shape converges after repeated mutations at each build boundary.
 #[test]
 fn index_lifecycle_all_index_shapes_reenter_catch_up_before_activation() {
     std::thread::Builder::new()

--- a/crates/db/tests/index_lifecycle_contracts.rs
+++ b/crates/db/tests/index_lifecycle_contracts.rs
@@ -73,6 +73,32 @@ fn index_lifecycle_all_index_shapes_reenter_catch_up_before_activation() {
         .expect("all-index validation test thread should not panic");
 }
 
+/// Proves real public writes survive every secondary/vector build boundary.
+#[test]
+fn index_lifecycle_secondary_vector_public_writes_cover_every_build_boundary() {
+    std::thread::Builder::new()
+        .name("index-lifecycle-secondary-vector-public-boundary".to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .thread_stack_size(16 * 1024 * 1024)
+                .build()
+                .expect("secondary/vector public-boundary runtime should build")
+                .block_on(async {
+                    let _permit = CONTRACT_SUITE
+                        .acquire()
+                        .await
+                        .expect("lifecycle contract semaphore remains open");
+                    db::index_lifecycle_testing::run_secondary_vector_public_boundary_contracts()
+                        .await;
+                });
+        })
+        .expect("secondary/vector public-boundary test thread should spawn")
+        .join()
+        .expect("secondary/vector public-boundary test thread should not panic");
+}
+
 /// Proves simultaneous CREATE requests converge after retryable serialization.
 #[tokio::test(flavor = "multi_thread")]
 async fn index_lifecycle_concurrent_create_converges_for_every_family() {

--- a/crates/db/tests/production_support/index_lifecycle_scale.rs
+++ b/crates/db/tests/production_support/index_lifecycle_scale.rs
@@ -999,12 +999,17 @@ async fn drop_index(db: &HelixDB, scope: DataScope, spec: ir::IndexDdlDropSpec) 
 }
 
 /// Opens a writer and seeds one positive unscoped authoritative shape.
-async fn open_seeded_unscoped(database: &str, entity_count: NonZeroUsize) -> HelixDB {
+async fn open_seeded_unscoped(
+    database: &str,
+    entity_count: NonZeroUsize,
+) -> (ProcessLocalDatabaseToken, HelixDB) {
     let entity_count = entity_count.get();
     let token = ProcessLocalDatabaseToken::new(database).expect("scale database token is valid");
-    let db = HelixDB::open(HelixDbSource::InMemoryToken { token })
-        .await
-        .expect("scale writer opens");
+    let db = HelixDB::open(HelixDbSource::InMemoryToken {
+        token: token.clone(),
+    })
+    .await
+    .expect("scale writer opens");
     let crate::HelixStorage::Writer(writer) = db.storage() else {
         panic!("scale database should be a writer");
     };
@@ -1032,7 +1037,19 @@ async fn open_seeded_unscoped(database: &str, entity_count: NonZeroUsize) -> Hel
         entity_count.div_ceil(SEED_BATCH_ROWS),
         seed_started.elapsed().as_millis(),
     );
-    db
+    (token, db)
+}
+
+/// Cold-reopens one process-local scale database without replacing its store.
+async fn reopen_process_local(db: &mut HelixDB, token: &ProcessLocalDatabaseToken) {
+    db.close()
+        .await
+        .expect("scale writer closes before restart validation");
+    *db = HelixDB::open(HelixDbSource::InMemoryToken {
+        token: token.clone(),
+    })
+    .await
+    .expect("scale writer reopens for restart validation");
 }
 
 /// Runs secondary, text, multi-scope, and cleanup scale oracles.
@@ -1042,7 +1059,7 @@ pub(super) async fn run_secondary_text_tenant() {
         "release scale shape must remain fixed"
     );
     assert_eq!(TENANT_COUNT, 16, "tenant release shape must remain fixed");
-    let db = open_seeded_unscoped(
+    let (token, mut db) = open_seeded_unscoped(
         "index-lifecycle-production-secondary-text-scale",
         NonZeroUsize::new(ENTITY_COUNT).expect("release entity count is positive"),
     )
@@ -1184,6 +1201,67 @@ pub(super) async fn run_secondary_text_tenant() {
         tenant_seed_started.elapsed().as_millis(),
     );
 
+    reopen_process_local(&mut db, &token).await;
+    let mut actual = projected_node_ids(
+        db.execute(
+            &equality_search_plan(
+                NON_UNIQUE_PROPERTY,
+                PlannerPropertyValue::String("shared-target".to_string()),
+                catalog::IndexUniqueness::NonUnique,
+            ),
+            context::ParamBindings::default(),
+        )
+        .await
+        .expect("non-unique scale search survives restart"),
+    );
+    actual.sort_unstable();
+    assert_eq!(actual, vec![0, 1]);
+    assert_eq!(
+        projected_node_ids(
+            db.execute(
+                &equality_search_plan(
+                    UNIQUE_PROPERTY,
+                    PlannerPropertyValue::String("external-99999".to_string()),
+                    catalog::IndexUniqueness::Unique,
+                ),
+                context::ParamBindings::default(),
+            )
+            .await
+            .expect("unique scale search survives restart"),
+        ),
+        vec![99_999]
+    );
+    assert_eq!(
+        projected_node_ids(
+            db.execute(
+                &text_search_plan("uniqueneedle"),
+                context::ParamBindings::default(),
+            )
+            .await
+            .expect("paged scale text search survives restart"),
+        ),
+        vec![0]
+    );
+    for tenant_ordinal in 0..TENANT_COUNT {
+        let scope = DataScope::Tenant(TenantId::from_u128(
+            u128::try_from(tenant_ordinal + 1).expect("tenant ordinal fits u128"),
+        ));
+        assert!(!projected_node_ids(
+            db.execute_scoped(
+                &equality_search_plan(
+                    NON_UNIQUE_PROPERTY,
+                    PlannerPropertyValue::String("tenant-group-0".to_string()),
+                    catalog::IndexUniqueness::NonUnique,
+                ),
+                context::ParamBindings::default(),
+                scope,
+            )
+            .await
+            .expect("tenant scale search survives restart"),
+        )
+        .is_empty());
+    }
+
     for tenant_ordinal in 0..TENANT_COUNT {
         let scope = DataScope::Tenant(TenantId::from_u128(
             u128::try_from(tenant_ordinal + 1).expect("tenant ordinal fits u128"),
@@ -1320,7 +1398,7 @@ async fn run_vector_fixture(database: &str, entity_count: NonZeroUsize) {
         VECTOR_DIMENSION, 128,
         "vector release shape must remain fixed"
     );
-    let db = open_seeded_unscoped(database, entity_count).await;
+    let (token, mut db) = open_seeded_unscoped(database, entity_count).await;
     let property_key = catalog::ScopedPropertyKey::try_new(LABEL, VECTOR_PROPERTY)
         .expect("scale vector property key is valid");
 
@@ -1337,6 +1415,7 @@ async fn run_vector_fixture(database: &str, entity_count: NonZeroUsize) {
         },
     )
     .await;
+    reopen_process_local(&mut db, &token).await;
     let query = vector(0);
     let brute_force = (0..u64::try_from(entity_count.get()).expect("scale entity count fits u64"))
         .min_by(|left, right| {

--- a/crates/db/tests/production_text_correctness_regressions.rs
+++ b/crates/db/tests/production_text_correctness_regressions.rs
@@ -493,6 +493,22 @@ async fn insert_node(db: &HelixDB, text: &str) -> u64 {
     )
 }
 
+async fn delete_node(db: &HelixDB, entity_id: u64, expectation: &str) {
+    let parameter = name("text_lifecycle_delete");
+    execute_with_transaction_retry(
+        db,
+        &node_mutation_plan(parameter.clone(), exec::ExecMutationPlan::Drop),
+        context::ParamBindings::default().with_value(
+            parameter,
+            PropertyValue::I64(
+                i64::try_from(entity_id).expect("fixture node ID fits signed input"),
+            ),
+        ),
+        expectation,
+    )
+    .await;
+}
+
 async fn insert_edge(db: &HelixDB, from: u64, to: u64, text: &str) -> u64 {
     let parameter = name("fragmented_edge_from");
     created_edge_id(
@@ -2954,6 +2970,83 @@ async fn late_build_delta_after_catch_up_converges_to_active() {
         "late BuildDelta must re-enter catch-up without rejecting a populated manifest root:\n{}",
         failures.join("\n")
     );
+}
+
+#[tokio::test]
+async fn delete_during_entity_state_validation_returns_to_catch_up_and_activates() {
+    let token = ProcessLocalDatabaseToken::new("fts-delete-during-entity-validation")
+        .expect("late-delete token validates");
+    let db = HelixDB::open_for_index_lifecycle_testing(
+        HelixDbSource::InMemoryToken {
+            token: token.clone(),
+        },
+        DbConfig::new(),
+        LifecycleTestScheduling::Explicit,
+    )
+    .await
+    .expect("late-delete fixture opens");
+    let deleted_id = insert_node(&db, "deletedwhilevalidating").await;
+    let controller = LifecycleTestController::new();
+    let definition: ValidatedDynamicIndexDefinition =
+        TextIndexDefinition::new_node(LABEL, PROPERTY)
+            .expect("late-delete definition validates")
+            .try_into()
+            .expect("late-delete definition converts");
+    let operation_id = receipt_operation_id(
+        controller
+            .create_index(
+                &db,
+                DataScope::LegacyUnscoped,
+                definition,
+                ir::IndexCreateMode::ErrorIfExists,
+            )
+            .await
+            .expect("late-delete text CREATE is accepted"),
+    );
+    drive_to_late_delta_pause(
+        &db,
+        &controller,
+        operation_id,
+        LateDeltaPause::Validation(TextManifestValidationLane::EntityStates),
+    )
+    .await
+    .expect("entity-state validation pause is reached");
+
+    delete_node(
+        &db,
+        deleted_id,
+        "deletion during entity-state validation commits",
+    )
+    .await;
+    let terminal = drive_to_terminal_explicit(&db, &controller, operation_id)
+        .await
+        .expect("late-delete lifecycle remains runnable");
+    assert!(
+        matches!(terminal, IndexOperationStatus::Succeeded { .. }),
+        "late delete must return validation to catch-up, observed {terminal:?}"
+    );
+
+    db.planner_context_scoped(context::ParamBindings::default(), DataScope::LegacyUnscoped)
+        .await
+        .expect("late-delete Active definition refreshes into the planner catalog");
+    let response = db
+        .query(QueryRequest::read(
+            batch::read_batch()
+                .var_as(
+                    "ids",
+                    traversal::g()
+                        .text_search_nodes(LABEL, PROPERTY, "deletedwhilevalidating", 10, None)
+                        .id(),
+                )
+                .returning(["ids"]),
+        ))
+        .await
+        .expect("late-delete Active index remains queryable");
+    assert!(
+        query_node_ids(&response, "ids").is_empty(),
+        "deleted entity must not survive catch-up and activation"
+    );
+    db.close().await.expect("late-delete fixture closes");
 }
 
 fn text_row_node_ids(result: ExecutionResult) -> Vec<u64> {

--- a/crates/db/tests/production_vector_planner.rs
+++ b/crates/db/tests/production_vector_planner.rs
@@ -656,6 +656,76 @@ enum VectorAction {
     AbortBlockedBuild,
 }
 
+/// Invalid public mutation values and the exact error family each must retain.
+#[derive(Debug, Clone, Copy)]
+enum InvalidVectorUpdate {
+    WrongDimension,
+    NotANumber,
+    PositiveInfinity,
+    NegativeInfinity,
+    UnsupportedProperty,
+}
+
+impl InvalidVectorUpdate {
+    const ALL: [Self; 5] = [
+        Self::WrongDimension,
+        Self::NotANumber,
+        Self::PositiveInfinity,
+        Self::NegativeInfinity,
+        Self::UnsupportedProperty,
+    ];
+
+    fn value(self) -> PropertyValue {
+        match self {
+            Self::WrongDimension => PropertyValue::F32Array(vec![1.0]),
+            Self::NotANumber => PropertyValue::F32Array(vec![f32::NAN, 1.0]),
+            Self::PositiveInfinity => PropertyValue::F32Array(vec![1.0, f32::INFINITY]),
+            Self::NegativeInfinity => PropertyValue::F32Array(vec![f32::NEG_INFINITY, 1.0]),
+            Self::UnsupportedProperty => PropertyValue::String("not-a-vector".to_string()),
+        }
+    }
+
+    fn assert_error(self, error: &db::error::HelixDbError) {
+        match self {
+            Self::WrongDimension => assert!(
+                matches!(
+                    error,
+                    db::error::HelixDbError::InvalidDimension {
+                        expected: 2,
+                        got: 1
+                    }
+                ),
+                "wrong-dimension update returned {error:?}"
+            ),
+            Self::NotANumber => assert!(
+                matches!(
+                    error,
+                    db::error::HelixDbError::InvalidVectorComponent { index: 0 }
+                ),
+                "NaN update returned {error:?}"
+            ),
+            Self::PositiveInfinity => assert!(
+                matches!(
+                    error,
+                    db::error::HelixDbError::InvalidVectorComponent { index: 1 }
+                ),
+                "positive-infinity update returned {error:?}"
+            ),
+            Self::NegativeInfinity => assert!(
+                matches!(
+                    error,
+                    db::error::HelixDbError::InvalidVectorComponent { index: 0 }
+                ),
+                "negative-infinity update returned {error:?}"
+            ),
+            Self::UnsupportedProperty => assert!(
+                matches!(error, db::error::HelixDbError::Query(reason) if reason.contains("numeric array")),
+                "unsupported-property update returned {error:?}"
+            ),
+        }
+    }
+}
+
 /// Independent brute-force oracle for visible vector membership.
 #[derive(Default)]
 struct VectorReferenceModel {
@@ -820,6 +890,40 @@ impl VectorMachine {
             }
             VectorAction::RetryAfterHigherLimit => self.exercise_limit_retry().await,
             VectorAction::AbortBlockedBuild => self.exercise_blocked_abort().await,
+        }
+    }
+
+    /// Proves invalid public updates roll back graph, physical, and cache state.
+    async fn reject_invalid_updates(&self, slot: VectorSlot) {
+        assert!(self.model.active, "invalid update requires an Active index");
+        let (entity_id, vector) = *self
+            .model
+            .vectors
+            .get(&slot)
+            .expect("invalid update names an existing vector");
+        for case in InvalidVectorUpdate::ALL {
+            let parameter = name("invalid_vector_model_node");
+            let error = self
+                .db
+                .execute(
+                    &node_property_mutation_plan(
+                        parameter.clone(),
+                        exec::ExecMutationPlan::SetProperty {
+                            name: name("embedding"),
+                            value: ir::PropertyInputPlan::Value(case.value()),
+                        },
+                    ),
+                    context::ParamBindings::default().with_value(
+                        parameter,
+                        PropertyValue::I64(
+                            i64::try_from(entity_id).expect("fixture node ID fits i64"),
+                        ),
+                    ),
+                )
+                .await
+                .expect_err("invalid vector update fails closed");
+            case.assert_error(&error);
+            self.assert_search(vector).await;
         }
     }
 
@@ -1199,6 +1303,54 @@ async fn public_vector_lifecycle_matches_reference_model_contract() {
         .expect("vector lifecycle writer closes cleanly");
 }
 
+/// Proves every invalid vector value rolls back and cannot poison a rebuild.
+#[test]
+fn public_invalid_vector_updates_are_atomic_across_reopen_and_rebuild() {
+    std::thread::Builder::new()
+        .name("public-invalid-vector-updates".to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .thread_stack_size(16 * 1024 * 1024)
+                .build()
+                .expect("invalid-vector runtime should build")
+                .block_on(async {
+                    let mut machine = VectorMachine::open().await;
+                    machine
+                        .apply(VectorAction::Insert {
+                            slot: VectorSlot::First,
+                            vector: [0.75, 0.25],
+                        })
+                        .await;
+                    machine.apply(VectorAction::Create).await;
+                    Box::pin(machine.reject_invalid_updates(VectorSlot::First)).await;
+                    machine.apply(VectorAction::Reopen).await;
+                    machine
+                        .apply(VectorAction::Search {
+                            query: [0.75, 0.25],
+                        })
+                        .await;
+                    machine.apply(VectorAction::Drop).await;
+                    machine.apply(VectorAction::Recreate).await;
+                    machine
+                        .apply(VectorAction::Search {
+                            query: [0.75, 0.25],
+                        })
+                        .await;
+                    machine.apply(VectorAction::Drop).await;
+                    machine
+                        .db
+                        .close()
+                        .await
+                        .expect("invalid-vector writer closes cleanly");
+                });
+        })
+        .expect("invalid-vector test thread should spawn")
+        .join()
+        .expect("invalid-vector test thread should not panic");
+}
+
 #[tokio::test]
 async fn public_dynamic_vector_ddl_backfills_existing_nodes() {
     let database = "production-vector-ddl-backfill";
@@ -1309,6 +1461,39 @@ async fn public_managed_search_executes_every_active_vector_metric() {
             vec![node_ids[0]]
         );
     }
+
+    let node = name("zero_cosine_node");
+    let error = db
+        .execute(
+            &node_property_mutation_plan(
+                node.clone(),
+                exec::ExecMutationPlan::SetProperty {
+                    name: name("cosine_embedding"),
+                    value: ir::PropertyInputPlan::Value(PropertyValue::F32Array(vec![0.0, -0.0])),
+                },
+            ),
+            context::ParamBindings::default().with_value(
+                node,
+                PropertyValue::I64(i64::try_from(node_ids[0]).expect("fixture node ID fits i64")),
+            ),
+        )
+        .await
+        .expect_err("zero-norm cosine update fails closed");
+    assert!(
+        matches!(error, db::error::HelixDbError::ZeroNormCosineVector),
+        "zero-norm cosine update returned {error:?}"
+    );
+    assert_eq!(
+        projected_node_ids(
+            db.execute(
+                &node_vector_search_plan("Doc", "cosine_embedding", vec![1.0, 0.0]),
+                context::ParamBindings::default(),
+            )
+            .await
+            .expect("cosine search survives rejected zero-norm update"),
+        ),
+        vec![node_ids[0]]
+    );
 
     db.close().await.expect("writer closes");
 }

--- a/crates/db/tests/production_vector_planner.rs
+++ b/crates/db/tests/production_vector_planner.rs
@@ -758,7 +758,8 @@ struct VectorMachine {
 impl VectorMachine {
     /// Opens one coordinated writer whose token survives model reopen actions.
     async fn open(database: &'static str) -> Self {
-        let token = ProcessLocalDatabaseToken::new(database).expect("vector lifecycle token is valid");
+        let token =
+            ProcessLocalDatabaseToken::new(database).expect("vector lifecycle token is valid");
         let db = HelixDB::open(HelixDbSource::InMemoryToken {
             token: token.clone(),
         })

--- a/crates/db/tests/production_vector_planner.rs
+++ b/crates/db/tests/production_vector_planner.rs
@@ -757,9 +757,8 @@ struct VectorMachine {
 
 impl VectorMachine {
     /// Opens one coordinated writer whose token survives model reopen actions.
-    async fn open() -> Self {
-        let token = ProcessLocalDatabaseToken::new("production-vector-lifecycle-state-machine")
-            .expect("vector lifecycle token is valid");
+    async fn open(database: &'static str) -> Self {
+        let token = ProcessLocalDatabaseToken::new(database).expect("vector lifecycle token is valid");
         let db = HelixDB::open(HelixDbSource::InMemoryToken {
             token: token.clone(),
         })
@@ -1258,7 +1257,7 @@ fn public_vector_lifecycle_matches_reference_model() {
 }
 
 async fn public_vector_lifecycle_matches_reference_model_contract() {
-    let mut machine = VectorMachine::open().await;
+    let mut machine = VectorMachine::open("production-vector-lifecycle-state-machine").await;
     for action in [
         VectorAction::Insert {
             slot: VectorSlot::First,
@@ -1316,7 +1315,8 @@ fn public_invalid_vector_updates_are_atomic_across_reopen_and_rebuild() {
                 .build()
                 .expect("invalid-vector runtime should build")
                 .block_on(async {
-                    let mut machine = VectorMachine::open().await;
+                    let mut machine =
+                        VectorMachine::open("production-vector-invalid-update-state-machine").await;
                     machine
                         .apply(VectorAction::Insert {
                             slot: VectorSlot::First,

--- a/crates/db/tests/unit/index_lifecycle_secondary_contracts.rs
+++ b/crates/db/tests/unit/index_lifecycle_secondary_contracts.rs
@@ -32,6 +32,20 @@ fn equality(value: &str) -> CanonicalSecondaryValue {
     CanonicalSecondaryValue::equality_string(value)
 }
 
+fn entity_state_key(
+    definition: &ValidatedSecondaryIndexDefinition,
+    entity_id: IndexEntityId,
+) -> IndexEntityStateKey {
+    IndexEntityStateKey {
+        index_id: IndexId::initial(),
+        generation: IndexGenerationId::initial(),
+        entity: IndexEntity {
+            kind: definition.element_kind(),
+            id: entity_id,
+        },
+    }
+}
+
 fn applied_key(
     scope: DataScope,
     definition: &ValidatedSecondaryIndexDefinition,
@@ -39,14 +53,7 @@ fn applied_key(
 ) -> Bytes {
     scoped_index_key(
         scope,
-        ScopedKey::AppliedState(IndexEntityStateKey {
-            index_id: IndexId::initial(),
-            generation: IndexGenerationId::initial(),
-            entity: IndexEntity {
-                kind: definition.element_kind(),
-                id: entity_id,
-            },
-        }),
+        ScopedKey::AppliedState(entity_state_key(definition, entity_id)),
     )
 }
 
@@ -143,15 +150,17 @@ async fn legacy_secondary_marker_without_applied_state_fails_closed() {
         .await
         .unwrap();
     let definition = validated(SecondaryIndexDefinition::node_equality("User", "email").unwrap());
+    let entity = IndexEntity {
+        kind: definition.element_kind(),
+        id: IndexEntityId::new(7),
+    };
 
     assert!(matches!(
         reconciliation_plan(
             &transaction,
             DataScope::LegacyUnscoped,
-            IndexId::initial(),
-            IndexGenerationId::initial(),
+            entity_state_key(&definition, entity.id),
             &definition,
-            IndexEntityId::new(7),
             &CoalescedBuildDeltaState::Marker,
             Some(equality("current@example.com")),
         )
@@ -173,15 +182,17 @@ async fn reconciliation_executes_exact_bitmap_add_noop_and_remove_programs() {
     let scope = DataScope::LegacyUnscoped;
     let definition = validated(SecondaryIndexDefinition::node_equality("User", "email").unwrap());
     let entity_id = IndexEntityId::new(7);
+    let entity = IndexEntity {
+        kind: definition.element_kind(),
+        id: entity_id,
+    };
     let value = equality("first@example.com");
 
     let ReconciliationPlan::Writes(add) = reconciliation_plan(
         &transaction,
         scope,
-        IndexId::initial(),
-        IndexGenerationId::initial(),
+        entity_state_key(&definition, entity.id),
         &definition,
-        entity_id,
         &CoalescedBuildDeltaState::SecondaryBefore(None),
         Some(value.clone()),
     )
@@ -200,10 +211,8 @@ async fn reconciliation_executes_exact_bitmap_add_noop_and_remove_programs() {
     let ReconciliationPlan::Writes(noop) = reconciliation_plan(
         &transaction,
         scope,
-        IndexId::initial(),
-        IndexGenerationId::initial(),
+        entity_state_key(&definition, entity.id),
         &definition,
-        entity_id,
         &CoalescedBuildDeltaState::Marker,
         Some(value),
     )
@@ -217,10 +226,8 @@ async fn reconciliation_executes_exact_bitmap_add_noop_and_remove_programs() {
     let ReconciliationPlan::Writes(remove) = reconciliation_plan(
         &transaction,
         scope,
-        IndexId::initial(),
-        IndexGenerationId::initial(),
+        entity_state_key(&definition, entity.id),
         &definition,
-        entity_id,
         &CoalescedBuildDeltaState::Marker,
         None,
     )
@@ -250,6 +257,10 @@ async fn reconciliation_unique_observations_block_foreign_release_and_claim() {
     let definition =
         validated(SecondaryIndexDefinition::node_unique_equality("User", "email").unwrap());
     let entity_id = IndexEntityId::new(7);
+    let entity = IndexEntity {
+        kind: definition.element_kind(),
+        id: entity_id,
+    };
     let foreign_id = IndexEntityId::new(9);
     let previous = equality("previous@example.com");
     let next = equality("next@example.com");
@@ -286,10 +297,8 @@ async fn reconciliation_unique_observations_block_foreign_release_and_claim() {
     }) = reconciliation_plan(
         &transaction,
         scope,
-        IndexId::initial(),
-        IndexGenerationId::initial(),
+        entity_state_key(&definition, entity.id),
         &definition,
-        entity_id,
         &CoalescedBuildDeltaState::Marker,
         Some(next.clone()),
     )
@@ -312,10 +321,8 @@ async fn reconciliation_unique_observations_block_foreign_release_and_claim() {
     }) = reconciliation_plan(
         &transaction,
         scope,
-        IndexId::initial(),
-        IndexGenerationId::initial(),
+        entity_state_key(&definition, entity.id),
         &definition,
-        entity_id,
         &CoalescedBuildDeltaState::Marker,
         Some(next),
     )

--- a/crates/db/tests/unit/index_lifecycle_secondary_contracts.rs
+++ b/crates/db/tests/unit/index_lifecycle_secondary_contracts.rs
@@ -77,6 +77,93 @@ fn encoded_owner(
 }
 
 #[tokio::test]
+async fn repeated_build_deltas_preserve_the_first_secondary_value() {
+    let db = tests::test_db("secondary-build-delta-first-value").await;
+    let scope = DataScope::LegacyUnscoped;
+    let definition = validated(SecondaryIndexDefinition::node_equality("User", "email").unwrap());
+    let target = SecondaryMutationTarget {
+        index_id: IndexId::initial(),
+        generation: IndexGenerationId::initial(),
+        definition,
+        mode: SecondaryMutationMode::RecordBuildDelta,
+    };
+    let transaction = db
+        .begin(IsolationLevel::SerializableSnapshot)
+        .await
+        .unwrap();
+
+    for (entity_id, first, second) in [
+        (
+            IndexEntityId::new(7),
+            Some(equality("original@example.com")),
+            Some(equality("intermediate@example.com")),
+        ),
+        (
+            IndexEntityId::new(8),
+            None,
+            Some(equality("created@example.com")),
+        ),
+    ] {
+        let entity = IndexEntity {
+            kind: IndexElementKind::Node,
+            id: entity_id,
+        };
+        stage_secondary_build_delta(&transaction, scope, &target, entity, first.clone())
+            .await
+            .unwrap();
+        stage_secondary_build_delta(&transaction, scope, &target, entity, second)
+            .await
+            .unwrap();
+
+        let key = scoped_index_key(
+            scope,
+            ScopedKey::BuildDelta(IndexEntityStateKey {
+                index_id: target.index_id,
+                generation: target.generation,
+                entity,
+            }),
+        );
+        let (_, delta) =
+            decode_delta(scope, &key, &transaction.get(&key).await.unwrap().unwrap()).unwrap();
+        assert_eq!(
+            delta.state,
+            CoalescedBuildDeltaState::SecondaryBefore(first)
+        );
+    }
+
+    transaction.rollback();
+    db.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn legacy_secondary_marker_without_applied_state_fails_closed() {
+    let db = tests::test_db("secondary-legacy-marker-fails-closed").await;
+    let transaction = db
+        .begin(IsolationLevel::SerializableSnapshot)
+        .await
+        .unwrap();
+    let definition = validated(SecondaryIndexDefinition::node_equality("User", "email").unwrap());
+
+    assert!(matches!(
+        reconciliation_plan(
+            &transaction,
+            DataScope::LegacyUnscoped,
+            IndexId::initial(),
+            IndexGenerationId::initial(),
+            &definition,
+            IndexEntityId::new(7),
+            &CoalescedBuildDeltaState::Marker,
+            Some(equality("current@example.com")),
+        )
+        .await,
+        Err(HelixDbError::IndexCatalogCorruption(_))
+    ));
+
+    transaction.rollback();
+    db.close().await.unwrap();
+}
+
+#[tokio::test]
 async fn reconciliation_executes_exact_bitmap_add_noop_and_remove_programs() {
     let db = tests::test_db("secondary-reconciliation-bitmap-contracts").await;
     let transaction = db
@@ -95,6 +182,7 @@ async fn reconciliation_executes_exact_bitmap_add_noop_and_remove_programs() {
         IndexGenerationId::initial(),
         &definition,
         entity_id,
+        &CoalescedBuildDeltaState::SecondaryBefore(None),
         Some(value.clone()),
     )
     .await
@@ -116,6 +204,7 @@ async fn reconciliation_executes_exact_bitmap_add_noop_and_remove_programs() {
         IndexGenerationId::initial(),
         &definition,
         entity_id,
+        &CoalescedBuildDeltaState::Marker,
         Some(value),
     )
     .await
@@ -132,6 +221,7 @@ async fn reconciliation_executes_exact_bitmap_add_noop_and_remove_programs() {
         IndexGenerationId::initial(),
         &definition,
         entity_id,
+        &CoalescedBuildDeltaState::Marker,
         None,
     )
     .await
@@ -200,6 +290,7 @@ async fn reconciliation_unique_observations_block_foreign_release_and_claim() {
         IndexGenerationId::initial(),
         &definition,
         entity_id,
+        &CoalescedBuildDeltaState::Marker,
         Some(next.clone()),
     )
     .await
@@ -225,6 +316,7 @@ async fn reconciliation_unique_observations_block_foreign_release_and_claim() {
         IndexGenerationId::initial(),
         &definition,
         entity_id,
+        &CoalescedBuildDeltaState::Marker,
         Some(next),
     )
     .await
@@ -915,6 +1007,7 @@ fn typed_secondary_decoders_reject_wrong_kind_family_and_ownership() {
         generation: IndexGenerationId::initial(),
         entity_kind: entity.kind,
         entity_id: entity.id,
+        state: CoalescedBuildDeltaState::SecondaryBefore(None),
     };
     assert_eq!(
         decode_delta(scope, &delta_key, &encode_build_delta(&delta))

--- a/crates/db/tests/unit/index_lifecycle_text_driver_prepared.rs
+++ b/crates/db/tests/unit/index_lifecycle_text_driver_prepared.rs
@@ -1,8 +1,18 @@
+use std::collections::HashSet;
+use std::fmt;
 use std::num::{NonZeroU64, NonZeroUsize};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
+use futures::stream::BoxStream;
 use slatedb::object_store::memory::InMemory;
+use slatedb::object_store::path::Path;
+use slatedb::object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as ObjectStoreResult,
+};
 use slatedb::{Db, IsolationLevel};
+use tokio::sync::Notify;
 
 use super::*;
 use crate::index_lifecycle::{
@@ -76,6 +86,388 @@ fn batch_limits(
         NonZeroU64::new(max_output_bytes).unwrap(),
     )
     .unwrap()
+}
+
+#[derive(Debug, Default)]
+struct HeadState {
+    active: usize,
+    armed: bool,
+    entered: usize,
+    peak: usize,
+    released: bool,
+    transient: HashSet<Path>,
+}
+
+#[derive(Debug, Default)]
+struct ControlledHeadStore {
+    inner: InMemory,
+    state: Mutex<HeadState>,
+    changed: Notify,
+}
+
+impl ControlledHeadStore {
+    fn arm(&self) {
+        let mut state = self.state.lock().expect("head state is healthy");
+        state.active = 0;
+        state.armed = true;
+        state.entered = 0;
+        state.peak = 0;
+        state.released = false;
+    }
+
+    fn fail_head(&self, path: Path) {
+        self.state
+            .lock()
+            .expect("head state is healthy")
+            .transient
+            .insert(path);
+    }
+
+    async fn wait_until_entered(&self, expected: usize) {
+        loop {
+            let notified = self.changed.notified();
+            if self.state.lock().expect("head state is healthy").entered >= expected {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    fn release(&self) {
+        self.state.lock().expect("head state is healthy").released = true;
+        self.changed.notify_waiters();
+    }
+
+    fn peak(&self) -> usize {
+        self.state.lock().expect("head state is healthy").peak
+    }
+}
+
+struct ActiveHeadGuard<'a> {
+    state: &'a Mutex<HeadState>,
+}
+
+impl Drop for ActiveHeadGuard<'_> {
+    fn drop(&mut self) {
+        self.state.lock().expect("head state is healthy").active -= 1;
+    }
+}
+
+impl fmt::Display for ControlledHeadStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("controlled-head-memory")
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for ControlledHeadStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        options: PutOptions,
+    ) -> ObjectStoreResult<PutResult> {
+        self.inner.put_opts(location, payload, options).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        options: PutMultipartOptions,
+    ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, options).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> ObjectStoreResult<GetResult> {
+        let _guard = if options.head {
+            let armed = {
+                let mut state = self.state.lock().expect("head state is healthy");
+                state.active += 1;
+                state.entered += 1;
+                state.peak = state.peak.max(state.active);
+                state.armed
+            };
+            self.changed.notify_waiters();
+            if armed {
+                loop {
+                    let notified = self.changed.notified();
+                    if self.state.lock().expect("head state is healthy").released {
+                        break;
+                    }
+                    notified.await;
+                }
+            }
+            Some(ActiveHeadGuard { state: &self.state })
+        } else {
+            None
+        };
+        if options.head
+            && self
+                .state
+                .lock()
+                .expect("head state is healthy")
+                .transient
+                .contains(location)
+        {
+            return Err(slatedb::object_store::Error::Generic {
+                store: "controlled-head-memory",
+                source: Box::new(std::io::Error::other("injected HEAD failure")),
+            });
+        }
+        self.inner.get_opts(location, options).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, ObjectStoreResult<Path>>,
+    ) -> BoxStream<'static, ObjectStoreResult<Path>> {
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> ObjectStoreResult<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> ObjectStoreResult<()> {
+        self.inner.copy_opts(from, to, options).await
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum HeadFixture {
+    Valid,
+    Missing,
+    WrongSize,
+    Transient,
+}
+
+async fn validation_head_fixture(
+    database: &str,
+    fixtures: &[HeadFixture],
+) -> (
+    Db,
+    IndexOperationRecord,
+    ValidatedTextIndexDefinition,
+    TextManifestValidationProgress,
+    TextStorageRuntime,
+    Arc<ControlledHeadStore>,
+) {
+    let scope = DataScope::LegacyUnscoped;
+    let operation = operation();
+    let definition = definition();
+    let dynamic = ValidatedDynamicIndexDefinition::Text(definition.clone());
+    let record = IndexRecordV2::building(
+        operation.index_id(),
+        dynamic,
+        operation.index_record_revision(),
+        crate::index_lifecycle::PhysicalGeneration::Text {
+            generation: operation.generation(),
+        },
+        operation.operation_id(),
+    )
+    .unwrap();
+    let db = Db::open(database, Arc::new(InMemory::new())).await.unwrap();
+    db.put(
+        scoped_index_key(scope, ScopedKey::index_record(record.identity().clone())),
+        crate::encoding::v2::values::encode_index_record(&record),
+    )
+    .await
+    .unwrap();
+
+    let partition = TextPartition::Unpartitioned;
+    let root = TextManifestRootKey {
+        index_id: operation.index_id(),
+        generation: operation.generation(),
+        partition: partition.fingerprint(),
+    };
+    let root_value = work::TextManifestRootValue::try_new(
+        operation.index_id(),
+        operation.generation(),
+        partition.clone(),
+        TextManifestRevision::new(2).unwrap(),
+        1,
+        u64::try_from(fixtures.len()).unwrap(),
+    )
+    .unwrap();
+    db.put(
+        scoped_index_key(scope, ScopedKey::TextManifestRoot(root)),
+        crate::encoding::v2::values::encode_manifest_root(&root_value),
+    )
+    .await
+    .unwrap();
+
+    let store = Arc::new(ControlledHeadStore::default());
+    let mut splits = Vec::new();
+    for (ordinal, fixture) in fixtures.iter().copied().enumerate() {
+        let seed = u8::try_from(ordinal + 1).unwrap();
+        let split = crate::index_lifecycle::text::test_support::split(seed, 128);
+        let path = crate::search::text::blob_object_store_path(database, *split.blob().hash());
+        match fixture {
+            HeadFixture::Valid | HeadFixture::Transient => {
+                store
+                    .put(&path, PutPayload::from(vec![0; 128]))
+                    .await
+                    .unwrap();
+            }
+            HeadFixture::Missing => {}
+            HeadFixture::WrongSize => {
+                store
+                    .put(&path, PutPayload::from(vec![0; 127]))
+                    .await
+                    .unwrap();
+            }
+        }
+        if matches!(fixture, HeadFixture::Transient) {
+            store.fail_head(path);
+        }
+        splits.push(split);
+    }
+    let page = work::TextManifestPageValue::try_new(
+        operation.index_id(),
+        operation.generation(),
+        partition,
+        0,
+        splits,
+    )
+    .unwrap();
+    db.put(
+        scoped_index_key(
+            scope,
+            ScopedKey::TextManifestPage(crate::encoding::v2::keys::TextManifestPageKey {
+                root,
+                page: 0,
+            }),
+        ),
+        crate::encoding::v2::values::encode_manifest_page(&page),
+    )
+    .await
+    .unwrap();
+    let runtime = TextStorageRuntime {
+        object_store: store.clone(),
+        db_path: database.to_string(),
+        compaction_limits: crate::config::SearchIndexBackfillLimits::default().text_compaction(),
+    };
+    (
+        db,
+        operation,
+        definition,
+        TextManifestValidationProgress::initial(OperationCounters::default()),
+        runtime,
+        store,
+    )
+}
+
+async fn stage_prepared_validation(
+    db: &Db,
+    step: PreparedTextOperationStep,
+) -> IndexOperationStepResult {
+    let PreparedTextOperationStep::Validation(prepared) = step else {
+        panic!("manifest validation prepares an exact validation step")
+    };
+    let transaction = db.begin(IsolationLevel::Snapshot).await.unwrap();
+    match *prepared {
+        PreparedTextValidationStep::Database { prepared, .. } => {
+            prepared.stage(&transaction).await.unwrap()
+        }
+        PreparedTextValidationStep::Page { prepared, .. } => {
+            prepared.stage(&transaction).await.unwrap()
+        }
+    }
+}
+
+#[tokio::test]
+async fn manifest_blob_heads_run_with_exact_bounded_concurrency() {
+    let (db, operation, _, progress, runtime, store) =
+        validation_head_fixture("text-validation-concurrent-heads", &[HeadFixture::Valid; 9]).await;
+    store.arm();
+    let preparation = prepare_validation_step(
+        &db,
+        DataScope::LegacyUnscoped,
+        &operation,
+        &progress,
+        limits(u64::MAX),
+        &runtime,
+    );
+    tokio::pin!(preparation);
+    let reached_window = tokio::select! {
+        result = tokio::time::timeout(Duration::from_secs(1), store.wait_until_entered(8)) => {
+            result.is_ok()
+        }
+        _ = &mut preparation => panic!("validation completed before HEAD window filled"),
+    };
+    store.release();
+    let step = preparation.await.unwrap();
+    assert!(reached_window, "eight HEAD requests must overlap");
+    assert_eq!(store.peak(), 8);
+    assert!(matches!(
+        stage_prepared_validation(&db, step).await,
+        IndexOperationStepResult::Progressed(_)
+    ));
+}
+
+#[tokio::test]
+async fn concurrent_head_results_preserve_complete_error_classification() {
+    #[derive(Debug, Clone, Copy)]
+    enum Expected {
+        Progressed,
+        Blocked,
+        Transient,
+    }
+
+    for (ordinal, (fixtures, expected)) in [
+        (vec![HeadFixture::Valid], Expected::Progressed),
+        (vec![HeadFixture::Missing], Expected::Blocked),
+        (vec![HeadFixture::WrongSize], Expected::Blocked),
+        (vec![HeadFixture::Transient], Expected::Transient),
+        (
+            vec![HeadFixture::Transient, HeadFixture::WrongSize],
+            Expected::Blocked,
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let database = format!("text-validation-head-classification-{ordinal}");
+        let (db, operation, _, progress, runtime, _) =
+            validation_head_fixture(&database, &fixtures).await;
+        let step = prepare_validation_step(
+            &db,
+            DataScope::LegacyUnscoped,
+            &operation,
+            &progress,
+            limits(u64::MAX),
+            &runtime,
+        )
+        .await
+        .unwrap();
+        let actual = stage_prepared_validation(&db, step).await;
+        assert!(
+            matches!(
+                (actual, expected),
+                (
+                    IndexOperationStepResult::Progressed(_),
+                    Expected::Progressed
+                ) | (
+                    IndexOperationStepResult::Blocked(IndexOperationBlocker::InvariantViolation),
+                    Expected::Blocked
+                ) | (
+                    IndexOperationStepResult::TransientFailure,
+                    Expected::Transient
+                )
+            ),
+            "HEAD fixture {fixtures:?} returned the wrong result"
+        );
+        db.close().await.unwrap();
+    }
 }
 
 fn split_input(

--- a/crates/db/tests/unit/index_lifecycle_text_validation.rs
+++ b/crates/db/tests/unit/index_lifecycle_text_validation.rs
@@ -66,6 +66,289 @@ fn entity_progress(counters: OperationCounters) -> TextManifestValidationProgres
     })
 }
 
+fn build_delta_row(
+    scope: DataScope,
+    operation: &IndexOperationRecord,
+    entity: index_keys::IndexEntity,
+) -> (Bytes, Bytes) {
+    let key = scoped_key(
+        scope,
+        index_keys::ScopedKey::BuildDelta(index_keys::IndexEntityStateKey {
+            index_id: operation.index_id(),
+            generation: operation.generation(),
+            entity,
+        }),
+    );
+    let value = index_values::encode_build_delta(&work::CoalescedBuildDeltaValue {
+        index_id: operation.index_id(),
+        generation: operation.generation(),
+        entity_kind: entity.kind,
+        entity_id: entity.id,
+    });
+    (key, value)
+}
+
+fn assert_catch_up_with_counters(result: IndexOperationStepResult, expected: OperationCounters) {
+    let IndexOperationStepResult::Progressed(IndexOperationProgress::TextBuild(
+        TextBuildProgress::Constructing(TextBuildStage::CatchUp(progress)),
+    )) = result
+    else {
+        panic!("pending build delta must preempt manifest validation")
+    };
+    assert!(progress.cursor.is_none());
+    assert_eq!(progress.counters, expected);
+}
+
+#[tokio::test]
+async fn pending_delta_preempts_every_validation_lane_and_preserves_counters() {
+    let db = Db::open(
+        "text-validation-pending-delta-lanes",
+        Arc::new(InMemory::new()),
+    )
+    .await
+    .unwrap();
+    let transaction = db.begin(IsolationLevel::Snapshot).await.unwrap();
+    let operation = test_support::operation();
+    let definition = definition();
+    let scope = DataScope::LegacyUnscoped;
+    let counters = OperationCounters {
+        entities: 7,
+        input_bytes: 11,
+        output_operations: 13,
+        output_bytes: 17,
+    };
+    let entity = index_keys::IndexEntity {
+        kind: IndexElementKind::Node,
+        id: IndexEntityId::new(19),
+    };
+    let (delta_key, delta_value) = build_delta_row(scope, &operation, entity);
+    transaction.put(delta_key, delta_value).unwrap();
+
+    for progress in [
+        TextManifestValidationProgress::Pages(TextManifestPageValidationProgress::initial(
+            counters,
+        )),
+        root_progress(counters),
+        entity_progress(counters),
+    ] {
+        let ValidationSelection::Database(prepared) = select(
+            &transaction,
+            scope,
+            &operation,
+            &definition,
+            &progress,
+            test_support::batch_limits(u64::MAX, u64::MAX, u64::MAX),
+        )
+        .await
+        .unwrap() else {
+            panic!("pending build delta selects a database-only catch-up transition")
+        };
+        assert_catch_up_with_counters(prepared.stage(&transaction).await.unwrap(), counters);
+    }
+}
+
+#[tokio::test]
+async fn live_state_with_absent_marker_catches_up_only_when_a_delta_explains_it() {
+    let db = Db::open(
+        "text-validation-live-absent-delta",
+        Arc::new(InMemory::new()),
+    )
+    .await
+    .unwrap();
+    let transaction = db.begin(IsolationLevel::Snapshot).await.unwrap();
+    let operation = test_support::operation();
+    let definition = definition();
+    let scope = DataScope::LegacyUnscoped;
+    let partition = TextPartition::Unpartitioned;
+    let (root_typed, root_key) = root_key(scope, &operation, &partition);
+    transaction
+        .put(root_key, root_value(&operation, partition.clone(), 1, 1))
+        .unwrap();
+    let entity = index_keys::IndexEntity {
+        kind: IndexElementKind::Node,
+        id: IndexEntityId::new(23),
+    };
+    let state_key = scoped_key(
+        scope,
+        index_keys::ScopedKey::TextEntityState(index_keys::TextEntityStateKey {
+            root: root_typed,
+            entity,
+        }),
+    );
+    let state = work::TextEntityStateValue {
+        index_id: operation.index_id(),
+        generation: operation.generation(),
+        partition,
+        entity_kind: entity.kind,
+        entity_id: entity.id,
+        logical_version: TextLogicalVersion::initial(),
+        live: true,
+    };
+    transaction
+        .put(state_key, index_values::encode_text_entity_state(&state))
+        .unwrap();
+    let marker_key = scoped_key(
+        scope,
+        index_keys::ScopedKey::TextStatisticsEntity(index_keys::TextStatisticsEntityKey {
+            index_id: operation.index_id(),
+            generation: operation.generation(),
+            entity,
+        }),
+    );
+    let marker = work::TextStatisticsEntityValue {
+        index_id: operation.index_id(),
+        generation: operation.generation(),
+        entity_kind: entity.kind,
+        entity_id: entity.id,
+        contribution: work::TextStatisticsContribution::Absent,
+    };
+    transaction
+        .put(marker_key, index_values::encode_statistics_entity(&marker))
+        .unwrap();
+    let progress = entity_progress(OperationCounters::default());
+    let limits = test_support::batch_limits(u64::MAX, u64::MAX, u64::MAX);
+
+    let ValidationSelection::Database(unexplained) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &progress,
+        limits,
+    )
+    .await
+    .unwrap() else {
+        panic!("entity-state validation is database-only")
+    };
+    assert!(matches!(
+        unexplained.stage(&transaction).await.unwrap(),
+        IndexOperationStepResult::Blocked(IndexOperationBlocker::InvariantViolation)
+    ));
+
+    let (delta_key, delta_value) = build_delta_row(scope, &operation, entity);
+    transaction.put(delta_key, delta_value).unwrap();
+    let ValidationSelection::Database(explained) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &progress,
+        limits,
+    )
+    .await
+    .unwrap() else {
+        panic!("explained marker mismatch selects database-only catch-up")
+    };
+    assert_catch_up_with_counters(
+        explained.stage(&transaction).await.unwrap(),
+        OperationCounters::default(),
+    );
+}
+
+#[tokio::test]
+async fn delta_inserted_after_preparation_invalidates_database_selection() {
+    let db = Db::open(
+        "text-validation-concurrent-delta-fence",
+        Arc::new(InMemory::new()),
+    )
+    .await
+    .unwrap();
+    let transaction = db.begin(IsolationLevel::Snapshot).await.unwrap();
+    let operation = test_support::operation();
+    let definition = definition();
+    let scope = DataScope::LegacyUnscoped;
+    let limits = test_support::batch_limits(u64::MAX, u64::MAX, u64::MAX);
+
+    let ValidationSelection::Database(database) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &TextManifestValidationProgress::Pages(TextManifestPageValidationProgress::initial(
+            OperationCounters::default(),
+        )),
+        limits,
+    )
+    .await
+    .unwrap() else {
+        panic!("empty page lane selects a database transition")
+    };
+
+    let entity = index_keys::IndexEntity {
+        kind: IndexElementKind::Node,
+        id: IndexEntityId::new(37),
+    };
+    let (delta_key, delta_value) = build_delta_row(scope, &operation, entity);
+    transaction.put(delta_key, delta_value).unwrap();
+    assert!(matches!(
+        database.stage(&transaction).await.unwrap(),
+        IndexOperationStepResult::TransientFailure
+    ));
+}
+
+#[tokio::test]
+async fn delta_inserted_after_preparation_invalidates_page_selection() {
+    let db = Db::open(
+        "text-validation-concurrent-delta-page-fence",
+        Arc::new(InMemory::new()),
+    )
+    .await
+    .unwrap();
+    let transaction = db.begin(IsolationLevel::Snapshot).await.unwrap();
+    let operation = test_support::operation();
+    let definition = definition();
+    let scope = DataScope::LegacyUnscoped;
+    let limits = test_support::batch_limits(u64::MAX, u64::MAX, u64::MAX);
+    let partition = TextPartition::Unpartitioned;
+    let (root_typed, root_key) = root_key(scope, &operation, &partition);
+    let page_key = scoped_key(
+        scope,
+        index_keys::ScopedKey::TextManifestPage(index_keys::TextManifestPageKey {
+            root: root_typed,
+            page: 0,
+        }),
+    );
+    let page = work::TextManifestPageValue::try_new(
+        operation.index_id(),
+        operation.generation(),
+        partition.clone(),
+        0,
+        vec![test_support::split(31, 128)],
+    )
+    .unwrap();
+    transaction
+        .put(root_key, root_value(&operation, partition, 1, 1))
+        .unwrap();
+    transaction
+        .put(page_key, index_values::encode_manifest_page(&page))
+        .unwrap();
+    let ValidationSelection::Page(page) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &TextManifestValidationProgress::Pages(TextManifestPageValidationProgress::initial(
+            OperationCounters::default(),
+        )),
+        limits,
+    )
+    .await
+    .unwrap() else {
+        panic!("valid manifest page selects external validation")
+    };
+
+    let entity = index_keys::IndexEntity {
+        kind: IndexElementKind::Node,
+        id: IndexEntityId::new(37),
+    };
+    let (delta_key, delta_value) = build_delta_row(scope, &operation, entity);
+    transaction.put(delta_key, delta_value).unwrap();
+    assert!(matches!(
+        page.stage(&transaction).await.unwrap(),
+        IndexOperationStepResult::TransientFailure
+    ));
+}
+
 #[tokio::test]
 async fn prepared_database_revalidation_rejects_missing_changed_and_appended_rows() {
     let db = Db::open("text-validation-stale-ranges", Arc::new(InMemory::new()))

--- a/crates/db/tests/unit/index_lifecycle_text_validation.rs
+++ b/crates/db/tests/unit/index_lifecycle_text_validation.rs
@@ -1412,7 +1412,13 @@ async fn moved_non_live_entity_requires_the_exact_live_state_in_marker_partition
     transaction
         .put(marker_key, index_values::encode_statistics_entity(&marker))
         .unwrap();
-    let (new_root_typed, _) = root_key(scope, &operation, &new_partition);
+    let (new_root_typed, new_root_key) = root_key(scope, &operation, &new_partition);
+    transaction
+        .put(
+            new_root_key,
+            root_value(&operation, new_partition.clone(), 1, 1),
+        )
+        .unwrap();
     let live_key = scoped_key(
         scope,
         index_keys::ScopedKey::TextEntityState(index_keys::TextEntityStateKey {

--- a/crates/db/tests/unit/index_lifecycle_text_validation.rs
+++ b/crates/db/tests/unit/index_lifecycle_text_validation.rs
@@ -1,3 +1,4 @@
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 
 use slatedb::object_store::memory::InMemory;
@@ -64,6 +65,416 @@ fn entity_progress(counters: OperationCounters) -> TextManifestValidationProgres
         cursor: None,
         counters,
     })
+}
+
+fn validation_batch_limits(max_entities: usize, max_input_bytes: u64) -> SearchIndexBatchLimits {
+    SearchIndexBatchLimits::try_new(
+        NonZeroUsize::new(max_entities).unwrap(),
+        NonZeroU64::new(max_input_bytes).unwrap(),
+        NonZeroU64::new(u64::MAX).unwrap(),
+        NonZeroU64::new(u64::MAX).unwrap(),
+        NonZeroU64::new(u64::MAX).unwrap(),
+    )
+    .unwrap()
+}
+
+fn entity_state_progress(result: IndexOperationStepResult) -> PrefixScanProgress {
+    let IndexOperationStepResult::Progressed(IndexOperationProgress::TextBuild(
+        TextBuildProgress::Constructing(TextBuildStage::ValidateManifests(
+            TextManifestValidationProgress::EntityStates(progress),
+        )),
+    )) = result
+    else {
+        panic!("entity-state batch must remain in its validation lane")
+    };
+    progress
+}
+
+#[tokio::test]
+async fn entity_state_validation_admits_1025_rows_in_three_default_sized_batches() {
+    const ENTITY_COUNT: u64 = 1_025;
+    const BATCH_ENTITIES: usize = 512;
+
+    let db = Db::open(
+        "text-validation-entity-default-batches",
+        Arc::new(InMemory::new()),
+    )
+    .await
+    .unwrap();
+    let transaction = db.begin(IsolationLevel::Snapshot).await.unwrap();
+    let operation = test_support::operation();
+    let definition = definition();
+    let scope = DataScope::LegacyUnscoped;
+    let partition = TextPartition::Unpartitioned;
+    let (root_typed, root_key) = root_key(scope, &operation, &partition);
+    let root_value = root_value(&operation, partition.clone(), 0, 0);
+    transaction.put(root_key, root_value).unwrap();
+    let mut state_keys = Vec::new();
+    for entity_id in 0..ENTITY_COUNT {
+        let entity = index_keys::IndexEntity {
+            kind: IndexElementKind::Node,
+            id: IndexEntityId::new(entity_id),
+        };
+        let state_key = scoped_key(
+            scope,
+            index_keys::ScopedKey::TextEntityState(index_keys::TextEntityStateKey {
+                root: root_typed,
+                entity,
+            }),
+        );
+        let state = work::TextEntityStateValue {
+            index_id: operation.index_id(),
+            generation: operation.generation(),
+            partition: partition.clone(),
+            entity_kind: entity.kind,
+            entity_id: entity.id,
+            logical_version: TextLogicalVersion::initial(),
+            live: false,
+        };
+        transaction
+            .put(
+                state_key.clone(),
+                index_values::encode_text_entity_state(&state),
+            )
+            .unwrap();
+        state_keys.push(state_key);
+        let marker_key = scoped_key(
+            scope,
+            index_keys::ScopedKey::TextStatisticsEntity(index_keys::TextStatisticsEntityKey {
+                index_id: operation.index_id(),
+                generation: operation.generation(),
+                entity,
+            }),
+        );
+        let marker = work::TextStatisticsEntityValue {
+            index_id: operation.index_id(),
+            generation: operation.generation(),
+            entity_kind: entity.kind,
+            entity_id: entity.id,
+            contribution: work::TextStatisticsContribution::Absent,
+        };
+        transaction
+            .put(marker_key, index_values::encode_statistics_entity(&marker))
+            .unwrap();
+    }
+
+    let limits = validation_batch_limits(BATCH_ENTITIES, u64::MAX);
+    let mut progress = PrefixScanProgress {
+        cursor: None,
+        counters: OperationCounters::default(),
+    };
+    for expected_last in [511, 1023, 1024] {
+        let ValidationSelection::Database(prepared) = select(
+            &transaction,
+            scope,
+            &operation,
+            &definition,
+            &TextManifestValidationProgress::EntityStates(progress),
+            limits,
+        )
+        .await
+        .unwrap() else {
+            panic!("entity-state validation is database-only")
+        };
+        progress = entity_state_progress(prepared.stage(&transaction).await.unwrap());
+        assert_eq!(
+            progress.cursor.as_ref().unwrap().as_bytes(),
+            state_keys[expected_last].as_ref()
+        );
+    }
+
+    let ValidationSelection::Database(exhausted) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &TextManifestValidationProgress::EntityStates(progress),
+        limits,
+    )
+    .await
+    .unwrap() else {
+        panic!("entity-state exhaustion is database-only")
+    };
+    assert!(matches!(
+        exhausted.stage(&transaction).await.unwrap(),
+        IndexOperationStepResult::Progressed(IndexOperationProgress::TextBuild(
+            TextBuildProgress::Constructing(TextBuildStage::Activate(_))
+        ))
+    ));
+}
+
+#[tokio::test]
+async fn entity_state_batch_stops_before_the_first_row_exceeding_its_byte_budget() {
+    let db = Db::open(
+        "text-validation-entity-byte-batches",
+        Arc::new(InMemory::new()),
+    )
+    .await
+    .unwrap();
+    let transaction = db.begin(IsolationLevel::Snapshot).await.unwrap();
+    let operation = test_support::operation();
+    let definition = definition();
+    let scope = DataScope::LegacyUnscoped;
+    let partition = TextPartition::Unpartitioned;
+    let (root_typed, root_key) = root_key(scope, &operation, &partition);
+    let root_value = root_value(&operation, partition.clone(), 0, 0);
+    transaction
+        .put(root_key.clone(), root_value.clone())
+        .unwrap();
+    let mut state_keys = Vec::new();
+    let mut one_entity_bytes = None;
+    for entity_id in 0..3 {
+        let entity = index_keys::IndexEntity {
+            kind: IndexElementKind::Node,
+            id: IndexEntityId::new(entity_id),
+        };
+        let state_key = scoped_key(
+            scope,
+            index_keys::ScopedKey::TextEntityState(index_keys::TextEntityStateKey {
+                root: root_typed,
+                entity,
+            }),
+        );
+        let state = work::TextEntityStateValue {
+            index_id: operation.index_id(),
+            generation: operation.generation(),
+            partition: partition.clone(),
+            entity_kind: entity.kind,
+            entity_id: entity.id,
+            logical_version: TextLogicalVersion::initial(),
+            live: false,
+        };
+        let state_value = index_values::encode_text_entity_state(&state);
+        transaction
+            .put(state_key.clone(), state_value.clone())
+            .unwrap();
+        state_keys.push(state_key.clone());
+        let marker_key = scoped_key(
+            scope,
+            index_keys::ScopedKey::TextStatisticsEntity(index_keys::TextStatisticsEntityKey {
+                index_id: operation.index_id(),
+                generation: operation.generation(),
+                entity,
+            }),
+        );
+        let marker = work::TextStatisticsEntityValue {
+            index_id: operation.index_id(),
+            generation: operation.generation(),
+            entity_kind: entity.kind,
+            entity_id: entity.id,
+            contribution: work::TextStatisticsContribution::Absent,
+        };
+        let marker_value = index_values::encode_statistics_entity(&marker);
+        transaction
+            .put(marker_key.clone(), marker_value.clone())
+            .unwrap();
+        let bytes = row_bytes(&state_key, Some(&state_value))
+            .saturating_add(row_bytes(&root_key, Some(&root_value)))
+            .saturating_add(row_bytes(&marker_key, Some(&marker_value)));
+        assert!(one_entity_bytes.is_none_or(|expected| expected == bytes));
+        one_entity_bytes = Some(bytes);
+    }
+    let one_entity_bytes = one_entity_bytes.unwrap();
+    let limits = validation_batch_limits(8, one_entity_bytes.saturating_mul(2));
+
+    let ValidationSelection::Database(first) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &entity_progress(OperationCounters::default()),
+        limits,
+    )
+    .await
+    .unwrap() else {
+        panic!("entity-state validation is database-only")
+    };
+    let first = entity_state_progress(first.stage(&transaction).await.unwrap());
+    assert_eq!(first.cursor.as_ref().unwrap().as_bytes(), &state_keys[1]);
+    assert_eq!(first.counters.input_bytes, one_entity_bytes * 2);
+
+    let ValidationSelection::Database(second) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &TextManifestValidationProgress::EntityStates(first),
+        limits,
+    )
+    .await
+    .unwrap() else {
+        panic!("remaining entity-state validation is database-only")
+    };
+    let second = entity_state_progress(second.stage(&transaction).await.unwrap());
+    assert_eq!(second.cursor.as_ref().unwrap().as_bytes(), &state_keys[2]);
+    assert_eq!(second.counters.input_bytes, one_entity_bytes * 3);
+}
+
+#[tokio::test]
+async fn page_validation_batches_contiguous_pages_and_preserves_partition_progress() {
+    let db = Db::open("text-validation-page-batches", Arc::new(InMemory::new()))
+        .await
+        .unwrap();
+    let transaction = db.begin(IsolationLevel::Snapshot).await.unwrap();
+    let operation = test_support::operation();
+    let definition = definition();
+    let scope = DataScope::LegacyUnscoped;
+    let partition = TextPartition::Unpartitioned;
+    let (root_typed, root_key) = root_key(scope, &operation, &partition);
+    transaction
+        .put(root_key, root_value(&operation, partition.clone(), 3, 3))
+        .unwrap();
+    let mut page_keys = Vec::new();
+    for page in 0..3 {
+        let page_key = scoped_key(
+            scope,
+            index_keys::ScopedKey::TextManifestPage(index_keys::TextManifestPageKey {
+                root: root_typed,
+                page,
+            }),
+        );
+        let value = work::TextManifestPageValue::try_new(
+            operation.index_id(),
+            operation.generation(),
+            partition.clone(),
+            page,
+            vec![test_support::split(u8::try_from(page + 1).unwrap(), 128)],
+        )
+        .unwrap();
+        transaction
+            .put(page_key.clone(), index_values::encode_manifest_page(&value))
+            .unwrap();
+        page_keys.push(page_key);
+    }
+    let limits = validation_batch_limits(2, u64::MAX);
+
+    let ValidationSelection::Page(first) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &TextManifestValidationProgress::Pages(TextManifestPageValidationProgress::initial(
+            OperationCounters::default(),
+        )),
+        limits,
+    )
+    .await
+    .unwrap() else {
+        panic!("valid pages select external validation")
+    };
+    assert_eq!(first.blobs().len(), 2);
+    let IndexOperationStepResult::Progressed(IndexOperationProgress::TextBuild(
+        TextBuildProgress::Constructing(TextBuildStage::ValidateManifests(
+            TextManifestValidationProgress::Pages(first_progress),
+        )),
+    )) = first.stage(&transaction).await.unwrap()
+    else {
+        panic!("partial page batch remains in page validation")
+    };
+    assert_eq!(first_progress.cursor().unwrap().as_bytes(), &page_keys[1]);
+    assert_eq!(first_progress.partition().unwrap().next_page(), 2);
+
+    let ValidationSelection::Page(second) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &TextManifestValidationProgress::Pages(first_progress),
+        limits,
+    )
+    .await
+    .unwrap() else {
+        panic!("remaining valid page selects external validation")
+    };
+    assert_eq!(second.blobs().len(), 1);
+    let IndexOperationStepResult::Progressed(IndexOperationProgress::TextBuild(
+        TextBuildProgress::Constructing(TextBuildStage::ValidateManifests(
+            TextManifestValidationProgress::Pages(second_progress),
+        )),
+    )) = second.stage(&transaction).await.unwrap()
+    else {
+        panic!("final page batch records page-lane exhaustion cursor")
+    };
+    assert_eq!(second_progress.cursor().unwrap().as_bytes(), &page_keys[2]);
+    assert!(second_progress.partition().is_none());
+}
+
+#[tokio::test]
+async fn root_validation_batches_tenant_partitions_in_key_order() {
+    let db = Db::open("text-validation-root-batches", Arc::new(InMemory::new()))
+        .await
+        .unwrap();
+    let transaction = db.begin(IsolationLevel::Snapshot).await.unwrap();
+    let operation = test_support::operation();
+    let definition = ValidatedTextIndexDefinition::try_from_runtime(
+        &crate::config::TextIndexDefinition::new_node("Document", "body")
+            .unwrap()
+            .with_tenant_property("tenant")
+            .unwrap(),
+    )
+    .unwrap();
+    let scope = DataScope::LegacyUnscoped;
+    let mut root_keys = Vec::new();
+    for tenant in ["alpha", "beta", "gamma"] {
+        let partition = TextPartition::try_tenant_value(Bytes::from(tenant.to_string())).unwrap();
+        let (_, key) = root_key(scope, &operation, &partition);
+        transaction
+            .put(key.clone(), root_value(&operation, partition, 0, 0))
+            .unwrap();
+        root_keys.push(key);
+    }
+    root_keys.sort();
+    let limits = validation_batch_limits(2, u64::MAX);
+
+    let ValidationSelection::Database(first) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &root_progress(OperationCounters::default()),
+        limits,
+    )
+    .await
+    .unwrap() else {
+        panic!("root validation is database-only")
+    };
+    let IndexOperationStepResult::Progressed(IndexOperationProgress::TextBuild(
+        TextBuildProgress::Constructing(TextBuildStage::ValidateManifests(
+            TextManifestValidationProgress::Roots(first_progress),
+        )),
+    )) = first.stage(&transaction).await.unwrap()
+    else {
+        panic!("partial root batch remains in root validation")
+    };
+    assert_eq!(
+        first_progress.cursor.as_ref().unwrap().as_bytes(),
+        &root_keys[1]
+    );
+
+    let ValidationSelection::Database(second) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &TextManifestValidationProgress::Roots(first_progress),
+        limits,
+    )
+    .await
+    .unwrap() else {
+        panic!("remaining root validation is database-only")
+    };
+    let IndexOperationStepResult::Progressed(IndexOperationProgress::TextBuild(
+        TextBuildProgress::Constructing(TextBuildStage::ValidateManifests(
+            TextManifestValidationProgress::Roots(second_progress),
+        )),
+    )) = second.stage(&transaction).await.unwrap()
+    else {
+        panic!("final root row remains in root validation until exhaustion is proved")
+    };
+    assert_eq!(
+        second_progress.cursor.as_ref().unwrap().as_bytes(),
+        &root_keys[2]
+    );
 }
 
 fn build_delta_row(

--- a/crates/db/tests/unit/index_lifecycle_text_validation.rs
+++ b/crates/db/tests/unit/index_lifecycle_text_validation.rs
@@ -678,6 +678,7 @@ fn build_delta_row(
         generation: operation.generation(),
         entity_kind: entity.kind,
         entity_id: entity.id,
+        state: work::CoalescedBuildDeltaState::Marker,
     });
     (key, value)
 }

--- a/crates/db/tests/unit/index_lifecycle_text_validation.rs
+++ b/crates/db/tests/unit/index_lifecycle_text_validation.rs
@@ -400,6 +400,104 @@ async fn page_validation_batches_contiguous_pages_and_preserves_partition_progre
 }
 
 #[tokio::test]
+async fn page_batch_defers_on_bytes_deduplicates_heads_and_fences_every_page() {
+    let db = Db::open(
+        "text-validation-page-batch-contracts",
+        Arc::new(InMemory::new()),
+    )
+    .await
+    .unwrap();
+    let transaction = db.begin(IsolationLevel::Snapshot).await.unwrap();
+    let operation = test_support::operation();
+    let definition = definition();
+    let scope = DataScope::LegacyUnscoped;
+    let partition = TextPartition::Unpartitioned;
+    let (root_typed, root_key) = root_key(scope, &operation, &partition);
+    let root_value = root_value(&operation, partition.clone(), 2, 2);
+    transaction
+        .put(root_key.clone(), root_value.clone())
+        .unwrap();
+    let shared_split = test_support::split(8, 128);
+    let mut pages = Vec::new();
+    for page in 0..2 {
+        let key = scoped_key(
+            scope,
+            index_keys::ScopedKey::TextManifestPage(index_keys::TextManifestPageKey {
+                root: root_typed,
+                page,
+            }),
+        );
+        let value = index_values::encode_manifest_page(
+            &work::TextManifestPageValue::try_new(
+                operation.index_id(),
+                operation.generation(),
+                partition.clone(),
+                page,
+                vec![shared_split],
+            )
+            .unwrap(),
+        );
+        transaction.put(key.clone(), value.clone()).unwrap();
+        pages.push((key, value));
+    }
+    let one_page_bytes = row_bytes(&pages[0].0, Some(&pages[0].1))
+        .saturating_add(row_bytes(&root_key, Some(&root_value)));
+    assert_eq!(
+        one_page_bytes,
+        row_bytes(&pages[1].0, Some(&pages[1].1))
+            .saturating_add(row_bytes(&root_key, Some(&root_value)))
+    );
+
+    let ValidationSelection::Page(first) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &TextManifestValidationProgress::Pages(TextManifestPageValidationProgress::initial(
+            OperationCounters::default(),
+        )),
+        validation_batch_limits(8, one_page_bytes),
+    )
+    .await
+    .unwrap() else {
+        panic!("one page fits the exact byte budget")
+    };
+    let IndexOperationStepResult::Progressed(IndexOperationProgress::TextBuild(
+        TextBuildProgress::Constructing(TextBuildStage::ValidateManifests(
+            TextManifestValidationProgress::Pages(first_progress),
+        )),
+    )) = first.stage(&transaction).await.unwrap()
+    else {
+        panic!("the deferred second page remains pending")
+    };
+    assert_eq!(first_progress.cursor().unwrap().as_bytes(), &pages[0].0);
+    assert_eq!(first_progress.counters().input_bytes, one_page_bytes);
+
+    let ValidationSelection::Page(batch) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &TextManifestValidationProgress::Pages(TextManifestPageValidationProgress::initial(
+            OperationCounters::default(),
+        )),
+        validation_batch_limits(8, u64::MAX),
+    )
+    .await
+    .unwrap() else {
+        panic!("both pages form one externally validated batch")
+    };
+    assert_eq!(batch.blobs(), &[shared_split.blob()]);
+    transaction
+        .put(pages[1].0.clone(), Bytes::from_static(b"changed"))
+        .unwrap();
+    assert!(matches!(
+        batch.stage(&transaction).await.unwrap(),
+        IndexOperationStepResult::TransientFailure
+    ));
+}
+
+#[tokio::test]
 async fn root_validation_batches_tenant_partitions_in_key_order() {
     let db = Db::open("text-validation-root-batches", Arc::new(InMemory::new()))
         .await
@@ -475,6 +573,91 @@ async fn root_validation_batches_tenant_partitions_in_key_order() {
         second_progress.cursor.as_ref().unwrap().as_bytes(),
         &root_keys[2]
     );
+}
+
+#[tokio::test]
+async fn root_batch_defers_on_bytes_and_fences_every_admitted_root() {
+    let db = Db::open(
+        "text-validation-root-batch-contracts",
+        Arc::new(InMemory::new()),
+    )
+    .await
+    .unwrap();
+    let transaction = db.begin(IsolationLevel::Snapshot).await.unwrap();
+    let operation = test_support::operation();
+    let definition = ValidatedTextIndexDefinition::try_from_runtime(
+        &crate::config::TextIndexDefinition::new_node("Document", "body")
+            .unwrap()
+            .with_tenant_property("tenant")
+            .unwrap(),
+    )
+    .unwrap();
+    let scope = DataScope::LegacyUnscoped;
+    let mut roots = Vec::new();
+    for tenant in ["alpha", "bravo"] {
+        let partition = TextPartition::try_tenant_value(Bytes::from(tenant.to_string())).unwrap();
+        let (_, key) = root_key(scope, &operation, &partition);
+        let value = root_value(&operation, partition.clone(), 0, 0);
+        let corpus_key = super::super::statistics::corpus_key(
+            scope,
+            operation.index_id(),
+            operation.generation(),
+            &partition,
+        );
+        transaction.put(key.clone(), value.clone()).unwrap();
+        roots.push((key, value, corpus_key));
+    }
+    roots.sort_by(|left, right| left.0.cmp(&right.0));
+    let one_root_bytes =
+        row_bytes(&roots[0].0, Some(&roots[0].1)).saturating_add(row_bytes(&roots[0].2, None));
+    assert_eq!(
+        one_root_bytes,
+        row_bytes(&roots[1].0, Some(&roots[1].1)).saturating_add(row_bytes(&roots[1].2, None))
+    );
+
+    let ValidationSelection::Database(first) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &root_progress(OperationCounters::default()),
+        validation_batch_limits(8, one_root_bytes),
+    )
+    .await
+    .unwrap() else {
+        panic!("root validation is database-only")
+    };
+    let IndexOperationStepResult::Progressed(IndexOperationProgress::TextBuild(
+        TextBuildProgress::Constructing(TextBuildStage::ValidateManifests(
+            TextManifestValidationProgress::Roots(first_progress),
+        )),
+    )) = first.stage(&transaction).await.unwrap()
+    else {
+        panic!("the deferred second root remains pending")
+    };
+    assert_eq!(
+        first_progress.cursor.as_ref().unwrap().as_bytes(),
+        &roots[0].0
+    );
+    assert_eq!(first_progress.counters.input_bytes, one_root_bytes);
+
+    let ValidationSelection::Database(batch) = select(
+        &transaction,
+        scope,
+        &operation,
+        &definition,
+        &root_progress(OperationCounters::default()),
+        validation_batch_limits(8, u64::MAX),
+    )
+    .await
+    .unwrap() else {
+        panic!("root validation is database-only")
+    };
+    transaction.delete(roots[1].0.clone()).unwrap();
+    assert!(matches!(
+        batch.stage(&transaction).await.unwrap(),
+        IndexOperationStepResult::TransientFailure
+    ));
 }
 
 fn build_delta_row(

--- a/scripts/index-lifecycle-production-coverage-baselines.json
+++ b/scripts/index-lifecycle-production-coverage-baselines.json
@@ -2,12 +2,12 @@
   "schema_version": 1,
   "uncovered_test_required_positions": {
     "lines": {
-      "count": 1266,
-      "sha256": "57e5c775d3383e3a4fb0fbf7c0b10630b51331566211d4497cbee8d105077cc5"
+      "count": 1237,
+      "sha256": "3eb8d81c1e42763e6b3fb7eda7326e752d412abb88df5060166d20fc53d72f4f"
     },
     "functions": {
-      "count": 112,
-      "sha256": "acbc6a04874f87a93adc53e4cc990c59c099d45e4d7185b99c4b212ff883a462"
+      "count": 111,
+      "sha256": "0df494021cca43faa438a6c588bc044b8707fe19b8ff43d4db1fa5a64cb65e1e"
     },
     "classification": "test-required",
     "reason": "Every remaining uncovered Index V2 production position is part of the explicit merged test backlog. Exact line and function digests make additions, removals, and newly covered positions require a reviewed baseline update; structurally unreachable, platform-gated, and LLVM-artifact positions remain individually justified in the exclusions file."

--- a/scripts/index-lifecycle-production-coverage-baselines.json
+++ b/scripts/index-lifecycle-production-coverage-baselines.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "uncovered_test_required_positions": {
     "lines": {
-      "count": 1237,
-      "sha256": "3eb8d81c1e42763e6b3fb7eda7326e752d412abb88df5060166d20fc53d72f4f"
+      "count": 1236,
+      "sha256": "2b0117c2919407faede3ab89e97c731dace8bfba1421a8bdf9ebf5d8bf9384c4"
     },
     "functions": {
       "count": 111,


### PR DESCRIPTION
## Summary

- make text manifest validation bounded, restartable, and fenced against late build deltas
- make secondary, vector, and text builds re-enter catch-up when writes race validation or activation
- tighten authoritative source, entity-state, and uniqueness reconciliation before activation
- add a 220-case lifecycle matrix covering every secondary, vector, and text shape
- add public-write, cold-restart, invalid-vector rollback, tenant-move, cleanup, and scale regressions

## Test coverage

- 220 lifecycle cases: 28 secondary, 48 vector, and 144 text
- exact Scan, CatchUp, validation, and Activate boundaries
- insert, repeated update, delete, delta coalescing, restart, retry, abort, drop, and recreate paths
- vector dimension, NaN, positive/negative infinity, property type, zero-norm cosine, metric, restricted search, and tenant isolation
- secondary equality, unique equality, ascending/descending range, node/edge, conflict repair, and tenant scope
- 8k x 128D vector build, cold reopen, oracle query, drop, and residue gate
- compiled 100k vector and 100k secondary/text/16-tenant release gates

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- all runnable workspace tests and doctests
- instrumented lifecycle coverage workload
- Index lifecycle coverage: 13,097 / 14,333 lines (91.3765%)
- Index lifecycle coverage: 1,235 / 1,346 functions (91.7533%)

The 100k release-scale gates compile but were not executed locally. External Docker and separately published registry tests remain intentionally ignored.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR strengthens convergence across secondary, vector, and text index lifecycles, particularly when mutations race backfill, validation, or activation.

- Persists family-specific pre-mutation state in coalesced secondary and vector build deltas.
- Reconciles authoritative and applied entity state before secondary and vector activation.
- Makes text manifest validation bounded, restartable, concurrently checked, and fenced against late deltas.
- Consolidates startup migration wiring and adds broad lifecycle, restart, tenant, rollback, and scale coverage.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/index_lifecycle/secondary.rs | Preserves the original secondary value in coalesced deltas and uses it when applied state is unavailable during reconciliation. |
| crates/db/src/index_lifecycle/vector.rs | Adds analogous pre-mutation partition preservation for vector build reconciliation and tenant moves. |
| crates/db/src/index_lifecycle/vector/driver.rs | Tightens vector catch-up and activation convergence around applied state and late mutations. |
| crates/db/src/index_lifecycle/text/validation.rs | Reworks manifest validation into bounded, cursor-driven batches with exact transactional range fences. |
| crates/db/src/index_lifecycle/text/driver.rs | Re-enters catch-up for late deltas and validates immutable blob metadata with bounded concurrency. |
| crates/db/src/encoding/v2/values/lifecycle/entity_state.rs | Extends build-delta encoding compatibly while retaining support for legacy marker-only values. |
| crates/db/src/migrations/startup/pipeline.rs | Consolidates writer startup preparation and finishing without introducing mismatched production feature gates. |
| crates/db/src/index_lifecycle_testing/contracts/all_index_validation.rs | Adds a comprehensive cross-family lifecycle contract matrix covering mutation, restart, retry, cleanup, and tenant behavior. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Authoritative graph state] --> B[Bounded source scan]
  A --> C[Coalesced build deltas]
  B --> D[Family catch-up]
  C --> D
  D --> E[Physical and applied-state reconciliation]
  E --> F[Bounded validation]
  C -. late-delta fence .-> F
  F -->|delta detected| D
  F -->|validated| G[Atomic activation]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Refresh index lifecycle coverage baselin..."](https://github.com/helixdb/helix-db/commit/15b13164221d2eef02c2b3a312ff7a7c88e55c14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59382554)</sub>

**Context used:**

- Knowledge Base — [Index lifecycle and search](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/index-lifecycle-and-search.md)
- Knowledge Base — [Database engine](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/database-engine.md)

<!-- /greptile_comment -->