### PR TITLE
fix: encode floats order-preservingly in PropertyValue::to_index_string

### DIFF
--- a/crates/db/src/encoding/v2/values/property/mod.rs
+++ b/crates/db/src/encoding/v2/values/property/mod.rs
@@ -13,5 +13,5 @@ pub use property::Property;
 pub use row::decode_properties;
 pub(crate) use row::{
     datetime_millis_to_rfc3339, encode_index_partition_value, encode_properties,
-    sortable_i64_index_string,
+    sortable_f64_index_string, sortable_i64_index_string,
 };

--- a/crates/db/src/encoding/v2/values/property/property_value.rs
+++ b/crates/db/src/encoding/v2/values/property/property_value.rs
@@ -5,7 +5,9 @@ use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use serde::{Deserialize, Serialize, Serializer};
 use std::{cmp::Ordering, collections::BTreeMap};
 
-use crate::encoding::property::{datetime_millis_to_rfc3339, sortable_i64_index_string};
+use crate::encoding::property::{
+    datetime_millis_to_rfc3339, sortable_f64_index_string, sortable_i64_index_string,
+};
 use crate::encoding::v2::values::property::canonical_number::{self, CanonicalNumber};
 
 ///
@@ -281,8 +283,10 @@ impl PropertyValue {
     /// Convert to a string representation suitable for index keys
     ///
     /// Numbers are zero-padded for lexicographic ordering:
-    /// - i64: 20-character zero-padded decimal
-    /// - f64: Scientific notation with sign prefix
+    /// - i64: 20-character zero-padded decimal of the sign-flipped bits
+    /// - f64/f32: 20-character zero-padded decimal of the order-preserving
+    ///   bits (the `F32` variant stores its value as `f64`, so it shares
+    ///   the `f64` encoding)
     /// - Strings: As-is
     /// - Other types: Debug representation (not indexable)
     pub fn to_index_string(&self) -> String {
@@ -292,13 +296,13 @@ impl PropertyValue {
             // was PropertyValue::I64(n) => format!("{:020}", n), check compatibility
             PropertyValue::I64(n) => sortable_i64_index_string(*n),
             PropertyValue::DateTime(n) => sortable_i64_index_string(*n),
-            PropertyValue::F64(n) => format!("{:+024.15e}", n),
+            PropertyValue::F64(n) => sortable_f64_index_string(*n),
             PropertyValue::String(s) => s.clone(),
             PropertyValue::Bytes(b) => format!("<bytes:{}>", b.len()),
             PropertyValue::I64Array(a) => format!("<i64[{}]>", a.len()),
             PropertyValue::F64Array(a) => format!("<f64[{}]>", a.len()),
             PropertyValue::StringArray(a) => format!("<str[{}]>", a.len()),
-            PropertyValue::F32(n) => format!("{:+024.15e}", n),
+            PropertyValue::F32(n) => sortable_f64_index_string(*n),
             PropertyValue::F32Array(items) => format!("<f32[{}]>", items.len()),
             PropertyValue::Array(a) => format!("<array[{}]>", a.len()),
             PropertyValue::Object(o) => format!("<object[{}]>", o.len()),
@@ -612,6 +616,58 @@ mod tests {
     }
 
     #[test]
+    fn f64_index_strings_preserve_numeric_order() {
+        // regression test: `{:+024.15e}` did not zero-pad the exponent and
+        // did not invert digits for negative numbers, so the previous
+        // encoding sorted as roughly [1, 1000, 0.001, -1, -1000, -0.001]
+        // instead of numeric order.
+        let values = [
+            f64::NEG_INFINITY,
+            -1000.0,
+            -1.0,
+            -0.001,
+            -0.0,
+            0.0,
+            0.001,
+            1.0,
+            1000.0,
+            f64::INFINITY,
+        ];
+        let encoded = values
+            .iter()
+            .map(|value| PropertyValue::F64(*value).to_index_string())
+            .collect::<Vec<_>>();
+
+        assert!(encoded.windows(2).all(|pair| pair[0] < pair[1]));
+    }
+
+    #[test]
+    fn f32_variant_index_strings_preserve_numeric_order() {
+        // `PropertyValue::F32` stores its value as `f64` (see the variant
+        // definition), so it shares `F64`'s encoding. this exercises that
+        // arm directly so a future change that special-cases `F32` again
+        // can't silently reintroduce the same bug.
+        let values = [
+            f64::NEG_INFINITY,
+            -1000.0,
+            -1.0,
+            -0.001,
+            -0.0,
+            0.0,
+            0.001,
+            1.0,
+            1000.0,
+            f64::INFINITY,
+        ];
+        let encoded = values
+            .iter()
+            .map(|value| PropertyValue::F32(*value).to_index_string())
+            .collect::<Vec<_>>();
+
+        assert!(encoded.windows(2).all(|pair| pair[0] < pair[1]));
+    }
+
+    #[test]
     fn property_value_accessors_and_equality_work_for_common_types() {
         assert_eq!(PropertyValue::from("hello").as_str(), Some("hello"));
         assert_eq!(PropertyValue::from(42i64).as_i64(), Some(42));
@@ -751,8 +807,8 @@ mod tests {
                 "09223372036854775808",
                 "1970-01-01T00:00:00.000Z",
             ),
-            (PropertyValue::F64(1.5), "+00001.500000000000000e0", "1.5"),
-            (PropertyValue::F32(2.5), "+00002.500000000000000e0", "2.5"),
+            (PropertyValue::F64(1.5), "13832806255468478464", "1.5"),
+            (PropertyValue::F32(2.5), "13836183955189006336", "2.5"),
             (PropertyValue::String("value".to_string()), "value", "value"),
             (PropertyValue::Bytes(vec![1, 2]), "<bytes:2>", "<bytes:2>"),
             (PropertyValue::I64Array(vec![1, 2]), "<i64[2]>", "<i64[2]>"),

--- a/crates/db/src/encoding/v2/values/property/row.rs
+++ b/crates/db/src/encoding/v2/values/property/row.rs
@@ -20,9 +20,27 @@ pub(crate) fn datetime_millis_to_rfc3339(millis: i64) -> Option<String> {
         .map(|dt| dt.to_rfc3339_opts(SecondsFormat::Millis, true))
 }
 
-const SIGNED_I64_SORT_MASK: u64 = 0x8000_0000_0000_0000;
+const U64_SIGN_BIT: u64 = 0x8000_0000_0000_0000;
 pub(crate) fn sortable_i64_index_string(value: i64) -> String {
-    format!("{:020}", (value as u64) ^ SIGNED_I64_SORT_MASK)
+    format!("{:020}", (value as u64) ^ U64_SIGN_BIT)
+}
+
+/// Maps `value`'s IEEE-754 bits onto an order-preserving `u64`: for a
+/// negative value (sign bit set) every bit is inverted, for a non-negative
+/// value only the sign bit is set. Ascending order over the returned `u64`
+/// then matches ascending order over the original `f64`, including across
+/// the negative/positive boundary and for the two zeros.
+fn sortable_f64_bits(value: f64) -> u64 {
+    let bits = value.to_bits();
+    if bits & U64_SIGN_BIT != 0 {
+        !bits
+    } else {
+        bits | U64_SIGN_BIT
+    }
+}
+
+pub(crate) fn sortable_f64_index_string(value: f64) -> String {
+    format!("{:020}", sortable_f64_bits(value))
 }
 
 pub(super) const PROPERTY_ALIGNMENT: usize = core::mem::align_of::<rkyv::Archived<Vec<Property>>>();

--- a/crates/db/src/search/mod.rs
+++ b/crates/db/src/search/mod.rs
@@ -52,6 +52,8 @@ use crate::encoding::keys::scope::DataScope;
 use crate::encoding::keys::{EdgeEndpointsKey, EdgePropertyByIdKey};
 use crate::encoding::property::property::Property;
 use crate::encoding::property::property_value::PropertyValue;
+#[cfg(test)]
+use crate::encoding::property::sortable_f64_index_string;
 use crate::encoding::property::{decode_properties, encode_properties};
 use crate::encoding::v2::keys::indexes::PropertyIndexKey;
 use crate::encoding::v2::keys::{DataKey, DataKeyKind};
@@ -570,8 +572,8 @@ pub fn property_value_to_index_string(value: &PropertyValue) -> String {
         PropertyValue::Bool(b) => b.to_string(),
         PropertyValue::I64(n) => format!("{:020}", n),
         PropertyValue::DateTime(n) => PropertyValue::DateTime(*n).to_index_string(),
-        PropertyValue::F64(n) => format!("{:+024.15e}", n),
-        PropertyValue::F32(n) => format!("{:+024.15e}", n),
+        PropertyValue::F64(n) => sortable_f64_index_string(*n),
+        PropertyValue::F32(n) => sortable_f64_index_string(*n),
         PropertyValue::String(s) => s.clone(),
         PropertyValue::Bytes(b) => format!("<bytes:{:?}>", b),
         PropertyValue::I64Array(a) => format!("<i64[{}]>", a.len()),
@@ -3462,11 +3464,11 @@ mod tests {
         );
         assert_eq!(
             property_value_to_index_string(&PropertyValue::F64(1.5)),
-            "+00001.500000000000000e0"
+            "13832806255468478464"
         );
         assert_eq!(
             property_value_to_index_string(&PropertyValue::F32(1.5)),
-            "+00001.500000000000000e0"
+            "13832806255468478464"
         );
         assert_eq!(
             property_value_to_index_string(&PropertyValue::String("hello".to_string())),


### PR DESCRIPTION
## summary

`PropertyValue::to_index_string()` formatted `f64`/`f32` as `format!("{:+024.15e}", n)`, documented as "zero-padded for lexicographic ordering." it wasn't. fixes #1066.

## problem

rust's `{:e}` formatter writes the exponent as a bare signed decimal (`e3`, `e-3`), not fixed-width, and it doesn't invert digits for negative numbers.

verified numerically: encoding `[1000.0, 1.0, 0.001, -1000.0, -1.0, -0.001]` with that format string and sorting the resulting strings gives `[1.0, 1000.0, 0.001, -1.0, -1000.0, -0.001]`, not the numeric order. every pair is wrong except `1.0 < 1000.0`, which only holds by coincidence.

`to_index_string`/`property_value_to_index_string` (the latter is a `#[cfg(test)]`-only helper in `search/mod.rs` that independently reimplemented the same broken format string) are documented as producing sortable strings for the same public range-index api covered by the sibling `RangeIndexKey` fix in #1067. `crates/db/src/index_lifecycle` doesn't call either function, current v2 production range-index writes go through `project_range_value`/`CanonicalRangeValue` instead, which already encodes floats correctly. so this doesn't corrupt a live index today, it's a `pub`, documented, tested function whose actual behavior contradicts its own doc comment.

## fix

added `sortable_f64_index_string` next to the existing `sortable_i64_index_string` in `row.rs`, using the standard order-preserving float-bits transform: invert every bit for a negative value (sign bit set), otherwise just set the sign bit. zero-pad the resulting `u64` to 20 digits, same width the i64 encoding already uses. `PropertyValue::F32` stores its value as `f64` (see the variant definition), so it shares this same encoding rather than needing its own 32-bit variant.

updated both broken call sites (`property_value.rs`'s `to_index_string` and `search/mod.rs`'s `property_value_to_index_string`) and every test that asserted the old scientific-notation strings. added two new regression tests reproducing the fix across the full f64/f32 range including both zeros and both infinities.

## testing

- `cargo build -p db`
- `cargo test -p db --lib`: 1507 passed, 0 failed
- `cargo test -p db --tests` (every integration suite under `crates/db/tests/`): all green, 0 failed on a clean rerun (one earlier run hit two failures in `execution::interpreter::count::tests` unrelated to this change, both pass reliably in isolation and in a clean full rerun, pre-existing test-parallelism flakiness, not a regression from this change)
- `cargo clippy -p db --all-targets -- -D warnings`, checked against both the workspace's pinned `1.97.1` toolchain and `1.98.0`: clean for every file this change touches
- `cargo fmt --check` on every changed file: clean

## notes for reviewers

same unrelated pre-existing clippy break in `crates/db/src/execution/interpreter/mutation/topology.rs` noted in #1067 also applies here, not touched, not this pr's concern.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the scientific-notation float index representation with a fixed-width IEEE-754 bit transformation that preserves lexicographic ordering for ordinary numeric values.

- Adds a shared sortable `f64` encoding alongside the existing signed-integer encoding.
- Applies it to both `F64` and `F32` property values and the test-only search helper.
- Adds regression coverage across negative and positive values, signed zero, and infinities.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/encoding/v2/values/property/row.rs | Adds the conventional sign-aware IEEE-754 bit transformation and renders its result as a fixed-width decimal string. |
| crates/db/src/encoding/v2/values/property/property_value.rs | Routes F64 and F32 index-string conversion through the shared sortable encoding and adds numeric-order regression tests. |
| crates/db/src/search/mod.rs | Updates the test-only duplicate conversion helper and its expected float encodings. |
| crates/db/src/encoding/v2/values/property/mod.rs | Exposes the new helper within the crate for its two call sites. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: encode floats order-preservingly in..."](https://github.com/helixdb/helix-db/commit/086c9dd693ee7441fa0ee6688da5d51b1f8a741b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59894486)</sub>

<!-- /greptile_comment -->