### PR TITLE
ci: use standard GitHub-hosted runners

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -44,9 +44,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-2vcpu-ubuntu-2404-arm
+          - ubuntu-24.04-arm
           - macos-latest
-          - blacksmith-2vcpu-windows-2025
+          - windows-2025
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -76,7 +76,7 @@ jobs:
   coverage:
     name: Coverage (Ubuntu)
     if: github.event_name != 'schedule'
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -107,7 +107,7 @@ jobs:
   registry-smoke:
     name: Published TypeScript SDK registry smoke
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cloud-launch-pr.yml
+++ b/.github/workflows/cloud-launch-pr.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   quality:
     name: Format, Clippy, and doctests
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
@@ -47,7 +47,7 @@ jobs:
 
   workspace-tests:
     name: Workspace tests
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     env:
       CARGO_BUILD_JOBS: "2"
@@ -67,7 +67,7 @@ jobs:
 
   db-all-targets:
     name: DB all targets
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v6
@@ -77,7 +77,7 @@ jobs:
 
   deterministic-contracts:
     name: Planner, lifecycle, isolation, and transports
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v6
@@ -95,7 +95,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     env:
       HELIX_HYPERSCALE_REPO: ${{ github.workspace }}/helix-hyperscale

--- a/.github/workflows/cloud-launch-prelaunch.yml
+++ b/.github/workflows/cloud-launch-prelaunch.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   release-scale:
     name: Release scale — ${{ matrix.name }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 370
     strategy:
       fail-fast: false
@@ -65,7 +65,7 @@ jobs:
 
   release-contracts:
     name: Stable failpoint and coordinator contracts
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -78,7 +78,7 @@ jobs:
 
   vector-diagnostic:
     name: Vector recall and throughput diagnostic
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -92,7 +92,7 @@ jobs:
 
   sustained:
     name: Ten-run LocalFileSystem and long lifecycle matrix
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6
@@ -111,7 +111,7 @@ jobs:
 
   performance-decision:
     name: Same-host performance, lag, and resource decision
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6
@@ -129,7 +129,7 @@ jobs:
 
   final-quality:
     name: Final quality and coverage
-    runs-on: blacksmith-6vcpu-macos-15
+    runs-on: macos-15
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   quality:
     name: Workspace and tooling quality
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -88,10 +88,10 @@ jobs:
         include:
           - architecture: amd64
             platform: linux/amd64
-            runner: blacksmith-2vcpu-ubuntu-2404
+            runner: ubuntu-24.04
           - architecture: arm64
             platform: linux/arm64
-            runner: blacksmith-2vcpu-ubuntu-2404-arm
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     env:

--- a/.github/workflows/sdk-query-parity.yml
+++ b/.github/workflows/sdk-query-parity.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   contracts:
     name: Contracts (Linux ARM)
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -90,7 +90,7 @@ jobs:
 
   embedded-go-generator:
     name: Go embedded binding generator (Linux ARM)
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     env:
       CARGO_BUILD_JOBS: "1"
       CARGO_PROFILE_DEV_DEBUG: "0"
@@ -138,7 +138,7 @@ jobs:
   embedded:
     name: Generated embedded bindings (Linux ARM)
     needs: embedded-go-generator
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     env:
       CARGO_PROFILE_DEV_DEBUG: "0"
     steps:
@@ -183,7 +183,7 @@ jobs:
 
   coverage:
     name: SDK coverage
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

- Replace Blacksmith runner labels with standard GitHub-hosted runners.
- Preserve each job's operating system and architecture.
- Remove all third-party runner labels from GitHub Actions workflows.

## Validation

- Parsed all 13 workflow YAML files.
- Validated runner labels with actionlint; only the existing create-github-app-token input findings were excluded.
- Confirmed no Blacksmith, BuildJet, or self-hosted label remains.
- Ran git diff --check.

No Rust source or persistent data format changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces third-party Blacksmith labels with matching standard GitHub-hosted runner labels while preserving each workflow job’s operating system and architecture.

- Migrates Linux ARM jobs to `ubuntu-24.04-arm`.
- Migrates Linux x64 and Windows jobs to `ubuntu-24.04` and `windows-2025`.
- Migrates the macOS pre-launch quality job to `macos-15`.
- Keeps Docker matrix platforms aligned with their native runner architectures.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/cli-tests.yml | Replaces Linux ARM and Windows Blacksmith labels with equivalent GitHub-hosted labels without changing the test matrix. |
| .github/workflows/cloud-launch-pr.yml | Moves all cloud-launch PR jobs to the standard Ubuntu 24.04 ARM runner without changing job behavior. |
| .github/workflows/cloud-launch-prelaunch.yml | Moves pre-launch Linux jobs to Ubuntu 24.04 ARM and the final quality job to macOS 15; no concrete workflow failure was established. |
| .github/workflows/docker-image.yml | Replaces runner labels while preserving native amd64 and arm64 runner-to-platform mappings. |
| .github/workflows/sdk-query-parity.yml | Moves SDK parity jobs to Ubuntu 24.04 ARM while retaining the existing resource controls and swap setup. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: use standard GitHub-hosted runners"](https://github.com/helixdb/helix-db/commit/fb5e7589850ab981fc87e83daa72bc1772f9f86d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59453933)</sub>

<!-- /greptile_comment -->