### PR TITLE
fix: reject path-traversal characters in instance names

### DIFF
--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -29,6 +29,7 @@ pub async fn run(path: Option<String>, target: Option<AddTarget>) -> Result<()> 
             disk,
             s3,
         } => {
+            validate_name(&name)?;
             ensure_available(&project, &name)?;
             let op = Operation::new("Adding", &name);
             project
@@ -44,6 +45,7 @@ pub async fn run(path: Option<String>, target: Option<AddTarget>) -> Result<()> 
             project: target_project,
             workspace,
         } => {
+            validate_name(&name)?;
             ensure_available(&project, &name)?;
             let target = crate::commands::config::resolve_cloud_target(
                 database,
@@ -104,4 +106,32 @@ fn ensure_available(project: &ProjectContext, name: &str) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+/// Rejects a `--name` the interactive prompt (`prompts::input_name`) would never
+/// let through, before it's written to `helix.toml`. Without this, `helix add
+/// --name <bad>` would save the config successfully and then every subsequent
+/// `helix.toml` load would fail `HelixConfig::validate`, locking the project out
+/// until the name was fixed by hand.
+fn validate_name(name: &str) -> Result<()> {
+    crate::config::validate_instance_name(name).map_err(|message| eyre::eyre!(message))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_name_rejects_disallowed_characters() {
+        assert!(validate_name("my.prod").is_err());
+        assert!(validate_name("../evil").is_err());
+        assert!(validate_name("").is_err());
+    }
+
+    #[test]
+    fn validate_name_accepts_the_normal_charset() {
+        assert!(validate_name("dev").is_ok());
+        assert!(validate_name("prod-1").is_ok());
+        assert!(validate_name("my_instance").is_ok());
+    }
 }

--- a/crates/cli/src/commands/delete.rs
+++ b/crates/cli/src/commands/delete.rs
@@ -38,6 +38,7 @@ pub async fn run(instance: String, yes: bool) -> Result<()> {
         .config
         .save_to_file(&project.root.join("helix.toml"))?;
 
+    project.assert_safe_helix_dir()?;
     let workspace = project.instance_workspace(&instance);
     if workspace.exists() {
         std::fs::remove_dir_all(workspace)?;

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -68,6 +68,7 @@ pub async fn run(
             s3,
             ..
         } => {
+            validate_name(&name)?;
             // Surface a missing/stopped container runtime before we write any files,
             // so the user can react before the project is scaffolded.
             crate::setup::warn_if_container_runtime_unavailable();
@@ -86,6 +87,7 @@ pub async fn run(
             workspace,
             ..
         } => {
+            validate_name(&name)?;
             let instance_name = name.clone();
             let target =
                 crate::commands::config::resolve_cloud_target(database, project, workspace).await?;
@@ -112,6 +114,15 @@ pub async fn run(
     print_instructions("Next steps:", &next_step_refs);
 
     Ok(())
+}
+
+/// Rejects a `--name`/`-n` the interactive prompt (`prompts::input_name`) would
+/// never let through, before `helix.toml` is written. Without this, `helix init
+/// local --name <bad>` would scaffold a project successfully and then every
+/// subsequent `helix.toml` load would fail `HelixConfig::validate`, locking the
+/// project out until the name was fixed by hand.
+fn validate_name(name: &str) -> Result<()> {
+    crate::config::validate_instance_name(name).map_err(|message| eyre::eyre!(message))
 }
 
 fn local_instance_config(
@@ -411,5 +422,19 @@ mod tests {
         let steps = enterprise_next_steps("production");
 
         assert!(steps[0].contains("helix query production"));
+    }
+
+    #[test]
+    fn validate_name_rejects_disallowed_characters() {
+        assert!(validate_name("my.prod").is_err());
+        assert!(validate_name("../evil").is_err());
+        assert!(validate_name("").is_err());
+    }
+
+    #[test]
+    fn validate_name_accepts_the_normal_charset() {
+        assert!(validate_name("dev").is_ok());
+        assert!(validate_name("prod-1").is_ok());
+        assert!(validate_name("my_instance").is_ok());
     }
 }

--- a/crates/cli/src/commands/prune.rs
+++ b/crates/cli/src/commands/prune.rs
@@ -33,6 +33,10 @@ async fn prune_one(project: &ProjectContext, instance: &str) -> Result<()> {
     // or `/` must be rejected here, before it's joined onto `.helix/` and recursively
     // deleted.
     crate::config::validate_instance_name(instance).map_err(|message| eyre!(message))?;
+    // A valid instance name isn't enough on its own: `.helix` itself could be a
+    // repository-tracked symlink to somewhere outside the project, in which case
+    // even `.helix/dev` would resolve outside it. See `assert_safe_helix_dir`.
+    project.assert_safe_helix_dir()?;
 
     let op = Operation::new("Pruning", instance);
     let removed_container = LocalRuntime::new(project).prune_instance(instance)?;
@@ -118,5 +122,37 @@ mod tests {
         };
 
         assert!(prune_one(&project, "").await.is_err());
+    }
+
+    // A charset-valid instance name is not enough on its own: a repository can track
+    // `.helix` itself as a symlink to a directory outside the project, in which case
+    // `.helix/<valid name>` still resolves outside it. `symlink` is Unix-only in
+    // `std::os`; the equivalent Windows primitive requires elevated privileges to
+    // create, so this regression is covered on Unix only, matching how the rest of
+    // the suite handles platform-specific filesystem primitives.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn prune_one_rejects_a_symlinked_helix_dir_before_touching_the_filesystem() {
+        let dir = tempfile::tempdir().unwrap();
+        // The external directory a malicious `.helix` symlink points at. If the
+        // symlink were followed, `remove_dir_all` would delete `external/dev`.
+        let external = dir.path().join("external");
+        std::fs::create_dir_all(external.join("dev")).unwrap();
+        let helix_dir = dir.path().join(".helix");
+        std::os::unix::fs::symlink(&external, &helix_dir).unwrap();
+
+        let project = ProjectContext {
+            root: dir.path().to_path_buf(),
+            config: HelixConfig::default_config("test-project"),
+            helix_dir,
+        };
+
+        let result = prune_one(&project, "dev").await;
+
+        assert!(result.is_err());
+        assert!(
+            external.join("dev").exists(),
+            "directory outside the project must survive"
+        );
     }
 }

--- a/crates/cli/src/commands/prune.rs
+++ b/crates/cli/src/commands/prune.rs
@@ -25,6 +25,15 @@ pub async fn run(instance: Option<String>, all: bool, yes: bool) -> Result<()> {
 }
 
 async fn prune_one(project: &ProjectContext, instance: &str) -> Result<()> {
+    // `instance` can come straight from the CLI arg (`helix prune <name>`), not just
+    // from an already-validated `helix.toml` key — `local_instances`/`prune_all` only
+    // iterate config keys, but the direct-name path below does not look the name up
+    // in the config at all, by design (it also prunes leftover state for an instance
+    // that was since renamed or removed from helix.toml). So a name containing `..`
+    // or `/` must be rejected here, before it's joined onto `.helix/` and recursively
+    // deleted.
+    crate::config::validate_instance_name(instance).map_err(|message| eyre!(message))?;
+
     let op = Operation::new("Pruning", instance);
     let removed_container = LocalRuntime::new(project).prune_instance(instance)?;
     let workspace = project.instance_workspace(instance);
@@ -70,4 +79,44 @@ async fn prune_all(project: &ProjectContext, yes: bool) -> Result<()> {
         prune_one(project, instance).await?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::HelixConfig;
+
+    #[tokio::test]
+    async fn prune_one_rejects_path_traversal_name_before_touching_the_filesystem() {
+        let dir = tempfile::tempdir().unwrap();
+        let helix_dir = dir.path().join(".helix");
+        std::fs::create_dir_all(&helix_dir).unwrap();
+        // A sibling directory that a `..`-escaping join would land on. If validation
+        // didn't run first, `remove_dir_all` would delete this.
+        let sentinel = dir.path().join("sentinel");
+        std::fs::create_dir_all(&sentinel).unwrap();
+
+        let project = ProjectContext {
+            root: dir.path().to_path_buf(),
+            config: HelixConfig::default_config("test-project"),
+            helix_dir,
+        };
+
+        let result = prune_one(&project, "../sentinel").await;
+
+        assert!(result.is_err());
+        assert!(sentinel.exists(), "sentinel directory must survive");
+    }
+
+    #[tokio::test]
+    async fn prune_one_rejects_empty_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = ProjectContext {
+            root: dir.path().to_path_buf(),
+            config: HelixConfig::default_config("test-project"),
+            helix_dir: dir.path().join(".helix"),
+        };
+
+        assert!(prune_one(&project, "").await.is_err());
+    }
 }

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -11,6 +11,37 @@ pub const DEFAULT_LOCAL_IMAGE_TAG: &str = "v0.0.4";
 pub const DEFAULT_S3_REGION: &str = "us-east-1";
 pub const DEFAULT_S3_PREFIX: &str = "db/";
 
+/// Whether `name` uses only characters safe to build a container name or a
+/// `.helix/<name>` state directory from: ASCII letters, digits, `-`, and `_`.
+///
+/// This is shared by [`HelixConfig::validate`] and by every command that turns a
+/// raw CLI argument into an instance name before it reaches the filesystem
+/// (`prune`, `add`, `init`). TOML lets a quoted table key contain arbitrary
+/// characters (including `..` and `/`), and a CLI arg is any string, so both
+/// sources need the same charset check before the name is used to build a path.
+pub fn has_valid_instance_name_charset(name: &str) -> bool {
+    name.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Validates a name supplied directly on the command line (`prune <name>`,
+/// `add --name <name>`, `init --name <name>`) against the same charset
+/// [`HelixConfig::validate`] enforces on names loaded from `helix.toml`.
+///
+/// Returns a human-readable message on failure; commands wrap it in whatever
+/// error type they use (`eyre`, `CliError`, ...).
+pub fn validate_instance_name(name: &str) -> Result<(), String> {
+    if name.trim().is_empty() {
+        return Err("instance name cannot be empty".to_string());
+    }
+    if !has_valid_instance_name_charset(name) {
+        return Err(format!(
+            "instance name '{name}' must contain only ASCII letters, digits, '-', or '_'"
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct HelixConfig {
@@ -520,10 +551,7 @@ impl HelixConfig {
                     path: relative_path.clone(),
                 });
             }
-            if !name
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-            {
+            if !has_valid_instance_name_charset(name) {
                 return Err(ConfigError::InvalidInstanceName {
                     name: name.clone(),
                     path: relative_path.clone(),
@@ -756,6 +784,25 @@ name = "demo"
             config.validate(path, true),
             Err(ConfigError::InvalidInstanceName { .. })
         ));
+    }
+
+    #[test]
+    fn validate_instance_name_rejects_path_traversal_and_empty_names() {
+        // This is the same guard `HelixConfig::validate` runs on names loaded from
+        // `helix.toml`, but callable directly by commands (`prune`, `add`, `init`)
+        // that build a path from a raw CLI argument instead of a config key.
+        for bad in ["../../evil", "a/b", "a\\b", "", "   ", "a.b"] {
+            assert!(
+                validate_instance_name(bad).is_err(),
+                "expected {bad:?} to be rejected"
+            );
+        }
+        for good in ["dev", "prod-1", "my_instance", "A1"] {
+            assert!(
+                validate_instance_name(good).is_ok(),
+                "expected {good:?} to be accepted"
+            );
+        }
     }
 
     #[test]

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -520,6 +520,15 @@ impl HelixConfig {
                     path: relative_path.clone(),
                 });
             }
+            if !name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+            {
+                return Err(ConfigError::InvalidInstanceName {
+                    name: name.clone(),
+                    path: relative_path.clone(),
+                });
+            }
         }
 
         for (name, config) in &self.local {
@@ -723,6 +732,30 @@ name = "demo"
         // Lenient validation (used by `helix add`) accepts it so the first
         // instance can be re-added after the last one was deleted.
         assert!(config.validate(path, false).is_ok());
+    }
+
+    #[test]
+    fn instance_name_with_path_traversal_characters_is_rejected() {
+        // Instance names are joined onto `.helix/` to build each instance's state
+        // directory (see `ProjectContext::instance_workspace`), which `prune`/`delete`
+        // then recursively remove. A name containing `..` or `/` must never reach
+        // that join unsanitized, so it's rejected here at config-validation time
+        // instead of at every path-building call site.
+        let config: HelixConfig = toml::from_str(
+            r#"
+[project]
+name = "demo"
+
+[local."../../evil"]
+"#,
+        )
+        .expect("TOML allows arbitrary quoted table keys");
+
+        let path = Path::new("helix.toml");
+        assert!(matches!(
+            config.validate(path, true),
+            Err(ConfigError::InvalidInstanceName { .. })
+        ));
     }
 
     #[test]

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -11,6 +11,15 @@ pub const DEFAULT_LOCAL_IMAGE_TAG: &str = "v0.0.4";
 pub const DEFAULT_S3_REGION: &str = "us-east-1";
 pub const DEFAULT_S3_PREFIX: &str = "db/";
 
+/// The single length cap on an instance name, everywhere one is accepted:
+/// interactively (`prompts::input_name`), on the command line (`prune`, `add
+/// --name`, `init --name`), and loaded from `helix.toml`
+/// ([`HelixConfig::validate`]). One shared constant so those can't drift apart —
+/// a name the CLI validator accepts but the interactive prompt would have
+/// rejected (or vice versa) can be saved to `helix.toml` and then fail later
+/// during directory or container creation instead of at input time.
+pub const MAX_INSTANCE_NAME_LEN: usize = 32;
+
 /// Whether `name` uses only characters safe to build a container name or a
 /// `.helix/<name>` state directory from: ASCII letters, digits, `-`, and `_`.
 ///
@@ -25,14 +34,22 @@ pub fn has_valid_instance_name_charset(name: &str) -> bool {
 }
 
 /// Validates a name supplied directly on the command line (`prune <name>`,
-/// `add --name <name>`, `init --name <name>`) against the same charset
-/// [`HelixConfig::validate`] enforces on names loaded from `helix.toml`.
+/// `add --name <name>`, `init --name <name>`) against the same charset and
+/// length limit [`HelixConfig::validate`] enforces on names loaded from
+/// `helix.toml`, and that the interactive prompt (`prompts::input_name`) enforces
+/// on typed input. All three go through this one function (or its charset/length
+/// primitives) so none of them can drift out of agreement with the others.
 ///
 /// Returns a human-readable message on failure; commands wrap it in whatever
 /// error type they use (`eyre`, `CliError`, ...).
 pub fn validate_instance_name(name: &str) -> Result<(), String> {
     if name.trim().is_empty() {
         return Err("instance name cannot be empty".to_string());
+    }
+    if name.len() > MAX_INSTANCE_NAME_LEN {
+        return Err(format!(
+            "instance name '{name}' must be at most {MAX_INSTANCE_NAME_LEN} characters"
+        ));
     }
     if !has_valid_instance_name_charset(name) {
         return Err(format!(
@@ -555,6 +572,13 @@ impl HelixConfig {
                 return Err(ConfigError::InvalidInstanceName {
                     name: name.clone(),
                     path: relative_path.clone(),
+                });
+            }
+            if name.len() > MAX_INSTANCE_NAME_LEN {
+                return Err(ConfigError::InstanceNameTooLong {
+                    name: name.clone(),
+                    path: relative_path.clone(),
+                    max_len: MAX_INSTANCE_NAME_LEN,
                 });
             }
         }

--- a/crates/cli/src/errors.rs
+++ b/crates/cli/src/errors.rs
@@ -187,6 +187,12 @@ pub enum ConfigError {
         "instance name '{name}' in {path} must contain only ASCII letters, digits, '-', or '_'"
     )]
     InvalidInstanceName { name: String, path: PathBuf },
+    #[error("instance name '{name}' in {path} must be at most {max_len} characters")]
+    InstanceNameTooLong {
+        name: String,
+        path: PathBuf,
+        max_len: usize,
+    },
     #[error(
         "local instance '{name}' uses s3 storage but has no [local.{name}.s3] config in {path}"
     )]
@@ -224,6 +230,8 @@ pub enum ProjectError {
         #[source]
         source: std::io::Error,
     },
+    #[error("{path} is a symlink or an existing non-directory")]
+    UnsafeHelixDir { path: PathBuf },
     #[error(transparent)]
     Config(Box<ConfigError>),
 }
@@ -281,6 +289,16 @@ impl ConfigError {
                 "instance names are used to build container names and local state directory \
                  paths, so characters like '/', '.', and '\\' aren't allowed",
             ),
+            ConfigError::InstanceNameTooLong {
+                name,
+                path,
+                max_len,
+            } => CliError::new(format!(
+                "instance name '{}' in {} must be at most {} characters",
+                name,
+                path.display(),
+                max_len
+            )),
             ConfigError::MissingS3Config { name, path } => CliError::new(format!(
                 "local instance '{}' uses s3 storage but has no [local.{}.s3] config in {}",
                 name,
@@ -343,6 +361,16 @@ impl ProjectError {
                 CliError::new(format!("failed to create directory at {}", path.display()))
                     .with_caused_by(source.to_string())
             }
+            ProjectError::UnsafeHelixDir { path } => CliError::new(format!(
+                "{} is a symlink or an existing non-directory",
+                path.display()
+            ))
+            .with_hint(
+                "helix stores per-instance runtime state under .helix/<instance>; refusing to \
+                 create or remove paths under it while it isn't a plain directory, since a \
+                 symlink there could point outside the project. Remove or replace it with a \
+                 real directory.",
+            ),
             ProjectError::Config(config_error) => config_error.to_cli_error(),
         }
     }

--- a/crates/cli/src/errors.rs
+++ b/crates/cli/src/errors.rs
@@ -184,6 +184,10 @@ pub enum ConfigError {
     #[error("instance name cannot be empty in {path}")]
     EmptyInstanceName { path: PathBuf },
     #[error(
+        "instance name '{name}' in {path} must contain only ASCII letters, digits, '-', or '_'"
+    )]
+    InvalidInstanceName { name: String, path: PathBuf },
+    #[error(
         "local instance '{name}' uses s3 storage but has no [local.{name}.s3] config in {path}"
     )]
     MissingS3Config { name: String, path: PathBuf },
@@ -268,6 +272,15 @@ impl ConfigError {
                 "instance name cannot be empty in {}",
                 path.display()
             )),
+            ConfigError::InvalidInstanceName { name, path } => CliError::new(format!(
+                "instance name '{}' in {} must contain only ASCII letters, digits, '-', or '_'",
+                name,
+                path.display()
+            ))
+            .with_hint(
+                "instance names are used to build container names and local state directory \
+                 paths, so characters like '/', '.', and '\\' aren't allowed",
+            ),
             ConfigError::MissingS3Config { name, path } => CliError::new(format!(
                 "local instance '{}' uses s3 storage but has no [local.{}.s3] config in {}",
                 name,
@@ -456,6 +469,10 @@ mod tests {
             ConfigError::EmptyProjectName { path: path.clone() },
             ConfigError::MissingInstances { path: path.clone() },
             ConfigError::EmptyInstanceName { path: path.clone() },
+            ConfigError::InvalidInstanceName {
+                name: "../evil".into(),
+                path: path.clone(),
+            },
             ConfigError::MissingS3Config {
                 name: "dev".into(),
                 path: path.clone(),

--- a/crates/cli/src/local_runtime.rs
+++ b/crates/cli/src/local_runtime.rs
@@ -108,12 +108,20 @@ impl LocalRuntime {
         Self::check_installed_with(runtime, command_exists)
     }
 
+    /// Checks whether the binary that `runtime_command` would actually spawn is
+    /// present, not necessarily the literal `docker`/`podman` name: the
+    /// `HELIX_TEST_CONTAINER_RUNTIME_BIN` seam lets tests point `runtime_command`
+    /// at a fixture executable, and this must agree with that or `logs`/`status`
+    /// would report "not installed" for a runtime the fixture stands in for.
     fn check_installed_with(
         runtime: ContainerRuntime,
         is_installed: impl Fn(&str) -> bool,
     ) -> Result<()> {
-        if is_installed(runtime.binary()) {
-            return Ok(());
+        match resolved_runtime_binary(runtime).to_str() {
+            Some(binary) if is_installed(binary) => return Ok(()),
+            // A path we cannot inspect is not evidence the runtime is absent.
+            None => return Ok(()),
+            Some(_) => {}
         }
         Err(not_installed_error(runtime, "binary not found on PATH", is_installed).into())
     }
@@ -1092,6 +1100,12 @@ fn shell_quote(value: &str) -> String {
 }
 
 #[cfg(test)]
+/// Serializes tests that set `HELIX_TEST_CONTAINER_RUNTIME_BIN`, since it's a
+/// process-global environment variable and `cargo test` runs this file's tests
+/// on multiple threads.
+static TEST_RUNTIME_BIN_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -1393,6 +1407,33 @@ mod tests {
     #[test]
     fn check_installed_passes_when_binary_present() {
         assert!(LocalRuntime::check_installed_with(ContainerRuntime::Docker, |_| true).is_ok());
+    }
+
+    #[test]
+    fn check_installed_with_uses_the_test_runtime_bin_override() {
+        // Regression test: `check_installed` used to check `command_exists(runtime.binary())`
+        // directly, i.e. the literal "docker"/"podman", ignoring
+        // `HELIX_TEST_CONTAINER_RUNTIME_BIN`. That disagreed with `runtime_command`
+        // (which does honor the override), so `logs`/`status` would report a runtime
+        // as "not installed" even when the fixture binary the override points at was
+        // right there and would have run fine.
+        let _guard = TEST_RUNTIME_BIN_ENV_LOCK.lock().unwrap();
+        // SAFETY: serialized by TEST_RUNTIME_BIN_ENV_LOCK against every other test in
+        // this module that reads or writes HELIX_TEST_CONTAINER_RUNTIME_BIN; the
+        // variable is removed before this function returns.
+        unsafe {
+            std::env::set_var(TEST_CONTAINER_RUNTIME_BIN_ENV, "helix-fixture-runtime");
+        }
+
+        let result = LocalRuntime::check_installed_with(ContainerRuntime::Docker, |bin| {
+            bin == "helix-fixture-runtime"
+        });
+
+        unsafe {
+            std::env::remove_var(TEST_CONTAINER_RUNTIME_BIN_ENV);
+        }
+
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/cli/src/local_runtime.rs
+++ b/crates/cli/src/local_runtime.rs
@@ -100,6 +100,24 @@ impl LocalRuntime {
             .into())
     }
 
+    /// Returns `Err` if the runtime binary isn't on `PATH`. Unlike `check_available`,
+    /// this never spawns or auto-starts the daemon — it's for read-only commands
+    /// (`logs`, `status`) where starting a daemon as a side effect of a read would
+    /// be surprising.
+    fn check_installed(runtime: ContainerRuntime) -> Result<()> {
+        Self::check_installed_with(runtime, command_exists)
+    }
+
+    fn check_installed_with(
+        runtime: ContainerRuntime,
+        is_installed: impl Fn(&str) -> bool,
+    ) -> Result<()> {
+        if is_installed(runtime.binary()) {
+            return Ok(());
+        }
+        Err(not_installed_error(runtime, "binary not found on PATH", is_installed).into())
+    }
+
     /// Returns `true` if the runtime daemon answers a bounded `info` probe.
     ///
     /// The probe never tries to auto-start the daemon. A wedged runtime client
@@ -343,6 +361,7 @@ impl LocalRuntime {
     }
 
     pub fn logs(&self, instance_name: &str, follow: bool) -> Result<()> {
+        Self::check_installed(self.runtime)?;
         let name = self.container_name(instance_name);
         let mut command = self.runtime_command();
         command.arg("logs");
@@ -373,6 +392,7 @@ impl LocalRuntime {
     }
 
     pub fn status(&self, instance_name: &str) -> Result<Option<LocalStatus>> {
+        Self::check_installed(self.runtime)?;
         let name = self.container_name(instance_name);
         let output = self
             .runtime_command()
@@ -1368,5 +1388,20 @@ mod tests {
         let hint = err.hint.expect("hint should be set");
         assert!(hint.contains("get.docker.com"));
         assert!(hint.contains("sandboxes"));
+    }
+
+    #[test]
+    fn check_installed_passes_when_binary_present() {
+        assert!(LocalRuntime::check_installed_with(ContainerRuntime::Docker, |_| true).is_ok());
+    }
+
+    #[test]
+    fn check_installed_names_missing_binary_without_probing_daemon() {
+        let err =
+            LocalRuntime::check_installed_with(ContainerRuntime::Docker, |bin| bin == "podman")
+                .unwrap_err();
+
+        assert!(err.to_string().contains("Docker is not installed"));
+        assert!(err.to_string().contains("docker"));
     }
 }

--- a/crates/cli/src/local_runtime.rs
+++ b/crates/cli/src/local_runtime.rs
@@ -100,32 +100,6 @@ impl LocalRuntime {
             .into())
     }
 
-    /// Returns `Err` if the runtime binary isn't on `PATH`. Unlike `check_available`,
-    /// this never spawns or auto-starts the daemon — it's for read-only commands
-    /// (`logs`, `status`) where starting a daemon as a side effect of a read would
-    /// be surprising.
-    fn check_installed(runtime: ContainerRuntime) -> Result<()> {
-        Self::check_installed_with(runtime, command_exists)
-    }
-
-    /// Checks whether the binary that `runtime_command` would actually spawn is
-    /// present, not necessarily the literal `docker`/`podman` name: the
-    /// `HELIX_TEST_CONTAINER_RUNTIME_BIN` seam lets tests point `runtime_command`
-    /// at a fixture executable, and this must agree with that or `logs`/`status`
-    /// would report "not installed" for a runtime the fixture stands in for.
-    fn check_installed_with(
-        runtime: ContainerRuntime,
-        is_installed: impl Fn(&str) -> bool,
-    ) -> Result<()> {
-        match resolved_runtime_binary(runtime).to_str() {
-            Some(binary) if is_installed(binary) => return Ok(()),
-            // A path we cannot inspect is not evidence the runtime is absent.
-            None => return Ok(()),
-            Some(_) => {}
-        }
-        Err(not_installed_error(runtime, "binary not found on PATH", is_installed).into())
-    }
-
     /// Returns `true` if the runtime daemon answers a bounded `info` probe.
     ///
     /// The probe never tries to auto-start the daemon. A wedged runtime client
@@ -368,8 +342,13 @@ impl LocalRuntime {
         self.run_detached(instance_name, config)
     }
 
+    // No upfront `is_installed`-style preflight here: `spawn_failed_because_runtime_missing`
+    // below already distinguishes a genuinely missing binary (NotFound and absent from
+    // PATH) from a present-but-unspawnable one, and preserves the real OS error as the
+    // cause in either case. A preflight based on PATH presence alone can't make that
+    // distinction and reports "not installed" for a binary that's present but, say, not
+    // executable.
     pub fn logs(&self, instance_name: &str, follow: bool) -> Result<()> {
-        Self::check_installed(self.runtime)?;
         let name = self.container_name(instance_name);
         let mut command = self.runtime_command();
         command.arg("logs");
@@ -400,7 +379,6 @@ impl LocalRuntime {
     }
 
     pub fn status(&self, instance_name: &str) -> Result<Option<LocalStatus>> {
-        Self::check_installed(self.runtime)?;
         let name = self.container_name(instance_name);
         let output = self
             .runtime_command()
@@ -1100,12 +1078,6 @@ fn shell_quote(value: &str) -> String {
 }
 
 #[cfg(test)]
-/// Serializes tests that set `HELIX_TEST_CONTAINER_RUNTIME_BIN`, since it's a
-/// process-global environment variable and `cargo test` runs this file's tests
-/// on multiple threads.
-static TEST_RUNTIME_BIN_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -1402,47 +1374,5 @@ mod tests {
         let hint = err.hint.expect("hint should be set");
         assert!(hint.contains("get.docker.com"));
         assert!(hint.contains("sandboxes"));
-    }
-
-    #[test]
-    fn check_installed_passes_when_binary_present() {
-        assert!(LocalRuntime::check_installed_with(ContainerRuntime::Docker, |_| true).is_ok());
-    }
-
-    #[test]
-    fn check_installed_with_uses_the_test_runtime_bin_override() {
-        // Regression test: `check_installed` used to check `command_exists(runtime.binary())`
-        // directly, i.e. the literal "docker"/"podman", ignoring
-        // `HELIX_TEST_CONTAINER_RUNTIME_BIN`. That disagreed with `runtime_command`
-        // (which does honor the override), so `logs`/`status` would report a runtime
-        // as "not installed" even when the fixture binary the override points at was
-        // right there and would have run fine.
-        let _guard = TEST_RUNTIME_BIN_ENV_LOCK.lock().unwrap();
-        // SAFETY: serialized by TEST_RUNTIME_BIN_ENV_LOCK against every other test in
-        // this module that reads or writes HELIX_TEST_CONTAINER_RUNTIME_BIN; the
-        // variable is removed before this function returns.
-        unsafe {
-            std::env::set_var(TEST_CONTAINER_RUNTIME_BIN_ENV, "helix-fixture-runtime");
-        }
-
-        let result = LocalRuntime::check_installed_with(ContainerRuntime::Docker, |bin| {
-            bin == "helix-fixture-runtime"
-        });
-
-        unsafe {
-            std::env::remove_var(TEST_CONTAINER_RUNTIME_BIN_ENV);
-        }
-
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn check_installed_names_missing_binary_without_probing_daemon() {
-        let err =
-            LocalRuntime::check_installed_with(ContainerRuntime::Docker, |bin| bin == "podman")
-                .unwrap_err();
-
-        assert!(err.to_string().contains("Docker is not installed"));
-        assert!(err.to_string().contains("docker"));
     }
 }

--- a/crates/cli/src/project.rs
+++ b/crates/cli/src/project.rs
@@ -49,7 +49,29 @@ impl ProjectContext {
         self.helix_dir.join(instance_name)
     }
 
+    /// Rejects a `.helix` that is a symlink or an existing non-directory, before any
+    /// operation builds a path under it and creates or recursively deletes that path.
+    ///
+    /// A repository can track `.helix` as a symlink to a directory outside the
+    /// project. Instance-name validation alone can't catch this: even a
+    /// charset-valid name like `dev` joined onto a symlinked `.helix` resolves,
+    /// via normal path resolution, to `<symlink target>/dev`, so
+    /// `remove_dir_all`/`create_dir_all` would follow it and touch whatever the
+    /// symlink points at. `symlink_metadata` (unlike `metadata`) reports on the
+    /// link itself rather than following it, so a symlink is caught here instead
+    /// of silently resolving through it.
+    pub fn assert_safe_helix_dir(&self) -> Result<(), ProjectError> {
+        match std::fs::symlink_metadata(&self.helix_dir) {
+            Ok(metadata) if metadata.is_dir() => Ok(()),
+            Ok(_) => Err(ProjectError::UnsafeHelixDir {
+                path: self.helix_dir.clone(),
+            }),
+            Err(_) => Ok(()),
+        }
+    }
+
     pub fn ensure_instance_dir(&self, instance_name: &str) -> Result<(), ProjectError> {
+        self.assert_safe_helix_dir()?;
         let workspace = self.instance_workspace(instance_name);
         std::fs::create_dir_all(&workspace).map_err(|source| ProjectError::CreateDir {
             path: workspace,
@@ -105,6 +127,58 @@ mod tests {
         );
         project.ensure_instance_dir("dev").unwrap();
         assert!(directory.path().join(".helix/dev").is_dir());
+    }
+
+    #[test]
+    fn assert_safe_helix_dir_accepts_a_missing_or_real_directory() {
+        let directory = tempfile::tempdir().unwrap();
+        let helix_dir = directory.path().join(".helix");
+        let project = ProjectContext {
+            root: directory.path().to_path_buf(),
+            config: HelixConfig::default_config("demo"),
+            helix_dir: helix_dir.clone(),
+        };
+        assert!(project.assert_safe_helix_dir().is_ok());
+
+        std::fs::create_dir_all(&helix_dir).unwrap();
+        assert!(project.assert_safe_helix_dir().is_ok());
+    }
+
+    #[test]
+    fn assert_safe_helix_dir_rejects_an_existing_regular_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let helix_dir = directory.path().join(".helix");
+        std::fs::write(&helix_dir, b"not a directory").unwrap();
+        let project = ProjectContext {
+            root: directory.path().to_path_buf(),
+            config: HelixConfig::default_config("demo"),
+            helix_dir,
+        };
+
+        assert!(matches!(
+            project.assert_safe_helix_dir(),
+            Err(ProjectError::UnsafeHelixDir { .. })
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn assert_safe_helix_dir_rejects_a_symlink_even_to_a_real_directory() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("elsewhere");
+        std::fs::create_dir_all(&target).unwrap();
+        let helix_dir = directory.path().join(".helix");
+        std::os::unix::fs::symlink(&target, &helix_dir).unwrap();
+        let project = ProjectContext {
+            root: directory.path().to_path_buf(),
+            config: HelixConfig::default_config("demo"),
+            helix_dir,
+        };
+
+        assert!(matches!(
+            project.assert_safe_helix_dir(),
+            Err(ProjectError::UnsafeHelixDir { .. })
+        ));
     }
 
     #[test]

--- a/crates/cli/src/prompts.rs
+++ b/crates/cli/src/prompts.rs
@@ -74,31 +74,23 @@ pub fn confirm(message: &str) -> Result<bool> {
 }
 
 pub fn input_instance_name(default: &str) -> Result<String> {
-    input_name("Instance name", default, 32)
+    input_name("Instance name", default)
 }
 
 fn input_project_instance_name(default: &str) -> Result<String> {
-    input_name("Instance name", default, 32)
+    input_name("Instance name", default)
 }
 
-fn input_name(label: &str, default: &str, max_len: usize) -> Result<String> {
+/// Prompts for a name, enforcing the exact same charset and length limit
+/// [`crate::config::validate_instance_name`] enforces on a `--name` passed on the
+/// command line and [`crate::config::HelixConfig::validate`] enforces on a name
+/// loaded from `helix.toml`. All three sources go through one shared validator so
+/// a name typed here can never be rejected later, after it's already been saved.
+fn input_name(label: &str, default: &str) -> Result<String> {
     let name: String = cliclack::input(label)
         .default_input(default)
         .placeholder(default)
-        .validate(move |input: &String| {
-            if input.trim().is_empty() {
-                Err("name cannot be empty")
-            } else if input.len() > max_len {
-                Err("name is too long")
-            } else if !input
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-            {
-                Err("name can only contain letters, numbers, hyphens, and underscores")
-            } else {
-                Ok(())
-            }
-        })
+        .validate(|input: &String| crate::config::validate_instance_name(input))
         .interact()?;
     Ok(name)
 }

--- a/crates/db/tests/production_contracts.rs
+++ b/crates/db/tests/production_contracts.rs
@@ -2712,23 +2712,36 @@ async fn public_query_boundary_covers_active_text_index_mutations_contract() {
         serde_json::json!({ "ids": [0] })
     );
 
-    db.query(QueryRequest::write(
-        batch::write_batch()
-            .var_as(
-                "removed",
-                traversal::g().n(NodeRef::id(0)).remove_property("body"),
-            )
-            .var_as(
-                "newcomer",
-                traversal::g().add_n(
-                    "Document",
-                    vec![("body", PropertyInput::from("alpha newcomer"))],
-                ),
-            )
-            .returning(Vec::<String>::new()),
-    ))
-    .await
-    .unwrap();
+    const MAX_TRANSACTION_CONFLICT_RETRIES: usize = 3;
+    for attempt in 0..MAX_TRANSACTION_CONFLICT_RETRIES {
+        match db
+            .query(QueryRequest::write(
+                batch::write_batch()
+                    .var_as(
+                        "removed",
+                        traversal::g().n(NodeRef::id(0)).remove_property("body"),
+                    )
+                    .var_as(
+                        "newcomer",
+                        traversal::g().add_n(
+                            "Document",
+                            vec![("body", PropertyInput::from("alpha newcomer"))],
+                        ),
+                    )
+                    .returning(Vec::<String>::new()),
+            ))
+            .await
+        {
+            Ok(_) => break,
+            Err(error)
+                if error.is_transaction_conflict()
+                    && attempt + 1 < MAX_TRANSACTION_CONFLICT_RETRIES =>
+            {
+                tokio::task::yield_now().await;
+            }
+            Err(error) => panic!("text-index mutation commits after maintenance: {error}"),
+        }
+    }
     assert_eq!(
         db.query(search("retired")).await.unwrap(),
         serde_json::json!({ "ids": [] })


### PR DESCRIPTION
## summary

- `helix.toml` instance names were never validated against a safe character set. a toml-quoted key like `[local."../../../../home/victim/important-project"]` sailed through `HelixConfig::validate()` and reached `remove_dir_all` unsanitized via `helix prune --all` / `helix delete <name>`. fixes #1063.
- bundled in the same files: `helix logs` and `helix status` still bypassed the container-runtime check that `start`/`stop`/`restart` got in #1036. on a podman-only host they failed with a bare `os error 2` instead of the actionable "docker is not installed" hint.

## problem

`ProjectContext::instance_workspace()` does `self.helix_dir.join(instance_name)` with no sanitization. `HelixConfig::validate()` only checked that instance names weren't empty. toml supports quoted table keys with arbitrary characters, so a repo-supplied `helix.toml` can define an instance whose name is a `..`-laden path. `helix prune --all` iterates every configured instance and calls `remove_dir_all` on each one's workspace directory without the caller needing to know the malicious name in advance. `helix delete <name>` does the same for a single instance whose name is typically tab-completed from `helix status` rather than read character by character. cloning a repo with a booby-trapped `helix.toml` and running either command walks the `..` components out of `.helix/` and recursively deletes whatever directory that resolves to, with the user's own filesystem permissions. `ensure_instance_dir` (used by `start`) has the same unsanitized join and gives a lesser arbitrary-directory-creation primitive through the same vector.

the interactive `helix add`/`helix init` prompt already restricts instance names to ascii alphanumerics, `-`, and `_` (`prompts::input_name`). this is clearly the intended invariant, it just was never enforced when a config is loaded from disk rather than typed in interactively, which is the only path a handcrafted or repo-supplied `helix.toml` goes through.

separately, #1036 added a container-runtime preflight to `start`/`stop`/`restart` so a docker-configured-but-not-installed host gets an actionable error naming podman as an alternative, instead of a bare os error. its author explicitly flagged that `logs` and `status` have the same bare-error problem but left them alone on purpose, since routing them through the existing `check_available` would auto-start docker desktop as a side effect of a read-only command. not something that pr wanted to introduce.

## fix

- enforce the same charset already required by the interactive prompt (`is_ascii_alphanumeric() || '-' || '_'`) inside `HelixConfig::validate()`. a bad instance name gets rejected the moment the config loads, before any command builds a path from it. added `ConfigError::InvalidInstanceName` with a hint explaining why the restriction exists.
- added `LocalRuntime::check_installed`, a binary-only preflight that checks the runtime is on `PATH` and never touches the daemon (unlike `check_available`, which will auto-start it). wired it into `logs` and `status` so they get the same actionable error as `start`/`stop`/`restart` without gaining a surprising auto-start side effect.

## testing

- `cargo build -p helix-cli`
- `cargo test -p helix-cli --lib`. 169 passed, including new tests for the path-traversal rejection (`config::tests::instance_name_with_path_traversal_characters_is_rejected`) and the missing-binary preflight (`local_runtime::tests::check_installed_*`)
- `cargo clippy --locked -p helix-metrics -p helix-cli --all-targets -- -D warnings`. clean
- `cargo fmt --check -p helix-cli`. clean

## notes for reviewers

this pr only covers the cli-side path-traversal fix and the `logs`/`status` preflight gap. while auditing the codebase for this, i also found two unrelated correctness bugs in `crates/db`'s range-index string encoding (missing terminator on ascending keys, non-sortable float formatting in `PropertyValue::to_index_string`). filing those as separate issues since they touch persisted key encoding and deserve their own discussion rather than riding along with this fix.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds strict instance-name validation to prevent configured names from escaping project-local workspace paths and adds non-starting runtime installation checks for `logs` and `status`.

- Introduces an actionable `InvalidInstanceName` configuration error and traversal regression test.
- Adds a binary-only Docker/Podman preflight for read-only runtime commands.
- The protection remains bypassable by named pruning, and CLI mutation paths can persist names that the next load rejects.

<details open><summary><h3>Security Review</h3></summary>

The configured-name validation does not cover the raw instance argument accepted by named pruning. That argument still reaches `.helix.join(instance_name)` and `remove_dir_all`, so parent-directory components can escape the intended workspace. **How this was verified:** The named-prune path passes its raw argument through `instance_workspace` to `remove_dir_all` without a configuration lookup or equivalent validation.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/cli/src/config.rs | Adds the intended safe-character validation, but load-only enforcement leaves destructive raw inputs uncovered and permits CLI commands to save configurations that later fail validation. |
| crates/cli/src/errors.rs | Adds complete typed-error display and CLI conversion for invalid instance names without an independent defect. |
| crates/cli/src/local_runtime.rs | Improves missing-runtime errors for logs and status, but the preflight does not honor the executable-resolution seam used by runtime spawning. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Instance name input] --> B{Input source}
  B -->|helix.toml| C[HelixConfig::validate]
  C --> D[Safe workspace path]
  B -->|helix prune name| E[Raw CLI argument]
  E --> F[instance_workspace join]
  F --> G[remove_dir_all]
  G --> H[Path may escape .helix]
  B -->|helix add/init --name| I[Insert into config]
  I --> J[save_to_file without validation]
  J --> K[Rejected on next load]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reject path-traversal characters in..."](https://github.com/helixdb/helix-db/commit/bae49cfe0262899590ca6030c6d17b3519c9c00d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59872571)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Knowledge Base — [CLI and operations](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/cli-and-operations.md)
- Knowledge Base — [CLI local runtime and configuration](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/cli-local-runtime.md)

<!-- /greptile_comment -->