### PR TITLE
Support a separate WAL object store

### DIFF
--- a/crates/db/src/config/db.rs
+++ b/crates/db/src/config/db.rs
@@ -1,5 +1,9 @@
+use std::fmt;
 use std::num::{NonZeroU64, NonZeroUsize};
+use std::sync::Arc;
 use std::time::Duration;
+
+use slatedb::object_store::ObjectStore;
 
 use super::cache::{
     CacheConfig, CacheMode, FtsMemoryCacheConfig, FtsWarmConfig, SimHasherCacheSettings,
@@ -156,6 +160,15 @@ pub struct HelixConfig {
     db: DbConfig,
 }
 
+#[derive(Clone)]
+struct WalObjectStore(Arc<dyn ObjectStore>);
+
+impl fmt::Debug for WalObjectStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("<redacted>")
+    }
+}
+
 impl HelixConfig {
     /// Build a full runtime config from DB settings.
     pub const fn new(db: DbConfig) -> Self {
@@ -179,6 +192,9 @@ pub struct DbConfig {
 
     /// Whether to enable write-ahead logging
     pub(crate) enable_wal: bool,
+
+    /// Optional object store dedicated to write-ahead log objects.
+    wal_object_store: Option<WalObjectStore>,
 
     /// Maximum concurrent reads during traversal
     max_concurrent_reads: NonZeroUsize,
@@ -224,6 +240,7 @@ impl DbConfig {
         Self {
             default_encoding_type: EdgeEncoding::None,
             enable_wal: true,
+            wal_object_store: None,
             max_concurrent_reads: NonZeroUsize::new(64)
                 .expect("default read concurrency is nonzero"),
             edge_update_policy: EdgeUpdatePolicy::Eager,
@@ -346,6 +363,11 @@ impl DbConfig {
         self.migrations
     }
 
+    /// Borrow the object store dedicated to write-ahead log objects, when configured.
+    pub fn wal_object_store(&self) -> Option<&Arc<dyn ObjectStore>> {
+        self.wal_object_store.as_ref().map(|store| &store.0)
+    }
+
     /// Set the default encoding type for edges
     pub fn with_encoding_type(mut self, encoding_type: EdgeEncoding) -> Self {
         self.default_encoding_type = encoding_type;
@@ -361,6 +383,15 @@ impl DbConfig {
     /// Enable or disable write-ahead logging
     pub fn with_wal(mut self, enable: bool) -> Self {
         self.enable_wal = enable;
+        self
+    }
+
+    /// Route write-ahead log objects through a dedicated object store.
+    ///
+    /// The database path is unchanged. When this is not set, SlateDB stores
+    /// write-ahead log objects in the main object store.
+    pub fn with_wal_object_store(mut self, object_store: Arc<dyn ObjectStore>) -> Self {
+        self.wal_object_store = Some(WalObjectStore(object_store));
         self
     }
 

--- a/crates/db/src/config/tests.rs
+++ b/crates/db/src/config/tests.rs
@@ -1,5 +1,7 @@
 //! Contract tests for database, cache, and index configuration validation.
 
+use std::sync::Arc;
+
 use super::{
     scoped_secondary_index_property, CacheConfig, CacheMode, CacheWarmMode, DbConfig,
     DiskCacheConfig, EdgeEncoding, EdgeUpdatePolicy, FtsHybridCacheConfig, FtsMemoryCacheConfig,
@@ -18,6 +20,7 @@ use crate::index_lifecycle::{
 };
 use crate::search::vector::{VectorDistanceMetric, SIMHASH_BITS};
 use helix_planner::{catalog, ir};
+use slatedb::object_store::{memory::InMemory, ObjectStore};
 
 fn v2_secondary(definition: SecondaryIndexDefinition) -> ValidatedDynamicIndexDefinition {
     ValidatedDynamicIndexDefinition::try_from(definition).unwrap()
@@ -195,6 +198,31 @@ fn db_config_accepts_nonzero_id_lease_size_type_directly() {
     let config = DbConfig::new().with_id_lease_size(lease_size);
 
     assert_eq!(config.id_lease_size(), 17);
+}
+
+#[test]
+fn db_config_wal_object_store_is_optional_cloned_and_redacted() {
+    let default = DbConfig::new();
+    assert!(default.wal_object_store().is_none());
+
+    let wal_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let config = default.with_wal_object_store(Arc::clone(&wal_object_store));
+    let configured_store = config
+        .wal_object_store()
+        .expect("WAL object store should be configured");
+    assert!(Arc::ptr_eq(configured_store, &wal_object_store));
+
+    let cloned = config.clone();
+    assert!(Arc::ptr_eq(
+        cloned
+            .wal_object_store()
+            .expect("cloned WAL object store should be configured"),
+        &wal_object_store,
+    ));
+
+    let debug = format!("{config:?}");
+    assert!(debug.contains("wal_object_store: Some(<redacted>)"));
+    assert!(!debug.contains("InMemory"));
 }
 
 #[test]

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -924,9 +924,9 @@ impl HelixDB {
 
     /// Opens a database for a transport server that owns its metrics recorder.
     #[doc(hidden)]
-    pub async fn open_for_server(source: HelixDbSource) -> Result<Self> {
+    pub async fn open_for_server(source: HelixDbSource, config: DbConfig) -> Result<Self> {
         let (path, object_store) = source.into_parts()?;
-        Self::open_writer_inner(path, object_store, DbConfig::new()).await
+        Self::open_writer_inner(path, object_store, config).await
     }
 
     #[cfg(test)]
@@ -1049,6 +1049,12 @@ impl HelixDB {
                     .slate()
                     .to_writer_settings(config.cache().object_store_cache()),
             );
+        match config.wal_object_store() {
+            Some(wal_object_store) => {
+                builder = builder.with_wal_object_store(Arc::clone(wal_object_store));
+            }
+            None => {}
+        }
         if let WriterOpenMode::Managed { writer_epoch, .. } = &open_mode {
             builder = builder.with_writer_epoch(*writer_epoch);
         }
@@ -1269,6 +1275,12 @@ impl HelixDB {
                     .slate()
                     .to_reader_options(config.cache().object_store_cache()),
             );
+        match config.wal_object_store() {
+            Some(wal_object_store) => {
+                builder = builder.with_wal_object_store(Arc::clone(wal_object_store));
+            }
+            None => {}
+        }
         match config.cache().mode() {
             CacheMode::VectorMemoryOnly => builder = builder.with_db_cache_disabled(),
             CacheMode::Memory { .. } | CacheMode::Hybrid { .. } => {
@@ -3086,6 +3098,19 @@ mod tests {
     use helix_ast::traversal::g;
     use helix_ast::value::PropertyInput;
 
+    async fn object_paths(object_store: &Arc<dyn ObjectStore>) -> Vec<String> {
+        object_store
+            .list(None)
+            .map(|result| {
+                result
+                    .expect("object listing should succeed")
+                    .location
+                    .to_string()
+            })
+            .collect()
+            .await
+    }
+
     fn tenant_scope(value: &str) -> DataScope {
         DataScope::Tenant(TenantId::from_ulid_str(value).expect("valid tenant"))
     }
@@ -3378,6 +3403,150 @@ mod tests {
             .unwrap();
         assert!(Arc::ptr_eq(reader.object_store(), &expected_store,));
         reader.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn default_writer_keeps_wal_objects_in_the_main_store() {
+        let main_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let database = "facade-default-wal-object-store";
+        let writer = HelixDB::open_with_object_store_and_config(
+            database,
+            Arc::clone(&main_object_store),
+            DbConfig::new(),
+        )
+        .await
+        .expect("writer opens with the default WAL store");
+        writer
+            .inner_db()
+            .put(b"default-wal-key", b"default-wal-value")
+            .await
+            .expect("WAL-backed write succeeds");
+
+        let paths = object_paths(&main_object_store).await;
+        assert!(
+            paths
+                .iter()
+                .any(|path| path.starts_with(&format!("{database}/wal/"))),
+            "default WAL objects should use the main store: {paths:?}"
+        );
+        assert!(
+            paths
+                .iter()
+                .any(|path| path.starts_with(&format!("{database}/manifest/"))),
+            "manifests should use the main store: {paths:?}"
+        );
+        writer.close().await.expect("writer closes");
+    }
+
+    #[tokio::test]
+    async fn configured_writer_routes_only_wal_objects_to_the_wal_store() {
+        let main_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let wal_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let database = "facade-separate-wal-object-store";
+        let writer = HelixDB::open_with_object_store_and_config(
+            database,
+            Arc::clone(&main_object_store),
+            DbConfig::new().with_wal_object_store(Arc::clone(&wal_object_store)),
+        )
+        .await
+        .expect("writer opens with a separate WAL store");
+        writer
+            .inner_db()
+            .put(b"separate-wal-key", b"separate-wal-value")
+            .await
+            .expect("separate WAL write succeeds");
+        writer
+            .inner_db()
+            .flush_with_options(slatedb::config::FlushOptions {
+                flush_type: slatedb::config::FlushType::MemTable,
+            })
+            .await
+            .expect("memtable flush succeeds");
+
+        let main_paths = object_paths(&main_object_store).await;
+        let wal_paths = object_paths(&wal_object_store).await;
+        assert!(
+            main_paths
+                .iter()
+                .any(|path| path.starts_with(&format!("{database}/manifest/"))),
+            "manifests should use the main store: {main_paths:?}"
+        );
+        assert!(
+            main_paths
+                .iter()
+                .any(|path| path.starts_with(&format!("{database}/compacted/"))),
+            "compacted SSTs should use the main store: {main_paths:?}"
+        );
+        assert!(
+            main_paths
+                .iter()
+                .all(|path| !path.starts_with(&format!("{database}/wal/"))),
+            "WAL objects must not use the main store: {main_paths:?}"
+        );
+        assert!(
+            wal_paths
+                .iter()
+                .any(|path| path.starts_with(&format!("{database}/wal/"))),
+            "WAL objects should use the separate store: {wal_paths:?}"
+        );
+        assert!(
+            wal_paths.iter().all(|path| {
+                !path.starts_with(&format!("{database}/manifest/"))
+                    && !path.starts_with(&format!("{database}/compacted/"))
+            }),
+            "non-WAL objects must not use the separate store: {wal_paths:?}"
+        );
+        writer.close().await.expect("writer closes");
+    }
+
+    #[tokio::test]
+    async fn reader_replays_unflushed_rows_from_the_configured_wal_store() {
+        let main_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let wal_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let database = "facade-reader-separate-wal-object-store";
+        let config = DbConfig::new().with_wal_object_store(Arc::clone(&wal_object_store));
+        let writer = HelixDB::open_with_object_store_and_config(
+            database,
+            Arc::clone(&main_object_store),
+            config.clone(),
+        )
+        .await
+        .expect("writer opens with a separate WAL store");
+        writer
+            .inner_db()
+            .put(b"wal-only-key", b"reader-visible-value")
+            .await
+            .expect("unflushed WAL write succeeds");
+
+        let main_paths = object_paths(&main_object_store).await;
+        assert!(
+            main_paths
+                .iter()
+                .all(|path| !path.starts_with(&format!("{database}/wal/"))),
+            "the row WAL must exist only in the separate store: {main_paths:?}"
+        );
+
+        let reader = HelixDB::open_reader_with_object_store_and_config(
+            database,
+            Arc::clone(&main_object_store),
+            config,
+        )
+        .await
+        .expect("reader opens with the same separate WAL store");
+        let HelixStorage::Reader(raw_reader) = reader.storage() else {
+            panic!("reader handle should expose reader storage");
+        };
+        assert_eq!(
+            raw_reader
+                .get(b"wal-only-key")
+                .await
+                .expect("reader lookup succeeds")
+                .as_deref(),
+            Some(b"reader-visible-value".as_slice())
+        );
+
+        reader.close().await.expect("reader closes");
+        writer.close().await.expect("writer closes");
     }
 
     #[test]

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1049,12 +1049,12 @@ impl HelixDB {
                     .slate()
                     .to_writer_settings(config.cache().object_store_cache()),
             );
-        match config.wal_object_store() {
-            Some(wal_object_store) => {
-                builder = builder.with_wal_object_store(Arc::clone(wal_object_store));
-            }
-            None => {}
-        }
+        builder = config
+            .wal_object_store()
+            .into_iter()
+            .fold(builder, |builder, wal_object_store| {
+                builder.with_wal_object_store(Arc::clone(wal_object_store))
+            });
         if let WriterOpenMode::Managed { writer_epoch, .. } = &open_mode {
             builder = builder.with_writer_epoch(*writer_epoch);
         }
@@ -1275,12 +1275,12 @@ impl HelixDB {
                     .slate()
                     .to_reader_options(config.cache().object_store_cache()),
             );
-        match config.wal_object_store() {
-            Some(wal_object_store) => {
-                builder = builder.with_wal_object_store(Arc::clone(wal_object_store));
-            }
-            None => {}
-        }
+        builder = config
+            .wal_object_store()
+            .into_iter()
+            .fold(builder, |builder, wal_object_store| {
+                builder.with_wal_object_store(Arc::clone(wal_object_store))
+            });
         match config.cache().mode() {
             CacheMode::VectorMemoryOnly => builder = builder.with_db_cache_disabled(),
             CacheMode::Memory { .. } | CacheMode::Hybrid { .. } => {

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1,8 +1,10 @@
 use std::env;
 use std::net::{AddrParseError, SocketAddr};
 use std::path::PathBuf;
+use std::sync::Arc;
 
-use db::HelixDbSource;
+use db::{DbConfig, HelixDbSource};
+use object_store::aws::AmazonS3Builder;
 
 /// Runtime configuration for the standalone server.
 #[derive(Debug, Clone)]
@@ -15,6 +17,8 @@ pub struct ServerConfig {
     pub db_path: String,
     /// Storage backend.
     pub storage: StorageConfig,
+    /// Optional S3-compatible object store dedicated to WAL objects.
+    pub wal_storage: Option<WalStorageConfig>,
 }
 
 impl ServerConfig {
@@ -38,12 +42,14 @@ impl ServerConfig {
         )?;
         let db_path = lookup("DB_PATH").unwrap_or_else(|| "db/".to_string());
         let storage = StorageConfig::from_lookup(&mut lookup)?;
+        let wal_storage = WalStorageConfig::from_lookup(&storage, &mut lookup)?;
 
         Ok(Self {
             http_addr,
             grpc_addr,
             db_path,
             storage,
+            wal_storage,
         })
     }
 
@@ -70,6 +76,100 @@ impl ServerConfig {
                 allow_http: *allow_http,
             },
         }
+    }
+
+    /// Build DB runtime configuration, including the optional WAL object store.
+    pub fn db_config(&self) -> Result<DbConfig, ServerConfigError> {
+        let Some(wal_storage) = &self.wal_storage else {
+            return Ok(DbConfig::new());
+        };
+        let mut builder = AmazonS3Builder::from_env()
+            .with_bucket_name(&wal_storage.bucket)
+            .with_region(&wal_storage.region)
+            .with_allow_http(wal_storage.allow_http);
+        builder = wal_storage
+            .endpoint
+            .iter()
+            .fold(builder, |builder, endpoint| builder.with_endpoint(endpoint));
+        let wal_object_store: Arc<dyn object_store::ObjectStore> = Arc::new(
+            builder
+                .build()
+                .map_err(|source| ServerConfigError::WalObjectStore { source })?,
+        );
+        Ok(DbConfig::new().with_wal_object_store(wal_object_store))
+    }
+}
+
+/// Resolved S3-compatible storage settings for WAL objects.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalStorageConfig {
+    /// Bucket name.
+    pub bucket: String,
+    /// Region.
+    pub region: String,
+    /// Optional endpoint for S3-compatible storage or a WAL cache/proxy.
+    pub endpoint: Option<String>,
+    /// Whether HTTP endpoints are allowed.
+    pub allow_http: bool,
+}
+
+impl WalStorageConfig {
+    fn from_lookup(
+        storage: &StorageConfig,
+        lookup: &mut impl FnMut(&str) -> Option<String>,
+    ) -> Result<Option<Self>, ServerConfigError> {
+        let bucket = lookup("WAL_S3_BUCKET");
+        let endpoint = lookup("WAL_AWS_ENDPOINT").or_else(|| lookup("WAL_AWS_ENDPOINT_URL_S3"));
+        let region_override = lookup("WAL_S3_REGION");
+        let allow_http_override = lookup("WAL_AWS_ALLOW_HTTP");
+
+        if bucket.is_none() && endpoint.is_none() {
+            if region_override.is_some() || allow_http_override.is_some() {
+                return Err(ServerConfigError::WalOverridesWithoutStorage);
+            }
+            return Ok(None);
+        }
+
+        let bucket = match bucket {
+            Some(bucket) => bucket,
+            None => match storage {
+                StorageConfig::S3 { bucket, .. } => bucket.clone(),
+                StorageConfig::Memory | StorageConfig::Disk { .. } => {
+                    return Err(ServerConfigError::WalEndpointWithoutBucket);
+                }
+            },
+        };
+        let region = match region_override {
+            Some(region) => region,
+            None => match storage {
+                StorageConfig::S3 { region, .. } => region.clone(),
+                StorageConfig::Memory | StorageConfig::Disk { .. } => resolved_s3_region(lookup),
+            },
+        };
+        let endpoint = match endpoint {
+            Some(endpoint) => Some(endpoint),
+            None => match storage {
+                StorageConfig::S3 { endpoint, .. } => endpoint.clone(),
+                StorageConfig::Memory | StorageConfig::Disk { .. } => resolved_s3_endpoint(lookup),
+            },
+        };
+        let allow_http = match allow_http_override {
+            Some(value) => environment_flag(&value),
+            None => match storage {
+                StorageConfig::S3 { allow_http, .. } => *allow_http,
+                StorageConfig::Memory | StorageConfig::Disk { .. } => lookup("AWS_ALLOW_HTTP")
+                    .as_deref()
+                    .map(environment_flag)
+                    .unwrap_or(false),
+            },
+        };
+
+        Ok(Some(Self {
+            bucket,
+            region,
+            endpoint,
+            allow_http,
+        }))
     }
 }
 
@@ -113,13 +213,11 @@ impl StorageConfig {
         let Some(bucket) = bucket else {
             return Ok(Self::Memory);
         };
-        let region = lookup("S3_REGION")
-            .or_else(|| lookup("AWS_REGION"))
-            .or_else(|| lookup("AWS_DEFAULT_REGION"))
-            .unwrap_or_else(|| "us-east-1".to_string());
-        let endpoint = lookup("AWS_ENDPOINT").or_else(|| lookup("AWS_ENDPOINT_URL_S3"));
+        let region = resolved_s3_region(lookup);
+        let endpoint = resolved_s3_endpoint(lookup);
         let allow_http = lookup("AWS_ALLOW_HTTP")
-            .map(|value| value.eq_ignore_ascii_case("true") || value == "1")
+            .as_deref()
+            .map(environment_flag)
             .unwrap_or(false);
 
         Ok(Self::S3 {
@@ -129,6 +227,21 @@ impl StorageConfig {
             allow_http,
         })
     }
+}
+
+fn resolved_s3_region(lookup: &mut impl FnMut(&str) -> Option<String>) -> String {
+    lookup("S3_REGION")
+        .or_else(|| lookup("AWS_REGION"))
+        .or_else(|| lookup("AWS_DEFAULT_REGION"))
+        .unwrap_or_else(|| "us-east-1".to_string())
+}
+
+fn resolved_s3_endpoint(lookup: &mut impl FnMut(&str) -> Option<String>) -> Option<String> {
+    lookup("AWS_ENDPOINT").or_else(|| lookup("AWS_ENDPOINT_URL_S3"))
+}
+
+fn environment_flag(value: &str) -> bool {
+    value.eq_ignore_ascii_case("true") || value == "1"
 }
 
 fn parse_addr(value: String) -> Result<SocketAddr, ServerConfigError> {
@@ -151,6 +264,21 @@ pub enum ServerConfigError {
     /// Two mutually exclusive storage backends were configured.
     #[error("HELIX_DATA_DIR and S3_BUCKET cannot be set together")]
     ConflictingStorageConfiguration,
+    /// WAL-only overrides were supplied without enabling separate WAL storage.
+    #[error(
+        "WAL_S3_REGION and WAL_AWS_ALLOW_HTTP require WAL_S3_BUCKET, WAL_AWS_ENDPOINT, or WAL_AWS_ENDPOINT_URL_S3"
+    )]
+    WalOverridesWithoutStorage,
+    /// A WAL endpoint needs a bucket, either explicit or inherited from main S3 storage.
+    #[error("a WAL endpoint requires WAL_S3_BUCKET or S3_BUCKET")]
+    WalEndpointWithoutBucket,
+    /// The configured WAL object store could not be built.
+    #[error("invalid WAL object store configuration: {source}")]
+    WalObjectStore {
+        /// Object-store configuration error.
+        #[source]
+        source: object_store::Error,
+    },
 }
 
 #[cfg(test)]
@@ -172,6 +300,8 @@ mod tests {
         );
         assert_eq!(config.db_path, "db/");
         assert_eq!(config.storage, StorageConfig::Memory);
+        assert_eq!(config.wal_storage, None);
+        assert!(config.db_config().unwrap().wal_object_store().is_none());
     }
 
     #[test]
@@ -239,6 +369,132 @@ mod tests {
                 ..
             } if region == "us-east-1"
         ));
+        assert_eq!(config.wal_storage, None);
+    }
+
+    #[test]
+    fn wal_environment_uses_explicit_precedence() {
+        let values = BTreeMap::from([
+            ("S3_BUCKET", "main-bucket"),
+            ("S3_REGION", "main-region"),
+            ("AWS_ENDPOINT", "http://main-primary:9000"),
+            ("AWS_ALLOW_HTTP", "true"),
+            ("WAL_S3_BUCKET", "wal-bucket"),
+            ("WAL_S3_REGION", "wal-region"),
+            ("WAL_AWS_ENDPOINT", "http://wal-primary:9000"),
+            ("WAL_AWS_ENDPOINT_URL_S3", "http://wal-fallback:9000"),
+            ("WAL_AWS_ALLOW_HTTP", "false"),
+        ]);
+        let config =
+            ServerConfig::from_lookup(|name| values.get(name).map(|value| (*value).to_string()))
+                .unwrap();
+
+        assert_eq!(
+            config.wal_storage,
+            Some(WalStorageConfig {
+                bucket: "wal-bucket".to_string(),
+                region: "wal-region".to_string(),
+                endpoint: Some("http://wal-primary:9000".to_string()),
+                allow_http: false,
+            })
+        );
+        assert!(config.db_config().unwrap().wal_object_store().is_some());
+    }
+
+    #[test]
+    fn wal_endpoint_only_inherits_main_s3_bucket_and_region() {
+        let values = BTreeMap::from([
+            ("S3_BUCKET", "main-bucket"),
+            ("AWS_REGION", "eu-west-1"),
+            ("WAL_AWS_ENDPOINT_URL_S3", "http://wal-cache:9000"),
+        ]);
+        let config =
+            ServerConfig::from_lookup(|name| values.get(name).map(|value| (*value).to_string()))
+                .unwrap();
+
+        assert_eq!(
+            config.wal_storage,
+            Some(WalStorageConfig {
+                bucket: "main-bucket".to_string(),
+                region: "eu-west-1".to_string(),
+                endpoint: Some("http://wal-cache:9000".to_string()),
+                allow_http: false,
+            })
+        );
+    }
+
+    #[test]
+    fn wal_bucket_inherits_main_endpoint_and_http_policy() {
+        let values = BTreeMap::from([
+            ("S3_BUCKET", "main-bucket"),
+            ("AWS_DEFAULT_REGION", "ap-southeast-2"),
+            ("AWS_ENDPOINT_URL_S3", "http://main-store:9000"),
+            ("AWS_ALLOW_HTTP", "1"),
+            ("WAL_S3_BUCKET", "wal-bucket"),
+        ]);
+        let config =
+            ServerConfig::from_lookup(|name| values.get(name).map(|value| (*value).to_string()))
+                .unwrap();
+
+        assert_eq!(
+            config.wal_storage,
+            Some(WalStorageConfig {
+                bucket: "wal-bucket".to_string(),
+                region: "ap-southeast-2".to_string(),
+                endpoint: Some("http://main-store:9000".to_string()),
+                allow_http: true,
+            })
+        );
+    }
+
+    #[test]
+    fn explicit_wal_bucket_can_back_memory_or_disk_storage() {
+        for data_dir in [None, Some("/var/lib/helix")] {
+            let config = ServerConfig::from_lookup(|name| match name {
+                "HELIX_DATA_DIR" => data_dir.map(str::to_string),
+                "WAL_S3_BUCKET" => Some("wal-bucket".to_string()),
+                "AWS_DEFAULT_REGION" => Some("us-west-2".to_string()),
+                "AWS_ENDPOINT_URL_S3" => Some("http://wal-store:9000".to_string()),
+                "AWS_ALLOW_HTTP" => Some("TRUE".to_string()),
+                _ => None,
+            })
+            .unwrap();
+
+            assert_eq!(
+                config.wal_storage,
+                Some(WalStorageConfig {
+                    bucket: "wal-bucket".to_string(),
+                    region: "us-west-2".to_string(),
+                    endpoint: Some("http://wal-store:9000".to_string()),
+                    allow_http: true,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn wal_region_or_http_without_storage_is_rejected() {
+        for variable in ["WAL_S3_REGION", "WAL_AWS_ALLOW_HTTP"] {
+            let error = ServerConfig::from_lookup(|name| match name {
+                "S3_BUCKET" => Some("main-bucket".to_string()),
+                name if name == variable => Some("override".to_string()),
+                _ => None,
+            })
+            .unwrap_err();
+            assert!(matches!(
+                error,
+                ServerConfigError::WalOverridesWithoutStorage
+            ));
+        }
+    }
+
+    #[test]
+    fn wal_endpoint_without_an_explicit_or_main_bucket_is_rejected() {
+        let error = ServerConfig::from_lookup(|name| {
+            (name == "WAL_AWS_ENDPOINT").then(|| "http://wal-cache:9000".to_string())
+        })
+        .unwrap_err();
+        assert!(matches!(error, ServerConfigError::WalEndpointWithoutBucket));
     }
 
     #[test]

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::fmt;
 use std::net::{AddrParseError, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -91,6 +92,14 @@ impl ServerConfig {
             .endpoint
             .iter()
             .fold(builder, |builder, endpoint| builder.with_endpoint(endpoint));
+        builder = wal_storage
+            .credentials
+            .iter()
+            .fold(builder, |builder, credentials| {
+                builder
+                    .with_access_key_id(credentials.access_key_id.clone())
+                    .with_secret_access_key(credentials.secret_access_key.clone())
+            });
         let wal_object_store: Arc<dyn object_store::ObjectStore> = Arc::new(
             builder
                 .build()
@@ -111,6 +120,20 @@ pub struct WalStorageConfig {
     pub endpoint: Option<String>,
     /// Whether HTTP endpoints are allowed.
     pub allow_http: bool,
+    /// Optional WAL-specific credentials.
+    credentials: Option<WalStorageCredentials>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct WalStorageCredentials {
+    access_key_id: String,
+    secret_access_key: String,
+}
+
+impl fmt::Debug for WalStorageCredentials {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("<redacted>")
+    }
 }
 
 impl WalStorageConfig {
@@ -122,9 +145,22 @@ impl WalStorageConfig {
         let endpoint = lookup("WAL_AWS_ENDPOINT").or_else(|| lookup("WAL_AWS_ENDPOINT_URL_S3"));
         let region_override = lookup("WAL_S3_REGION");
         let allow_http_override = lookup("WAL_AWS_ALLOW_HTTP");
+        let credentials = match (
+            lookup("WAL_AWS_ACCESS_KEY_ID"),
+            lookup("WAL_AWS_SECRET_ACCESS_KEY"),
+        ) {
+            (Some(access_key_id), Some(secret_access_key)) => Some(WalStorageCredentials {
+                access_key_id,
+                secret_access_key,
+            }),
+            (None, None) => None,
+            (Some(_), None) | (None, Some(_)) => {
+                return Err(ServerConfigError::IncompleteWalCredentials);
+            }
+        };
 
         if bucket.is_none() && endpoint.is_none() {
-            if region_override.is_some() || allow_http_override.is_some() {
+            if region_override.is_some() || allow_http_override.is_some() || credentials.is_some() {
                 return Err(ServerConfigError::WalOverridesWithoutStorage);
             }
             return Ok(None);
@@ -169,6 +205,7 @@ impl WalStorageConfig {
             region,
             endpoint,
             allow_http,
+            credentials,
         }))
     }
 }
@@ -266,9 +303,12 @@ pub enum ServerConfigError {
     ConflictingStorageConfiguration,
     /// WAL-only overrides were supplied without enabling separate WAL storage.
     #[error(
-        "WAL_S3_REGION and WAL_AWS_ALLOW_HTTP require WAL_S3_BUCKET, WAL_AWS_ENDPOINT, or WAL_AWS_ENDPOINT_URL_S3"
+        "WAL region, HTTP, and credential overrides require WAL_S3_BUCKET, WAL_AWS_ENDPOINT, or WAL_AWS_ENDPOINT_URL_S3"
     )]
     WalOverridesWithoutStorage,
+    /// WAL-specific credentials must be configured as a complete pair.
+    #[error("WAL_AWS_ACCESS_KEY_ID and WAL_AWS_SECRET_ACCESS_KEY must be set together")]
+    IncompleteWalCredentials,
     /// A WAL endpoint needs a bucket, either explicit or inherited from main S3 storage.
     #[error("a WAL endpoint requires WAL_S3_BUCKET or S3_BUCKET")]
     WalEndpointWithoutBucket,
@@ -384,6 +424,8 @@ mod tests {
             ("WAL_AWS_ENDPOINT", "http://wal-primary:9000"),
             ("WAL_AWS_ENDPOINT_URL_S3", "http://wal-fallback:9000"),
             ("WAL_AWS_ALLOW_HTTP", "false"),
+            ("WAL_AWS_ACCESS_KEY_ID", "wal-access-key-id"),
+            ("WAL_AWS_SECRET_ACCESS_KEY", "wal-secret-access-key"),
         ]);
         let config =
             ServerConfig::from_lookup(|name| values.get(name).map(|value| (*value).to_string()))
@@ -396,8 +438,16 @@ mod tests {
                 region: "wal-region".to_string(),
                 endpoint: Some("http://wal-primary:9000".to_string()),
                 allow_http: false,
+                credentials: Some(WalStorageCredentials {
+                    access_key_id: "wal-access-key-id".to_string(),
+                    secret_access_key: "wal-secret-access-key".to_string(),
+                }),
             })
         );
+        let debug = format!("{config:?}");
+        assert!(debug.contains("credentials: Some(<redacted>)"));
+        assert!(!debug.contains("wal-access-key-id"));
+        assert!(!debug.contains("wal-secret-access-key"));
         assert!(config.db_config().unwrap().wal_object_store().is_some());
     }
 
@@ -419,6 +469,7 @@ mod tests {
                 region: "eu-west-1".to_string(),
                 endpoint: Some("http://wal-cache:9000".to_string()),
                 allow_http: false,
+                credentials: None,
             })
         );
     }
@@ -443,6 +494,7 @@ mod tests {
                 region: "ap-southeast-2".to_string(),
                 endpoint: Some("http://main-store:9000".to_string()),
                 allow_http: true,
+                credentials: None,
             })
         );
     }
@@ -467,6 +519,7 @@ mod tests {
                     region: "us-west-2".to_string(),
                     endpoint: Some("http://wal-store:9000".to_string()),
                     allow_http: true,
+                    credentials: None,
                 })
             );
         }
@@ -495,6 +548,36 @@ mod tests {
         })
         .unwrap_err();
         assert!(matches!(error, ServerConfigError::WalEndpointWithoutBucket));
+    }
+
+    #[test]
+    fn wal_credentials_must_be_a_complete_pair() {
+        for variable in ["WAL_AWS_ACCESS_KEY_ID", "WAL_AWS_SECRET_ACCESS_KEY"] {
+            let error = ServerConfig::from_lookup(|name| match name {
+                "WAL_S3_BUCKET" => Some("wal-bucket".to_string()),
+                name if name == variable => Some("wal-credential".to_string()),
+                _ => None,
+            })
+            .unwrap_err();
+            assert!(matches!(error, ServerConfigError::IncompleteWalCredentials));
+        }
+    }
+
+    #[test]
+    fn wal_credentials_without_storage_are_rejected() {
+        let error = ServerConfig::from_lookup(|name| match name {
+            "WAL_AWS_ACCESS_KEY_ID" => Some("wal-access-key-id".to_string()),
+            "WAL_AWS_SECRET_ACCESS_KEY" => Some("wal-secret-access-key".to_string()),
+            _ => None,
+        })
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            ServerConfigError::WalOverridesWithoutStorage
+        ));
+        let debug = format!("{error:?}");
+        assert!(!debug.contains("wal-access-key-id"));
+        assert!(!debug.contains("wal-secret-access-key"));
     }
 
     #[test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -19,7 +19,7 @@ use state::ServerState;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
