### PR TITLE
test(db): check simd kernels against the scalar reference on rounding sensitive input

### DIFF
--- a/crates/db/src/search/vector/spaces/mod.rs
+++ b/crates/db/src/search/vector/spaces/mod.rs
@@ -14,3 +14,68 @@ pub(super) mod simple_avx;
 
 #[cfg(target_arch = "aarch64")]
 pub(super) mod simple_neon;
+
+#[cfg(test)]
+pub(super) mod kernel_agreement {
+    //! Support for checking a SIMD kernel against the scalar reference.
+    //!
+    //! The SIMD kernels fuse the multiply into the accumulate and carry four
+    //! partial sums that are combined at the end. The scalar reference
+    //! multiplies separately and accumulates in order. Both are correct, and
+    //! they round differently, so agreement between them is bounded rather
+    //! than exact. Integer inputs hide this because every intermediate is
+    //! exactly representable.
+
+    /// Largest relative gap allowed between a kernel and the scalar reference.
+    ///
+    /// Measured worst case on aarch64 over 4000 random pairs was 2.0e-6 at
+    /// 1536 dimensions. This leaves headroom for wider lanes and different
+    /// summation groupings on the x86 kernels while staying far below the
+    /// error a genuinely wrong kernel would produce.
+    pub const RELATIVE_TOLERANCE: f32 = 1e-4;
+
+    /// Deterministic generator so a failure reproduces exactly.
+    pub struct TestRng(pub u64);
+
+    impl TestRng {
+        pub fn next_f32(&mut self) -> f32 {
+            self.0 ^= self.0 << 13;
+            self.0 ^= self.0 >> 7;
+            self.0 ^= self.0 << 17;
+            ((self.0 >> 40) as f32 / 8_388_608.0) * 2.0 - 1.0
+        }
+
+        pub fn vector(&mut self, dimension: usize) -> Vec<f32> {
+            (0..dimension).map(|_| self.next_f32()).collect()
+        }
+    }
+
+    /// Dimensions covering the main loop and the trailing remainder of every
+    /// kernel, including the 32 wide AVX stride.
+    pub const AGREEMENT_DIMENSIONS: [usize; 5] = [17, 33, 64, 384, 1536];
+
+    /// Assert a kernel matches the scalar reference to within the tolerance.
+    ///
+    /// `scale` is the magnitude the error is measured against. Euclidean
+    /// distance sums squares and never cancels, so it scales against its own
+    /// result. Dot products can cancel to near zero, which makes a relative
+    /// bound on the result meaningless, so they scale against the summed
+    /// magnitude of the products instead.
+    pub fn assert_agrees(kernel: f32, scalar: f32, scale: f32, what: &str, dimension: usize) {
+        let allowed = RELATIVE_TOLERANCE * scale.abs().max(f32::MIN_POSITIVE);
+        let error = (kernel - scalar).abs();
+        assert!(
+            error <= allowed,
+            "{what} at {dimension} dimensions: kernel {kernel}, scalar {scalar}, \
+             error {error} exceeds allowed {allowed}"
+        );
+    }
+
+    /// Conditioning scale for a dot product.
+    pub fn dot_scale(left: &[f32], right: &[f32]) -> f32 {
+        left.iter()
+            .zip(right.iter())
+            .map(|(l, r)| (l * r).abs())
+            .sum()
+    }
+}

--- a/crates/db/src/search/vector/spaces/mod.rs
+++ b/crates/db/src/search/vector/spaces/mod.rs
@@ -42,7 +42,7 @@ pub(super) mod kernel_agreement {
             self.0 ^= self.0 << 13;
             self.0 ^= self.0 >> 7;
             self.0 ^= self.0 << 17;
-            ((self.0 >> 40) as f32 / 8_388_608.0) * 2.0 - 1.0
+            ((self.0 >> 40) as f32 / 8_388_608.0) - 1.0
         }
 
         pub fn vector(&mut self, dimension: usize) -> Vec<f32> {

--- a/crates/db/src/search/vector/spaces/simple_neon.rs
+++ b/crates/db/src/search/vector/spaces/simple_neon.rs
@@ -128,4 +128,51 @@ mod tests {
             println!("neon test skipped");
         }
     }
