### PR TITLE
fix(go): accept every value type in typed datetime parameters

### DIFF
--- a/sdks/go/dsl.go
+++ b/sdks/go/dsl.go
@@ -3023,19 +3023,11 @@ func normalizeTypedQueryValue(parameterType QueryParamType, value QueryValue, pa
 		}
 		return QueryString(typed), nil
 	case paramKindDateTime:
-		typed, ok := value.(string)
-		if !ok {
-			return nil, ErrInvalidDateTimeParameter
-		}
-		dateTime, err := ParseDateTimeRFC3339(typed)
+		formatted, err := queryDateTime(value)
 		if err != nil {
 			return nil, ErrInvalidDateTimeParameter
 		}
-		normalized, err := dateTime.RFC3339()
-		if err != nil {
-			return nil, ErrInvalidDateTimeParameter
-		}
-		return QueryString(normalized), nil
+		return QueryString(formatted), nil
 	case paramKindBytes:
 		return nil, ErrUnsupportedBytesParameter
 	case paramKindValue:

--- a/sdks/go/dsl_test.go
+++ b/sdks/go/dsl_test.go
@@ -568,6 +568,64 @@ func TestFloatParametersAcceptEveryIntegerWidth(t *testing.T) {
 	}
 }
 
+func TestTypedDateTimeParameterAcceptsSameValuesAsConvenienceHelper(t *testing.T) {
+	// The convenience helper ParamDateTime accepts DateTime, time.Time, RFC3339
+	// strings and epoch-millis ints. The low-level typed insertion path
+	// (WithTypedParameter / InsertTypedParameter with ParamTypeDateTime) must
+	// accept the same values so both insertion styles serialize identically.
+	millis := int64(1_776_000_000_000)
+	expected, err := DateTimeFromMillis(millis).RFC3339()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	convenience := NewReadQueryRequest(Read())
+	convenience.ParamDateTime("t", millis)
+
+	typed := NewReadQueryRequest(Read())
+	typed.WithTypedParameter("t_millis", ParamTypeDateTime(), QueryI64(millis))
+	typed.WithTypedParameter("t_rfc3339", ParamTypeDateTime(), QueryString(expected))
+	typed.WithTypedParameter("t_time", ParamTypeDateTime(), time.UnixMilli(millis))
+	typed.WithTypedParameter("t_datetime", ParamTypeDateTime(), DateTimeFromMillis(millis))
+
+	if err := typed.Validate(); err != nil {
+		t.Fatalf("typed datetime parameters failed: %v", err)
+	}
+	convenienceBody, err := json.Marshal(convenience)
+	if err != nil {
+		t.Fatal(err)
+	}
+	typedBody, err := json.Marshal(typed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var conveniencePayload struct {
+		Parameters map[string]string `json:"parameters"`
+	}
+	if err := json.Unmarshal(convenienceBody, &conveniencePayload); err != nil {
+		t.Fatal(err)
+	}
+	if got := conveniencePayload.Parameters["t"]; got != expected {
+		t.Fatalf("convenience datetime parameter unexpected value: got %s want %s", got, expected)
+	}
+	var typedPayload struct {
+		Parameters map[string]string `json:"parameters"`
+	}
+	if err := json.Unmarshal(typedBody, &typedPayload); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"t_millis", "t_rfc3339", "t_time", "t_datetime"} {
+		if got := typedPayload.Parameters[name]; got != expected {
+			t.Fatalf("typed datetime parameter %s serialized as %s, want %s", name, got, expected)
+		}
+	}
+
+	rejected := NewReadQueryRequest(Read())
+	rejected.WithTypedParameter("bad", ParamTypeDateTime(), QueryBool(true))
+	if !errors.Is(rejected.Validate(), ErrInvalidDateTimeParameter) {
+		t.Fatal("non-date typed datetime parameter unexpectedly accepted")
+	}
+}
 func TestBatchDecodersCoverClosedVariantsAndMalformedShapes(t *testing.T) {
 	for _, input := range []string{
 		`"prev_not_empty"`,


### PR DESCRIPTION
## Summary

- the convenience helper `ParamDateTime` accepts `DateTime`, `time.Time`, RFC3339 strings and epoch-millis ints, but the low-level typed insertion path (`WithTypedParameter` / `InsertTypedParameter` with `ParamTypeDateTime`) rejected everything except a pre-formatted string with `ErrInvalidDateTimeParameter`
- this forced callers using the typed API to manually normalize values to RFC3339 strings before inserting, and made the two insertion styles silently asymmetric
- the typed path now delegates normalization to the existing shared `queryDateTime` helper, so both styles accept and serialize identically (and still reject genuinely invalid values with `ErrInvalidDateTimeParameter`)

This is the datetime sibling of #1032, which fixed the identical asymmetry for typed float parameters.

## Test coverage

- new `TestTypedDateTimeParameterAcceptsSameValuesAsConvenienceHelper` asserts the typed path accepts `int64`, RFC3339 string, `time.Time` and `DateTime` inputs and serializes them to exactly the same wire value as the convenience helper, and still rejects non-date values
- verified the new test fails on `main` (`t_millis: helix: invalid datetime parameter`) before the fix and passes after
- full `go test ./...` for `sdks/go` passes, `gofmt` and `go vet` clean


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes typed Go datetime parameters use the same established normalization helper as the convenience API.
- Accepts `DateTime`, `time.Time`, RFC3339 strings, and epoch-millisecond integers through `ParamTypeDateTime`.
- Preserves canonical RFC3339 serialization and invalid-value rejection.
- Adds parity coverage for all supported representations and a non-date rejection case.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdks/go/dsl.go | Replaces string-only typed datetime normalization with the existing shared helper while preserving error mapping. |
| sdks/go/dsl_test.go | Verifies convenience and typed datetime paths serialize supported inputs identically and reject invalid values. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(go): accept every value type in type..."](https://github.com/helixdb/helix-db/commit/376104ef42b332cb1c66c8e4bc19612631bd75ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59534147)</sub>

<!-- /greptile_comment -->