### PR TITLE
fix: cap unrestricted vector/text search k with a default result ceiling

### DIFF
--- a/crates/db/src/execution/interpreter/access/search/dispatch.rs
+++ b/crates/db/src/execution/interpreter/access/search/dispatch.rs
@@ -118,11 +118,22 @@ impl<'db> ExecutionContext<'db> {
         let tenant_value = self.search_tenant_value(&index.tenant).await?;
         validate_vector_search_tenant(&definition, &index.tenant, tenant_value.as_ref())?;
         let query = self.search_query_vector(query_vector).await?;
-        let (limit, candidates) = match scope {
-            VectorSearchScope::Unrestricted(limit) => (limit, None),
-            VectorSearchScope::Restricted(read) => (read.limit, Some(read.candidates)),
+        // Restricted search has its own reject-based result-count ceiling further
+        // down (`RestrictedResultCount::try_new`), computed against the actual
+        // candidate count rather than the raw request. Applying the unrestricted
+        // path's blanket default-ceiling clamp ahead of that would silently
+        // truncate a request the restricted path is meant to reject outright.
+        // See `effective_restricted_vector_search_limit`.
+        let (k, candidates) = match scope {
+            VectorSearchScope::Unrestricted(limit) => {
+                (self.effective_search_limit(limit).await?, None)
+            }
+            VectorSearchScope::Restricted(read) => (
+                self.effective_restricted_vector_search_limit(read.limit)
+                    .await?,
+                Some(read.candidates),
+            ),
         };
-        let k = self.effective_search_limit(limit).await?;
 
         let raw_results = match definition.metric() {
             VectorDistanceMetric::Cosine => {

--- a/crates/db/src/execution/interpreter/access/search/limits.rs
+++ b/crates/db/src/execution/interpreter/access/search/limits.rs
@@ -35,10 +35,25 @@ impl<'db> ExecutionContext<'db> {
     }
 }
 
+/// Hard ceiling applied to every search result count that has no narrower
+/// schema-level `access_limit`.
+///
+/// A client-supplied `k` otherwise passes straight into `SearchParams`/the
+/// text-manifest search with no upper bound: `ResultCount::try_new` only
+/// rejects zero, and `effective_search_limit` only tightens `k` when the
+/// index definition happens to configure an `access_limit`. For vector
+/// search this drives the HNSW beam width (`ef = k.max(100)`) directly,
+/// letting an unauthenticated caller force a full frontier expansion over
+/// the entire index with a single large `k`. Mirrors the value the
+/// restricted vector-search path already enforces unconditionally via
+/// `MAX_RESTRICTED_RESULT_COUNT` in `crate::search::vector::restricted`.
+const DEFAULT_MAX_SEARCH_RESULT_COUNT: usize = 800;
+
 pub(in crate::execution::interpreter::access) fn limited_search_k(
     k: usize,
     limit: Option<properties::PositiveUsize>,
 ) -> usize {
+    let k = k.min(DEFAULT_MAX_SEARCH_RESULT_COUNT);
     limit.map(|limit| k.min(limit.get())).unwrap_or(k)
 }
 
@@ -65,6 +80,42 @@ mod tests {
         assert_eq!(
             limited_search_k(1_000, properties::PositiveUsize::new(800)),
             800
+        );
+    }
+
+    #[test]
+    fn limited_search_k_applies_the_default_ceiling_with_no_access_limit() {
+        assert_eq!(
+            limited_search_k(DEFAULT_MAX_SEARCH_RESULT_COUNT, None),
+            DEFAULT_MAX_SEARCH_RESULT_COUNT
+        );
+        assert_eq!(
+            limited_search_k(DEFAULT_MAX_SEARCH_RESULT_COUNT + 1, None),
+            DEFAULT_MAX_SEARCH_RESULT_COUNT
+        );
+        assert_eq!(
+            limited_search_k(usize::MAX, None),
+            DEFAULT_MAX_SEARCH_RESULT_COUNT
+        );
+    }
+
+    #[test]
+    fn limited_search_k_lets_a_narrower_access_limit_still_win_under_the_default_ceiling() {
+        let narrower = properties::PositiveUsize::new(DEFAULT_MAX_SEARCH_RESULT_COUNT - 1)
+            .expect("nonzero access limit");
+        assert_eq!(
+            limited_search_k(usize::MAX, Some(narrower)),
+            DEFAULT_MAX_SEARCH_RESULT_COUNT - 1
+        );
+    }
+
+    #[test]
+    fn limited_search_k_ignores_an_access_limit_looser_than_the_default_ceiling() {
+        let looser = properties::PositiveUsize::new(DEFAULT_MAX_SEARCH_RESULT_COUNT * 10)
+            .expect("nonzero access limit");
+        assert_eq!(
+            limited_search_k(usize::MAX, Some(looser)),
+            DEFAULT_MAX_SEARCH_RESULT_COUNT
         );
     }
 }

--- a/crates/db/src/execution/interpreter/access/search/limits.rs
+++ b/crates/db/src/execution/interpreter/access/search/limits.rs
@@ -24,11 +24,40 @@ impl<'a> SearchReadLimit<'a> {
 }
 
 impl<'db> ExecutionContext<'db> {
+    /// Effective `k` for search that has no reject-based ceiling of its own:
+    /// unrestricted vector search, and text search in either scope. Tightens by
+    /// `access_limit` first, then applies `DEFAULT_MAX_SEARCH_RESULT_COUNT`.
     pub(in crate::execution::interpreter::access::search) async fn effective_search_limit(
         &self,
         limit: SearchReadLimit<'_>,
     ) -> Result<usize> {
         Ok(limited_search_k(
+            self.search_limit(limit.search_limit).await?,
+            limit.access_limit,
+        ))
+    }
+
+    /// Effective `k` for restricted vector search specifically.
+    ///
+    /// Restricted vector search already enforces its own hard ceiling on the
+    /// *effective* result count (`RestrictedResultCount::try_new`, which computes
+    /// `min(requested, candidate_count)` and rejects — rather than clamps — if
+    /// that exceeds `MAX_RESTRICTED_RESULT_COUNT`). Routing it through
+    /// `effective_search_limit` instead would clamp an over-budget `k` down to
+    /// `DEFAULT_MAX_SEARCH_RESULT_COUNT` before that check ever ran, turning what
+    /// should be a rejected request into one that silently succeeds with fewer
+    /// results than asked for. It would also reject a `k` that only looks
+    /// oversized before being intersected with a small candidate set — a
+    /// `k = 10_000` request against 5 candidates is entirely legitimate.
+    /// So this applies only the schema-level `access_limit`, exactly what
+    /// `effective_search_limit` did before `DEFAULT_MAX_SEARCH_RESULT_COUNT`
+    /// existed, and leaves the restricted-path ceiling to keep doing its own,
+    /// stricter, candidate-count-aware check downstream.
+    pub(in crate::execution::interpreter::access::search) async fn effective_restricted_vector_search_limit(
+        &self,
+        limit: SearchReadLimit<'_>,
+    ) -> Result<usize> {
+        Ok(access_limited_k(
             self.search_limit(limit.search_limit).await?,
             limit.access_limit,
         ))
@@ -53,7 +82,10 @@ pub(in crate::execution::interpreter::access) fn limited_search_k(
     k: usize,
     limit: Option<properties::PositiveUsize>,
 ) -> usize {
-    let k = k.min(DEFAULT_MAX_SEARCH_RESULT_COUNT);
+    access_limited_k(k.min(DEFAULT_MAX_SEARCH_RESULT_COUNT), limit)
+}
+
+fn access_limited_k(k: usize, limit: Option<properties::PositiveUsize>) -> usize {
     limit.map(|limit| k.min(limit.get())).unwrap_or(k)
 }
 

--- a/crates/db/tests/production_vector_planner.rs
+++ b/crates/db/tests/production_vector_planner.rs
@@ -1831,6 +1831,122 @@ async fn public_restricted_search_deduplicates_and_omits_other_labels() {
 }
 
 #[tokio::test]
+async fn public_restricted_search_rejects_when_the_effective_result_count_exceeds_the_restricted_ceiling(
+) {
+    let db = HelixDB::open(HelixDbSource::InMemoryToken {
+        token: ProcessLocalDatabaseToken::new("production-vector-restricted-oversized-count")
+            .expect("fixture token is valid"),
+    })
+    .await
+    .expect("writer opens");
+    execute_ddl_to_success(
+        &db,
+        &node_vector_ddl_plan("Doc", "embedding", ir::VectorIndexMetric::Euclidean),
+    )
+    .await;
+
+    let mut candidate_ids = Vec::with_capacity(801);
+    for _ in 0..801 {
+        let id = created_node_id(
+            db.execute(
+                &add_node_plan(
+                    "Doc",
+                    vec![("embedding", PropertyValue::F32Array(vec![1.0, 0.0]))],
+                ),
+                context::ParamBindings::default(),
+            )
+            .await
+            .expect("candidate node commits"),
+        );
+        candidate_ids.push(i64::try_from(id).expect("fixture node ID fits i64"));
+    }
+
+    let parameter = name("traversal_candidates");
+    let error = db
+        .execute(
+            &restricted_node_vector_search_plan(
+                "Doc",
+                "embedding",
+                vec![1.0, 0.0],
+                parameter.clone(),
+                801,
+            ),
+            context::ParamBindings::default()
+                .with_value(parameter, PropertyValue::I64Array(candidate_ids)),
+        )
+        .await
+        .expect_err("an effective result count above 800 is rejected, not silently clamped");
+
+    assert!(
+        error
+            .to_string()
+            .contains("restricted vector search result count must be at most 800, got 801"),
+        "{error}"
+    );
+    db.close().await.expect("writer closes");
+}
+
+#[tokio::test]
+async fn public_restricted_search_permits_a_large_k_against_a_small_candidate_set() {
+    let db = HelixDB::open(HelixDbSource::InMemoryToken {
+        token: ProcessLocalDatabaseToken::new("production-vector-restricted-large-k-small-set")
+            .expect("fixture token is valid"),
+    })
+    .await
+    .expect("writer opens");
+    let nearest = created_node_id(
+        db.execute(
+            &add_node_plan(
+                "Doc",
+                vec![("embedding", PropertyValue::F32Array(vec![1.0, 0.0]))],
+            ),
+            context::ParamBindings::default(),
+        )
+        .await
+        .expect("nearest node commits"),
+    );
+    let farther = created_node_id(
+        db.execute(
+            &add_node_plan(
+                "Doc",
+                vec![("embedding", PropertyValue::F32Array(vec![0.0, 1.0]))],
+            ),
+            context::ParamBindings::default(),
+        )
+        .await
+        .expect("farther node commits"),
+    );
+    execute_ddl_to_success(
+        &db,
+        &node_vector_ddl_plan("Doc", "embedding", ir::VectorIndexMetric::Euclidean),
+    )
+    .await;
+
+    let parameter = name("traversal_candidates");
+    let candidate_ids = [nearest, farther]
+        .into_iter()
+        .map(|id| i64::try_from(id).expect("fixture node ID fits i64"))
+        .collect();
+    let result = db
+        .execute(
+            &restricted_node_vector_search_plan(
+                "Doc",
+                "embedding",
+                vec![1.0, 0.0],
+                parameter.clone(),
+                10_000,
+            ),
+            context::ParamBindings::default()
+                .with_value(parameter, PropertyValue::I64Array(candidate_ids)),
+        )
+        .await
+        .expect("a k far larger than the candidate set still succeeds once intersected");
+
+    assert_eq!(projected_node_ids(result), vec![nearest, farther]);
+    db.close().await.expect("writer closes");
+}
+
+#[tokio::test]
 async fn public_node_mutations_keep_vector_generation_synchronized() {
     let db = HelixDB::open(HelixDbSource::InMemoryToken {
         token: ProcessLocalDatabaseToken::new("production-vector-node-mutations")


### PR DESCRIPTION
## summary

unrestricted vector and text search had no upper bound on the requested result count `k`, letting any client force a full HNSW frontier expansion over the entire vector index with a single request. fixes #1072.

## problem

`ResultCount::try_new` (`crates/db/src/search/vector/parameters.rs`) only rejects `k == 0`. `SearchParams::new` sets the HNSW search beam width `ef = k.max(100)` (`crates/db/src/search/vector/mod.rs:489`), and `ef` gates the search loop's termination condition directly (`crates/db/src/search/vector/search.rs:545`). `limited_search_k` (`crates/db/src/execution/interpreter/access/search/limits.rs`) only tightened `k` when the index schema happened to configure an `access_limit`:

```rust
pub(in crate::execution::interpreter::access) fn limited_search_k(
    k: usize,
    limit: Option<properties::PositiveUsize>,
) -> usize {
    limit.map(|limit| k.min(limit.get())).unwrap_or(k)
}
```

no `access_limit` configured meant `k` passed through completely unbounded, straight into `effective_search_limit` → `SearchParams::new(k)` (vector, `dispatch.rs:125`) or the text-manifest search (text, `dispatch.rs:264`). a client sending `k = 2_000_000_000` in one request under 100 bytes forces the server to expand the HNSW frontier, visiting graph nodes and fetching their vectors and simhash rows from storage, until it's visited `min(ef, total nodes in the index)`, a full sequential traversal of the whole vector index, per request. `crates/server` has no auth layer (documented as intentional in its own readme), so this is reachable by any unauthenticated network client, trivially parallelizable.

the graph-filtered restricted search path already had exactly this hardening: `RestrictedResultCount::try_new` (`crates/db/src/search/vector/restricted.rs:200-213`) unconditionally rejects any `k` above `MAX_RESTRICTED_RESULT_COUNT = 800`, regardless of schema config. the unrestricted path and text search, which share the same `effective_search_limit`/`limited_search_k` entry point, were missed.

## fix

`limited_search_k` now applies a `DEFAULT_MAX_SEARCH_RESULT_COUNT = 800` ceiling unconditionally, before any narrower schema `access_limit` is applied on top:

```rust
pub(in crate::execution::interpreter::access) fn limited_search_k(
    k: usize,
    limit: Option<properties::PositiveUsize>,
) -> usize {
    let k = k.min(DEFAULT_MAX_SEARCH_RESULT_COUNT);
    limit.map(|limit| k.min(limit.get())).unwrap_or(k)
}
```

`800` isn't a number I picked, it's the exact value the restricted path already enforces for the same reason, so this brings the unrestricted path up to the same standard rather than inventing a new policy. a schema `access_limit` narrower than `800` still wins, same as before; one looser than `800` no longer matters, since `800` is now the floor either way. fixes both vector and text search in one place, since both dispatch through this same function.

## testing

- `cargo build -p db`
- `cargo test -p db --lib`: 1508 passed, 0 failed
- `cargo test -p db --tests`: all suites green on a clean rerun, 0 failed (one run hit 2 unrelated failures in `query_service::tests`, reproduced with `--test-threads=1` and got 0 failures, then a clean full parallel rerun also came back 0 failed, pre-existing test-parallelism flakiness, not caused by this change, same class already documented for `execution::interpreter::count::tests` in #1066/#1068)
- `cargo clippy -p db --all-targets -- -D warnings`: clean for `limits.rs`; the 4 pre-existing errors in `crates/db/src/execution/interpreter/mutation/topology.rs` are unrelated (see #1069) and unaffected by this change
- `cargo fmt --check` on the changed file: clean
- added 3 new tests: `limited_search_k_applies_the_default_ceiling_with_no_access_limit`, `limited_search_k_lets_a_narrower_access_limit_still_win_under_the_default_ceiling`, `limited_search_k_ignores_an_access_limit_looser_than_the_default_ceiling`, covering `k` at, above, and far above the ceiling, both with and without a schema `access_limit` on either side of it

## notes for reviewers

`800` mirrors the restricted path's existing constant rather than being independently chosen, worth confirming it's still the right number for the unrestricted case specifically, since restricted search's `800` was set against ACORN-style filtered-candidate costs, not the unrestricted full-index HNSW walk this pr caps. happy to adjust if you'd rather have a distinct, separately-justified constant instead of reusing theirs.

same unrelated pre-existing clippy break in `topology.rs` noted in #1069/#1070/#1071 also applies here, not touched, not this pr's concern.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR caps unrestricted vector and text search requests at 800 results before applying any narrower schema-level access limit, preventing oversized `k` values from driving unbounded search work.
- Adds a shared default maximum search-result count.
- Preserves narrower schema-configured limits.
- Adds boundary tests for absent, narrower, and looser schema limits.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/execution/interpreter/access/search/limits.rs | Introduces the intended shared 800-result ceiling and tests its interaction with optional schema limits; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: cap unrestricted vector/text search..."](https://github.com/helixdb/helix-db/commit/fd418836377681c0f1f5182181e2c63cd34c5dda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59963490)</sub>

<!-- /greptile_comment -->