### PR TITLE
fix: give graph labels exact CanonicalLabel identity

### DIFF
--- a/crates/db/src/encoding/error.rs
+++ b/crates/db/src/encoding/error.rs
@@ -45,6 +45,10 @@ pub enum EncodingError {
     #[error("Canonical equality digest does not match canonical bytes")]
     CanonicalEqualityDigestMismatch,
 
+    /// Persisted graph-label digest does not match its canonical UTF-8 bytes.
+    #[error("Canonical label digest does not match canonical bytes")]
+    CanonicalLabelDigestMismatch,
+
     /// Invalid range index direction
     #[error("Invalid range index direction: {0}")]
     InvalidRangeIndexDirection(u8),

--- a/crates/db/src/encoding/v2/keys/data.rs
+++ b/crates/db/src/encoding/v2/keys/data.rs
@@ -908,19 +908,21 @@ mod tests {
     #[test]
     fn tenant_key_prefixes_edge_label_index_key() {
         let tenant = TenantId::from_ulid_str("0000000000000000000000000B").expect("valid tenant");
-        let label_hash = [5, 6, 7, 8, 9, 10, 11, 12];
         let encoded = DataKey::Data {
             scope: DataScope::Tenant(tenant),
-            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(
-                label_hash,
-            ))),
+            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(
+                EdgeLabelKey::from_label("FOLLOWS")
+                    .expect("test labels are valid canonical labels"),
+            )),
         }
         .to_bytes();
 
         let mut expected = vec![scope::TENANT_KEY_PREFIX];
         expected.extend_from_slice(&tenant.as_u128().to_be_bytes());
         expected.extend_from_slice(&[0x03, 0x04]);
-        expected.extend_from_slice(&label_hash);
+        crate::encoding::indexes::CanonicalLabel::from_label("FOLLOWS")
+            .unwrap()
+            .encode_into(&mut expected);
 
         assert_eq!(encoded.as_ref(), expected.as_slice());
     }

--- a/crates/db/src/encoding/v2/keys/indexes/canonical_label.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/canonical_label.rs
@@ -1,0 +1,216 @@
+//! Canonical graph-label identity.
+//!
+//! The digest is only a scan accelerator. Exact identity is always the
+//! length-delimited UTF-8 label. Hash-only label keys are unrepresentable.
+
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
+
+use bytes::{BufMut, Bytes};
+use sha2::{Digest, Sha256};
+
+use crate::encoding::error::EncodingError;
+
+pub(crate) const LABEL_DIGEST_LEN: usize = core::mem::size_of::<u64>();
+pub(crate) const LABEL_LEN_LEN: usize = core::mem::size_of::<u32>();
+pub(crate) const MAX_LABEL_CANONICAL_LEN: usize = 1024 * 1024 - 64;
+
+/// Exact graph-label bytes and their bounded scan digest.
+#[derive(Debug, Clone, Eq)]
+pub(crate) struct CanonicalLabel {
+    digest: [u8; LABEL_DIGEST_LEN],
+    canonical: Bytes,
+}
+
+impl PartialEq for CanonicalLabel {
+    fn eq(&self, other: &Self) -> bool {
+        self.canonical == other.canonical
+    }
+}
+
+impl Hash for CanonicalLabel {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.canonical.hash(state);
+    }
+}
+
+impl PartialOrd for CanonicalLabel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CanonicalLabel {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.canonical.cmp(&other.canonical)
+    }
+}
+
+impl CanonicalLabel {
+    fn new(canonical: Bytes) -> Self {
+        let digest = label_digest(&canonical);
+        Self { digest, canonical }
+    }
+
+    /// Constructs a label from its UTF-8 graph name.
+    pub(crate) fn from_label(label: &str) -> Result<Self, EncodingError> {
+        if label.len() > MAX_LABEL_CANONICAL_LEN {
+            return Err(EncodingError::InvalidKey(format!(
+                "canonical label exceeds {MAX_LABEL_CANONICAL_LEN} bytes"
+            )));
+        }
+        Ok(Self::new(Bytes::copy_from_slice(label.as_bytes())))
+    }
+
+    /// Reconstructs a persisted label while validating its canonical frame.
+    pub(crate) fn try_from_parts(
+        digest: [u8; LABEL_DIGEST_LEN],
+        canonical: Bytes,
+    ) -> Result<Self, EncodingError> {
+        if canonical.len() > MAX_LABEL_CANONICAL_LEN {
+            return Err(EncodingError::InvalidKey(format!(
+                "canonical label exceeds {MAX_LABEL_CANONICAL_LEN} bytes"
+            )));
+        }
+        std::str::from_utf8(&canonical)?;
+        if digest != label_digest(&canonical) {
+            return Err(EncodingError::CanonicalLabelDigestMismatch);
+        }
+        Ok(Self { digest, canonical })
+    }
+
+    pub(crate) const fn digest(&self) -> &[u8; LABEL_DIGEST_LEN] {
+        &self.digest
+    }
+
+    #[cfg(test)]
+    pub(crate) fn as_str(&self) -> &str {
+        std::str::from_utf8(&self.canonical).expect("canonical labels are validated UTF-8")
+    }
+
+    pub(crate) fn encoded_len(&self) -> usize {
+        LABEL_DIGEST_LEN + LABEL_LEN_LEN + self.canonical.len()
+    }
+
+    pub(crate) fn encode_into<B: BufMut>(&self, buf: &mut B) {
+        buf.put_slice(self.digest());
+        buf.put_u32(
+            u32::try_from(self.canonical.len()).expect("canonical labels are bounded below u32"),
+        );
+        buf.put_slice(&self.canonical);
+    }
+
+    /// Parses a complete canonical-label frame. Trailing or truncated bytes fail closed.
+    pub(crate) fn parse_from_slice(slice: &[u8]) -> Result<Self, EncodingError> {
+        let header = LABEL_DIGEST_LEN + LABEL_LEN_LEN;
+        if slice.len() < header {
+            return Err(EncodingError::BufferTooShort {
+                expected: header,
+                actual: slice.len(),
+            });
+        }
+        let digest = slice[0..LABEL_DIGEST_LEN]
+            .try_into()
+            .expect("label digest slice is 8 bytes");
+        let canonical_len = u32::from_be_bytes(
+            slice[LABEL_DIGEST_LEN..LABEL_DIGEST_LEN + LABEL_LEN_LEN]
+                .try_into()
+                .expect("label length slice is 4 bytes"),
+        ) as usize;
+        let expected = header + canonical_len;
+        match slice.len().cmp(&expected) {
+            Ordering::Less => {
+                return Err(EncodingError::BufferTooShort {
+                    expected,
+                    actual: slice.len(),
+                });
+            }
+            Ordering::Equal => {}
+            Ordering::Greater => {
+                return Err(EncodingError::InvalidIndexKey(format!(
+                    "expected {expected} bytes, got {}",
+                    slice.len()
+                )));
+            }
+        }
+        Self::try_from_parts(
+            digest,
+            Bytes::copy_from_slice(
+                &slice[LABEL_DIGEST_LEN + LABEL_LEN_LEN
+                    ..LABEL_DIGEST_LEN + LABEL_LEN_LEN + canonical_len],
+            ),
+        )
+    }
+
+    /// Constructs an in-memory digest-collision fixture that must not be persisted.
+    #[cfg(test)]
+    pub(crate) fn with_test_digest_unchecked(label: &str, digest: [u8; LABEL_DIGEST_LEN]) -> Self {
+        Self {
+            digest,
+            canonical: Bytes::copy_from_slice(label.as_bytes()),
+        }
+    }
+}
+
+fn label_digest(canonical: &[u8]) -> [u8; LABEL_DIGEST_LEN] {
+    let hash = Sha256::digest(canonical);
+    hash[..LABEL_DIGEST_LEN]
+        .try_into()
+        .expect("SHA-256 contains an eight-byte digest prefix")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_labels_are_exact_utf8_identity() {
+        let user = CanonicalLabel::from_label("User").unwrap();
+        assert_eq!(user.as_str(), "User");
+        assert_eq!(
+            CanonicalLabel::try_from_parts(
+                *user.digest(),
+                Bytes::copy_from_slice(user.canonical.as_ref())
+            )
+            .unwrap(),
+            user
+        );
+        assert_ne!(
+            CanonicalLabel::from_label("User").unwrap(),
+            CanonicalLabel::from_label("user").unwrap()
+        );
+    }
+
+    #[test]
+    fn persisted_canonical_digest_mismatches_fail_closed() {
+        let value = CanonicalLabel::from_label("User").unwrap();
+        let mut mismatched = *value.digest();
+        mismatched[0] ^= 0xFF;
+        assert!(matches!(
+            CanonicalLabel::try_from_parts(
+                mismatched,
+                Bytes::copy_from_slice(value.canonical.as_ref())
+            ),
+            Err(EncodingError::CanonicalLabelDigestMismatch)
+        ));
+    }
+
+    #[test]
+    fn digest_collisions_retain_distinct_exact_canonical_identity() {
+        let digest = [0xA5; LABEL_DIGEST_LEN];
+        let first = CanonicalLabel::with_test_digest_unchecked("alpha", digest);
+        let second = CanonicalLabel::with_test_digest_unchecked("beta", digest);
+        assert_eq!(first.digest(), second.digest());
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn parse_rejects_invalid_utf8_and_old_hash_only_frames() {
+        assert!(CanonicalLabel::parse_from_slice(&[1, 2, 3]).is_err());
+        let mut invalid_utf8 = Vec::new();
+        invalid_utf8.extend_from_slice(&label_digest(&[0xFF]));
+        invalid_utf8.extend_from_slice(&1u32.to_be_bytes());
+        invalid_utf8.push(0xFF);
+        assert!(CanonicalLabel::parse_from_slice(&invalid_utf8).is_err());
+    }
+}

--- a/crates/db/src/encoding/v2/keys/indexes/label.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/label.rs
@@ -1,8 +1,8 @@
 use crate::encoding::{
     error::EncodingError,
     indexes::{
-        EdgeDirection, IndexPrefix, ValueHash, INDEX_PREFIX_LEN, NODE_ID_MAX_LEN,
-        VALUE_HASH_MAX_LEN,
+        canonical_label::{CanonicalLabel, LABEL_DIGEST_LEN},
+        EdgeDirection, IndexPrefix, INDEX_PREFIX_LEN, NODE_ID_MAX_LEN,
     },
     keys::{KeyPrefix, PREFIX_LEN},
     v2::keys::codec::read_u64,
@@ -10,20 +10,115 @@ use crate::encoding::{
 };
 use bytes::{BufMut, Bytes};
 
+/// Builtin node-label index: label -> set of NodeIds.
+///
+/// ```text
+/// Key: [0x03][0x07][digest:8][u32 len][utf8]
+/// Value: RoaringTreemap<NodeId>
+/// ```
+///
+/// The digest is a scan accelerator. Exact identity is the canonical UTF-8 label.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NodeLabelKey {
+    label: CanonicalLabel,
+}
+
+impl NodeLabelKey {
+    pub(crate) fn from_label(label: &str) -> Result<Self, EncodingError> {
+        Ok(Self {
+            label: CanonicalLabel::from_label(label)?,
+        })
+    }
+
+    pub(crate) fn from_canonical(label: CanonicalLabel) -> Self {
+        Self { label }
+    }
+
+    #[inline]
+    pub(crate) const fn key_prefix() -> KeyPrefix {
+        KeyPrefix::PropertyIndex
+    }
+
+    #[inline]
+    pub(crate) const fn index_prefix() -> IndexPrefix {
+        IndexPrefix::NodeLabel
+    }
+
+    pub(crate) fn encoded_len(&self) -> usize {
+        PREFIX_LEN + INDEX_PREFIX_LEN + self.label.encoded_len()
+    }
+
+    pub(crate) fn parse_from_slice(slice: &[u8]) -> Result<Self, EncodingError> {
+        let header = PREFIX_LEN + INDEX_PREFIX_LEN;
+        if slice.len() < header {
+            return Err(EncodingError::BufferTooShort {
+                expected: header,
+                actual: slice.len(),
+            });
+        }
+
+        let key_prefix = KeyPrefix::from_u8(slice[0])?;
+        if key_prefix != Self::key_prefix() {
+            return Err(EncodingError::Custom(format!(
+                "expected PropertyIndex key prefix, got {:?}",
+                key_prefix
+            )));
+        }
+
+        let index_prefix = IndexPrefix::from_slice(slice)?;
+        if index_prefix != Self::index_prefix() {
+            return Err(EncodingError::Custom(format!(
+                "expected NodeLabel index prefix, got {:?}",
+                index_prefix
+            )));
+        }
+
+        Ok(Self {
+            label: CanonicalLabel::parse_from_slice(&slice[header..])?,
+        })
+    }
+
+    pub(crate) fn encode_into<B: BufMut>(&self, buf: &mut B) {
+        buf.put_u8(KeyPrefix::from(self).as_u8());
+        buf.put_slice(IndexPrefix::from(self).as_slice());
+        self.label.encode_into(buf);
+    }
+}
+
+impl From<&NodeLabelKey> for KeyPrefix {
+    fn from(_: &NodeLabelKey) -> KeyPrefix {
+        NodeLabelKey::key_prefix()
+    }
+}
+
+impl From<&NodeLabelKey> for IndexPrefix {
+    fn from(_: &NodeLabelKey) -> IndexPrefix {
+        NodeLabelKey::index_prefix()
+    }
+}
+
 /// Edge label index: label -> set of EdgeIds.
 ///
 /// ```text
-/// Key: [0x03][0x04][label_hash:8]
+/// Key: [0x03][0x04][digest:8][u32 len][utf8]
 /// Value: RoaringTreemap<EdgeId>
 /// ```
+///
+/// The digest is a scan accelerator. Exact identity is the canonical UTF-8 label.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct EdgeLabelKey {
-    label_hash: ValueHash,
+    label: CanonicalLabel,
 }
 
 impl EdgeLabelKey {
-    pub(crate) const fn new(label_hash: ValueHash) -> Self {
-        Self { label_hash }
+    pub(crate) fn from_label(label: &str) -> Result<Self, EncodingError> {
+        Ok(Self {
+            label: CanonicalLabel::from_label(label)?,
+        })
+    }
+
+    pub(crate) fn from_canonical(label: CanonicalLabel) -> Self {
+        Self { label }
     }
 
     #[inline]
@@ -36,22 +131,17 @@ impl EdgeLabelKey {
         IndexPrefix::EdgeLabel
     }
 
+    pub(crate) fn encoded_len(&self) -> usize {
+        PREFIX_LEN + INDEX_PREFIX_LEN + self.label.encoded_len()
+    }
+
     pub(crate) fn parse_from_slice(slice: &[u8]) -> Result<Self, EncodingError> {
-        let expected = PREFIX_LEN + INDEX_PREFIX_LEN + VALUE_HASH_MAX_LEN;
-        match slice.len().cmp(&expected) {
-            core::cmp::Ordering::Less => {
-                return Err(EncodingError::BufferTooShort {
-                    expected,
-                    actual: slice.len(),
-                });
-            }
-            core::cmp::Ordering::Equal => {}
-            core::cmp::Ordering::Greater => {
-                return Err(EncodingError::InvalidIndexKey(format!(
-                    "expected {expected} bytes, got {}",
-                    slice.len()
-                )));
-            }
+        let header = PREFIX_LEN + INDEX_PREFIX_LEN;
+        if slice.len() < header {
+            return Err(EncodingError::BufferTooShort {
+                expected: header,
+                actual: slice.len(),
+            });
         }
 
         let key_prefix = KeyPrefix::from_u8(slice[0])?;
@@ -70,18 +160,15 @@ impl EdgeLabelKey {
             )));
         }
 
-        let label_hash = slice
-            [PREFIX_LEN + INDEX_PREFIX_LEN..PREFIX_LEN + INDEX_PREFIX_LEN + VALUE_HASH_MAX_LEN]
-            .try_into()
-            .expect("label hash slice is 8 bytes");
-
-        Ok(Self::new(label_hash))
+        Ok(Self {
+            label: CanonicalLabel::parse_from_slice(&slice[header..])?,
+        })
     }
 
     pub(crate) fn encode_into<B: BufMut>(&self, buf: &mut B) {
         buf.put_u8(KeyPrefix::from(self).as_u8());
         buf.put_slice(IndexPrefix::from(self).as_slice());
-        buf.put_slice(&self.label_hash);
+        self.label.encode_into(buf);
     }
 }
 
