### PR TITLE
fix: terminate ascending range-index string values before the trailing id

### DIFF
--- a/crates/db/src/encoding/v2/keys/indexes/prefix.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/prefix.rs
@@ -372,7 +372,7 @@ mod tests {
 
         let inclusive_end =
             RangeScanValuePrefix::new(RangeIndexDirection::Asc, PROP, "a").inclusive_end_bound();
-        let mut expected = vec![0x03, 0x01, 1, 2, 3, 4, b'a'];
+        let mut expected = vec![0x03, 0x01, 1, 2, 3, 4, b'a', 0x00, 0x00];
         expected.extend_from_slice(&u64::MAX.to_be_bytes());
         expected.push(0);
         assert_eq!(inclusive_end.as_ref(), expected.as_slice());
@@ -414,7 +414,7 @@ mod tests {
         let inclusive_end =
             GlobalEdgeRangeScanValuePrefix::new(RangeIndexDirection::Asc, PROP, "a")
                 .inclusive_end_bound();
-        let mut expected = vec![0x03, 0x09, 1, 2, 3, 4, b'a'];
+        let mut expected = vec![0x03, 0x09, 1, 2, 3, 4, b'a', 0x00, 0x00];
         expected.extend_from_slice(&u64::MAX.to_be_bytes());
         expected.push(0);
         assert_eq!(inclusive_end.as_ref(), expected.as_slice());
@@ -465,6 +465,7 @@ mod tests {
         value_expected.extend_from_slice(&endpoint.to_be_bytes());
         value_expected.extend_from_slice(&PROP);
         value_expected.push(b'a');
+        value_expected.extend_from_slice(&[0x00, 0x00]);
         let value_prefix = EdgeRangeScanValuePrefix::new(
             RangeEdgeDirection::In,
             EdgeRangeIndexDirection::Asc,

--- a/crates/db/src/encoding/v2/keys/indexes/range/edge.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/range/edge.rs
@@ -1,7 +1,11 @@
 //! Edge ordered secondary-index key codecs.
 //!
-//! Ascending values retain their UTF-8 bytes. Descending values invert bytes,
-//! escape embedded zeroes, and end with a fixed terminator. V2 generation
+//! Ascending values escape embedded zeroes and end with a fixed terminator.
+//! Descending values additionally invert every byte. Both directions need
+//! the terminator: without it, a value that is a proper prefix of another
+//! value in the same index can compare incorrectly once the comparison
+//! reaches the trailing edge id, since nothing marks where the value ends
+//! and the id begins. V2 generation
 //! entries reuse this value encoding through [`decode_range_value`], keeping
 //! ordering and validation identical across both physical namespaces.
 
@@ -55,8 +59,8 @@ impl EdgeRangeIndexDirection {
 /// Edge range index: source+prop+value+edgeId -> presence
 ///
 /// ```text
-/// Out asc:  [0x03][0x03][0x00][source:8][prop_hash:4][value:var][edge_id:8]
-/// In asc:   [0x03][0x03][0x01][target:8][prop_hash:4][value:var][edge_id:8]
+/// Out asc:  [0x03][0x03][0x00][source:8][prop_hash:4][asc_value:var][edge_id:8]
+/// In asc:   [0x03][0x03][0x01][target:8][prop_hash:4][asc_value:var][edge_id:8]
 /// Out desc: [0x03][0x06][0x00][source:8][prop_hash:4][desc_value:var][edge_id:8]
 /// In desc:  [0x03][0x06][0x01][target:8][prop_hash:4][desc_value:var][edge_id:8]
 /// Value: empty/presence
@@ -120,11 +124,11 @@ impl<'a> EdgeRangeIndexKey<'a> {
 
     /// Parse the edge range key from a slice.
     ///
-    /// key is `[0x03][0x03][0x00][source:8][prop_hash:4][value:var][edge_id:8]`
+    /// key is `[0x03][0x03][0x00][source:8][prop_hash:4][asc_value:var][edge_id:8]`
     ///
     /// starts from the edge-range index prefix because the first byte is handled by `Key` parsing.
     ///
-    /// e.g. `[0x03][0x00][source:8][prop_hash:4][value:var][edge_id:8]` is what is parsed from the slice
+    /// e.g. `[0x03][0x00][source:8][prop_hash:4][asc_value:var][edge_id:8]` is what is parsed from the slice
     pub fn parse_from_slice(slice: &'a [u8]) -> Result<Self, EncodingError> {
         // Checks AT LEAST the expected length
         // Variable length value means `value` and `node_id` access should be checked
@@ -199,7 +203,34 @@ impl<'a> EdgeRangeIndexKey<'a> {
                 actual: slice.len(),
             })?;
         let value = match range_direction {
-            EdgeRangeIndexDirection::Asc => Cow::Borrowed(std::str::from_utf8(value_bytes)?),
+            EdgeRangeIndexDirection::Asc => {
+                if !value_bytes.ends_with(&[0x00, 0x00]) {
+                    return Err(EncodingError::InvalidIndexKey(
+                        "ascending range value missing terminator".to_string(),
+                    ));
+                }
+
+                let mut decoded = Vec::with_capacity(value_bytes.len().saturating_sub(2));
+                let mut index = 0;
+                let value_body_len = value_bytes.len() - 2;
+                while index < value_body_len {
+                    let byte = value_bytes[index];
+                    if byte == 0x00 {
+                        if value_bytes.get(index + 1) != Some(&0xFF) {
+                            return Err(EncodingError::InvalidIndexKey(
+                                "invalid ascending range value escape".to_string(),
+                            ));
+                        }
+                        decoded.push(0x00);
+                        index += 2;
+                    } else {
+                        decoded.push(byte);
+                        index += 1;
+                    }
+                }
+
+                Cow::Owned(std::str::from_utf8(&decoded)?.to_owned())
+            }
             EdgeRangeIndexDirection::Desc => {
                 if !value_bytes.ends_with(&[0xFF, 0xFE]) {
                     return Err(EncodingError::InvalidIndexKey(
@@ -244,6 +275,11 @@ impl<'a> EdgeRangeIndexKey<'a> {
 
     /// Encode the edge range key into a buffer.
     ///
+    /// For ascending direction, the value is encoded as follows:
+    /// - Each byte is written as-is
+    /// - If a byte is 0x00, it is escaped with 0x00 0xFF
+    /// - The final bytes are 0x00 0x00 to indicate the end of the value.
+    ///
     /// For descending direction, the value is encoded as follows:
     /// - Each byte is inverted (0x00 -> 0xFF, 0xFF -> 0x00)
     /// - If a byte is 0x00, it is escaped with 0xFF 0x00
@@ -254,7 +290,16 @@ impl<'a> EdgeRangeIndexKey<'a> {
         buf.put_u64(self.source);
         buf.put_slice(&self.property_hash);
         match self.range_direction {
-            EdgeRangeIndexDirection::Asc => buf.put_slice(self.value.as_bytes()),
+            EdgeRangeIndexDirection::Asc => {
+                for byte in self.value.as_bytes().iter() {
+                    buf.put_u8(*byte);
+                    if *byte == 0x00 {
+                        buf.put_u8(0xFF);
+                    }
+                }
+                buf.put_u8(0x00);
+                buf.put_u8(0x00);
+            }
             EdgeRangeIndexDirection::Desc => {
                 for byte in self.value.as_bytes().iter() {
                     buf.put_u8(!byte);
@@ -285,7 +330,7 @@ impl From<&EdgeRangeIndexKey<'_>> for IndexPrefix {
 /// Global edge range index: property+value+edgeId -> presence.
 ///
 /// ```text
-/// Asc:  [0x03][0x09][prop_hash:4][value:var][edge_id:8]
+/// Asc:  [0x03][0x09][prop_hash:4][asc_value:var][edge_id:8]
 /// Desc: [0x03][0x0a][prop_hash:4][desc_value:var][edge_id:8]
 /// Value: empty/presence
 /// ```
@@ -381,7 +426,34 @@ impl<'a> GlobalEdgeRangeIndexKey<'a> {
                 actual: slice.len(),
             })?;
         let value = match range_direction {
-            RangeIndexDirection::Asc => Cow::Borrowed(std::str::from_utf8(value_bytes)?),
+            RangeIndexDirection::Asc => {
+                if !value_bytes.ends_with(&[0x00, 0x00]) {
+                    return Err(EncodingError::InvalidIndexKey(
+                        "ascending global edge range value missing terminator".to_string(),
+                    ));
+                }
+
+                let mut decoded = Vec::with_capacity(value_bytes.len().saturating_sub(2));
+                let mut index = 0;
+                let value_body_len = value_bytes.len() - 2;
+                while index < value_body_len {
+                    let byte = value_bytes[index];
+                    if byte == 0x00 {
+                        if value_bytes.get(index + 1) != Some(&0xFF) {
+                            return Err(EncodingError::InvalidIndexKey(
+                                "invalid ascending global edge range value escape".to_string(),
+                            ));
+                        }
+                        decoded.push(0x00);
+                        index += 2;
+                    } else {
+                        decoded.push(byte);
+                        index += 1;
+                    }
+                }
+
+                Cow::Owned(std::str::from_utf8(&decoded)?.to_owned())
+            }
             RangeIndexDirection::Desc => {
                 if !value_bytes.ends_with(&[0xFF, 0xFE]) {
                     return Err(EncodingError::InvalidIndexKey(
@@ -421,7 +493,16 @@ impl<'a> GlobalEdgeRangeIndexKey<'a> {
         buf.put_slice(self.index_prefix().as_slice());
         buf.put_slice(&self.property_hash);
         match self.range_direction {
-            RangeIndexDirection::Asc => buf.put_slice(self.value.as_bytes()),
+            RangeIndexDirection::Asc => {
+                for byte in self.value.as_bytes().iter() {
+                    buf.put_u8(*byte);
+                    if *byte == 0x00 {
+                        buf.put_u8(0xFF);
+                    }
+                }
+                buf.put_u8(0x00);
+                buf.put_u8(0x00);
+            }
             RangeIndexDirection::Desc => {
                 for byte in self.value.as_bytes().iter() {
                     buf.put_u8(!byte);
@@ -469,6 +550,7 @@ mod tests {
         let mut expected = vec![0x03, 0x01];
         expected.extend_from_slice(&PROP);
         expected.extend_from_slice(b"az");
+        expected.extend_from_slice(&[0x00, 0x00]);
         expected.extend_from_slice(&0x0102_0304_0506_0708u64.to_be_bytes());
         assert_eq!(encoded.as_ref(), expected.as_slice());
 
@@ -540,6 +622,7 @@ mod tests {
         expected_in_asc.extend_from_slice(&7u64.to_be_bytes());
         expected_in_asc.extend_from_slice(&PROP);
         expected_in_asc.extend_from_slice(b"az");
+        expected_in_asc.extend_from_slice(&[0x00, 0x00]);
         expected_in_asc.extend_from_slice(&11u64.to_be_bytes());
 
         assert_eq!(out_desc.as_ref(), expected_out_desc.as_slice());
@@ -694,6 +777,47 @@ mod tests {
     }
 
     #[test]
+    fn ascending_range_index_key_round_trips_embedded_null() {
+        let key = DataKeyKind::PropertyIndex(PropertyIndexKey::Range(RangeIndexKey::new(
+            RangeIndexDirection::Asc,
+            PROP,
+            Cow::Borrowed("a\0z"),
+            1,
+        )));
+        let encoded = key.clone().to_bytes();
+
+        let DataKeyKind::PropertyIndex(PropertyIndexKey::Range(parsed)) =
+            DataKeyKind::parse_from_slice(&encoded).unwrap()
+        else {
+            panic!("expected range index key");
+        };
+        assert_eq!(parsed.value(), "a\0z");
+        assert_eq!(parsed.direction(), RangeIndexDirection::Asc);
+    }
+
+    #[test]
+    fn ascending_range_index_keys_sort_correctly_when_one_value_is_a_prefix_of_another() {
+        // regression test: a proper-prefix value must always sort before the longer
+        // value it prefixes, regardless of what bytes the trailing node id happens
+        // to contribute. before the ascending encoding gained a terminator, this
+        // could invert depending on the id's leading byte or an embedded null in
+        // the longer value.
+        let shorter = DataKeyKind::PropertyIndex(PropertyIndexKey::Range(RangeIndexKey::new(
+            RangeIndexDirection::Asc,
+            PROP,
+            Cow::Borrowed("a"),
+            5,
+        )))
+        .to_bytes();
+        let longer_with_embedded_null = DataKeyKind::PropertyIndex(PropertyIndexKey::Range(
+            RangeIndexKey::new(RangeIndexDirection::Asc, PROP, Cow::Borrowed("a\0"), 1),
+        ))
+        .to_bytes();
+
+        assert!(shorter < longer_with_embedded_null);
+    }
+
+    #[test]
     fn global_edge_range_index_key_has_exact_layout_and_round_trips() {
         let asc = DataKeyKind::PropertyIndex(PropertyIndexKey::GlobalEdgeRange(
             GlobalEdgeRangeIndexKey::new(
@@ -707,6 +831,7 @@ mod tests {
         let mut expected = vec![0x03, 0x09];
         expected.extend_from_slice(&PROP);
         expected.extend_from_slice(b"value");
+        expected.extend_from_slice(&[0x00, 0x00]);
         expected.extend_from_slice(&0x0102_0304_0506_0708u64.to_be_bytes());
         assert_eq!(encoded.as_ref(), expected.as_slice());
         assert_eq!(DataKeyKind::parse_from_slice(&encoded).unwrap(), asc);
@@ -771,6 +896,7 @@ mod tests {
         let mut invalid_utf8 = vec![0x03, 0x01];
         invalid_utf8.extend_from_slice(&PROP);
         invalid_utf8.push(0xFF);
+        invalid_utf8.extend_from_slice(&[0x00, 0x00]);
         invalid_utf8.extend_from_slice(&1u64.to_be_bytes());
         assert!(matches!(
             RangeIndexKey::parse_from_slice(&invalid_utf8),
@@ -837,6 +963,7 @@ mod tests {
         invalid_utf8.extend_from_slice(&1u64.to_be_bytes());
         invalid_utf8.extend_from_slice(&PROP);
         invalid_utf8.push(0xFF);
+        invalid_utf8.extend_from_slice(&[0x00, 0x00]);
         invalid_utf8.extend_from_slice(&2u64.to_be_bytes());
         assert!(matches!(
             EdgeRangeIndexKey::parse_from_slice(&invalid_utf8),
@@ -909,6 +1036,7 @@ mod tests {
         let mut invalid_utf8 = vec![0x03, 0x09];
         invalid_utf8.extend_from_slice(&PROP);
         invalid_utf8.push(0xFF);
+        invalid_utf8.extend_from_slice(&[0x00, 0x00]);
         invalid_utf8.extend_from_slice(&1u64.to_be_bytes());
         assert!(matches!(
             GlobalEdgeRangeIndexKey::parse_from_slice(&invalid_utf8),

--- a/crates/db/src/encoding/v2/keys/indexes/range/node.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/range/node.rs
@@ -1,7 +1,11 @@
 //! Canonical ordered node secondary-index key codecs.
 //!
-//! Ascending values retain their UTF-8 bytes. Descending values invert bytes,
-//! escape embedded zeroes, and end with a fixed terminator. V2 generation
+//! Ascending values escape embedded zeroes and end with a fixed terminator.
+//! Descending values additionally invert every byte. Both directions need
+//! the terminator: without it, a value that is a proper prefix of another
+//! value in the same index can compare incorrectly once the comparison
+//! reaches the trailing node id, since nothing marks where the value ends
+//! and the id begins. V2 generation
 //! Generation-qualified entries reuse this value encoding through [`decode_range_value`], keeping
 //! ordering and validation identical across both physical namespaces.
 
@@ -24,7 +28,34 @@ pub(crate) fn decode_range_value(
     value_bytes: &[u8],
 ) -> Result<Cow<'_, str>, EncodingError> {
     match direction {
-        RangeIndexDirection::Asc => Ok(Cow::Borrowed(std::str::from_utf8(value_bytes)?)),
+        RangeIndexDirection::Asc => {
+            if !value_bytes.ends_with(&[0x00, 0x00]) {
+                return Err(EncodingError::InvalidIndexKey(
+                    "ascending range value missing terminator".to_string(),
+                ));
+            }
+
+            let mut decoded = Vec::with_capacity(value_bytes.len().saturating_sub(2));
+            let mut index = 0;
+            let value_body_len = value_bytes.len() - 2;
+            while index < value_body_len {
+                let byte = value_bytes[index];
+                if byte == 0x00 {
+                    if value_bytes.get(index + 1) != Some(&0xFF) {
+                        return Err(EncodingError::InvalidIndexKey(
+                            "invalid ascending range value escape".to_string(),
+                        ));
+                    }
+                    decoded.push(0x00);
+                    index += 2;
+                } else {
+                    decoded.push(byte);
+                    index += 1;
+                }
+            }
+
+            Ok(Cow::Owned(std::str::from_utf8(&decoded)?.to_owned()))
+        }
         RangeIndexDirection::Desc => {
             if !value_bytes.ends_with(&[0xFF, 0xFE]) {
                 return Err(EncodingError::InvalidIndexKey(
@@ -88,7 +119,7 @@ impl RangeIndexDirection {
 /// Range index: property+value+nodeId -> presence
 ///
 /// ```text
-/// Asc:  [0x03][0x01][prop_hash:4][value:var][node_id:8]
+/// Asc:  [0x03][0x01][prop_hash:4][asc_value:var][node_id:8]
 /// Desc: [0x03][0x05][prop_hash:4][desc_value:var][node_id:8]
 /// Value: empty/presence
 /// ```
@@ -146,7 +177,7 @@ impl<'a> RangeIndexKey<'a> {
 
     /// Parse a range index key from a slice.
     ///
-    /// key is `[0x03][0x01][prop_hash:4][value:var][node_id:8]`
+    /// key is `[0x03][0x01][prop_hash:4][asc_value:var][node_id:8]`
     pub fn parse_from_slice(slice: &'a [u8]) -> Result<Self, EncodingError> {
         // Checks AT LEAST the expected length
         // Variable length value means `value` and `node_id` access should be checked
@@ -204,18 +235,32 @@ impl<'a> RangeIndexKey<'a> {
 
     /// Encode the range key into a buffer.
     ///
+    /// For ascending direction, the value is encoded as follows:
+    /// - Each byte is written as-is
+    /// - If a byte is 0x00, it is escaped with 0x00 0xFF
+    /// - The final bytes are 0x00 0x00 to indicate the end of the value.
+    ///
     /// For descending direction, the value is encoded as follows:
     /// - Each byte is inverted (0x00 -> 0xFF, 0xFF -> 0x00)
     /// - If a byte is 0x00, it is escaped with 0xFF 0x00
     /// - The final bytes are 0xFF 0xFE to indicate the end of the value.
     ///
-    /// size of descending value is `2 + number of 0x00 bytes` longer than ascending value
+    /// both directions carry the same `2 + number of 0x00 bytes` overhead over the raw value
     pub fn encode_into<B: BufMut>(&self, buf: &mut B) {
         buf.put_u8(KeyPrefix::PropertyIndex.as_u8());
         buf.put_u8(self.range_direction.as_u8());
         buf.put_slice(&self.property_hash);
         match self.range_direction {
-            RangeIndexDirection::Asc => buf.put_slice(self.value.as_bytes()),
+            RangeIndexDirection::Asc => {
+                for byte in self.value.as_bytes().iter() {
+                    buf.put_u8(*byte);
+                    if *byte == 0x00 {
+                        buf.put_u8(0xFF);
+                    }
+                }
+                buf.put_u8(0x00);
+                buf.put_u8(0x00);
+            }
             RangeIndexDirection::Desc => {
                 for byte in self.value.as_bytes().iter() {
                     buf.put_u8(!byte);

--- a/crates/db/src/encoding/v2/keys/indexes/range/scans.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/range/scans.rs
@@ -116,13 +116,7 @@ impl<'a> RangeScanValuePrefix<'a> {
     }
 
     fn encoded_len(&self) -> usize {
-        PREFIX_LEN
-            + INDEX_PREFIX_LEN
-            + PROPERTY_HASH_MAX_LEN
-            + ordered_value_len(
-                matches!(self.direction, RangeIndexDirection::Desc),
-                self.value,
-            )
+        PREFIX_LEN + INDEX_PREFIX_LEN + PROPERTY_HASH_MAX_LEN + ordered_value_len(self.value)
     }
 }
 
@@ -225,13 +219,7 @@ impl<'a> GlobalEdgeRangeScanValuePrefix<'a> {
     }
 
     fn encoded_len(&self) -> usize {
-        PREFIX_LEN
-            + INDEX_PREFIX_LEN
-            + PROPERTY_HASH_MAX_LEN
-            + ordered_value_len(
-                matches!(self.direction, RangeIndexDirection::Desc),
-                self.value,
-            )
+        PREFIX_LEN + INDEX_PREFIX_LEN + PROPERTY_HASH_MAX_LEN + ordered_value_len(self.value)
     }
 }
 
@@ -385,16 +373,22 @@ impl<'a> EdgeRangeScanValuePrefix<'a> {
             + core::mem::size_of::<RangeEdgeDirection>()
             + NODE_ID_MAX_LEN
             + PROPERTY_HASH_MAX_LEN
-            + ordered_value_len(
-                matches!(self.range_direction, EdgeRangeIndexDirection::Desc),
-                self.value,
-            )
+            + ordered_value_len(self.value)
     }
 }
 
 fn put_ordered_value<B: BufMut>(buf: &mut B, descending: bool, value: &str) {
     match descending {
-        false => buf.put_slice(value.as_bytes()),
+        false => {
+            for byte in value.as_bytes() {
+                buf.put_u8(*byte);
+                if *byte == 0x00 {
+                    buf.put_u8(0xFF);
+                }
+            }
+            buf.put_u8(0x00);
+            buf.put_u8(0x00);
+        }
         true => {
             for byte in value.as_bytes() {
                 buf.put_u8(!byte);
@@ -408,16 +402,11 @@ fn put_ordered_value<B: BufMut>(buf: &mut B, descending: bool, value: &str) {
     }
 }
 
-fn ordered_value_len(descending: bool, value: &str) -> usize {
-    match descending {
-        false => value.len(),
-        true => {
-            value
-                .as_bytes()
-                .iter()
-                .map(|byte| if *byte == 0x00 { 2 } else { 1 })
-                .sum::<usize>()
-                + 2
-        }
-    }
+fn ordered_value_len(value: &str) -> usize {
+    value
+        .as_bytes()
+        .iter()
+        .map(|byte| if *byte == 0x00 { 2 } else { 1 })
+        .sum::<usize>()
+        + 2
 }

--- a/crates/db/src/encoding/v2/keys/indexes/vector/mod.rs
+++ b/crates/db/src/encoding/v2/keys/indexes/vector/mod.rs
@@ -460,7 +460,7 @@ mod tests {
         );
         let mut edge_range_bytes = Vec::new();
         edge_range.encode_into(&mut edge_range_bytes);
-        assert_eq!(edge_range_bytes.len(), 43);
+        assert_eq!(edge_range_bytes.len(), 45);
         assert_eq!(
             &edge_range_bytes[0..2],
             &[KEY_SPACE_INDEX, INDEX_TYPE_VECTOR]


### PR DESCRIPTION
## summary

`RangeIndexKey`, `EdgeRangeIndexKey`, and `GlobalEdgeRangeIndexKey` encoded ascending range-index values as `value_bytes || node_id:8` (or `edge_id:8`) with nothing marking where the value ends and the id begins. the descending direction already carries a terminator for exactly this reason. fixes #1065.

## problem

the module's own doc comment says it outright: "ascending values retain their utf-8 bytes. descending values invert bytes, escape embedded zeroes, and end with a fixed terminator." only descending got the terminator.

without one, when an indexed value is a proper prefix of another value in the same index, physical byte order can diverge from logical string order once the comparison spills past the value into the trailing id bytes. concrete counterexample, no large ids needed: index `"a"` at node id `5` and `"a\0"` at node id `1`. `"a"` is a proper prefix of `"a\0"`, so `"a" < "a\0"` under standard byte-lexicographic order, unconditionally. encoded suffixes (key prefix and property hash identical for both, so they drop out of the comparison):

```
a:    61 00 00 00 00 00 00 00 05          (9 bytes)
a\0:  61 00 00 00 00 00 00 00 00 01       (10 bytes)
```

first 8 bytes tie. byte 8: `a`'s id byte is `05`, `a\0`'s is `00` (still inside its id's own leading zero bytes). `05 > 00`, so `a` sorts after `a\0` physically, backwards from the logical order. a full ascending scan returns them in the wrong order, and a bound built from the same encoding drops or includes the wrong rows at that boundary.

this is a `pub`/`pub(crate)` codec used by `db::search::add_to_range_index*` and `scan_range_index*`, and it's exercised by test infrastructure, but the live v2 production write path doesn't go through it. `index_lifecycle` builds range-index values through `project_range_value`/`CanonicalRangeValue` (`range_index_value.rs`) instead, which already terminates and escapes strings correctly. so this doesn't corrupt a live index today, it's a correctness bug in a documented, tested, public codec whose actual behavior doesn't match its own doc comment.

## fix

gave the ascending direction the same terminator/escape scheme the descending direction already has, just without the byte inversion: each byte written as-is, `0x00` escaped as `0x00 0xFF`, terminated with `0x00 0x00`. matches the scheme `range_index_value.rs` already uses for its string domain, so the codebase now has one convention instead of two. applied to all three key types (`node.rs`, `edge.rs`) plus the scan-bound builder in `scans.rs` (`put_ordered_value`/`ordered_value_len`), which has to stay byte-compatible with the full keys it builds bounds against.

updated every exact-byte-layout test that asserted the old unterminated ascending format across `node.rs`, `edge.rs`, `prefix.rs`, and `vector/mod.rs`. added two new regression tests in `edge.rs`: one round-tripping an ascending value with an embedded null, one directly reproducing the prefix-ordering counterexample above.

## testing

- `cargo build -p db`
- `cargo test -p db --lib`: 1507 passed, 0 failed
- `cargo test -p db --tests` (every integration suite under `crates/db/tests/`): all green, 0 failed
- `cargo clippy -p db --all-targets -- -D warnings`, checked against both the workspace's pinned `1.97.1` toolchain and `1.98.0`: clean for every file this change touches
- `cargo fmt --check` on every changed file: clean

## notes for reviewers

while running the full-crate clippy gate to verify this change, i found `cargo clippy --workspace -- -D warnings` currently fails on a clean checkout of `main` (confirmed against the pinned `1.97.1` toolchain, not a version mismatch on my end), 4 errors in `crates/db/src/execution/interpreter/mutation/topology.rs`, unrelated to this change: a function with too many arguments, a field-reassign-outside-default, and two needless-range-loop lints. not touching it here since it's a separate file and a separate concern. flagging it in case it's not already known.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes lexical ordering for ascending string range-index keys by escaping embedded null bytes and terminating values before the trailing entity ID.
- Applies the encoding consistently to node, edge, and global-edge keys.
- Updates matching scan-bound construction and encoded-length calculations.
- Updates exact-layout tests and adds embedded-null and prefix-ordering regressions.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/encoding/v2/keys/indexes/range/node.rs | Node ascending range values now encode, decode, validate, and order using escaped nulls and a fixed terminator. |
| crates/db/src/encoding/v2/keys/indexes/range/edge.rs | Edge and global-edge codecs consistently adopt the ascending terminator scheme, with focused regression coverage. |
| crates/db/src/encoding/v2/keys/indexes/range/scans.rs | Node and edge scan bounds now use the same ordered-value bytes and length calculation as complete keys. |
| crates/db/src/encoding/v2/keys/indexes/prefix.rs | Exact scan-prefix expectations were updated for the terminated ascending representation. |
| crates/db/src/encoding/v2/keys/indexes/vector/mod.rs | The composite encoding length assertion accounts for the two-byte ascending terminator. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    S[UTF-8 string] --> E[Escape 0x00 as 0x00 0xFF]
    E --> T[Append 0x00 0x00 terminator]
    T --> I[Append entity ID]
    I --> K[Lexicographically ordered range key]
    B[Scan-bound value] --> E
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: terminate ascending range-index str..."](https://github.com/helixdb/helix-db/commit/1f4fa7144649024cf0492299db7f42bc98fbaa73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59887546)</sub>

<!-- /greptile_comment -->