+
+    /// The fixed vectors above are small integers, so every intermediate is
+    /// exactly representable and the kernel cannot disagree with the scalar
+    /// reference no matter how it rounds. This covers the inputs that can.
+    #[test]
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    fn neon_kernels_agree_with_scalar_on_rounding_sensitive_input() {
+        use super::*;
+        use crate::search::vector::spaces::kernel_agreement::{
+            assert_agrees, dot_scale, TestRng, AGREEMENT_DIMENSIONS,
+        };
+        use crate::search::vector::spaces::simple::{
+            dot_product_non_optimized, euclidean_distance_non_optimized,
+        };
+        use crate::search::vector::unaligned_vector::UnalignedVector;
+
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            let mut rng = TestRng(0x2026_09_04);
+            for dimension in AGREEMENT_DIMENSIONS {
+                let left_values = rng.vector(dimension);
+                let right_values = rng.vector(dimension);
+                let left = UnalignedVector::from_slice(&left_values[..]);
+                let right = UnalignedVector::from_slice(&right_values[..]);
+                let pair = SameDimensionPair::try_new(&left, &right).unwrap();
+
+                let euclid_kernel = unsafe { euclid_similarity_neon(pair) };
+                let euclid_scalar = euclidean_distance_non_optimized(&left, &right);
+                assert_agrees(
+                    euclid_kernel,
+                    euclid_scalar,
+                    euclid_scalar,
+                    "euclidean",
+                    dimension,
+                );
+
+                let dot_kernel = unsafe { dot_similarity_neon(pair) };
+                let dot_scalar = dot_product_non_optimized(&left, &right);
+                assert_agrees(
+                    dot_kernel,
+                    dot_scalar,
+                    dot_scale(&left_values, &right_values),
+                    "dot",
+                    dimension,
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
i am on an aarch64 laptop and went looking at which distance kernel my machine actually runs. the neon test at `simple_neon.rs:95` passes, and while reading it i noticed it cannot fail.

`test_spaces_neon` feeds 10..31 against 40..61 and asserts `assert_eq!` against the scalar reference. every intermediate in those vectors is exactly representable, so the kernel and the scalar loop round identically no matter what either does internally. the sse and avx tests use the same integers padded out.

that matters because the kernels do round differently. `euclid_similarity_neon` accumulates with `vfmaq_f32`, one rounding per term. `euclidean_distance_scalar` does `distance += (left - right) * (left - right)`, two roundings, and accumulates in order rather than into four partial sums. measured over 4000 random pairs per dimension, samples uniform in [-1, 1):

| dimensions | euclid disagree | euclid worst | dot disagree | dot worst rel |
|---:|---:|---:|---:|---:|
| 22 | 1530 / 4000 | 3 ulp | 1963 / 4000 | 1.04e-2 |
| 32 | 2501 / 4000 | 4 ulp | 3106 / 4000 | 1.37e-2 |
| 128 | 3184 / 4000 | 8 ulp | 3445 / 4000 | 3.70e-4 |
| 384 | 3463 / 4000 | 15 ulp | 3683 / 4000 | 4.04e-3 |
| 768 | 3650 / 4000 | 19 ulp | 3768 / 4000 | 3.97e-3 |
| 1536 | 3737 / 4000 | 30 ulp | 3848 / 4000 | 4.21e-4 |

the existing vectors, for contrast, agree bit for bit. euclid 19800 from both, dot 23661 from both.

so this adds a second test beside the existing one rather than changing it. the exact assertions stay, they catch a grossly wrong kernel and cost nothing. the diff is additive. the new test runs the same comparison over seeded random vectors at 17, 33, 64, 384 and 1536 dimensions, covering the main loop and the trailing remainder of every kernel including the 32 wide avx stride, and asserts a bounded relative error instead of equality.

to check the new one is actually capable of failing, i dropped the tolerance to 1e-9 and ran it:

```
euclidean at 33 dimensions: kernel 15.312184, scalar 15.312185,
error 0.0000009536743 exceeds allowed 0.000000015312185
test result: FAILED. 0 passed; 1 failed
```

back at 1e-4 it passes, both neon tests pass together, and `cargo clippy -p db --all-targets -- -D warnings` is clean.

on the tolerance. euclid's measured worst case is 2.0e-6 relative at 1536 dimensions, so 1e-4 is about fifty times headroom. that felt right since i cannot run the sse or avx kernels on this box and their lane widths group the summation differently. a kernel that is actually wrong misses by orders of magnitude, not by 1e-4.

euclid and dot need different error models, and the table above is why. euclid sums squares so it never cancels, and its error stays at the 1e-6 level however many dimensions you give it. dot products cancel, and their error measured against their own result reaches 1.37e-2 at 32 dimensions purely from the result landing near zero. bounding dot against its own result would need a 1.4e-2 tolerance to stay green, which would accept almost anything. it is bounded against `sum |left_i * right_i|` instead, which is the conditioning of the sum rather than the size of the answer.

scope, and say if you want it wider. only the neon test is added here, because it is the only one i can execute. `db-vector-production-coverage.yml` already runs the sse, avx and neon matrices, so the same test dropped into the other two files would be covered there, but i would rather see this one green first than push two tests i cannot run myself.

also noticed while in there, the commented out cosine assertions in all three files call `cosine_preprocess_neon` and its sse and avx equivalents, and none of those functions exist anywhere in the tree. left them alone, but they look like dead references worth deleting at some point.