@@ -100,27 +187,39 @@ impl From<&EdgeLabelKey> for IndexPrefix {
 /// Edge-label neighbor index: endpoint+label -> set of opposite NodeIds.
 ///
 /// ```text
-/// Out: [0x03][0x10][0x00][source:8][label_hash:8]
-/// In:  [0x03][0x10][0x01][target:8][label_hash:8]
+/// Out: [0x03][0x10][0x00][source:8][digest:8][u32 len][utf8]
+/// In:  [0x03][0x10][0x01][target:8][digest:8][u32 len][utf8]
 /// Value: RoaringTreemap<NodeId>
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct EdgeLabelNeighborKey {
     direction: EdgeDirection,
     node_id: NodeId,
-    label_hash: ValueHash,
+    label: CanonicalLabel,
 }
 
 impl EdgeLabelNeighborKey {
-    pub(crate) const fn new(
+    pub(crate) fn from_label(
         direction: EdgeDirection,
         node_id: NodeId,
-        label_hash: ValueHash,
+        label: &str,
+    ) -> Result<Self, EncodingError> {
+        Ok(Self {
+            direction,
+            node_id,
+            label: CanonicalLabel::from_label(label)?,
+        })
+    }
+
+    pub(crate) fn from_canonical(
+        direction: EdgeDirection,
+        node_id: NodeId,
+        label: CanonicalLabel,
     ) -> Self {
         Self {
             direction,
             node_id,
-            label_hash,
+            label,
         }
     }
 
@@ -139,26 +238,22 @@ impl EdgeLabelNeighborKey {
         Self::index_prefix(self.direction)
     }
 
-    pub(crate) fn parse_from_slice(slice: &[u8]) -> Result<Self, EncodingError> {
-        let expected = PREFIX_LEN
+    pub(crate) fn encoded_len(&self) -> usize {
+        PREFIX_LEN
             + INDEX_PREFIX_LEN
             + size_of::<EdgeDirection>()
-            + size_of::<NodeId>()
-            + VALUE_HASH_MAX_LEN;
-        match slice.len().cmp(&expected) {
-            core::cmp::Ordering::Less => {
-                return Err(EncodingError::BufferTooShort {
-                    expected,
-                    actual: slice.len(),
-                });
-            }
-            core::cmp::Ordering::Equal => {}
-            core::cmp::Ordering::Greater => {
-                return Err(EncodingError::InvalidIndexKey(format!(
-                    "expected {expected} bytes, got {}",
-                    slice.len()
-                )));
-            }
+            + NODE_ID_MAX_LEN
+            + self.label.encoded_len()
+    }
+
+    pub(crate) fn parse_from_slice(slice: &[u8]) -> Result<Self, EncodingError> {
+        let header =
+            PREFIX_LEN + INDEX_PREFIX_LEN + size_of::<EdgeDirection>() + size_of::<NodeId>();
+        if slice.len() < header {
+            return Err(EncodingError::BufferTooShort {
+                expected: header,
+                actual: slice.len(),
+            });
         }
 
         let key_prefix = KeyPrefix::from_u8(slice[0])?;
@@ -181,24 +276,18 @@ impl EdgeLabelNeighborKey {
             slice,
             PREFIX_LEN + INDEX_PREFIX_LEN + size_of::<EdgeDirection>(),
         )?;
-        let label_hash =
-            slice[PREFIX_LEN + INDEX_PREFIX_LEN + size_of::<EdgeDirection>() + size_of::<NodeId>()
-                ..PREFIX_LEN
-                    + INDEX_PREFIX_LEN
-                    + size_of::<EdgeDirection>()
-                    + size_of::<NodeId>()
-                    + VALUE_HASH_MAX_LEN]
-                .try_into()
-                .expect("label hash slice is 8 bytes");
-
-        Ok(Self::new(direction, node_id, label_hash))
+        Ok(Self {
+            direction,
+            node_id,
+            label: CanonicalLabel::parse_from_slice(&slice[header..])?,
+        })
     }
 
     pub(crate) fn encode_into<B: BufMut>(&self, buf: &mut B) {
         buf.put_u8(KeyPrefix::from(self).as_u8());
         buf.put_slice(IndexPrefix::from(self).as_slice());
         buf.put_u64(self.node_id);
-        buf.put_slice(&self.label_hash);
+        self.label.encode_into(buf);
     }
 }
 
@@ -217,48 +306,108 @@ impl From<&EdgeLabelNeighborKey> for IndexPrefix {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::encoding::indexes::canonical_label::LABEL_DIGEST_LEN;
     use crate::encoding::indexes::PropertyIndexKey;
 
-    const LABEL_HASH: ValueHash = [5, 6, 7, 8, 9, 10, 11, 12];
-
-    #[test]
-    fn edge_label_key_has_exact_layout_and_round_trips() {
-        let key = PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(LABEL_HASH));
+    fn encode_key(key: &PropertyIndexKey<'_>) -> Vec<u8> {
         let mut encoded = Vec::with_capacity(key.encoded_len());
         key.encode_into(&mut encoded);
+        encoded
+    }
 
-        assert_eq!(encoded.as_slice(), &[0x03, 0x04, 5, 6, 7, 8, 9, 10, 11, 12]);
-        assert_eq!(PropertyIndexKey::parse_from_slice(&encoded).unwrap(), key);
+    fn expected_label_frame(label: &str) -> Vec<u8> {
+        let canonical = CanonicalLabel::from_label(label).unwrap();
+        let mut frame = Vec::with_capacity(canonical.encoded_len());
+        canonical.encode_into(&mut frame);
+        frame
     }
 
     #[test]
-    fn edge_label_neighbor_key_has_exact_layout_and_round_trips() {
+    fn node_and_edge_label_keys_have_canonical_layout_and_round_trip() {
+        let node = PropertyIndexKey::NodeLabel(NodeLabelKey::from_label("User").unwrap());
+        let mut expected_node = vec![0x03, 0x07];
+        expected_node.extend_from_slice(&expected_label_frame("User"));
+        let encoded_node = encode_key(&node);
+        assert_eq!(encoded_node, expected_node);
+        assert_eq!(
+            PropertyIndexKey::parse_from_slice(&encoded_node).unwrap(),
+            node
+        );
+
+        let edge = PropertyIndexKey::EdgeLabel(EdgeLabelKey::from_label("FOLLOWS").unwrap());
+        let mut expected_edge = vec![0x03, 0x04];
+        expected_edge.extend_from_slice(&expected_label_frame("FOLLOWS"));
+        let encoded_edge = encode_key(&edge);
+        assert_eq!(encoded_edge, expected_edge);
+        assert_eq!(
+            PropertyIndexKey::parse_from_slice(&encoded_edge).unwrap(),
+            edge
+        );
+    }
+
+    #[test]
+    fn edge_label_neighbor_key_has_canonical_layout_and_round_trips() {
         let node_id = 0x0102_0304_0506_0708u64;
-        let key = PropertyIndexKey::EdgeLabelNeighbor(EdgeLabelNeighborKey::new(
-            EdgeDirection::Out,
-            node_id,
-            LABEL_HASH,
-        ));
-        let mut encoded = Vec::with_capacity(key.encoded_len());
-        key.encode_into(&mut encoded);
+        let key = PropertyIndexKey::EdgeLabelNeighbor(
+            EdgeLabelNeighborKey::from_label(EdgeDirection::Out, node_id, "FOLLOWS").unwrap(),
+        );
+        let mut encoded = encode_key(&key);
 
         let mut expected = vec![0x03, 0x10, 0x00];
         expected.extend_from_slice(&node_id.to_be_bytes());
-        expected.extend_from_slice(&LABEL_HASH);
+        expected.extend_from_slice(&expected_label_frame("FOLLOWS"));
 
         assert_eq!(encoded, expected);
         assert_eq!(PropertyIndexKey::parse_from_slice(&encoded).unwrap(), key);
+        encoded.push(0);
+        assert!(PropertyIndexKey::parse_from_slice(&encoded).is_err());
+    }
+
+    #[test]
+    fn digest_colliding_labels_encode_distinct_keys() {
+        let digest = [0xA5; LABEL_DIGEST_LEN];
+        let first = CanonicalLabel::with_test_digest_unchecked("alpha", digest);
+        let second = CanonicalLabel::with_test_digest_unchecked("beta", digest);
+        let first_key = EdgeLabelKey::from_canonical(first.clone());
+        let second_key = EdgeLabelKey::from_canonical(second.clone());
+        let mut first_bytes = Vec::new();
+        first_key.encode_into(&mut first_bytes);
+        let mut second_bytes = Vec::new();
+        second_key.encode_into(&mut second_bytes);
+        assert_ne!(first_bytes, second_bytes);
+        assert!(matches!(
+            EdgeLabelKey::parse_from_slice(&first_bytes),
+            Err(EncodingError::CanonicalLabelDigestMismatch)
+        ));
+        assert!(matches!(
+            EdgeLabelKey::parse_from_slice(&second_bytes),
+            Err(EncodingError::CanonicalLabelDigestMismatch)
+        ));
+
+        let first_node = NodeLabelKey::from_canonical(first);
+        let second_node = NodeLabelKey::from_canonical(second);
+        let mut first_node_bytes = Vec::new();
+        first_node.encode_into(&mut first_node_bytes);
+        let mut second_node_bytes = Vec::new();
+        second_node.encode_into(&mut second_node_bytes);
+        assert_ne!(first_node_bytes, second_node_bytes);
     }
 
     #[test]
     fn edge_label_key_prefix_contracts_cover_all_shapes() {
-        let label = EdgeLabelKey::new(LABEL_HASH);
+        let label = EdgeLabelKey::from_label("FOLLOWS").unwrap();
         assert_eq!(EdgeLabelKey::key_prefix(), KeyPrefix::PropertyIndex);
         assert_eq!(EdgeLabelKey::index_prefix(), IndexPrefix::EdgeLabel);
         assert_eq!(KeyPrefix::from(&label), KeyPrefix::PropertyIndex);
         assert_eq!(IndexPrefix::from(&label), IndexPrefix::EdgeLabel);
 
-        let neighbor = EdgeLabelNeighborKey::new(EdgeDirection::In, 99, LABEL_HASH);
+        let node = NodeLabelKey::from_label("User").unwrap();
+        assert_eq!(NodeLabelKey::key_prefix(), KeyPrefix::PropertyIndex);
+        assert_eq!(NodeLabelKey::index_prefix(), IndexPrefix::NodeLabel);
+        assert_eq!(KeyPrefix::from(&node), KeyPrefix::PropertyIndex);
+        assert_eq!(IndexPrefix::from(&node), IndexPrefix::NodeLabel);
+
+        let neighbor = EdgeLabelNeighborKey::from_label(EdgeDirection::In, 99, "FOLLOWS").unwrap();
         assert_eq!(EdgeLabelNeighborKey::key_prefix(), KeyPrefix::PropertyIndex);
         assert_eq!(
             EdgeLabelNeighborKey::index_prefix(EdgeDirection::In),
@@ -279,11 +428,36 @@ mod tests {
     fn edge_label_neighbor_rejects_invalid_direction() {
         let mut key = vec![0x03, 0x10, 0x02];
         key.extend_from_slice(&1u64.to_be_bytes());
-        key.extend_from_slice(&LABEL_HASH);
+        key.extend_from_slice(&expected_label_frame("FOLLOWS"));
 
         assert!(matches!(
             EdgeLabelNeighborKey::parse_from_slice(&key),
             Err(EncodingError::InvalidEdgeIndexDirection(0x02))
+        ));
+    }
+
+    #[test]
+    fn hash_only_label_keys_fail_closed() {
+        let mut old_edge = vec![0x03, 0x04];
+        old_edge.extend_from_slice(&[5, 6, 7, 8, 9, 10, 11, 12]);
+        assert!(matches!(
+            EdgeLabelKey::parse_from_slice(&old_edge),
+            Err(EncodingError::BufferTooShort { .. })
+        ));
+
+        let mut old_neighbor = vec![0x03, 0x10, 0x00];
+        old_neighbor.extend_from_slice(&1u64.to_be_bytes());
+        old_neighbor.extend_from_slice(&[5, 6, 7, 8, 9, 10, 11, 12]);
+        assert!(matches!(
+            EdgeLabelNeighborKey::parse_from_slice(&old_neighbor),
+            Err(EncodingError::BufferTooShort { .. })
+        ));
+
+        let mut old_node = vec![0x03, 0x07];
+        old_node.extend_from_slice(&[5, 6, 7, 8, 9, 10, 11, 12]);
+        assert!(matches!(
+            NodeLabelKey::parse_from_slice(&old_node),
+            Err(EncodingError::BufferTooShort { .. })
         ));
     }
 
@@ -294,8 +468,10 @@ mod tests {
             Err(EncodingError::BufferTooShort { .. })
         ));
 
-        let mut key = vec![0x03, 0x04];
-        key.extend_from_slice(&LABEL_HASH);
+        let mut key = Vec::new();
+        EdgeLabelKey::from_label("FOLLOWS")
+            .unwrap()
+            .encode_into(&mut key);
         key.push(0);
         assert!(matches!(
             EdgeLabelKey::parse_from_slice(&key),
@@ -307,9 +483,10 @@ mod tests {
             Err(EncodingError::BufferTooShort { .. })
         ));
 
-        let mut neighbor = vec![0x03, 0x10, 0x00];
-        neighbor.extend_from_slice(&1u64.to_be_bytes());
-        neighbor.extend_from_slice(&LABEL_HASH);
+        let mut neighbor = Vec::new();
+        EdgeLabelNeighborKey::from_label(EdgeDirection::Out, 1, "FOLLOWS")
+            .unwrap()
+            .encode_into(&mut neighbor);
         neighbor.push(0);
         assert!(matches!(
             EdgeLabelNeighborKey::parse_from_slice(&neighbor),
@@ -318,16 +495,30 @@ mod tests {
     }
 
     #[test]
+    fn persisted_label_digest_mismatch_fails_closed() {
+        let mut key = Vec::new();
+        EdgeLabelKey::from_label("FOLLOWS")
+            .unwrap()
+            .encode_into(&mut key);
+        key[PREFIX_LEN + INDEX_PREFIX_LEN] ^= 0xFF;
+        assert!(matches!(
+            EdgeLabelKey::parse_from_slice(&key),
+            Err(EncodingError::CanonicalLabelDigestMismatch)
+        ));
+    }
+
+    #[test]
     fn edge_label_parsers_reject_wrong_prefixes_and_index_kinds() {
+        let frame = expected_label_frame("FOLLOWS");
         let mut wrong_label_key_prefix = vec![0x02, 0x04];
-        wrong_label_key_prefix.extend_from_slice(&LABEL_HASH);
+        wrong_label_key_prefix.extend_from_slice(&frame);
         assert!(matches!(
             EdgeLabelKey::parse_from_slice(&wrong_label_key_prefix),
             Err(EncodingError::Custom(_))
         ));
 
         let mut wrong_label_index_prefix = vec![0x03, 0x00];
-        wrong_label_index_prefix.extend_from_slice(&LABEL_HASH);
+        wrong_label_index_prefix.extend_from_slice(&frame);
         assert!(matches!(
             EdgeLabelKey::parse_from_slice(&wrong_label_index_prefix),
             Err(EncodingError::Custom(_))
@@ -335,7 +526,7 @@ mod tests {
 
         let mut wrong_neighbor_key_prefix = vec![0x02, 0x10, 0x00];
         wrong_neighbor_key_prefix.extend_from_slice(&1u64.to_be_bytes());
-        wrong_neighbor_key_prefix.extend_from_slice(&LABEL_HASH);
+        wrong_neighbor_key_prefix.extend_from_slice(&frame);
         assert!(matches!(
             EdgeLabelNeighborKey::parse_from_slice(&wrong_neighbor_key_prefix),
             Err(EncodingError::Custom(_))
@@ -343,7 +534,7 @@ mod tests {
 
         let mut wrong_neighbor_index_prefix = vec![0x03, 0x04, 0x00];
         wrong_neighbor_index_prefix.extend_from_slice(&1u64.to_be_bytes());
-        wrong_neighbor_index_prefix.extend_from_slice(&LABEL_HASH);
+        wrong_neighbor_index_prefix.extend_from_slice(&frame);
         assert!(matches!(
             EdgeLabelNeighborKey::parse_from_slice(&wrong_neighbor_index_prefix),
             Err(EncodingError::Custom(_))
@@ -353,9 +544,25 @@ mod tests {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
+pub(crate) enum NodeLabelScanPrefix {
+    Index,
+}
+
+#[allow(dead_code)]
+impl NodeLabelScanPrefix {
+    pub(crate) fn to_bytes(self) -> Bytes {
+        let mut buf = Vec::with_capacity(PREFIX_LEN + INDEX_PREFIX_LEN);
+        buf.put_u8(KeyPrefix::PropertyIndex.as_u8());
+        buf.put_slice(IndexPrefix::NodeLabel.as_slice());
+        Bytes::from(buf)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 pub(crate) enum EdgeLabelScanPrefix {
     Index,
-    Label { label_hash: ValueHash },
+    Digest { digest: [u8; LABEL_DIGEST_LEN] },
 }
 
 #[allow(dead_code)]
@@ -370,16 +577,16 @@ impl EdgeLabelScanPrefix {
         buf.put_u8(KeyPrefix::PropertyIndex.as_u8());
         buf.put_slice(IndexPrefix::EdgeLabel.as_slice());
 
-        let EdgeLabelScanPrefix::Label { label_hash } = self else {
+        let EdgeLabelScanPrefix::Digest { digest } = self else {
             return;
         };
-        buf.put_slice(label_hash);
+        buf.put_slice(digest);
     }
 
-    const fn encoded_len(&self) -> usize {
+    fn encoded_len(&self) -> usize {
         match self {
             EdgeLabelScanPrefix::Index => PREFIX_LEN + INDEX_PREFIX_LEN,
-            EdgeLabelScanPrefix::Label { .. } => PREFIX_LEN + INDEX_PREFIX_LEN + VALUE_HASH_MAX_LEN,
+            EdgeLabelScanPrefix::Digest { .. } => PREFIX_LEN + INDEX_PREFIX_LEN + LABEL_DIGEST_LEN,
         }
     }
 }
@@ -395,10 +602,10 @@ pub(crate) enum EdgeLabelNeighborScanPrefix {
         direction: EdgeDirection,
         node_id: NodeId,
     },
-    Label {
+    Digest {
         direction: EdgeDirection,
         node_id: NodeId,
-        label_hash: ValueHash,
+        digest: [u8; LABEL_DIGEST_LEN],
     },
 }
 
@@ -423,19 +630,19 @@ impl EdgeLabelNeighborScanPrefix {
                 buf.put_slice(IndexPrefix::EdgeLabelNeighbor(*direction).as_slice());
                 buf.put_u64(*node_id);
             }
-            EdgeLabelNeighborScanPrefix::Label {
+            EdgeLabelNeighborScanPrefix::Digest {
                 direction,
                 node_id,
-                label_hash,
+                digest,
             } => {
                 buf.put_slice(IndexPrefix::EdgeLabelNeighbor(*direction).as_slice());
                 buf.put_u64(*node_id);
-                buf.put_slice(label_hash);
+                buf.put_slice(digest);
             }
         }
     }
 
-    const fn encoded_len(&self) -> usize {
+    fn encoded_len(&self) -> usize {
         match self {
             EdgeLabelNeighborScanPrefix::Index => PREFIX_LEN + INDEX_PREFIX_LEN,
             EdgeLabelNeighborScanPrefix::Direction { .. } => {
@@ -447,12 +654,12 @@ impl EdgeLabelNeighborScanPrefix {
                     + core::mem::size_of::<EdgeDirection>()
                     + NODE_ID_MAX_LEN
             }
-            EdgeLabelNeighborScanPrefix::Label { .. } => {
+            EdgeLabelNeighborScanPrefix::Digest { .. } => {
                 PREFIX_LEN
                     + INDEX_PREFIX_LEN
                     + core::mem::size_of::<EdgeDirection>()
                     + NODE_ID_MAX_LEN
-                    + VALUE_HASH_MAX_LEN
+                    + LABEL_DIGEST_LEN
             }
         }
     }

--- a/crates/db/src/encoding/v2/keys/indexes/mod.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/mod.rs
@@ -7,6 +7,7 @@ use crate::encoding::v2::values::property::equality_index_value::CanonicalEquali
 use crate::encoding::v2::values::property::range_index_value::CanonicalRangeValue;
 use crate::index_lifecycle::{IndexEntityId, IndexGenerationId, IndexId};
 
+pub(crate) mod canonical_label;
 pub(crate) mod direction;
 pub(crate) mod equality;
 pub(crate) mod label;
@@ -17,6 +18,7 @@ pub(crate) mod secondary;
 pub(crate) mod text;
 pub(crate) mod vector;
 
+pub(crate) use canonical_label::CanonicalLabel;
 pub(crate) use direction::EdgeDirection;
 pub(crate) use prefix::IndexPrefix;
 pub(crate) use property::{

--- a/crates/db/src/encoding/v2/keys/indexes/prefix.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/prefix.rs
@@ -18,6 +18,7 @@ pub(crate) enum IndexPrefix {
     Equality,
     Range(RangeIndexDirection),
     EdgeEquality,
+    NodeLabel,
     EdgeLabel,
     EdgeLabelNeighbor(EdgeDirection),
     EdgeRange(EdgeRangeIndexDirection, EdgeDirection),
@@ -34,6 +35,7 @@ impl IndexPrefix {
                 RangeIndexDirection::Desc => &[0x05],
             },
             IndexPrefix::EdgeEquality => &[0x02],
+            IndexPrefix::NodeLabel => &[0x07],
             IndexPrefix::EdgeLabel => &[0x04],
             IndexPrefix::EdgeLabelNeighbor(direction) => match direction {
                 EdgeDirection::Out => &[0x10, 0x00],
@@ -87,6 +89,7 @@ impl IndexPrefix {
             0x01 => Ok(IndexPrefix::Range(RangeIndexDirection::Asc)),
             0x05 => Ok(IndexPrefix::Range(RangeIndexDirection::Desc)),
             0x02 => Ok(IndexPrefix::EdgeEquality),
+            0x07 => Ok(IndexPrefix::NodeLabel),
             0x04 => Ok(IndexPrefix::EdgeLabel),
             0x08 => Ok(IndexPrefix::GlobalEdgeEquality),
             0x09 => Ok(IndexPrefix::GlobalEdgeRange(RangeIndexDirection::Asc)),
@@ -140,7 +143,9 @@ pub(crate) fn exclusive_prefix_end_bound(prefix: &Bytes) -> Option<Bytes> {
 mod tests {
     use super::super::direction::EdgeDirection as RangeEdgeDirection;
     use super::super::equality::{scans::*, EdgeDirection as EqualityEdgeDirection};
-    use super::super::label::{EdgeLabelNeighborScanPrefix, EdgeLabelScanPrefix};
+    use super::super::label::{
+        EdgeLabelNeighborScanPrefix, EdgeLabelScanPrefix, NodeLabelScanPrefix,
+    };
     use super::super::range::scans::*;
     use super::*;
     use crate::encoding::indexes::{PropertyHash, ValueHash};
@@ -290,14 +295,18 @@ mod tests {
     }
 
     #[test]
-    fn edge_label_prefixes_encode_label_hash_layouts() {
+    fn edge_label_prefixes_encode_digest_accelerators_not_identity() {
         let node_id = 0x0102_0304_0506_0708u64;
+        assert_eq!(
+            NodeLabelScanPrefix::Index.to_bytes().as_ref(),
+            &[0x03, 0x07]
+        );
         assert_eq!(
             EdgeLabelScanPrefix::Index.to_bytes().as_ref(),
             &[0x03, 0x04]
         );
         assert_eq!(
-            EdgeLabelScanPrefix::Label { label_hash: VALUE }
+            EdgeLabelScanPrefix::Digest { digest: VALUE }
                 .to_bytes()
                 .as_ref(),
             &[0x03, 0x04, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -329,10 +338,10 @@ mod tests {
 
         endpoint.extend_from_slice(&VALUE);
         assert_eq!(
-            EdgeLabelNeighborScanPrefix::Label {
+            EdgeLabelNeighborScanPrefix::Digest {
                 direction: RangeEdgeDirection::In,
                 node_id,
-                label_hash: VALUE,
+                digest: VALUE,
             }
             .to_bytes()
             .as_ref(),

--- a/crates/db/src/encoding/v2/keys/indexes/property.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/property.rs
@@ -4,7 +4,7 @@ use crate::encoding::{
     error::EncodingError,
     indexes::{
         equality::{EdgeEqualityIndexKey, EqualityIndexKey, GlobalEdgeEqualityIndexKey},
-        label::{EdgeLabelKey, EdgeLabelNeighborKey},
+        label::{EdgeLabelKey, EdgeLabelNeighborKey, NodeLabelKey},
         range::{
             EdgeRangeIndexDirection, EdgeRangeIndexKey, GlobalEdgeRangeIndexKey,
             RangeIndexDirection, RangeIndexKey,
@@ -16,9 +16,11 @@ use crate::encoding::{
 use bytes::BufMut;
 
 #[cfg(test)]
+use super::direction::EdgeDirection;
+#[cfg(test)]
 use crate::encoding::keys::KeyPrefix;
 
-use super::{direction::EdgeDirection, prefix::IndexPrefix};
+use super::prefix::IndexPrefix;
 
 pub type PropertyHash = [u8; 4];
 pub type ValueHash = [u8; 8];
@@ -63,17 +65,24 @@ pub(crate) enum PropertyIndexKey<'a> {
     /// ```
     EdgeEquality(EdgeEqualityIndexKey),
 
+    /// Builtin node-label index: label -> set of NodeIds
+    /// ```text
+    /// Key: [0x03][0x07][digest:8][u32 len][utf8]
+    /// Value: RoaringTreemap<NodeId>
+    /// ```
+    NodeLabel(NodeLabelKey),
+
     /// Edge label index: label -> set of EdgeIds
     /// ```text
-    /// Key: [0x03][0x04][label_hash:8]
+    /// Key: [0x03][0x04][digest:8][u32 len][utf8]
     /// Value: RoaringTreemap<EdgeId>
     /// ```
     EdgeLabel(EdgeLabelKey),
 
     /// Edge-label neighbor index: endpoint+label -> set of opposite NodeIds
     /// ```text
-    /// Out: [0x03][0x10][0x00][source:8][label_hash:8]
-    /// In:  [0x03][0x10][0x01][target:8][label_hash:8]
+    /// Out: [0x03][0x10][0x00][source:8][digest:8][u32 len][utf8]
+    /// In:  [0x03][0x10][0x01][target:8][digest:8][u32 len][utf8]
     /// Value: RoaringTreemap<NodeId>
     /// ```
     EdgeLabelNeighbor(EdgeLabelNeighborKey),
@@ -123,6 +132,7 @@ impl<'a> PropertyIndexKey<'a> {
                 range_direction, ..
             }) => IndexPrefix::Range(*range_direction),
             PropertyIndexKey::EdgeEquality(_) => IndexPrefix::EdgeEquality,
+            PropertyIndexKey::NodeLabel(_) => IndexPrefix::NodeLabel,
             PropertyIndexKey::EdgeLabel(_) => IndexPrefix::EdgeLabel,
             PropertyIndexKey::EdgeLabelNeighbor(key) => key.index_prefix_for_key(),
             PropertyIndexKey::GlobalEdgeEquality(_) => IndexPrefix::GlobalEdgeEquality,
@@ -144,6 +154,7 @@ impl<'a> PropertyIndexKey<'a> {
             PropertyIndexKey::Equality(_) => EqualityIndexKey::key_prefix(),
             PropertyIndexKey::Range(_) => RangeIndexKey::key_prefix(),
             PropertyIndexKey::EdgeEquality(_) => EdgeEqualityIndexKey::key_prefix(),
+            PropertyIndexKey::NodeLabel(_) => NodeLabelKey::key_prefix(),
             PropertyIndexKey::EdgeLabel(_) => EdgeLabelKey::key_prefix(),
             PropertyIndexKey::EdgeLabelNeighbor(_) => EdgeLabelNeighborKey::key_prefix(),
             PropertyIndexKey::EdgeRange(_) => EdgeRangeIndexKey::key_prefix(),
@@ -159,6 +170,7 @@ impl<'a> PropertyIndexKey<'a> {
             PropertyIndexKey::Equality(_) => EqualityIndexKey::index_prefix(),
             PropertyIndexKey::Range(key) => key.index_prefix(),
             PropertyIndexKey::EdgeEquality(_) => EdgeEqualityIndexKey::index_prefix(),
+            PropertyIndexKey::NodeLabel(_) => NodeLabelKey::index_prefix(),
             PropertyIndexKey::EdgeLabel(_) => EdgeLabelKey::index_prefix(),
             PropertyIndexKey::EdgeLabelNeighbor(key) => key.index_prefix_for_key(),
             PropertyIndexKey::EdgeRange(key) => key.index_prefix(),
@@ -178,6 +190,9 @@ impl<'a> PropertyIndexKey<'a> {
             )?)),
             IndexPrefix::EdgeEquality => Ok(PropertyIndexKey::EdgeEquality(
                 EdgeEqualityIndexKey::parse_from_slice(slice)?,
+            )),
+            IndexPrefix::NodeLabel => Ok(PropertyIndexKey::NodeLabel(
+                NodeLabelKey::parse_from_slice(slice)?,
             )),
             IndexPrefix::EdgeLabel => Ok(PropertyIndexKey::EdgeLabel(
                 EdgeLabelKey::parse_from_slice(slice)?,
@@ -236,14 +251,9 @@ impl<'a> PropertyIndexKey<'a> {
                     + PROPERTY_HASH_MAX_LEN
                     + VALUE_HASH_MAX_LEN
             }
-            PropertyIndexKey::EdgeLabel(_) => PREFIX_LEN + INDEX_PREFIX_LEN + VALUE_HASH_MAX_LEN,
-            PropertyIndexKey::EdgeLabelNeighbor(_) => {
-                PREFIX_LEN
-                    + INDEX_PREFIX_LEN
-                    + size_of::<EdgeDirection>()
-                    + NODE_ID_MAX_LEN
-                    + VALUE_HASH_MAX_LEN
-            }
+            PropertyIndexKey::NodeLabel(key) => key.encoded_len(),
+            PropertyIndexKey::EdgeLabel(key) => key.encoded_len(),
+            PropertyIndexKey::EdgeLabelNeighbor(key) => key.encoded_len(),
             PropertyIndexKey::GlobalEdgeEquality(_) => {
                 PREFIX_LEN + INDEX_PREFIX_LEN + PROPERTY_HASH_MAX_LEN + VALUE_HASH_MAX_LEN
             }
@@ -300,6 +310,7 @@ impl<'a> PropertyIndexKey<'a> {
             PropertyIndexKey::Equality(key) => key.encode_into(buf),
             PropertyIndexKey::Range(key) => key.encode_into(buf),
             PropertyIndexKey::EdgeEquality(key) => key.encode_into(buf),
+            PropertyIndexKey::NodeLabel(key) => key.encode_into(buf),
             PropertyIndexKey::EdgeLabel(key) => key.encode_into(buf),
             PropertyIndexKey::EdgeLabelNeighbor(key) => key.encode_into(buf),
             PropertyIndexKey::EdgeRange(key) => key.encode_into(buf),
@@ -315,7 +326,7 @@ mod tests {
     use crate::encoding::indexes::equality::{
         self as equality_index, EdgeEqualityIndexKey, EqualityIndexKey, GlobalEdgeEqualityIndexKey,
     };
-    use crate::encoding::indexes::label::{EdgeLabelKey, EdgeLabelNeighborKey};
+    use crate::encoding::indexes::label::{EdgeLabelKey, EdgeLabelNeighborKey, NodeLabelKey};
     use crate::encoding::indexes::range::{
         EdgeRangeIndexKey, GlobalEdgeRangeIndexKey, RangeIndexKey,
     };
@@ -341,6 +352,7 @@ mod tests {
             &[0x05]
         );
         assert_eq!(IndexPrefix::EdgeEquality.as_slice(), &[0x02]);
+        assert_eq!(IndexPrefix::NodeLabel.as_slice(), &[0x07]);
         assert_eq!(IndexPrefix::EdgeLabel.as_slice(), &[0x04]);
         assert_eq!(
             IndexPrefix::EdgeLabelNeighbor(EdgeDirection::Out).as_slice(),
@@ -427,6 +439,10 @@ mod tests {
             IndexPrefix::EdgeEquality
         );
         assert_eq!(
+            IndexPrefix::from_slice(&[0x03, 0x07]).unwrap(),
+            IndexPrefix::NodeLabel
+        );
+        assert_eq!(
             IndexPrefix::from_slice(&[0x03, 0x04]).unwrap(),
             IndexPrefix::EdgeLabel
         );
@@ -487,12 +503,11 @@ mod tests {
             [3, 4, 5, 6],
             [8; 8],
         ));
-        let edge_label = PropertyIndexKey::EdgeLabel(EdgeLabelKey::new([9; 8]));
-        let edge_label_neighbor = PropertyIndexKey::EdgeLabelNeighbor(EdgeLabelNeighborKey::new(
-            EdgeDirection::In,
-            17,
-            [10; 8],
-        ));
+        let edge_label = PropertyIndexKey::EdgeLabel(EdgeLabelKey::from_label("FOLLOWS").unwrap());
+        let edge_label_neighbor = PropertyIndexKey::EdgeLabelNeighbor(
+            EdgeLabelNeighborKey::from_label(EdgeDirection::In, 17, "FOLLOWS").unwrap(),
+        );
+        let node_label = PropertyIndexKey::NodeLabel(NodeLabelKey::from_label("User").unwrap());
         let global_edge_equality = PropertyIndexKey::GlobalEdgeEquality(
             GlobalEdgeEqualityIndexKey::new([11, 12, 13, 14], [15; 8]),
         );
@@ -519,6 +534,7 @@ mod tests {
             equality,
             range,
             edge_equality,
+            node_label,
             edge_label,
             edge_label_neighbor,
             global_edge_equality,

--- a/crates/db/src/encoding/v2/keys/indexes/range/edge.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/range/edge.rs
@@ -156,6 +156,7 @@ impl<'a> EdgeRangeIndexKey<'a> {
             IndexPrefix::Equality
             | IndexPrefix::Range(_)
             | IndexPrefix::EdgeEquality
+            | IndexPrefix::NodeLabel
             | IndexPrefix::EdgeLabel
             | IndexPrefix::EdgeLabelNeighbor(_)
             | IndexPrefix::GlobalEdgeEquality
@@ -360,6 +361,7 @@ impl<'a> GlobalEdgeRangeIndexKey<'a> {
             IndexPrefix::Equality
             | IndexPrefix::Range(_)
             | IndexPrefix::EdgeEquality
+            | IndexPrefix::NodeLabel
             | IndexPrefix::EdgeLabel
             | IndexPrefix::EdgeLabelNeighbor(_)
             | IndexPrefix::EdgeRange(..)

--- a/crates/db/src/encoding/v2/keys/indexes/range/node.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/range/node.rs
@@ -173,6 +173,7 @@ impl<'a> RangeIndexKey<'a> {
             IndexPrefix::Range(direction) => direction,
             IndexPrefix::Equality
             | IndexPrefix::EdgeEquality
+            | IndexPrefix::NodeLabel
             | IndexPrefix::EdgeLabel
             | IndexPrefix::EdgeLabelNeighbor(_)
             | IndexPrefix::EdgeRange(..)

--- a/crates/db/src/execution/interpreter/access/tests/secondary_indexes.rs
+++ b/crates/db/src/execution/interpreter/access/tests/secondary_indexes.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use super::support::*;
 use crate::config::SecondaryIndexDefinition;
 use crate::encoding::indexes::equality::{EqualityIndexKey, GlobalEdgeEqualityIndexKey};
+use crate::encoding::indexes::label::NodeLabelKey;
 use crate::encoding::indexes::range::RangeIndexDirection as StorageRangeIndexDirection;
 use crate::encoding::indexes::{hash_property_name, hash_property_value, PropertyIndexKey};
 use crate::encoding::v2::keys::scope::DataScope;
@@ -2062,10 +2063,9 @@ async fn dynamic_equality_ignores_legacy_bitmaps_while_builtin_label_scan_remain
     for key in [
         DataKey::Data {
             scope: DataScope::LegacyUnscoped,
-            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(EqualityIndexKey::new(
-                hash_property_name("$label"),
-                hash_property_value("User"),
-            ))),
+            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::NodeLabel(
+                NodeLabelKey::from_label("User").expect("test labels are valid canonical labels"),
+            )),
         }
         .to_bytes(),
         DataKey::Data {

--- a/crates/db/src/execution/interpreter/mutation/topology.rs
+++ b/crates/db/src/execution/interpreter/mutation/topology.rs
@@ -10,10 +10,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use bytes::Bytes;
 use slatedb::DbTransaction;
 
-use crate::encoding::indexes::label::{EdgeLabelKey, EdgeLabelNeighborKey};
-use crate::encoding::indexes::{
-    hash_property_name, hash_property_value, EdgeDirection, PropertyIndexKey,
-};
+use crate::encoding::indexes::label::{EdgeLabelKey, EdgeLabelNeighborKey, NodeLabelKey};
+use crate::encoding::indexes::{CanonicalLabel, EdgeDirection, PropertyIndexKey};
 use crate::encoding::v2::keys::scope::DataScope;
 use crate::encoding::v2::keys::{AdjacencyKey, DataKey, DataKeyKind, EdgePairIndexKey};
 use crate::encoding::v2::values::{adjacency as edges, indexes as secondary};
@@ -28,11 +26,11 @@ enum MembershipMutation {
 
 /// Logical identity for one shared bitmap row. Physical keys are encoded once
 /// when the coalesced epoch is flushed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum BitmapRow {
     NodeLabel {
         scope: DataScope,
-        label_hash: [u8; 8],
+        label: CanonicalLabel,
     },
     EdgePair {
         scope: DataScope,
@@ -43,49 +41,46 @@ enum BitmapRow {
         scope: DataScope,
         direction: EdgeDirection,
         node: u64,
-        label_hash: [u8; 8],
+        label: CanonicalLabel,
     },
     GlobalEdgeLabel {
         scope: DataScope,
-        label_hash: [u8; 8],
+        label: CanonicalLabel,
     },
 }
 
 impl BitmapRow {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         match self {
-            Self::NodeLabel { scope, label_hash } => DataKey::Data {
-                scope,
-                kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(
-                    crate::encoding::indexes::equality::EqualityIndexKey::new(
-                        hash_property_name("$label"),
-                        label_hash,
-                    ),
+            Self::NodeLabel { scope, label } => DataKey::Data {
+                scope: *scope,
+                kind: DataKeyKind::PropertyIndex(PropertyIndexKey::NodeLabel(
+                    NodeLabelKey::from_canonical(label.clone()),
                 )),
             }
             .to_bytes(),
             Self::EdgePair { scope, from, to } => DataKey::Data {
-                scope,
-                kind: DataKeyKind::EdgePairIndex(EdgePairIndexKey::new(from, to)),
+                scope: *scope,
+                kind: DataKeyKind::EdgePairIndex(EdgePairIndexKey::new(*from, *to)),
             }
             .to_bytes(),
             Self::EdgeLabelNeighbor {
                 scope,
                 direction,
                 node,
-                label_hash,
+                label,
             } => DataKey::Data {
-                scope,
+                scope: *scope,
                 kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
-                    EdgeLabelNeighborKey::new(direction, node, label_hash),
+                    EdgeLabelNeighborKey::from_canonical(*direction, *node, label.clone()),
                 )),
             }
             .to_bytes(),
-            Self::GlobalEdgeLabel { scope, label_hash } => DataKey::Data {
-                scope,
-                kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(
-                    label_hash,
-                ))),
+            Self::GlobalEdgeLabel { scope, label } => DataKey::Data {
+                scope: *scope,
+                kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(
+                    EdgeLabelKey::from_canonical(label.clone()),
+                )),
             }
             .to_bytes(),
         }
@@ -154,7 +149,7 @@ impl TopologyMutationRuntime {
         self.record_bitmap(
             BitmapRow::NodeLabel {
                 scope,
-                label_hash: hash_property_value(label),
+                label: CanonicalLabel::from_label(label)?,
             },
             node_id,
             MembershipMutation::Present,
@@ -171,7 +166,7 @@ impl TopologyMutationRuntime {
         self.record_bitmap(
             BitmapRow::NodeLabel {
                 scope,
-                label_hash: hash_property_value(label),
+                label: CanonicalLabel::from_label(label)?,
             },
             node_id,
             MembershipMutation::Absent,
@@ -217,12 +212,13 @@ impl TopologyMutationRuntime {
         label: &str,
         edge_id: u64,
     ) -> Result<()> {
+        let label = CanonicalLabel::from_label(label)?;
         self.record_bitmap(
             BitmapRow::EdgeLabelNeighbor {
                 scope,
                 direction: EdgeDirection::Out,
                 node: from,
-                label_hash: hash_property_value(label),
+                label: label.clone(),
             },
             to,
             MembershipMutation::Present,
@@ -232,16 +228,13 @@ impl TopologyMutationRuntime {
                 scope,
                 direction: EdgeDirection::In,
                 node: to,
-                label_hash: hash_property_value(label),
+                label: label.clone(),
             },
             from,
             MembershipMutation::Present,
         )?;
         self.record_bitmap(
-            BitmapRow::GlobalEdgeLabel {
-                scope,
-                label_hash: hash_property_value(label),
-            },
+            BitmapRow::GlobalEdgeLabel { scope, label },
             edge_id,
             MembershipMutation::Present,
         )
@@ -257,7 +250,7 @@ impl TopologyMutationRuntime {
         self.record_bitmap(
             BitmapRow::GlobalEdgeLabel {
                 scope,
-                label_hash: hash_property_value(label),
+                label: CanonicalLabel::from_label(label)?,
             },
             edge_id,
             MembershipMutation::Absent,
@@ -272,12 +265,13 @@ impl TopologyMutationRuntime {
         to: u64,
         label: &str,
     ) -> Result<()> {
+        let label = CanonicalLabel::from_label(label)?;
         self.record_bitmap(
             BitmapRow::EdgeLabelNeighbor {
                 scope,
                 direction: EdgeDirection::Out,
                 node: from,
-                label_hash: hash_property_value(label),
+                label: label.clone(),
             },
             to,
             MembershipMutation::Absent,
@@ -287,7 +281,7 @@ impl TopologyMutationRuntime {
                 scope,
                 direction: EdgeDirection::In,
                 node: to,
-                label_hash: hash_property_value(label),
+                label,
             },
             from,
             MembershipMutation::Absent,
@@ -552,11 +546,8 @@ impl TopologyMutationRuntime {
 pub(super) fn node_label_key(scope: DataScope, label: &str) -> Bytes {
     DataKey::Data {
         scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(
-            crate::encoding::indexes::equality::EqualityIndexKey::new(
-                hash_property_name("$label"),
-                hash_property_value(label),
-            ),
+        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::NodeLabel(
+            NodeLabelKey::from_label(label).expect("test labels are valid canonical labels"),
         )),
     }
     .to_bytes()
@@ -581,7 +572,8 @@ pub(super) fn edge_label_neighbor_key(
     DataKey::Data {
         scope,
         kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
-            EdgeLabelNeighborKey::new(direction, node, hash_property_value(label)),
+            EdgeLabelNeighborKey::from_label(direction, node, label)
+                .expect("test labels are valid canonical labels"),
         )),
     }
     .to_bytes()
@@ -591,9 +583,9 @@ pub(super) fn edge_label_neighbor_key(
 pub(super) fn global_edge_label_key(scope: DataScope, label: &str) -> Bytes {
     DataKey::Data {
         scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(
-            hash_property_value(label),
-        ))),
+        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(
+            EdgeLabelKey::from_label(label).expect("test labels are valid canonical labels"),
+        )),
     }
     .to_bytes()
 }

--- a/crates/db/src/execution/interpreter/shortest_path.rs
+++ b/crates/db/src/execution/interpreter/shortest_path.rs
@@ -333,11 +333,12 @@ mod tests {
                         scope: keys::scope::DataScope::LegacyUnscoped,
                         kind: keys::DataKeyKind::PropertyIndex(
                             indexes::PropertyIndexKey::EdgeLabelNeighbor(
-                                indexes::label::EdgeLabelNeighborKey::new(
+                                indexes::label::EdgeLabelNeighborKey::from_label(
                                     index_direction,
                                     7,
-                                    indexes::hash_property_value(label.as_ref()),
-                                ),
+                                    label.as_ref(),
+                                )
+                                .expect("test labels are valid canonical labels"),
                             ),
                         ),
                     }

--- a/crates/db/src/index_lifecycle/metadata.rs
+++ b/crates/db/src/index_lifecycle/metadata.rs
@@ -6,19 +6,24 @@ use super::{
     IndexGenerationId, IndexId, IndexOperationId, IndexOperationRevision, VectorPhysicalIndexId,
 };
 
-/// Canonical V2 index format number written by this implementation.
-pub(crate) const CURRENT_INDEX_STORAGE_VERSION: u16 = 0x0004;
+/// First storage format whose managed equality indexes are V4 bitmaps.
+pub(crate) const EQUALITY_BITMAP_INDEX_STORAGE_VERSION: u16 = 0x0004;
 /// First storage format that permits persisted disjoint membership operands.
 pub(crate) const DISJOINT_MEMBERSHIP_INDEX_STORAGE_VERSION: u16 = 0x0005;
+/// First storage format whose graph `$label` indexes use exact canonical labels.
+pub(crate) const CANONICAL_LABEL_INDEX_STORAGE_VERSION: u16 = 0x0006;
+/// Canonical V2 index format number written by this implementation.
+pub(crate) const CURRENT_INDEX_STORAGE_VERSION: u16 = CANONICAL_LABEL_INDEX_STORAGE_VERSION;
 
 /// Decoded non-zero index storage format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct IndexStorageVersion(u16);
 
 impl IndexStorageVersion {
-    pub(crate) const CURRENT: Self = Self(CURRENT_INDEX_STORAGE_VERSION);
+    pub(crate) const EQUALITY_BITMAP: Self = Self(EQUALITY_BITMAP_INDEX_STORAGE_VERSION);
     pub(crate) const DISJOINT_MEMBERSHIP: Self = Self(DISJOINT_MEMBERSHIP_INDEX_STORAGE_VERSION);
-    pub(crate) const MAX_SUPPORTED: Self = Self::DISJOINT_MEMBERSHIP;
+    pub(crate) const CURRENT: Self = Self(CURRENT_INDEX_STORAGE_VERSION);
+    pub(crate) const MAX_SUPPORTED: Self = Self::CURRENT;
 
     pub(crate) fn new(value: u16) -> Result<Self, crate::encoding::error::EncodingError> {
         if value == 0 {

--- a/crates/db/src/index_lifecycle/repository.rs
+++ b/crates/db/src/index_lifecycle/repository.rs
@@ -229,7 +229,13 @@ fn validate_bootstrap_values(
     }
     match version.get() {
         0x0002 | 0x0003 => Ok(ValidatedReaderBootstrap::LegacyEqualityUnion),
-        0x0004 | 0x0005 => Ok(ValidatedReaderBootstrap::Current),
+        0x0004 | 0x0005 => Err(HelixDbError::WriterMigrationRequired {
+            requirement: WriterMigrationRequirement::StorageVersion {
+                found: version.get(),
+                target: IndexStorageVersion::CURRENT.get(),
+            },
+        }),
+        0x0006 => Ok(ValidatedReaderBootstrap::Current),
         _ => unreachable!("unsupported storage versions returned before compatibility dispatch"),
     }
 }
@@ -1142,8 +1148,8 @@ mod tests {
     use crate::migrations::startup::bootstrap_writer;
 
     #[test]
-    fn storage_versions_with_v4_equality_are_current() {
-        assert_eq!(IndexStorageVersion::CURRENT.get(), 0x0004);
+    fn storage_versions_with_canonical_labels_are_current() {
+        assert_eq!(IndexStorageVersion::CURRENT.get(), 0x0006);
         let logical = encode_metadata_value(&IndexV2MetadataValue::LogicalIndexIdWatermark(
             LogicalIndexIdWatermark {
                 next_id: IndexId::initial(),
@@ -1154,16 +1160,27 @@ mod tests {
                 next_id: VectorPhysicalIndexId::initial(),
             },
         ));
-        for current in [
+        let marker = encode_metadata_value(&IndexV2MetadataValue::StorageVersion(
             IndexStorageVersion::CURRENT,
-            IndexStorageVersion::DISJOINT_MEMBERSHIP,
-        ] {
-            let marker = encode_metadata_value(&IndexV2MetadataValue::StorageVersion(current));
-            assert_eq!(
-                validate_bootstrap_values(&marker, Some(&logical), Some(&vector))
-                    .expect("storage with V4 equality encoding is accepted"),
-                ValidatedReaderBootstrap::Current
-            );
+        ));
+        assert_eq!(
+            validate_bootstrap_values(&marker, Some(&logical), Some(&vector))
+                .expect("canonical-label storage is reader-current"),
+            ValidatedReaderBootstrap::Current
+        );
+        for found in [0x0004, 0x0005] {
+            let marker = encode_metadata_value(&IndexV2MetadataValue::StorageVersion(
+                IndexStorageVersion::new(found).unwrap(),
+            ));
+            assert!(matches!(
+                validate_bootstrap_values(&marker, Some(&logical), Some(&vector)),
+                Err(HelixDbError::WriterMigrationRequired {
+                    requirement: WriterMigrationRequirement::StorageVersion {
+                        found: refused,
+                        target: 0x0006,
+                    },
+                }) if refused == found
+            ));
         }
         for legacy in [0x0002, 0x0003] {
             let marker = encode_metadata_value(&IndexV2MetadataValue::StorageVersion(
@@ -1232,8 +1249,8 @@ mod tests {
         assert!(matches!(
             validate_bootstrap_values(&marker, None, None),
             Err(HelixDbError::UnsupportedIndexStorageVersion {
-                found: 0x0006,
-                supported: 0x0005,
+                found: 0x0007,
+                supported: 0x0006,
             })
         ));
     }
@@ -1278,7 +1295,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejected_writer_preflight_preserves_every_byte() {
-        for rejected_state in ["malformed", "partial", "v1", "v5"] {
+        for rejected_state in ["malformed", "partial", "v1", "unsupported"] {
             let db = Db::builder(
                 format!("writer-preflight-preserves-{rejected_state}"),
                 Arc::new(InMemory::new()),
@@ -1320,8 +1337,13 @@ mod tests {
                 "v1" => {
                     put_bootstrap_tuple(&db, IndexStorageVersion::new(0x0001).unwrap()).await;
                 }
-                "v5" => {
-                    put_bootstrap_tuple(&db, IndexStorageVersion::new(0x0005).unwrap()).await;
+                "unsupported" => {
+                    put_bootstrap_tuple(
+                        &db,
+                        IndexStorageVersion::new(IndexStorageVersion::MAX_SUPPORTED.get() + 1)
+                            .unwrap(),
+                    )
+                    .await;
                 }
                 _ => unreachable!(),
             }

--- a/crates/db/src/membership_delta.rs
+++ b/crates/db/src/membership_delta.rs
@@ -67,7 +67,9 @@ pub(crate) fn decode_write_mode(
         {
             Ok(MembershipDeltaWriteMode::LegacyExclusive)
         }
-        (MembershipDeltaWriteMode::DisjointV2, Some(IndexStorageVersion::DISJOINT_MEMBERSHIP)) => {
+        (MembershipDeltaWriteMode::DisjointV2, Some(version))
+            if version >= IndexStorageVersion::DISJOINT_MEMBERSHIP =>
+        {
             Ok(MembershipDeltaWriteMode::DisjointV2)
         }
         _ => Err(HelixDbError::MigrationRequired {
@@ -134,13 +136,6 @@ pub(crate) async fn activate(db: &Db) -> Result<()> {
                 )),
                 &no_expiry,
             )?;
-            transaction.put_with_options(
-                version_key,
-                encode_metadata_value(&IndexV2MetadataValue::StorageVersion(
-                    IndexStorageVersion::DISJOINT_MEMBERSHIP,
-                )),
-                &no_expiry,
-            )?;
         }
         MembershipDeltaWriteMode::DisjointV2 => {}
     }
@@ -185,7 +180,7 @@ mod tests {
         let version = db.get(storage_version_key()).await.unwrap().unwrap();
         assert_eq!(
             decode_metadata_value(&version).unwrap(),
-            IndexV2MetadataValue::StorageVersion(IndexStorageVersion::DISJOINT_MEMBERSHIP)
+            IndexV2MetadataValue::StorageVersion(IndexStorageVersion::CURRENT)
         );
     }
 
@@ -204,6 +199,14 @@ mod tests {
             write_mode_key(),
             encode_metadata_value(&IndexV2MetadataValue::MembershipDeltaWriteMode(
                 MembershipDeltaWriteMode::DisjointV2,
+            )),
+        )
+        .await
+        .unwrap();
+        db.put(
+            storage_version_key(),
+            encode_metadata_value(&IndexV2MetadataValue::StorageVersion(
+                IndexStorageVersion::EQUALITY_BITMAP,
             )),
         )
         .await

--- a/crates/db/src/migrations/indexes/equality_bitmap.rs
+++ b/crates/db/src/migrations/indexes/equality_bitmap.rs
@@ -178,6 +178,8 @@ pub(crate) async fn migrate_v3_to_v4(db: &Db) -> Result<()> {
     trip(EqualityBitmapMigrationFailpoint::VerificationBefore)?;
     trip(EqualityBitmapMigrationFailpoint::VerificationAfter)?;
 
+    super::labels::rewrite_and_verify_canonical_labels(db).await?;
+
     trip(EqualityBitmapMigrationFailpoint::PublicationBefore)?;
     let transaction = db.begin(IsolationLevel::SerializableSnapshot).await?;
     transaction.put(
@@ -192,7 +194,8 @@ pub(crate) async fn migrate_v3_to_v4(db: &Db) -> Result<()> {
     transaction.commit().await?;
     trip(EqualityBitmapMigrationFailpoint::PublicationAfter)?;
 
-    cleanup_v3_nonunique_equality_rows(db).await
+    cleanup_v3_nonunique_equality_rows(db).await?;
+    super::labels::cleanup_hash_only_label_keys(db).await
 }
 
 pub(crate) async fn cleanup_v3_nonunique_equality_rows(db: &Db) -> Result<()> {

--- a/crates/db/src/migrations/indexes/labels.rs
+++ b/crates/db/src/migrations/indexes/labels.rs
@@ -1,0 +1,810 @@
+//! Blocking rewrite of hash-only graph `$label` indexes to `CanonicalLabel`.
+//!
+//! The V4/V5 marker stays authoritative while every scope is rebuilt from
+//! graph rows and verified. Publication is one final marker write; hash-only
+//! keys are deleted only afterward, so a crash before publication resumes
+//! from the previous format.
+
+use std::collections::BTreeSet;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+use bytes::Bytes;
+use slatedb::{Db, IsolationLevel};
+
+use crate::encoding::indexes::equality::scans::EqualityScanPrefix;
+use crate::encoding::indexes::label::{EdgeLabelNeighborScanPrefix, EdgeLabelScanPrefix};
+use crate::encoding::indexes::{
+    hash_property_name, EdgeDirection, IndexPrefix, INDEX_PREFIX_LEN, NODE_ID_MAX_LEN,
+    PROPERTY_HASH_MAX_LEN, VALUE_HASH_MAX_LEN,
+};
+use crate::encoding::keys::{KeyPrefix, PREFIX_LEN};
+use crate::encoding::property::{decode_properties, Property};
+use crate::encoding::v2::keys::scope::DataScope;
+use crate::encoding::v2::keys::{DataKey, DataKeyKind, GlobalKey, ManagedIndexKey};
+use crate::encoding::v2::values::encode_metadata_value;
+use crate::error::{HelixDbError, Result};
+use crate::index_lifecycle::{IndexElementKind, IndexStorageVersion, IndexV2MetadataValue};
+use crate::search;
+
+const MIGRATION_BATCH_SIZE: usize = 256;
+const NODE_LABEL_PROPERTY: &str = "$label";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CanonicalLabelMigrationFailpoint {
+    RewriteBefore,
+    VerificationBefore,
+    PublicationBefore,
+    PublicationAfter,
+    CleanupBefore,
+}
+
+impl CanonicalLabelMigrationFailpoint {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::RewriteBefore => "rewrite_before",
+            Self::VerificationBefore => "verification_before",
+            Self::PublicationBefore => "publication_before",
+            Self::PublicationAfter => "publication_after",
+            Self::CleanupBefore => "cleanup_before",
+        }
+    }
+}
+
+static INJECTED_FAILPOINT: Mutex<Option<CanonicalLabelMigrationFailpoint>> = Mutex::new(None);
+static FAILPOINT_TRIGGERED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(test)]
+pub(crate) fn inject_once(failpoint: CanonicalLabelMigrationFailpoint) -> Result<()> {
+    let mut injected = INJECTED_FAILPOINT.lock().map_err(|_| {
+        HelixDbError::InvariantViolation(
+            "canonical label migration failpoint mutex was poisoned".to_string(),
+        )
+    })?;
+    *injected = Some(failpoint);
+    FAILPOINT_TRIGGERED.store(false, Ordering::SeqCst);
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn was_triggered() -> bool {
+    FAILPOINT_TRIGGERED.load(Ordering::SeqCst)
+}
+
+fn trip(failpoint: CanonicalLabelMigrationFailpoint) -> Result<()> {
+    let mut injected = INJECTED_FAILPOINT.lock().map_err(|_| {
+        HelixDbError::InvariantViolation(
+            "canonical label migration failpoint mutex was poisoned".to_string(),
+        )
+    })?;
+    if *injected == Some(failpoint) {
+        *injected = None;
+        FAILPOINT_TRIGGERED.store(true, Ordering::SeqCst);
+        return Err(injected_error(failpoint));
+    }
+    Ok(())
+}
+
+fn injected_error(failpoint: CanonicalLabelMigrationFailpoint) -> HelixDbError {
+    HelixDbError::InvariantViolation(format!(
+        "injected canonical label migration failpoint {}",
+        failpoint.as_str()
+    ))
+}
+
+fn corruption(message: &str) -> HelixDbError {
+    HelixDbError::IndexCatalogCorruption(message.to_string())
+}
+
+/// Rewrites hash-only graph labels from authoritative rows and publishes `0x0006`.
+pub(crate) async fn migrate_hash_labels_to_canonical(db: &Db) -> Result<()> {
+    rewrite_and_verify_canonical_labels(db).await?;
+
+    trip(CanonicalLabelMigrationFailpoint::PublicationBefore)?;
+    let transaction = db.begin(IsolationLevel::SerializableSnapshot).await?;
+    transaction.put(
+        ManagedIndexKey::Global {
+            kind: GlobalKey::StorageVersion,
+        }
+        .to_bytes(),
+        encode_metadata_value(&IndexV2MetadataValue::StorageVersion(
+            IndexStorageVersion::CURRENT,
+        )),
+    )?;
+    transaction.commit().await?;
+    trip(CanonicalLabelMigrationFailpoint::PublicationAfter)?;
+
+    cleanup_hash_only_label_keys(db).await
+}
+
+/// Rebuilds canonical label indexes from graph rows and verifies membership.
+pub(crate) async fn rewrite_and_verify_canonical_labels(db: &Db) -> Result<()> {
+    trip(CanonicalLabelMigrationFailpoint::RewriteBefore)?;
+    let scopes = discover_graph_scopes(db).await?;
+    for scope in &scopes {
+        rewrite_scope_labels(db, *scope).await?;
+    }
+    trip(CanonicalLabelMigrationFailpoint::VerificationBefore)?;
+    for scope in &scopes {
+        verify_scope_labels(db, *scope).await?;
+    }
+    Ok(())
+}
+
+/// Deletes hash-only `$label` equality, edge-label, and neighbor keys.
+pub(crate) async fn cleanup_hash_only_label_keys(db: &Db) -> Result<()> {
+    trip(CanonicalLabelMigrationFailpoint::CleanupBefore)?;
+    let scopes = discover_graph_scopes(db).await?;
+    for scope in scopes {
+        delete_matching_keys(db, hash_only_node_label_prefix(scope), |key| {
+            is_hash_only_node_label_key(scope, key)
+        })
+        .await?;
+        delete_matching_keys(db, edge_label_prefix(scope), |key| {
+            is_hash_only_edge_label_key(scope, key)
+        })
+        .await?;
+        delete_matching_keys(db, edge_label_neighbor_prefix(scope), |key| {
+            is_hash_only_edge_neighbor_key(scope, key)
+        })
+        .await?;
+    }
+    Ok(())
+}
+
+async fn discover_graph_scopes(db: &Db) -> Result<BTreeSet<DataScope>> {
+    let mut scopes = BTreeSet::from([DataScope::LegacyUnscoped]);
+    let mut rows = db.scan(..).await?;
+    while let Some(row) = rows.next().await? {
+        if let Some(scope) = graph_property_scope(&row.key) {
+            scopes.insert(scope);
+        }
+    }
+    Ok(scopes)
+}
+
+fn graph_property_scope(key: &[u8]) -> Option<DataScope> {
+    if let Ok(DataKey::Data {
+        kind: DataKeyKind::NodeProperty(_) | DataKeyKind::EdgePropertyById(_),
+        ..
+    }) = DataKey::parse_from_slice(DataScope::LegacyUnscoped, key)
+    {
+        return Some(DataScope::LegacyUnscoped);
+    }
+    let (tenant, _) = DataScope::strip_tenant_envelope(key)?;
+    let scope = DataScope::Tenant(tenant);
+    match DataKey::parse_from_slice(scope, key).ok()? {
+        DataKey::Data {
+            kind: DataKeyKind::NodeProperty(_) | DataKeyKind::EdgePropertyById(_),
+            ..
+        } => Some(scope),
+        DataKey::Data { .. } | DataKey::Global { .. } => None,
+    }
+}
+
+async fn rewrite_scope_labels(db: &Db, scope: DataScope) -> Result<()> {
+    rewrite_node_labels(db, scope).await?;
+    rewrite_edge_labels(db, scope).await
+}
+
+async fn rewrite_node_labels(db: &Db, scope: DataScope) -> Result<()> {
+    let mut rows = db
+        .scan_prefix(
+            crate::index_lifecycle::secondary::source_prefix(scope, IndexElementKind::Node),
+            ..,
+        )
+        .await?;
+    loop {
+        let mut batch = Vec::new();
+        while batch.len() < MIGRATION_BATCH_SIZE {
+            let Some(row) = rows.next().await? else {
+                break;
+            };
+            let Some(node_id) = crate::index_lifecycle::secondary::source_entity(
+                scope,
+                IndexElementKind::Node,
+                &row.key,
+            )?
+            else {
+                continue;
+            };
+            let properties = decode_properties(&row.value)?;
+            let Some(label) = graph_label(&properties) else {
+                continue;
+            };
+            batch.push((node_id.get(), label.to_string()));
+        }
+        if batch.is_empty() {
+            break;
+        }
+        let transaction = db.begin(IsolationLevel::SerializableSnapshot).await?;
+        for (node_id, label) in batch {
+            search::add_to_equality_index_scoped(
+                &transaction,
+                NODE_LABEL_PROPERTY,
+                &label,
+                node_id,
+                scope,
+            )
+            .await?;
+        }
+        transaction.commit().await?;
+    }
+    Ok(())
+}
+
+async fn rewrite_edge_labels(db: &Db, scope: DataScope) -> Result<()> {
+    let mut rows = db
+        .scan_prefix(
+            crate::index_lifecycle::secondary::source_prefix(scope, IndexElementKind::Edge),
+            ..,
+        )
+        .await?;
+    loop {
+        let mut batch = Vec::new();
+        while batch.len() < MIGRATION_BATCH_SIZE {
+            let Some(row) = rows.next().await? else {
+                break;
+            };
+            let Some(edge_id) = crate::index_lifecycle::secondary::source_entity(
+                scope,
+                IndexElementKind::Edge,
+                &row.key,
+            )?
+            else {
+                continue;
+            };
+            let properties = decode_properties(&row.value)?;
+            let Some(label) = graph_label(&properties) else {
+                continue;
+            };
+            let Some((from, to)) =
+                search::get_edge_endpoints_scoped(db, edge_id.get(), scope).await?
+            else {
+                return Err(corruption(
+                    "canonical label migration found an edge property row without endpoints",
+                ));
+            };
+            batch.push((edge_id.get(), from, to, label.to_string()));
+        }
+        if batch.is_empty() {
+            break;
+        }
+        let transaction = db.begin(IsolationLevel::SerializableSnapshot).await?;
+        for (edge_id, from, to, label) in batch {
+            search::add_to_edge_label_index_scoped(&transaction, from, to, &label, scope).await?;
+            search::add_to_global_edge_label_index_scoped(&transaction, &label, edge_id, scope)
+                .await?;
+        }
+        transaction.commit().await?;
+    }
+    Ok(())
+}
+
+async fn verify_scope_labels(db: &Db, scope: DataScope) -> Result<()> {
+    verify_node_labels(db, scope).await?;
+    verify_edge_labels(db, scope).await
+}
+
+async fn verify_node_labels(db: &Db, scope: DataScope) -> Result<()> {
+    let mut rows = db
+        .scan_prefix(
+            crate::index_lifecycle::secondary::source_prefix(scope, IndexElementKind::Node),
+            ..,
+        )
+        .await?;
+    while let Some(row) = rows.next().await? {
+        let Some(node_id) = crate::index_lifecycle::secondary::source_entity(
+            scope,
+            IndexElementKind::Node,
+            &row.key,
+        )?
+        else {
+            continue;
+        };
+        let properties = decode_properties(&row.value)?;
+        let Some(label) = graph_label(&properties) else {
+            continue;
+        };
+        let ids =
+            search::lookup_equality_index_set_scoped(db, NODE_LABEL_PROPERTY, label, scope).await?;
+        if !ids.contains(node_id.get()) {
+            return Err(corruption(
+                "canonical label migration missing a node after rewrite",
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn verify_edge_labels(db: &Db, scope: DataScope) -> Result<()> {
+    let mut rows = db
+        .scan_prefix(
+            crate::index_lifecycle::secondary::source_prefix(scope, IndexElementKind::Edge),
+            ..,
+        )
+        .await?;
+    while let Some(row) = rows.next().await? {
+        let Some(edge_id) = crate::index_lifecycle::secondary::source_entity(
+            scope,
+            IndexElementKind::Edge,
+            &row.key,
+        )?
+        else {
+            continue;
+        };
+        let properties = decode_properties(&row.value)?;
+        let Some(label) = graph_label(&properties) else {
+            continue;
+        };
+        let Some((from, to)) = search::get_edge_endpoints_scoped(db, edge_id.get(), scope).await?
+        else {
+            return Err(corruption(
+                "canonical label migration found an edge property row without endpoints",
+            ));
+        };
+        if !search::lookup_global_edge_label_index_scoped(db, label, scope)
+            .await?
+            .contains(edge_id.get())
+        {
+            return Err(corruption(
+                "canonical label migration missing a global edge label after rewrite",
+            ));
+        }
+        if !search::lookup_out_neighbors_by_label_scoped(db, from, label, scope)
+            .await?
+            .contains(to)
+        {
+            return Err(corruption(
+                "canonical label migration missing an outgoing neighbor after rewrite",
+            ));
+        }
+        if !search::lookup_in_neighbors_by_label_scoped(db, to, label, scope)
+            .await?
+            .contains(from)
+        {
+            return Err(corruption(
+                "canonical label migration missing an incoming neighbor after rewrite",
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn delete_matching_keys(
+    db: &Db,
+    prefix: Bytes,
+    should_delete: impl Fn(&[u8]) -> bool,
+) -> Result<()> {
+    loop {
+        let transaction = db.begin(IsolationLevel::SerializableSnapshot).await?;
+        let mut rows = transaction.scan_prefix(&prefix, ..).await?;
+        let mut keys = Vec::with_capacity(MIGRATION_BATCH_SIZE);
+        let mut scanned = 0;
+        while scanned < MIGRATION_BATCH_SIZE {
+            let Some(row) = rows.next().await? else {
+                break;
+            };
+            scanned += 1;
+            if should_delete(&row.key) {
+                keys.push(row.key);
+            }
+        }
+        drop(rows);
+        if keys.is_empty() {
+            transaction.rollback();
+            if scanned < MIGRATION_BATCH_SIZE {
+                return Ok(());
+            }
+            continue;
+        }
+        for key in keys {
+            transaction.delete(key)?;
+        }
+        transaction.commit().await?;
+        if scanned < MIGRATION_BATCH_SIZE {
+            return Ok(());
+        }
+    }
+}
+
+fn hash_only_node_label_prefix(scope: DataScope) -> Bytes {
+    DataKey::data_prefix(
+        scope,
+        EqualityScanPrefix::Property {
+            property_hash: hash_property_name(NODE_LABEL_PROPERTY),
+        }
+        .to_bytes(),
+    )
+}
+
+fn edge_label_prefix(scope: DataScope) -> Bytes {
+    DataKey::data_prefix(scope, EdgeLabelScanPrefix::Index.to_bytes())
+}
+
+fn edge_label_neighbor_prefix(scope: DataScope) -> Bytes {
+    DataKey::data_prefix(scope, EdgeLabelNeighborScanPrefix::Index.to_bytes())
+}
+
+fn is_hash_only_node_label_key(scope: DataScope, key: &[u8]) -> bool {
+    let Some(logical) = scope.strip_key(key) else {
+        return false;
+    };
+    const HASH_ONLY_NODE_LABEL_LEN: usize =
+        PREFIX_LEN + INDEX_PREFIX_LEN + PROPERTY_HASH_MAX_LEN + VALUE_HASH_MAX_LEN;
+    if logical.len() != HASH_ONLY_NODE_LABEL_LEN
+        || logical[0] != KeyPrefix::PropertyIndex.as_u8()
+        || logical[PREFIX_LEN] != IndexPrefix::Equality.as_slice()[0]
+    {
+        return false;
+    }
+    logical[PREFIX_LEN + INDEX_PREFIX_LEN..PREFIX_LEN + INDEX_PREFIX_LEN + PROPERTY_HASH_MAX_LEN]
+        == hash_property_name(NODE_LABEL_PROPERTY)
+}
+
+fn is_hash_only_edge_label_key(scope: DataScope, key: &[u8]) -> bool {
+    let Some(logical) = scope.strip_key(key) else {
+        return false;
+    };
+    logical.len() == PREFIX_LEN + INDEX_PREFIX_LEN + VALUE_HASH_MAX_LEN
+}
+
+fn is_hash_only_edge_neighbor_key(scope: DataScope, key: &[u8]) -> bool {
+    let Some(logical) = scope.strip_key(key) else {
+        return false;
+    };
+    logical.len()
+        == PREFIX_LEN
+            + INDEX_PREFIX_LEN
+            + core::mem::size_of::<EdgeDirection>()
+            + NODE_ID_MAX_LEN
+            + VALUE_HASH_MAX_LEN
+}
+
+fn graph_label(properties: &[Property]) -> Option<&str> {
+    properties
+        .iter()
+        .find(|property| property.name == NODE_LABEL_PROPERTY)
+        .and_then(|property| property.value.as_str())
+}
+
+#[cfg(test)]
+pub(crate) async fn published_storage_version(db: &Db) -> Result<IndexStorageVersion> {
+    let marker = db
+        .get(
+            ManagedIndexKey::Global {
+                kind: GlobalKey::StorageVersion,
+            }
+            .to_bytes(),
+        )
+        .await?
+        .ok_or_else(|| corruption("canonical label tests require a storage marker"))?;
+    let IndexV2MetadataValue::StorageVersion(version) =
+        crate::encoding::v2::values::decode_metadata_value(&marker)?
+    else {
+        return Err(corruption(
+            "canonical label tests found a non-version storage marker",
+        ));
+    };
+    Ok(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use roaring::RoaringTreemap;
+    use slatedb::object_store::memory::InMemory;
+    use slatedb::object_store::ObjectStore;
+
+    use super::*;
+    use crate::encoding::indexes::equality::EqualityIndexKey;
+    use crate::encoding::indexes::{hash_property_value, IndexPrefix, PropertyIndexKey};
+    use crate::encoding::keys::KeyPrefix;
+    use crate::encoding::property::{encode_properties, Property};
+    use crate::encoding::v2::keys::scope::TenantId;
+    use crate::encoding::v2::keys::{EdgePropertyByIdKey, NodePropertyKey};
+    use crate::encoding::v2::values::indexes::SecondaryEqualityValue;
+    use crate::error::WriterMigrationRequirement;
+    use crate::index_lifecycle::{
+        IndexId, IndexStorageVersion, LogicalIndexIdWatermark, VectorPhysicalIdWatermark,
+        VectorPhysicalIndexId,
+    };
+    use crate::migrations::startup::bootstrap_writer;
+
+    static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    async fn fixture_db(name: &str, store: Arc<dyn ObjectStore>, version: u16) -> Db {
+        let db = Db::builder(name, store)
+            .with_merge_operator(Arc::new(crate::merge_operator::HelixMergeOperator::new()))
+            .build()
+            .await
+            .unwrap();
+        db.put(
+            ManagedIndexKey::Global {
+                kind: GlobalKey::StorageVersion,
+            }
+            .to_bytes(),
+            encode_metadata_value(&IndexV2MetadataValue::StorageVersion(
+                IndexStorageVersion::new(version).unwrap(),
+            )),
+        )
+        .await
+        .unwrap();
+        db.put(
+            ManagedIndexKey::Global {
+                kind: GlobalKey::LogicalIndexIdWatermark,
+            }
+            .to_bytes(),
+            encode_metadata_value(&IndexV2MetadataValue::LogicalIndexIdWatermark(
+                LogicalIndexIdWatermark {
+                    next_id: IndexId::initial(),
+                },
+            )),
+        )
+        .await
+        .unwrap();
+        db.put(
+            ManagedIndexKey::Global {
+                kind: GlobalKey::VectorPhysicalIdWatermark,
+            }
+            .to_bytes(),
+            encode_metadata_value(&IndexV2MetadataValue::VectorPhysicalIdWatermark(
+                VectorPhysicalIdWatermark {
+                    next_id: VectorPhysicalIndexId::initial(),
+                },
+            )),
+        )
+        .await
+        .unwrap();
+        let transaction = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .unwrap();
+        crate::migrations::stage_reader_compatible_storage_schema_for_tests(&transaction).unwrap();
+        crate::migrations::stage_index_storage_v4_cleanup_ready(&transaction).unwrap();
+        transaction.commit().await.unwrap();
+        db
+    }
+
+    fn hash_only_node_label_key(scope: DataScope, label: &str) -> Bytes {
+        DataKey::Data {
+            scope,
+            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(EqualityIndexKey::new(
+                hash_property_name(NODE_LABEL_PROPERTY),
+                hash_property_value(label),
+            ))),
+        }
+        .to_bytes()
+    }
+
+    fn hash_only_edge_label_key(scope: DataScope, label: &str) -> Bytes {
+        let mut logical = Vec::with_capacity(PREFIX_LEN + INDEX_PREFIX_LEN + VALUE_HASH_MAX_LEN);
+        logical.push(KeyPrefix::PropertyIndex.as_u8());
+        logical.extend_from_slice(IndexPrefix::EdgeLabel.as_slice());
+        logical.extend_from_slice(&hash_property_value(label));
+        DataKey::data_prefix(scope, Bytes::from(logical))
+    }
+
+    fn hash_only_neighbor_key(
+        scope: DataScope,
+        direction: EdgeDirection,
+        node: u64,
+        label: &str,
+    ) -> Bytes {
+        let mut logical = Vec::with_capacity(
+            PREFIX_LEN
+                + INDEX_PREFIX_LEN
+                + core::mem::size_of::<EdgeDirection>()
+                + NODE_ID_MAX_LEN
+                + VALUE_HASH_MAX_LEN,
+        );
+        logical.push(KeyPrefix::PropertyIndex.as_u8());
+        logical.extend_from_slice(IndexPrefix::EdgeLabelNeighbor(direction).as_slice());
+        logical.extend_from_slice(&node.to_be_bytes());
+        logical.extend_from_slice(&hash_property_value(label));
+        DataKey::data_prefix(scope, Bytes::from(logical))
+    }
+
+    async fn put_labeled_node(db: &Db, scope: DataScope, node_id: u64, label: &str) {
+        db.put(
+            DataKey::Data {
+                scope,
+                kind: DataKeyKind::NodeProperty(NodePropertyKey::new(node_id)),
+            }
+            .to_bytes(),
+            encode_properties(&[Property::string(NODE_LABEL_PROPERTY, label)]),
+        )
+        .await
+        .unwrap();
+        db.put(
+            hash_only_node_label_key(scope, label),
+            SecondaryEqualityValue::encode_ids(&RoaringTreemap::from_iter([node_id])),
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn put_labeled_edge(
+        db: &Db,
+        scope: DataScope,
+        edge_id: u64,
+        from: u64,
+        to: u64,
+        label: &str,
+    ) {
+        let transaction = db.begin(IsolationLevel::Snapshot).await.unwrap();
+        transaction
+            .put(
+                DataKey::Data {
+                    scope,
+                    kind: DataKeyKind::EdgePropertyById(EdgePropertyByIdKey::new(edge_id)),
+                }
+                .to_bytes(),
+                encode_properties(&[Property::string(NODE_LABEL_PROPERTY, label)]),
+            )
+            .unwrap();
+        search::store_edge_endpoints_scoped(&transaction, edge_id, from, to, scope)
+            .await
+            .unwrap();
+        transaction
+            .put(
+                hash_only_edge_label_key(scope, label),
+                SecondaryEqualityValue::encode_ids(&RoaringTreemap::from_iter([edge_id])),
+            )
+            .unwrap();
+        transaction
+            .put(
+                hash_only_neighbor_key(scope, EdgeDirection::Out, from, label),
+                SecondaryEqualityValue::encode_ids(&RoaringTreemap::from_iter([to])),
+            )
+            .unwrap();
+        transaction
+            .put(
+                hash_only_neighbor_key(scope, EdgeDirection::In, to, label),
+                SecondaryEqualityValue::encode_ids(&RoaringTreemap::from_iter([from])),
+            )
+            .unwrap();
+        transaction.commit().await.unwrap();
+    }
+
+    async fn assert_canonical_lookups(db: &Db, scope: DataScope) {
+        assert_eq!(
+            search::lookup_equality_index_scoped(db, NODE_LABEL_PROPERTY, "User", scope)
+                .await
+                .unwrap(),
+            vec![11]
+        );
+        assert!(
+            search::lookup_global_edge_label_index_scoped(db, "FOLLOWS", scope)
+                .await
+                .unwrap()
+                .contains(99)
+        );
+        assert!(
+            search::lookup_out_neighbors_by_label_scoped(db, 11, "FOLLOWS", scope)
+                .await
+                .unwrap()
+                .contains(17)
+        );
+        assert!(db
+            .get(&hash_only_node_label_key(scope, "User"))
+            .await
+            .unwrap()
+            .is_none());
+        assert!(db
+            .get(&hash_only_edge_label_key(scope, "FOLLOWS"))
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn reader_refuses_hash_only_v4_until_writer_rewrites() {
+        let _guard = TEST_LOCK.lock().await;
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let database = "canonical-label-reader-refuses-v4";
+        let db = fixture_db(database, Arc::clone(&store), 0x0004).await;
+        put_labeled_node(&db, DataScope::LegacyUnscoped, 11, "User").await;
+        put_labeled_edge(&db, DataScope::LegacyUnscoped, 99, 11, 17, "FOLLOWS").await;
+        db.flush().await.unwrap();
+        db.close().await.unwrap();
+
+        let Err(error) =
+            crate::HelixDB::open_reader_with_object_store_for_tests(database, Arc::clone(&store))
+                .await
+        else {
+            panic!("hash-only V4 storage is not reader-current");
+        };
+        assert!(matches!(
+            error,
+            HelixDbError::WriterMigrationRequired {
+                requirement: WriterMigrationRequirement::StorageVersion {
+                    found: 0x0004,
+                    target: 0x0006,
+                },
+            }
+        ));
+
+        let opened = crate::HelixDB::open_with_object_store(database, store)
+            .await
+            .expect("writer bootstrap rewrites hash-only labels");
+        let storage = opened.inner_db();
+        assert_eq!(
+            published_storage_version(storage.as_ref()).await.unwrap(),
+            IndexStorageVersion::CURRENT
+        );
+        assert_canonical_lookups(storage.as_ref(), DataScope::LegacyUnscoped).await;
+        opened.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn writer_rewrites_hash_only_labels_in_every_scope() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let database = "canonical-label-rewrite-v5-scopes";
+        let tenant =
+            DataScope::Tenant(TenantId::from_ulid_str("01KZ6WZ9QREKZZ87492YXBTFJ3").unwrap());
+        let db = fixture_db(database, Arc::clone(&store), 0x0004).await;
+        put_labeled_node(&db, DataScope::LegacyUnscoped, 11, "User").await;
+        put_labeled_edge(&db, DataScope::LegacyUnscoped, 99, 11, 17, "FOLLOWS").await;
+        put_labeled_node(&db, tenant, 11, "User").await;
+        put_labeled_edge(&db, tenant, 99, 11, 17, "FOLLOWS").await;
+        db.flush().await.unwrap();
+
+        bootstrap_writer(&db)
+            .await
+            .expect("writer bootstrap rewrites hash-only labels in every scope");
+        assert_eq!(
+            published_storage_version(&db).await.unwrap(),
+            IndexStorageVersion::CURRENT
+        );
+        assert_canonical_lookups(&db, DataScope::LegacyUnscoped).await;
+        assert_canonical_lookups(&db, tenant).await;
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn publication_crash_leaves_previous_marker_and_resumes() {
+        let _guard = TEST_LOCK.lock().await;
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let database = "canonical-label-rewrite-resumes";
+        let db = fixture_db(database, Arc::clone(&store), 0x0004).await;
+        put_labeled_node(&db, DataScope::LegacyUnscoped, 11, "User").await;
+        put_labeled_edge(&db, DataScope::LegacyUnscoped, 99, 11, 17, "FOLLOWS").await;
+        db.flush().await.unwrap();
+
+        inject_once(CanonicalLabelMigrationFailpoint::PublicationBefore).unwrap();
+        assert!(bootstrap_writer(&db).await.is_err());
+        assert!(was_triggered());
+        assert_eq!(published_storage_version(&db).await.unwrap().get(), 0x0004);
+        db.flush().await.unwrap();
+        db.close().await.unwrap();
+
+        let opened = crate::HelixDB::open_with_object_store(database, store)
+            .await
+            .expect("writer restart finishes the canonical-label rewrite");
+        let storage = opened.inner_db();
+        assert_eq!(
+            published_storage_version(storage.as_ref()).await.unwrap(),
+            IndexStorageVersion::CURRENT
+        );
+        assert_canonical_lookups(storage.as_ref(), DataScope::LegacyUnscoped).await;
+        opened.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fresh_writer_bootstrap_publishes_canonical_label_version() {
+        let db = Db::builder("canonical-label-fresh-current", Arc::new(InMemory::new()))
+            .with_merge_operator(Arc::new(crate::merge_operator::HelixMergeOperator::new()))
+            .build()
+            .await
+            .unwrap();
+        bootstrap_writer(&db).await.unwrap();
+        assert_eq!(
+            published_storage_version(&db).await.unwrap(),
+            IndexStorageVersion::CURRENT
+        );
+        assert_eq!(IndexStorageVersion::CURRENT.get(), 0x0006);
+        db.close().await.unwrap();
+    }
+}

--- a/crates/db/src/migrations/indexes/mod.rs
+++ b/crates/db/src/migrations/indexes/mod.rs
@@ -1,3 +1,4 @@
 //! Managed-index storage migrations.
 
 pub(super) mod equality_bitmap;
+pub(super) mod labels;

--- a/crates/db/src/migrations/startup/bootstrap.rs
+++ b/crates/db/src/migrations/startup/bootstrap.rs
@@ -27,14 +27,40 @@ pub(crate) async fn bootstrap_writer(db: &Db) -> Result<()> {
 
     match plan {
         WriterBootstrapPlan::Initialize => initialize_writer_bootstrap(db).await,
-        WriterBootstrapPlan::MigrateToCurrent => {
-            super::super::indexes::equality_bitmap::migrate_v3_to_v4(db).await
-        }
+        WriterBootstrapPlan::MigrateToCurrent => migrate_to_current(db).await,
         WriterBootstrapPlan::CleanupCurrent => {
             super::super::indexes::equality_bitmap::cleanup_v3_nonunique_equality_rows(db).await
         }
         WriterBootstrapPlan::Ready => Ok(()),
     }
+}
+
+async fn migrate_to_current(db: &Db) -> Result<()> {
+    let version = read_writer_storage_version(db).await?;
+    if version < IndexStorageVersion::EQUALITY_BITMAP {
+        return super::super::indexes::equality_bitmap::migrate_v3_to_v4(db).await;
+    }
+    if version < IndexStorageVersion::CURRENT {
+        return super::super::indexes::labels::migrate_hash_labels_to_canonical(db).await;
+    }
+    Ok(())
+}
+
+async fn read_writer_storage_version(db: &Db) -> Result<IndexStorageVersion> {
+    let marker = db
+        .get(&global_key(GlobalKey::StorageVersion))
+        .await?
+        .ok_or_else(|| HelixDbError::MigrationRequired {
+            reason: "V2 storage marker disappeared after writer preflight".to_string(),
+        })?;
+    let IndexV2MetadataValue::StorageVersion(version) =
+        metadata_or_migration_required(&marker, "storage marker")?
+    else {
+        return Err(HelixDbError::MigrationRequired {
+            reason: "V2 storage marker contains the wrong value kind".to_string(),
+        });
+    };
+    Ok(version)
 }
 
 /// Initializes a pristine managed database without entering a migration path.
@@ -85,16 +111,17 @@ pub(crate) async fn require_current_managed_writer(db: &Db) -> Result<()> {
         });
     };
     validate_writer_bootstrap_values(&marker, logical.as_deref(), vector.as_deref())?;
+    if version < IndexStorageVersion::EQUALITY_BITMAP && cleanup_ready {
+        transaction.rollback();
+        return Err(HelixDbError::MigrationRequired {
+            reason: format!(
+                "index storage V4 cleanup is marked complete beside storage version {}",
+                version.get()
+            ),
+        });
+    }
     if version < IndexStorageVersion::CURRENT {
         transaction.rollback();
-        if cleanup_ready {
-            return Err(HelixDbError::MigrationRequired {
-                reason: format!(
-                    "index storage V4 cleanup is marked complete beside storage version {}",
-                    version.get()
-                ),
-            });
-        }
         return Err(HelixDbError::WriterMigrationRequired {
             requirement: WriterMigrationRequirement::StorageVersion {
                 found: version.get(),
@@ -170,7 +197,7 @@ async fn preflight_writer_bootstrap(db: &Db) -> Result<WriterBootstrapPlan> {
         });
     };
     validate_writer_bootstrap_values(&marker, logical.as_deref(), vector.as_deref())?;
-    if version < IndexStorageVersion::CURRENT && cleanup_ready {
+    if version < IndexStorageVersion::EQUALITY_BITMAP && cleanup_ready {
         return Err(HelixDbError::MigrationRequired {
             reason: format!(
                 "index storage V4 cleanup is marked complete beside storage version {}",

--- a/crates/db/src/search/mod.rs
+++ b/crates/db/src/search/mod.rs
@@ -35,7 +35,9 @@ use crate::encoding::indexes::equality::{
     scans::{EdgeEqualityScanPrefix, EqualityScanPrefix, GlobalEdgeEqualityScanPrefix},
     EdgeDirection as EdgeEqualityDirection, EdgeEqualityIndexKey, EqualityIndexKey,
 };
-use crate::encoding::indexes::label::{EdgeLabelKey, EdgeLabelNeighborKey, EdgeLabelScanPrefix};
+use crate::encoding::indexes::label::{
+    EdgeLabelKey, EdgeLabelNeighborKey, EdgeLabelScanPrefix, NodeLabelKey, NodeLabelScanPrefix,
+};
 use crate::encoding::indexes::prefix::exclusive_prefix_end_bound;
 use crate::encoding::indexes::range::{
     scans::{
@@ -68,6 +70,57 @@ use slatedb::DbReadOps;
 fn bounded_prefix_end(prefix: &Bytes) -> Bytes {
     exclusive_prefix_end_bound(prefix)
         .expect("typed index prefixes always have a finite lexicographic successor")
+}
+
+const NODE_LABEL_PROPERTY: &str = "$label";
+
+fn node_label_data_key(scope: DataScope, label: &str) -> Result<Bytes, HelixDbError> {
+    Ok(DataKey::Data {
+        scope,
+        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::NodeLabel(NodeLabelKey::from_label(
+            label,
+        )?)),
+    }
+    .to_bytes())
+}
+
+fn equality_data_key(scope: DataScope, property: &str, value: &str) -> Result<Bytes, HelixDbError> {
+    if property == NODE_LABEL_PROPERTY {
+        return node_label_data_key(scope, value);
+    }
+    Ok(DataKey::Data {
+        scope,
+        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(EqualityIndexKey::new(
+            hash_property_name(property),
+            hash_property_value(value),
+        ))),
+    }
+    .to_bytes())
+}
+
+fn edge_label_data_key(scope: DataScope, label: &str) -> Result<Bytes, HelixDbError> {
+    Ok(DataKey::Data {
+        scope,
+        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::from_label(
+            label,
+        )?)),
+    }
+    .to_bytes())
+}
+
+fn edge_label_neighbor_data_key(
+    scope: DataScope,
+    direction: EdgeRangeDirection,
+    node: NodeId,
+    label: &str,
+) -> Result<Bytes, HelixDbError> {
+    Ok(DataKey::Data {
+        scope,
+        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
+            EdgeLabelNeighborKey::from_label(direction, node, label)?,
+        )),
+    }
+    .to_bytes())
 }
 
 /// Build a deterministic vector index name from element type, label, and property.
@@ -408,7 +461,6 @@ pub fn migration_parity_graph_hash_contract(
 ) -> BTreeMap<String, Vec<u8>> {
     let property_hash = hash_property_name(property);
     let value_hash = hash_property_value(value);
-    let label_hash = hash_property_value(label);
     let mut rows = BTreeMap::new();
     rows.insert("property_name_hash".to_string(), property_hash.to_vec());
     rows.insert("property_value_hash".to_string(), value_hash.to_vec());
@@ -484,9 +536,9 @@ pub fn migration_parity_graph_hash_contract(
         "global_edge_label_key".to_string(),
         DataKey::Data {
             scope: DataScope::LegacyUnscoped,
-            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(
-                label_hash,
-            ))),
+            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(
+                EdgeLabelKey::from_label(label).expect("parity labels are valid canonical labels"),
+            )),
         }
         .to_bytes()
         .to_vec(),
@@ -500,7 +552,8 @@ pub fn migration_parity_graph_hash_contract(
             DataKey::Data {
                 scope: DataScope::LegacyUnscoped,
                 kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
-                    EdgeLabelNeighborKey::new(direction, endpoint, label_hash),
+                    EdgeLabelNeighborKey::from_label(direction, endpoint, label)
+                        .expect("parity labels are valid canonical labels"),
                 )),
             }
             .to_bytes()
@@ -679,14 +732,7 @@ pub async fn add_to_equality_index_scoped(
     node_id: NodeId,
     tenant_scope: DataScope,
 ) -> Result<(), HelixDbError> {
-    let key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(EqualityIndexKey::new(
-            hash_property_name(property),
-            hash_property_value(value),
-        ))),
-    }
-    .to_bytes();
+    let key = equality_data_key(tenant_scope, property, value)?;
 
     stage_shared_bitmap_membership(txn, &key, node_id, true).await
 }
@@ -709,14 +755,7 @@ pub async fn remove_from_equality_index_scoped(
     node_id: NodeId,
     tenant_scope: DataScope,
 ) -> Result<(), HelixDbError> {
-    let key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(EqualityIndexKey::new(
-            hash_property_name(property),
-            hash_property_value(value),
-        ))),
-    }
-    .to_bytes();
+    let key = equality_data_key(tenant_scope, property, value)?;
 
     stage_shared_bitmap_membership(txn, &key, node_id, false).await
 }
@@ -736,14 +775,7 @@ pub async fn lookup_equality_index_scoped(
     value: &str,
     tenant_scope: DataScope,
 ) -> Result<Vec<NodeId>, HelixDbError> {
-    let key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(EqualityIndexKey::new(
-            hash_property_name(property),
-            hash_property_value(value),
-        ))),
-    }
-    .to_bytes();
+    let key = equality_data_key(tenant_scope, property, value)?;
 
     match txn.get(&key).await? {
         Some(data) => {
@@ -769,14 +801,7 @@ pub async fn lookup_equality_index_set_scoped(
     value: &str,
     tenant_scope: DataScope,
 ) -> Result<RoaringTreemap, HelixDbError> {
-    let key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(EqualityIndexKey::new(
-            hash_property_name(property),
-            hash_property_value(value),
-        ))),
-    }
-    .to_bytes();
+    let key = equality_data_key(tenant_scope, property, value)?;
 
     match txn.get(&key).await? {
         Some(data) => decode_roaring_treemap(&data),
@@ -823,10 +848,14 @@ pub async fn scan_equality_index_property_prefix_limited_filtered_scoped(
         return Ok(RoaringTreemap::new());
     }
 
-    let prefix = EqualityScanPrefix::Property {
-        property_hash: hash_property_name(property),
-    }
-    .to_bytes();
+    let prefix = if property == NODE_LABEL_PROPERTY {
+        NodeLabelScanPrefix::Index.to_bytes()
+    } else {
+        EqualityScanPrefix::Property {
+            property_hash: hash_property_name(property),
+        }
+        .to_bytes()
+    };
     let mut iter = txn
         .scan_prefix(DataKey::data_prefix(tenant_scope, prefix), ..)
         .await?;
@@ -1629,26 +1658,10 @@ pub async fn add_to_edge_label_index_scoped(
     label: &str,
     tenant_scope: DataScope,
 ) -> Result<(), HelixDbError> {
-    let label_hash = hash_property_value(label);
-
-    // Update outgoing index: from + label -> to
-    let out_key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
-            EdgeLabelNeighborKey::new(EdgeRangeDirection::Out, from, label_hash),
-        )),
-    }
-    .to_bytes();
+    let out_key = edge_label_neighbor_data_key(tenant_scope, EdgeRangeDirection::Out, from, label)?;
     stage_shared_bitmap_membership(txn, &out_key, to, true).await?;
 
-    // Update incoming index: to + label -> from
-    let in_key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
-            EdgeLabelNeighborKey::new(EdgeRangeDirection::In, to, label_hash),
-        )),
-    }
-    .to_bytes();
+    let in_key = edge_label_neighbor_data_key(tenant_scope, EdgeRangeDirection::In, to, label)?;
     stage_shared_bitmap_membership(txn, &in_key, from, true).await
 }
 
@@ -1669,26 +1682,10 @@ pub async fn remove_from_edge_label_index_scoped(
     label: &str,
     tenant_scope: DataScope,
 ) -> Result<(), HelixDbError> {
-    let label_hash = hash_property_value(label);
-
-    // Update outgoing index
-    let out_key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
-            EdgeLabelNeighborKey::new(EdgeRangeDirection::Out, from, label_hash),
-        )),
-    }
-    .to_bytes();
+    let out_key = edge_label_neighbor_data_key(tenant_scope, EdgeRangeDirection::Out, from, label)?;
     stage_shared_bitmap_membership(txn, &out_key, to, false).await?;
 
-    // Update incoming index
-    let in_key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
-            EdgeLabelNeighborKey::new(EdgeRangeDirection::In, to, label_hash),
-        )),
-    }
-    .to_bytes();
+    let in_key = edge_label_neighbor_data_key(tenant_scope, EdgeRangeDirection::In, to, label)?;
     stage_shared_bitmap_membership(txn, &in_key, from, false).await
 }
 
@@ -1709,13 +1706,7 @@ pub async fn lookup_out_neighbors_by_label_scoped(
     label: &str,
     tenant_scope: DataScope,
 ) -> Result<RoaringTreemap, HelixDbError> {
-    let key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
-            EdgeLabelNeighborKey::new(EdgeRangeDirection::Out, source, hash_property_value(label)),
-        )),
-    }
-    .to_bytes();
+    let key = edge_label_neighbor_data_key(tenant_scope, EdgeRangeDirection::Out, source, label)?;
     match txn.get(&key).await? {
         Some(data) => decode_roaring_treemap(&data),
         None => Ok(RoaringTreemap::new()),
@@ -1739,13 +1730,7 @@ pub async fn lookup_in_neighbors_by_label_scoped(
     label: &str,
     tenant_scope: DataScope,
 ) -> Result<RoaringTreemap, HelixDbError> {
-    let key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
-            EdgeLabelNeighborKey::new(EdgeRangeDirection::In, target, hash_property_value(label)),
-        )),
-    }
-    .to_bytes();
+    let key = edge_label_neighbor_data_key(tenant_scope, EdgeRangeDirection::In, target, label)?;
     match txn.get(&key).await? {
         Some(data) => decode_roaring_treemap(&data),
         None => Ok(RoaringTreemap::new()),
@@ -2007,13 +1992,7 @@ pub async fn add_to_global_edge_label_index_scoped(
     edge_id: EdgeId,
     tenant_scope: DataScope,
 ) -> Result<(), HelixDbError> {
-    let key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(
-            hash_property_value(label),
-        ))),
-    }
-    .to_bytes();
+    let key = edge_label_data_key(tenant_scope, label)?;
     stage_shared_bitmap_membership(txn, &key, edge_id, true).await
 }
 
@@ -2032,13 +2011,7 @@ pub async fn remove_from_global_edge_label_index_scoped(
     edge_id: EdgeId,
     tenant_scope: DataScope,
 ) -> Result<(), HelixDbError> {
-    let key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(
-            hash_property_value(label),
-        ))),
-    }
-    .to_bytes();
+    let key = edge_label_data_key(tenant_scope, label)?;
     stage_shared_bitmap_membership(txn, &key, edge_id, false).await
 }
 
@@ -2055,13 +2028,7 @@ pub async fn lookup_global_edge_label_index_scoped(
     label: &str,
     tenant_scope: DataScope,
 ) -> Result<RoaringTreemap, HelixDbError> {
-    let key = DataKey::Data {
-        scope: tenant_scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(
-            hash_property_value(label),
-        ))),
-    }
-    .to_bytes();
+    let key = edge_label_data_key(tenant_scope, label)?;
     match txn.get(&key).await? {
         Some(data) => decode_roaring_treemap(&data),
         None => Ok(RoaringTreemap::new()),
@@ -2175,12 +2142,9 @@ pub async fn remove_from_edge_pair_index_scoped(
     stage_shared_bitmap_membership(txn, &key, edge_id, false).await
 }
 
-/// Delete all node `$label` equality-index entries before a full rebuild.
+/// Delete all builtin node-label index entries before a full rebuild.
 pub async fn clear_node_label_indexes(txn: &DbTransaction) -> Result<(), HelixDbError> {
-    let prefix = EqualityScanPrefix::Property {
-        property_hash: hash_property_name("$label"),
-    }
-    .to_bytes();
+    let prefix = NodeLabelScanPrefix::Index.to_bytes();
     let mut iter = txn.scan_prefix(prefix, ..).await?;
     let mut keys = Vec::new();
     while let Some(kv) = iter.next().await? {
@@ -5001,9 +4965,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn edge_label_indexes_use_hashed_encoding_keys() {
+    async fn edge_label_indexes_use_canonical_encoding_keys() {
         let db = crate::HelixDB::open(crate::HelixDbSource::InMemory {
-            database: "search-edge-label-hashed-keys".to_string(),
+            database: "search-edge-label-canonical-keys".to_string(),
         })
         .await
         .expect("db opens");
@@ -5012,7 +4976,6 @@ mod tests {
             .begin(IsolationLevel::Snapshot)
             .await
             .expect("transaction starts");
-        let label_hash = hash_property_value("FOLLOWS");
 
         add_to_edge_label_index(&txn, 1, 2, "FOLLOWS")
             .await
@@ -5021,36 +4984,35 @@ mod tests {
             .await
             .expect("global label index write succeeds");
 
-        let out_key = DataKey::Data {
-            scope: DataScope::LegacyUnscoped,
-            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
-                EdgeLabelNeighborKey::new(EdgeRangeDirection::Out, 1, label_hash),
-            )),
-        }
-        .to_bytes();
-        let in_key = DataKey::Data {
-            scope: DataScope::LegacyUnscoped,
-            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
-                EdgeLabelNeighborKey::new(EdgeRangeDirection::In, 2, label_hash),
-            )),
-        }
-        .to_bytes();
-        let global_key = DataKey::Data {
-            scope: DataScope::LegacyUnscoped,
-            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(
-                label_hash,
-            ))),
-        }
-        .to_bytes();
+        let out_key = edge_label_neighbor_data_key(
+            DataScope::LegacyUnscoped,
+            EdgeRangeDirection::Out,
+            1,
+            "FOLLOWS",
+        )
+        .expect("canonical neighbor key encodes");
+        let in_key = edge_label_neighbor_data_key(
+            DataScope::LegacyUnscoped,
+            EdgeRangeDirection::In,
+            2,
+            "FOLLOWS",
+        )
+        .expect("canonical neighbor key encodes");
+        let global_key = edge_label_data_key(DataScope::LegacyUnscoped, "FOLLOWS")
+            .expect("canonical global key encodes");
 
         let mut expected_out_key = vec![0x03, 0x10, 0x00];
         expected_out_key.extend_from_slice(&1u64.to_be_bytes());
-        expected_out_key.extend_from_slice(&label_hash);
+        let mut label_frame = Vec::new();
+        crate::encoding::indexes::CanonicalLabel::from_label("FOLLOWS")
+            .unwrap()
+            .encode_into(&mut label_frame);
+        expected_out_key.extend_from_slice(&label_frame);
         let mut expected_in_key = vec![0x03, 0x10, 0x01];
         expected_in_key.extend_from_slice(&2u64.to_be_bytes());
-        expected_in_key.extend_from_slice(&label_hash);
+        expected_in_key.extend_from_slice(&label_frame);
         let mut expected_global_key = vec![0x03, 0x04];
-        expected_global_key.extend_from_slice(&label_hash);
+        expected_global_key.extend_from_slice(&label_frame);
 
         assert_eq!(out_key.as_ref(), expected_out_key.as_slice());
         assert_eq!(in_key.as_ref(), expected_in_key.as_slice());
@@ -5148,5 +5110,99 @@ mod tests {
                 .expect("tenant a global lookup succeeds after clear")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn digest_colliding_labels_keep_distinct_bitmaps() {
+        let db = crate::HelixDB::open(crate::HelixDbSource::InMemory {
+            database: "search-label-digest-collision".to_string(),
+        })
+        .await
+        .expect("db opens");
+        let digest = [0xA5; crate::encoding::indexes::canonical_label::LABEL_DIGEST_LEN];
+        let first =
+            crate::encoding::indexes::CanonicalLabel::with_test_digest_unchecked("alpha", digest);
+        let second =
+            crate::encoding::indexes::CanonicalLabel::with_test_digest_unchecked("beta", digest);
+        let first_key = DataKey::Data {
+            scope: DataScope::LegacyUnscoped,
+            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(
+                EdgeLabelKey::from_canonical(first),
+            )),
+        }
+        .to_bytes();
+        let second_key = DataKey::Data {
+            scope: DataScope::LegacyUnscoped,
+            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(
+                EdgeLabelKey::from_canonical(second),
+            )),
+        }
+        .to_bytes();
+        assert_ne!(first_key, second_key);
+
+        db.inner_db()
+            .put(
+                first_key.clone(),
+                SecondaryEqualityValue::encode_ids(&RoaringTreemap::from_iter([1u64])),
+            )
+            .await
+            .expect("first colliding label persists");
+        db.inner_db()
+            .put(
+                second_key.clone(),
+                SecondaryEqualityValue::encode_ids(&RoaringTreemap::from_iter([2u64])),
+            )
+            .await
+            .expect("second colliding label persists");
+
+        let first_ids = decode_roaring_treemap(
+            &db.inner_db()
+                .get(&first_key)
+                .await
+                .expect("first get succeeds")
+                .expect("first bitmap exists"),
+        )
+        .expect("first bitmap decodes");
+        let second_ids = decode_roaring_treemap(
+            &db.inner_db()
+                .get(&second_key)
+                .await
+                .expect("second get succeeds")
+                .expect("second bitmap exists"),
+        )
+        .expect("second bitmap decodes");
+        assert!(first_ids.contains(1) && !first_ids.contains(2));
+        assert!(second_ids.contains(2) && !second_ids.contains(1));
+    }
+
+    #[tokio::test]
+    async fn hash_only_node_label_equality_keys_are_not_read() {
+        let db = crate::HelixDB::open(crate::HelixDbSource::InMemory {
+            database: "search-label-hash-only-unread".to_string(),
+        })
+        .await
+        .expect("db opens");
+        let txn = db
+            .inner_db()
+            .begin(IsolationLevel::Snapshot)
+            .await
+            .expect("transaction starts");
+        let stale = DataKey::Data {
+            scope: DataScope::LegacyUnscoped,
+            kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(EqualityIndexKey::new(
+                hash_property_name("$label"),
+                hash_property_value("User"),
+            ))),
+        }
+        .to_bytes();
+        txn.put(
+            &stale,
+            SecondaryEqualityValue::encode_ids(&RoaringTreemap::from_iter([7u64])),
+        )
+        .expect("stale hash-only label row stages");
+        assert!(lookup_equality_index(&txn, "$label", "User")
+            .await
+            .expect("canonical label lookup succeeds")
+            .is_empty());
     }
 }

--- a/crates/db/tests/production_support/interpreter_contracts.rs
+++ b/crates/db/tests/production_support/interpreter_contracts.rs
@@ -22,9 +22,7 @@ use slatedb::{Db, DbReadOps, IsolationLevel};
 use super::*;
 use crate::config::{DbConfig, TextIndexDefinition};
 use crate::encoding::indexes::label::{EdgeLabelKey, EdgeLabelNeighborKey};
-use crate::encoding::indexes::{
-    hash_property_name, hash_property_value, EdgeDirection, PropertyIndexKey,
-};
+use crate::encoding::indexes::{EdgeDirection, PropertyIndexKey};
 use crate::encoding::property::property_value::PropertyValue as DbPropertyValue;
 use crate::encoding::property::Property;
 use crate::encoding::v2::keys as index_keys;
@@ -1264,11 +1262,9 @@ pub(crate) async fn run_request_read_view_guards() {
 fn topology_node_label_key(scope: DataScope, label: &str) -> Bytes {
     DataKey::Data {
         scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::Equality(
-            crate::encoding::indexes::equality::EqualityIndexKey::new(
-                hash_property_name("$label"),
-                hash_property_value(label),
-            ),
+        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::NodeLabel(
+            crate::encoding::indexes::label::NodeLabelKey::from_label(label)
+                .expect("test labels are valid canonical labels"),
         )),
     }
     .to_bytes()
@@ -1299,7 +1295,8 @@ fn topology_edge_label_neighbor_key(
     DataKey::Data {
         scope,
         kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabelNeighbor(
-            EdgeLabelNeighborKey::new(direction, node, hash_property_value(label)),
+            EdgeLabelNeighborKey::from_label(direction, node, label)
+                .expect("test labels are valid canonical labels"),
         )),
     }
     .to_bytes()
@@ -1308,9 +1305,9 @@ fn topology_edge_label_neighbor_key(
 fn topology_global_edge_label_key(scope: DataScope, label: &str) -> Bytes {
     DataKey::Data {
         scope,
-        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(EdgeLabelKey::new(
-            hash_property_value(label),
-        ))),
+        kind: DataKeyKind::PropertyIndex(PropertyIndexKey::EdgeLabel(
+            EdgeLabelKey::from_label(label).expect("test labels are valid canonical labels"),
+        )),
     }
     .to_bytes()
 }


### PR DESCRIPTION
Fixes #1060.

## Summary
- Graph `$label` keys were SipHash-only, so colliding labels shared one Roaring bitmap. Identity is now `CanonicalLabel`: digest is a scan accelerator, exact identity is length-delimited UTF-8.
- Hash-only constructors are gone. Node labels get their own prefix (`0x07`). Edge-label and neighbor keys carry the same canonical frame. Parse fails closed on digest mismatch and on old 10-byte hash keys.
- Writes and lookups (topology, `LabelScan`, expand, count, shortest path) construct from the label string. Dual-read of hash keys is not the contract.

## Test plan
- [ ] `cargo test -p db --lib label`
- [ ] `cargo test -p db --lib topology`
- [ ] CI


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces hash-only graph-label identities with digest-accelerated, exact UTF-8 canonical keys across encoding, topology mutation, and graph lookup paths.
- Adds canonical node-label, edge-label, and labeled-neighbor key formats with strict parsing.
- Updates graph writes, label scans, expansion, counting, and shortest-path lookups to use exact label identity.
- Leaves existing current-version databases without a migration from their old hash-only label rows.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/encoding/v2/keys/indexes/canonical_label.rs | Introduces bounded exact UTF-8 label identity, digest validation, and length-delimited encoding. |
| crates/db/src/encoding/v2/keys/indexes/label.rs | Replaces persisted hash-only label key layouts and adds a distinct node-label key family, but old rows are intentionally unreadable. |
| crates/db/src/execution/interpreter/mutation/topology.rs | Coalesces and writes node, edge, and neighbor memberships using exact canonical labels. |
| crates/db/src/search/mod.rs | Routes graph-label reads and writes exclusively to canonical keys, exposing missing migrated rows in existing stores. |
| crates/db/src/migrations/startup/bootstrap.rs | Although unchanged, its current-version Ready path demonstrates that no migration is triggered for the new persisted label format. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Existing v4 database] --> B[Writer bootstrap]
  B --> C[Version already 0x0004]
  C --> D[No label-index migration]
  D --> E[Old hash-only label rows remain]
  F[Label lookup at head] --> G[Construct canonical label key]
  G --> H[No matching row]
  E --> H
  H --> I[Existing labeled graph data omitted]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: give graph labels exact CanonicalLa..."](https://github.com/helixdb/helix-db/commit/275c4953dd57d2bb7ee7322749a64e564c3e3343) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59657695)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Database engine](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/database-engine.md)
- Knowledge Base — [Graph mutations and transactions](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/graph-mutations-and-transactions.md)

<!-- /greptile_comment -->