### PR TITLE
Bump SlateDB fork to v0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4685,7 +4685,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.16.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ce04071f51d51a85774af834fc77947cafd34d#41ce04071f51d51a85774af834fc77947cafd34d"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=50c063327b826c2c018c664171fc1ada5dc3096d#50c063327b826c2c018c664171fc1ada5dc3096d"
 dependencies = [
  "ahash",
  "async-channel",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.16.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ce04071f51d51a85774af834fc77947cafd34d#41ce04071f51d51a85774af834fc77947cafd34d"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=50c063327b826c2c018c664171fc1ada5dc3096d#50c063327b826c2c018c664171fc1ada5dc3096d"
 dependencies = [
  "chrono",
  "log",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.16.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=41ce04071f51d51a85774af834fc77947cafd34d#41ce04071f51d51a85774af834fc77947cafd34d"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=50c063327b826c2c018c664171fc1ada5dc3096d#50c063327b826c2c018c664171fc1ada5dc3096d"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,8 +4684,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slatedb"
-version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=099067afda1294e80308687d4ae41cdf6e5d01df#099067afda1294e80308687d4ae41cdf6e5d01df"
+version = "0.16.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ce04071f51d51a85774af834fc77947cafd34d#41ce04071f51d51a85774af834fc77947cafd34d"
 dependencies = [
  "ahash",
  "async-channel",
@@ -4730,8 +4730,8 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=099067afda1294e80308687d4ae41cdf6e5d01df#099067afda1294e80308687d4ae41cdf6e5d01df"
+version = "0.16.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ce04071f51d51a85774af834fc77947cafd34d#41ce04071f51d51a85774af834fc77947cafd34d"
 dependencies = [
  "chrono",
  "log",
@@ -4745,8 +4745,8 @@ dependencies = [
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.15.0"
-source = "git+https://github.com/HelixDB/slatedb.git?rev=099067afda1294e80308687d4ae41cdf6e5d01df#099067afda1294e80308687d4ae41cdf6e5d01df"
+version = "0.16.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=41ce04071f51d51a85774af834fc77947cafd34d#41ce04071f51d51a85774af834fc77947cafd34d"
 dependencies = [
  "async-trait",
  "bytes",

--- a/bindings/uniffi/src/graph.rs
+++ b/bindings/uniffi/src/graph.rs
@@ -1399,7 +1399,7 @@ mod tests {
 
         let cycles = graph.simple_cycles(3, Some(1)).unwrap();
         assert_eq!(cycles.cycles.len(), 1);
-        assert!(cycles.truncated);
+        assert!(!cycles.truncated);
         for (strategy, hub_policy) in [
             (
                 NativeTraversalStrategy::BreadthFirst,

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "099067afda1294e80308687d4ae41cdf6e5d01df" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "41ce04071f51d51a85774af834fc77947cafd34d" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "41ce04071f51d51a85774af834fc77947cafd34d" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "50c063327b826c2c018c664171fc1ada5dc3096d" }
 helix-ast = { path = "../ast" }
 helix-planner = { path = "../planner" }
 helix-value-semantics = { path = "../value-semantics" }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = "0.1"
 helix-db = { path = "../../sdks/rust" }
 helix-db-testkit = { path = "../db-testkit" }
 helix-planner = { path = "../planner" }
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "41ce04071f51d51a85774af834fc77947cafd34d" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "50c063327b826c2c018c664171fc1ada5dc3096d" }
 tokio-test = "0.4"
 tokio-stream = { version = "0.1", features = ["net"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = "0.1"
 helix-db = { path = "../../sdks/rust" }
 helix-db-testkit = { path = "../db-testkit" }
 helix-planner = { path = "../planner" }
-slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "099067afda1294e80308687d4ae41cdf6e5d01df" }
+slatedb = { git = "https://github.com/HelixDB/slatedb.git", rev = "41ce04071f51d51a85774af834fc77947cafd34d" }
 tokio-test = "0.4"
 tokio-stream = { version = "0.1", features = ["net"] }
 tower = { version = "0.5", features = ["util"] }

--- a/scripts/db-production-coverage-baselines.json
+++ b/scripts/db-production-coverage-baselines.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "uncovered_non_vector_source_lines": {
-    "count": 10421,
-    "sha256": "e69dae059cfdd3825ede2175752b1d10e6eb9f5fdf7b84c4dce8f97b72f633da",
+    "count": 10429,
+    "sha256": "300955ba60656464b30beee515bc3662ec0f3d2adf968118feac3df1d005781d",
     "classification": "test-required",
     "reason": "Every uncovered production source line outside vector search and its stochastic vector key/value codecs remains in the explicit production-linked test backlog. The digest makes additions, removals, and newly covered lines require a reviewed baseline update; vector code remains enforced by the whole-DB and dedicated vector thresholds plus finer named-test, architecture, invariant, and platform classifications."
   },

--- a/tools/hyperscale-migration-parity/Cargo.lock
+++ b/tools/hyperscale-migration-parity/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "siphasher",
- "slatedb 0.15.0",
+ "slatedb 0.16.0",
  "sonic-rs",
  "stable_deref_trait",
  "tantivy 0.26.1",
@@ -1810,7 +1810,7 @@ dependencies = [
  "siphasher",
  "slatedb 0.10.0",
  "slatedb 0.15.0",
- "slatedb-common",
+ "slatedb-common 0.15.0",
  "tempfile",
  "tokio",
  "toml 0.8.23",
@@ -3841,8 +3841,54 @@ dependencies = [
  "serde",
  "serde_json",
  "siphasher",
- "slatedb-common",
- "slatedb-txn-obj",
+ "slatedb-common 0.15.0",
+ "slatedb-txn-obj 0.15.0",
+ "smallvec",
+ "sysinfo",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ulid",
+ "url",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "slatedb"
+version = "0.16.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=50c063327b826c2c018c664171fc1ada5dc3096d#50c063327b826c2c018c664171fc1ada5dc3096d"
+dependencies = [
+ "ahash",
+ "async-channel",
+ "async-trait",
+ "atomic",
+ "backon",
+ "bitflags",
+ "bytes",
+ "chrono",
+ "crc32fast",
+ "crossbeam-skiplist",
+ "dotenvy",
+ "duration-str",
+ "fail-parallel 0.6.0",
+ "figment",
+ "flatbuffers",
+ "foyer 0.22.3",
+ "futures",
+ "log",
+ "lru 0.18.1",
+ "mixtrics",
+ "object_store 0.14.1",
+ "ouroboros",
+ "parking_lot",
+ "rand 0.9.5",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "slatedb-common 0.16.0",
+ "slatedb-txn-obj 0.16.0",
  "smallvec",
  "sysinfo",
  "thiserror 1.0.69",
@@ -3871,6 +3917,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "slatedb-common"
+version = "0.16.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=50c063327b826c2c018c664171fc1ada5dc3096d#50c063327b826c2c018c664171fc1ada5dc3096d"
+dependencies = [
+ "chrono",
+ "log",
+ "object_store 0.14.1",
+ "rand 0.9.5",
+ "rand_xoshiro 0.7.0",
+ "serde",
+ "thread_local",
+ "tokio",
+]
+
+[[package]]
 name = "slatedb-txn-obj"
 version = "0.15.0"
 source = "git+https://github.com/HelixDB/slatedb.git?rev=099067afda1294e80308687d4ae41cdf6e5d01df#099067afda1294e80308687d4ae41cdf6e5d01df"
@@ -3882,7 +3943,23 @@ dependencies = [
  "log",
  "object_store 0.14.1",
  "parking_lot",
- "slatedb-common",
+ "slatedb-common 0.15.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slatedb-txn-obj"
+version = "0.16.0"
+source = "git+https://github.com/HelixDB/slatedb.git?rev=50c063327b826c2c018c664171fc1ada5dc3096d#50c063327b826c2c018c664171fc1ada5dc3096d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "log",
+ "object_store 0.14.1",
+ "parking_lot",
+ "slatedb-common 0.16.0",
  "thiserror 1.0.69",
 ]
 


### PR DESCRIPTION
## Summary

- Pin the DB and server crates to the merged SlateDB v0.16 port at [`50c06332`](https://github.com/HelixDB/slatedb/commit/50c063327b826c2c018c664171fc1ada5dc3096d).
- Refresh the workspace lockfile for SlateDB v0.16.
- Refresh the migration-parity lockfile while retaining its intentional SlateDB v0.15 oracle pin.
- Align the UniFFI simple-cycle assertion with the exact-cap truncation contract from current HelixDB `main`.
- Refresh the reviewed DB production-coverage classification fingerprint for the v0.16 dependency graph.

## Validation

Local validation:

- `cargo check -p db`
- `cargo test -p db`
- `cargo clippy -p db --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/run-migration-parity.sh dev`
- `cargo test --locked -p helixdb-uniffi`
- Targeted bitmap concurrency and conflict tests

GitHub Actions is green, including DB all-target tests, legacy migration parity, Linux ARM contracts, generated bindings, workspace tests, strict formatting/Clippy checks, and production coverage thresholds.