-pub use config::{ServerConfig, ServerConfigError, StorageConfig};
+pub use config::{ServerConfig, ServerConfigError, StorageConfig, WalStorageConfig};
 
 /// Boxed error returned by the server runtime.
 pub type ServerResult<T> = Result<T, Box<dyn Error + Send + Sync + 'static>>;
@@ -83,7 +83,8 @@ where
 /// Open the configured database and run all transports until Ctrl-C.
 pub async fn run_until_ctrl_c(config: ServerConfig) -> ServerResult<()> {
     let db_source = config.db_source();
-    let db = Arc::new(HelixDB::open_for_server(db_source, db::DbConfig::new()).await?);
+    let db_config = config.db_config()?;
+    let db = Arc::new(HelixDB::open_for_server(db_source, db_config).await?);
     run_open_database_until_shutdown(config, db, async {
         tokio::signal::ctrl_c().await?;
         Ok(())
@@ -107,6 +108,7 @@ pub async fn run_until_ctrl_c(config: ServerConfig) -> ServerResult<()> {
 ///     grpc_addr: "127.0.0.1:0".parse().unwrap(),
 ///     db_path: "server-shutdown-example".to_string(),
 ///     storage: StorageConfig::Memory,
+///     wal_storage: None,
 /// };
 /// server::run_with_shutdown(config, async {}).await.unwrap();
 /// # });
@@ -116,7 +118,8 @@ pub async fn run_with_shutdown(
     shutdown: impl Future<Output = ()> + Send + 'static,
 ) -> ServerResult<()> {
     let db_source = config.db_source();
-    let db = Arc::new(HelixDB::open_for_server(db_source, db::DbConfig::new()).await?);
+    let db_config = config.db_config()?;
+    let db = Arc::new(HelixDB::open_for_server(db_source, db_config).await?);
     run_open_database_until_shutdown(config, db, async move {
         shutdown.await;
         Ok(())

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -83,7 +83,7 @@ where
 /// Open the configured database and run all transports until Ctrl-C.
 pub async fn run_until_ctrl_c(config: ServerConfig) -> ServerResult<()> {
     let db_source = config.db_source();
-    let db = Arc::new(HelixDB::open_for_server(db_source).await?);
+    let db = Arc::new(HelixDB::open_for_server(db_source, db::DbConfig::new()).await?);
     run_open_database_until_shutdown(config, db, async {
         tokio::signal::ctrl_c().await?;
         Ok(())
@@ -116,7 +116,7 @@ pub async fn run_with_shutdown(
     shutdown: impl Future<Output = ()> + Send + 'static,
 ) -> ServerResult<()> {
     let db_source = config.db_source();
-    let db = Arc::new(HelixDB::open_for_server(db_source).await?);
+    let db = Arc::new(HelixDB::open_for_server(db_source, db::DbConfig::new()).await?);
     run_open_database_until_shutdown(config, db, async move {
         shutdown.await;
         Ok(())

--- a/crates/server/src/tests.rs
+++ b/crates/server/src/tests.rs
@@ -9,6 +9,7 @@ fn memory_config(name: &str) -> ServerConfig {
         grpc_addr: "127.0.0.1:0".parse().unwrap(),
         db_path: name.to_string(),
         storage: StorageConfig::Memory,
+        wal_storage: None,
     }
 }
 

--- a/docker-image/README.md
+++ b/docker-image/README.md
@@ -68,6 +68,9 @@ For S3 or an S3-compatible service, set `S3_BUCKET`, credentials through the sta
 
 `HELIX_DATA_DIR` and `S3_BUCKET` are mutually exclusive. Credentials are runtime-only and are never baked into the image.
 
+By default, WAL objects use the main object store. Leave all `WAL_*` variables unset
+to keep this behavior.
+
 To route only WAL objects through another S3-compatible client, set at least one
 of `WAL_S3_BUCKET`, `WAL_AWS_ENDPOINT`, or `WAL_AWS_ENDPOINT_URL_S3`:
 

--- a/docker-image/README.md
+++ b/docker-image/README.md
@@ -68,6 +68,23 @@ For S3 or an S3-compatible service, set `S3_BUCKET`, credentials through the sta
 
 `HELIX_DATA_DIR` and `S3_BUCKET` are mutually exclusive. Credentials are runtime-only and are never baked into the image.
 
+To route only WAL objects through another S3-compatible client, set at least one
+of `WAL_S3_BUCKET`, `WAL_AWS_ENDPOINT`, or `WAL_AWS_ENDPOINT_URL_S3`:
+
+| Variable | Purpose |
+| --- | --- |
+| `WAL_S3_BUCKET` | WAL bucket; defaults to `S3_BUCKET`. |
+| `WAL_S3_REGION` | WAL region; defaults to the resolved main S3 region. |
+| `WAL_AWS_ENDPOINT` | WAL endpoint; `WAL_AWS_ENDPOINT_URL_S3` is the fallback, then the main endpoint. |
+| `WAL_AWS_ALLOW_HTTP` | WAL HTTP policy; defaults to `AWS_ALLOW_HTTP`. |
+
+The WAL client uses the standard AWS credential variables and the same `DB_PATH`.
+For a cache or write-through proxy over the main bucket, set only a WAL endpoint;
+the main `S3_BUCKET` and path are inherited. The proxy must expose the existing WAL
+objects at that path because HelixDB does not migrate them. A WAL endpoint without
+`S3_BUCKET` or `WAL_S3_BUCKET` is rejected. WAL region or HTTP overrides without a
+WAL bucket or endpoint are also rejected.
+
 ## Test
 
 After loading a native image, run the full packaging and runtime suite:

--- a/docker-image/README.md
+++ b/docker-image/README.md
@@ -80,13 +80,19 @@ of `WAL_S3_BUCKET`, `WAL_AWS_ENDPOINT`, or `WAL_AWS_ENDPOINT_URL_S3`:
 | `WAL_S3_REGION` | WAL region; defaults to the resolved main S3 region. |
 | `WAL_AWS_ENDPOINT` | WAL endpoint; `WAL_AWS_ENDPOINT_URL_S3` is the fallback, then the main endpoint. |
 | `WAL_AWS_ALLOW_HTTP` | WAL HTTP policy; defaults to `AWS_ALLOW_HTTP`. |
+| `WAL_AWS_ACCESS_KEY_ID` | Optional WAL-specific access key; set it with `WAL_AWS_SECRET_ACCESS_KEY`. |
+| `WAL_AWS_SECRET_ACCESS_KEY` | Optional WAL-specific secret key; set it with `WAL_AWS_ACCESS_KEY_ID`. |
 
-The WAL client uses the standard AWS credential variables and the same `DB_PATH`.
+The WAL client uses the WAL-specific credential pair when both variables are set.
+Otherwise, it uses the standard AWS credential provider chain. Supply credentials
+at runtime through a secret manager or container secret injection; do not store them
+in an image or a checked-in environment file. The WAL client uses the same `DB_PATH`.
 For a cache or write-through proxy over the main bucket, set only a WAL endpoint;
 the main `S3_BUCKET` and path are inherited. The proxy must expose the existing WAL
 objects at that path because HelixDB does not migrate them. A WAL endpoint without
 `S3_BUCKET` or `WAL_S3_BUCKET` is rejected. WAL region or HTTP overrides without a
-WAL bucket or endpoint are also rejected.
+WAL bucket or endpoint are also rejected. Supplying only one WAL credential variable
+is rejected.
 
 ## Test
 

--- a/docker-image/tests/compose-smoke.sh
+++ b/docker-image/tests/compose-smoke.sh
@@ -117,17 +117,40 @@ if not isinstance(value, (list, dict)) or len(value) == 0:
 PY
 }
 
-assert_minio_objects_present() {
-  local objects
-  objects=$(docker run --rm \
+list_minio_bucket() {
+  local bucket=$1
+  docker run --rm \
     --platform "$platform" \
     --network "${project}_default" \
     --entrypoint /bin/sh \
     "$mc_image" \
-    -c 'until mc alias set local http://minio:9000 minioadmin minioadmin >/dev/null 2>&1; do sleep 1; done; mc ls --recursive local/helix-db')
-  if [[ "$objects" != *"db/manifest/"* ]]; then
-    printf '%s\n' "$objects" >&2
-    printf 'expected MinIO to contain db/manifest objects\n' >&2
+    -c 'until mc alias set local http://minio:9000 minioadmin minioadmin >/dev/null 2>&1; do sleep 1; done; mc ls --recursive "local/$1"' \
+    _ "$bucket"
+}
+
+assert_minio_object_placement() {
+  local main_objects
+  local wal_objects
+  main_objects=$(list_minio_bucket helix-db)
+  wal_objects=$(list_minio_bucket helix-wal)
+  if [[ "$main_objects" != *"db/manifest/"* ]]; then
+    printf '%s\n' "$main_objects" >&2
+    printf 'expected the main bucket to contain db/manifest objects\n' >&2
+    exit 1
+  fi
+  if [[ "$main_objects" == *"db/wal/"* ]]; then
+    printf '%s\n' "$main_objects" >&2
+    printf 'expected the main bucket not to contain db/wal objects\n' >&2
+    exit 1
+  fi
+  if [[ "$wal_objects" != *"db/wal/"* ]]; then
+    printf '%s\n' "$wal_objects" >&2
+    printf 'expected the WAL bucket to contain db/wal objects\n' >&2
+    exit 1
+  fi
+  if [[ "$wal_objects" == *"db/manifest/"* || "$wal_objects" == *"db/compacted/"* || "$wal_objects" == *"db/compactions/"* ]]; then
+    printf '%s\n' "$wal_objects" >&2
+    printf 'expected the WAL bucket not to contain main-store objects\n' >&2
     exit 1
   fi
 }
@@ -138,7 +161,7 @@ wait_for_http "http://127.0.0.1:${port}/healthz"
 wait_for_http "http://127.0.0.1:${port}/readyz"
 post_json dynamic-write.json true >/dev/null
 assert_users_nonempty "$(post_json dynamic-read.json)"
-assert_minio_objects_present
+assert_minio_object_placement
 
 log "Replacing Helix while preserving MinIO"
 compose up -d --force-recreate helix >/dev/null
@@ -150,4 +173,5 @@ compose down >/dev/null
 compose up -d >/dev/null
 wait_for_http "http://127.0.0.1:${port}/readyz"
 assert_users_nonempty "$(post_json dynamic-read.json)"
+assert_minio_object_placement
 log "S3-compatible Compose smoke test passed"

--- a/docker-image/tests/fixtures/docker-compose.yml
+++ b/docker-image/tests/fixtures/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - |
         until mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 1; done
         mc mb --ignore-existing local/helix-db
+        mc mb --ignore-existing local/helix-wal
 
   helix:
     image: ${HELIX_IMAGE_REF:?HELIX_IMAGE_REF must be set}
@@ -32,6 +33,7 @@ services:
       - "${HELIX_IMAGE_TEST_PORT:-18120}:8080"
     environment:
       S3_BUCKET: helix-db
+      WAL_S3_BUCKET: helix-wal
       S3_REGION: us-east-1
       DB_PATH: db/
       AWS_ACCESS_KEY_ID: minioadmin

--- a/docker-image/tests/fixtures/docker-compose.yml
+++ b/docker-image/tests/fixtures/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       AWS_SECRET_ACCESS_KEY: minioadmin
       AWS_ENDPOINT: http://minio:9000
       AWS_ALLOW_HTTP: "true"
+      WAL_AWS_ACCESS_KEY_ID: minioadmin
+      WAL_AWS_SECRET_ACCESS_KEY: minioadmin
 
 volumes:
   minio-data:

--- a/docker-image/tests/smoke.sh
+++ b/docker-image/tests/smoke.sh
@@ -232,6 +232,7 @@ run_invalid_configuration_tests() {
   local bad_address="helixdb-image-bad-address-$resource_suffix"
   local conflicting_storage="helixdb-image-conflicting-storage-$resource_suffix"
   local partial_wal="helixdb-image-partial-wal-$resource_suffix"
+  local partial_wal_credentials="helixdb-image-partial-wal-credentials-$resource_suffix"
 
   log "Testing invalid startup configuration"
   start_container "$bad_address" "$((base_port + 4))" -e HELIX_HTTP_ADDR=not-an-address
@@ -247,10 +248,16 @@ run_invalid_configuration_tests() {
   start_container "$partial_wal" "$((base_port + 6))" -e WAL_S3_REGION=us-east-1
   wait_for_exit "$partial_wal"
   assert_nonzero_exit "$partial_wal"
+
+  start_container "$partial_wal_credentials" "$((base_port + 7))" \
+    -e WAL_S3_BUCKET=wal \
+    -e WAL_AWS_ACCESS_KEY_ID=wal-access-key-id
+  wait_for_exit "$partial_wal_credentials"
+  assert_nonzero_exit "$partial_wal_credentials"
 }
 
 run_signal_test() {
-  local port=$((base_port + 7))
+  local port=$((base_port + 8))
   local container="helixdb-image-sigterm-$resource_suffix"
   local exit_code
 

--- a/docker-image/tests/smoke.sh
+++ b/docker-image/tests/smoke.sh
@@ -231,6 +231,7 @@ run_native_disk_test() {
 run_invalid_configuration_tests() {
   local bad_address="helixdb-image-bad-address-$resource_suffix"
   local conflicting_storage="helixdb-image-conflicting-storage-$resource_suffix"
+  local partial_wal="helixdb-image-partial-wal-$resource_suffix"
 
   log "Testing invalid startup configuration"
   start_container "$bad_address" "$((base_port + 4))" -e HELIX_HTTP_ADDR=not-an-address
@@ -242,10 +243,14 @@ run_invalid_configuration_tests() {
     -e S3_BUCKET=conflict
   wait_for_exit "$conflicting_storage"
   assert_nonzero_exit "$conflicting_storage"
+
+  start_container "$partial_wal" "$((base_port + 6))" -e WAL_S3_REGION=us-east-1
+  wait_for_exit "$partial_wal"
+  assert_nonzero_exit "$partial_wal"
 }
 
 run_signal_test() {
-  local port=$((base_port + 6))
+  local port=$((base_port + 7))
   local container="helixdb-image-sigterm-$resource_suffix"
   local exit_code
 

--- a/docs/database/helix-db/start-here/local-development/local-server.mdx
+++ b/docs/database/helix-db/start-here/local-development/local-server.mdx
@@ -118,7 +118,7 @@ S3-compatible storage and is interpreted as a real bucket name.
 
 ## Run with MinIO persistence
 
-This Compose configuration creates separate main and WAL buckets in the same
+This Compose configuration creates a bucket and stores HelixDB objects in the
 `minio-data` volume:
 
 ```yaml docker-compose.yaml expandable
@@ -144,7 +144,6 @@ services:
       - |
         until mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 1; done
         mc mb --ignore-existing local/helix-db
-        mc mb --ignore-existing local/helix-wal
 
   helix:
     image: ghcr.io/helixdb/helixdb:v0.0.4
@@ -156,7 +155,6 @@ services:
       - "6969:8080"
     environment:
       S3_BUCKET: helix-db
-      WAL_S3_BUCKET: helix-wal
       S3_REGION: us-east-1
       DB_PATH: db/
       AWS_ACCESS_KEY_ID: minioadmin
@@ -188,6 +186,9 @@ omit the MinIO services. For AWS S3, omit the endpoint and HTTP override.
 | `WAL_S3_REGION` | Optional WAL region; falls back to the resolved main region |
 | `WAL_AWS_ENDPOINT` or `WAL_AWS_ENDPOINT_URL_S3` | Optional WAL endpoint; falls back to the main endpoint |
 | `WAL_AWS_ALLOW_HTTP` | Optional WAL HTTP policy; falls back to `AWS_ALLOW_HTTP` |
+
+By default, WAL objects use the main `S3_BUCKET`. Leave all `WAL_*` variables unset
+to keep this behavior.
 
 Set a WAL bucket or WAL endpoint to enable the separate client. It uses the standard
 AWS credential variables and always shares `DB_PATH` with the main store. To put a

--- a/docs/database/helix-db/start-here/local-development/local-server.mdx
+++ b/docs/database/helix-db/start-here/local-development/local-server.mdx
@@ -118,7 +118,7 @@ S3-compatible storage and is interpreted as a real bucket name.
 
 ## Run with MinIO persistence
 
-This Compose configuration creates a bucket and stores HelixDB objects in the
+This Compose configuration creates separate main and WAL buckets in the same
 `minio-data` volume:
 
 ```yaml docker-compose.yaml expandable
@@ -144,6 +144,7 @@ services:
       - |
         until mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 1; done
         mc mb --ignore-existing local/helix-db
+        mc mb --ignore-existing local/helix-wal
 
   helix:
     image: ghcr.io/helixdb/helixdb:v0.0.4
@@ -155,6 +156,7 @@ services:
       - "6969:8080"
     environment:
       S3_BUCKET: helix-db
+      WAL_S3_BUCKET: helix-wal
       S3_REGION: us-east-1
       DB_PATH: db/
       AWS_ACCESS_KEY_ID: minioadmin
@@ -182,6 +184,21 @@ omit the MinIO services. For AWS S3, omit the endpoint and HTTP override.
 | `AWS_SESSION_TOKEN` | Optional temporary-credential token |
 | `AWS_ENDPOINT` or `AWS_ENDPOINT_URL_S3` | Non-AWS S3 endpoint |
 | `AWS_ALLOW_HTTP` | Set to `true` or `1` to permit an HTTP endpoint |
+| `WAL_S3_BUCKET` | Optional WAL bucket; falls back to `S3_BUCKET` |
+| `WAL_S3_REGION` | Optional WAL region; falls back to the resolved main region |
+| `WAL_AWS_ENDPOINT` or `WAL_AWS_ENDPOINT_URL_S3` | Optional WAL endpoint; falls back to the main endpoint |
+| `WAL_AWS_ALLOW_HTTP` | Optional WAL HTTP policy; falls back to `AWS_ALLOW_HTTP` |
+
+Set a WAL bucket or WAL endpoint to enable the separate client. It uses the standard
+AWS credential variables and always shares `DB_PATH` with the main store. To put a
+cache or write-through proxy in front of existing WAL objects, set only the WAL
+endpoint; the main bucket, region, and path are inherited. The proxy must expose the
+existing WAL objects because HelixDB does not migrate them. A WAL endpoint without a
+main or WAL bucket is rejected. WAL region or HTTP overrides without a WAL bucket or
+endpoint are also rejected.
+
+These WAL variables configure the standalone server image only. The local CLI and
+`helix.toml` do not expose separate WAL storage.
 
 The endpoint must be reachable from inside the container; container `localhost` is not
 the host machine. `DB_PATH` is not a host filesystem path, and mounting a volume at

--- a/docs/database/helix-db/start-here/local-development/local-server.mdx
+++ b/docs/database/helix-db/start-here/local-development/local-server.mdx
@@ -186,17 +186,22 @@ omit the MinIO services. For AWS S3, omit the endpoint and HTTP override.
 | `WAL_S3_REGION` | Optional WAL region; falls back to the resolved main region |
 | `WAL_AWS_ENDPOINT` or `WAL_AWS_ENDPOINT_URL_S3` | Optional WAL endpoint; falls back to the main endpoint |
 | `WAL_AWS_ALLOW_HTTP` | Optional WAL HTTP policy; falls back to `AWS_ALLOW_HTTP` |
+| `WAL_AWS_ACCESS_KEY_ID` | Optional WAL-specific access key; must be set with `WAL_AWS_SECRET_ACCESS_KEY` |
+| `WAL_AWS_SECRET_ACCESS_KEY` | Optional WAL-specific secret key; must be set with `WAL_AWS_ACCESS_KEY_ID` |
 
 By default, WAL objects use the main `S3_BUCKET`. Leave all `WAL_*` variables unset
 to keep this behavior.
 
-Set a WAL bucket or WAL endpoint to enable the separate client. It uses the standard
-AWS credential variables and always shares `DB_PATH` with the main store. To put a
+Set a WAL bucket or WAL endpoint to enable the separate client. It uses the WAL-specific
+credential pair when both variables are set; otherwise, it uses the standard AWS
+credential provider chain. Inject credentials at runtime from a secret manager and
+do not commit them to configuration files. The WAL client always shares `DB_PATH`
+with the main store. To put a
 cache or write-through proxy in front of existing WAL objects, set only the WAL
 endpoint; the main bucket, region, and path are inherited. The proxy must expose the
 existing WAL objects because HelixDB does not migrate them. A WAL endpoint without a
 main or WAL bucket is rejected. WAL region or HTTP overrides without a WAL bucket or
-endpoint are also rejected.
+endpoint are also rejected. Supplying only one WAL credential variable is rejected.
 
 These WAL variables configure the standalone server image only. The local CLI and
 `helix.toml` do not expose separate WAL storage.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -467,17 +467,22 @@ omit the MinIO services. For AWS S3, omit the endpoint and HTTP override.
 | `WAL_S3_REGION` | Optional WAL region; falls back to the resolved main region |
 | `WAL_AWS_ENDPOINT` or `WAL_AWS_ENDPOINT_URL_S3` | Optional WAL endpoint; falls back to the main endpoint |
 | `WAL_AWS_ALLOW_HTTP` | Optional WAL HTTP policy; falls back to `AWS_ALLOW_HTTP` |
+| `WAL_AWS_ACCESS_KEY_ID` | Optional WAL-specific access key; must be set with `WAL_AWS_SECRET_ACCESS_KEY` |
+| `WAL_AWS_SECRET_ACCESS_KEY` | Optional WAL-specific secret key; must be set with `WAL_AWS_ACCESS_KEY_ID` |
 
 By default, WAL objects use the main `S3_BUCKET`. Leave all `WAL_*` variables unset
 to keep this behavior.
 
-Set a WAL bucket or WAL endpoint to enable the separate client. It uses the standard
-AWS credential variables and always shares `DB_PATH` with the main store. To put a
+Set a WAL bucket or WAL endpoint to enable the separate client. It uses the WAL-specific
+credential pair when both variables are set; otherwise, it uses the standard AWS
+credential provider chain. Inject credentials at runtime from a secret manager and
+do not commit them to configuration files. The WAL client always shares `DB_PATH`
+with the main store. To put a
 cache or write-through proxy in front of existing WAL objects, set only the WAL
 endpoint; the main bucket, region, and path are inherited. The proxy must expose the
 existing WAL objects because HelixDB does not migrate them. A WAL endpoint without a
 main or WAL bucket is rejected. WAL region or HTTP overrides without a WAL bucket or
-endpoint are also rejected.
+endpoint are also rejected. Supplying only one WAL credential variable is rejected.
 
 These WAL variables configure the standalone server image only. The local CLI and
 `helix.toml` do not expose separate WAL storage.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -399,7 +399,7 @@ S3-compatible storage and is interpreted as a real bucket name.
 
 ## Run with MinIO persistence
 
-This Compose configuration creates a bucket and stores HelixDB objects in the
+This Compose configuration creates separate main and WAL buckets in the same
 `minio-data` volume:
 
 ```yaml docker-compose.yaml expandable
@@ -425,6 +425,7 @@ services:
       - |
         until mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 1; done
         mc mb --ignore-existing local/helix-db
+        mc mb --ignore-existing local/helix-wal
 
   helix:
     image: ghcr.io/helixdb/helixdb:v0.0.4
@@ -436,6 +437,7 @@ services:
       - "6969:8080"
     environment:
       S3_BUCKET: helix-db
+      WAL_S3_BUCKET: helix-wal
       S3_REGION: us-east-1
       DB_PATH: db/
       AWS_ACCESS_KEY_ID: minioadmin
@@ -463,6 +465,21 @@ omit the MinIO services. For AWS S3, omit the endpoint and HTTP override.
 | `AWS_SESSION_TOKEN` | Optional temporary-credential token |
 | `AWS_ENDPOINT` or `AWS_ENDPOINT_URL_S3` | Non-AWS S3 endpoint |
 | `AWS_ALLOW_HTTP` | Set to `true` or `1` to permit an HTTP endpoint |
+| `WAL_S3_BUCKET` | Optional WAL bucket; falls back to `S3_BUCKET` |
+| `WAL_S3_REGION` | Optional WAL region; falls back to the resolved main region |
+| `WAL_AWS_ENDPOINT` or `WAL_AWS_ENDPOINT_URL_S3` | Optional WAL endpoint; falls back to the main endpoint |
+| `WAL_AWS_ALLOW_HTTP` | Optional WAL HTTP policy; falls back to `AWS_ALLOW_HTTP` |
+
+Set a WAL bucket or WAL endpoint to enable the separate client. It uses the standard
+AWS credential variables and always shares `DB_PATH` with the main store. To put a
+cache or write-through proxy in front of existing WAL objects, set only the WAL
+endpoint; the main bucket, region, and path are inherited. The proxy must expose the
+existing WAL objects because HelixDB does not migrate them. A WAL endpoint without a
+main or WAL bucket is rejected. WAL region or HTTP overrides without a WAL bucket or
+endpoint are also rejected.
+
+These WAL variables configure the standalone server image only. The local CLI and
+`helix.toml` do not expose separate WAL storage.
 
 The endpoint must be reachable from inside the container; container `localhost` is not
 the host machine. `DB_PATH` is not a host filesystem path, and mounting a volume at

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -399,7 +399,7 @@ S3-compatible storage and is interpreted as a real bucket name.
 
 ## Run with MinIO persistence
 
-This Compose configuration creates separate main and WAL buckets in the same
+This Compose configuration creates a bucket and stores HelixDB objects in the
 `minio-data` volume:
 
 ```yaml docker-compose.yaml expandable
@@ -425,7 +425,6 @@ services:
       - |
         until mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 1; done
         mc mb --ignore-existing local/helix-db
-        mc mb --ignore-existing local/helix-wal
 
   helix:
     image: ghcr.io/helixdb/helixdb:v0.0.4
@@ -437,7 +436,6 @@ services:
       - "6969:8080"
     environment:
       S3_BUCKET: helix-db
-      WAL_S3_BUCKET: helix-wal
       S3_REGION: us-east-1
       DB_PATH: db/
       AWS_ACCESS_KEY_ID: minioadmin
@@ -469,6 +467,9 @@ omit the MinIO services. For AWS S3, omit the endpoint and HTTP override.
 | `WAL_S3_REGION` | Optional WAL region; falls back to the resolved main region |
 | `WAL_AWS_ENDPOINT` or `WAL_AWS_ENDPOINT_URL_S3` | Optional WAL endpoint; falls back to the main endpoint |
 | `WAL_AWS_ALLOW_HTTP` | Optional WAL HTTP policy; falls back to `AWS_ALLOW_HTTP` |
+
+By default, WAL objects use the main `S3_BUCKET`. Leave all `WAL_*` variables unset
+to keep this behavior.
 
 Set a WAL bucket or WAL endpoint to enable the separate client. It uses the standard
 AWS credential variables and always shares `DB_PATH` with the main store. To put a

--- a/scripts/db-production-coverage-baselines.json
+++ b/scripts/db-production-coverage-baselines.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "uncovered_non_vector_source_lines": {
-    "count": 10429,
-    "sha256": "300955ba60656464b30beee515bc3662ec0f3d2adf968118feac3df1d005781d",
+    "count": 10427,
+    "sha256": "eb0f6ef472afbaa7023857d192605c9c39ef80234f096732f9e3c421e614d345",
     "classification": "test-required",
     "reason": "Every uncovered production source line outside vector search and its stochastic vector key/value codecs remains in the explicit production-linked test backlog. The digest makes additions, removals, and newly covered lines require a reviewed baseline update; vector code remains enforced by the whole-DB and dedicated vector thresholds plus finer named-test, architecture, invariant, and platform classifications."
   },

--- a/scripts/server-production-coverage-baselines.json
+++ b/scripts/server-production-coverage-baselines.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "uncovered_source_lines": {
-    "count": 119,
-    "sha256": "98206e25c0bbcc32d40b21fa7ddb9d75beb00e6ff3e482dba638bc841e0af6a7",
+    "count": 120,
+    "sha256": "e8f08bf4245448a931ad27ceab1623c0f6780c5abaaf9ccdd452f28919ee3141",
     "classification": "test-required",
     "reason": "Every remaining uncovered production line in the transport server and its production-compiled query-service dependency remains in the explicit launch test backlog. Three static error-code mapping lines are exhaustively covered by the database mapping tests rather than this server-only shard. The exact digest makes coverage changes require a reviewed ratchet update."
   },


### PR DESCRIPTION
## Summary

- add an optional, debug-redacted WAL object store to `DbConfig`
- configure the same WAL store for SlateDB writers and readers while preserving the main-store fallback
- add standalone-server WAL S3 environment settings with validation and documented precedence
- support an optional WAL-specific access key and secret pair with redacted debug output
- test separate `helix-db` and `helix-wal` MinIO buckets, object placement, and recovery after restart

This builds on the SlateDB v0.16 support merged in #1055. It does not add WAL migration or change storage for manifests, SSTs, FTS, or vector artifacts.

## Validation

- `cargo test --workspace --locked`
- `cargo clippy --workspace --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo llvm-cov --locked -p server --lib --fail-under-lines 80` (91.23% lines)
- documentation generation and checks
- full ARM64 Docker image, archive, secret scan, runtime, two-bucket MinIO, and restart suite

## Known coverage gate

`scripts/workspace-coverage.sh db` completes its tests but the existing workspace thresholds are not met: DB is 93.765% versus 94%, and interpreter is 96.183% versus 98%. This branch does not lower those thresholds.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds optional separate object storage for SlateDB WAL data while retaining the main-store fallback.
- Adds a debug-redacted WAL object store to `DbConfig` and applies it consistently to writer and reader builders.
- Adds standalone-server WAL S3 environment resolution, validation, and startup wiring.
- Extends unit, MinIO smoke, restart, placement, and documentation coverage for separate main and WAL buckets.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/config/db.rs | Adds an optional cloned, debug-redacted WAL object-store setting and builder API. |
| crates/db/src/lib.rs | Propagates the configured WAL store through production writer and reader construction paths. |
| crates/server/src/config.rs | Resolves and validates WAL-specific S3 settings and constructs the optional WAL client. |
| crates/server/src/lib.rs | Passes the resolved database configuration through both standalone server startup paths. |
| docker-image/tests/compose-smoke.sh | Verifies WAL and non-WAL object placement before and after server and Compose restarts. |
| docs/database/helix-db/start-here/local-development/local-server.mdx | Documents WAL environment variables, inheritance, validation, and migration limitations. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  ENV[Server environment] --> SC[ServerConfig]
  SC --> MAIN[Main storage source]
  SC --> WAL[Optional WAL S3 client]
  MAIN --> OPEN[HelixDB open]
  WAL --> DBC[DbConfig]
  DBC --> OPEN
  OPEN --> WRITER[SlateDB writer]
  OPEN --> READER[SlateDB reader]
  WRITER --> MAINOBJ[Manifest and SST objects]
  WRITER --> WALOBJ[WAL objects]
  READER --> WALOBJ
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(docker): verify separate WAL storag..."](https://github.com/helixdb/helix-db/commit/d91f06c024f9efcb7627a3ffc0f694b4c35fe994) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59491207)</sub>

**Context used:**

- Knowledge Base — [Server and transports](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/server-and-transports.md)
- Knowledge Base — [Server configuration and state](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/server-configuration-and-state.md)

<!-- /greptile_comment -->