### PR TITLE
feat(db): renew ID leases proactively

### DIFF
--- a/crates/db/src/config/db.rs
+++ b/crates/db/src/config/db.rs
@@ -15,7 +15,7 @@ use crate::encoding::v2::values::adjacency::{
     EDGE_UPDATE_ADAPTIVE, EDGE_UPDATE_EAGER, EDGE_UPDATE_LAZY, ENCODING_TYPE_EFP,
     ENCODING_TYPE_NONE,
 };
-use crate::id_allocator::DEFAULT_LEASE_SIZE;
+use crate::id_allocator::{DEFAULT_LEASE_REFILL_THRESHOLD, DEFAULT_LEASE_SIZE};
 
 const MIB: u64 = 1024 * 1024;
 const EMBEDDED_VECTOR_MEMORY_BYTES: u64 = 64 * MIB;
@@ -193,8 +193,14 @@ pub struct DbConfig {
     /// Number of IDs to lease at a time for automatic ID allocation
     ///
     /// Higher values reduce storage operations but may "waste" IDs on restart.
-    /// Default: 1000
+    /// Default: 10,000
     id_lease_size: NonZeroU64,
+
+    /// Remaining durable IDs at which a proactive lease refill begins.
+    ///
+    /// This is an absolute count and does not scale with `id_lease_size`.
+    /// Default: 5,000
+    id_lease_refill_threshold: u64,
 
     /// SlateDB runtime settings.
     slate: SlateRuntimeConfig,
@@ -230,6 +236,7 @@ impl DbConfig {
             high_degree_threshold: 1000, // Vertices with >1000 edges use lazy updates
             id_lease_size: NonZeroU64::new(DEFAULT_LEASE_SIZE)
                 .expect("default lease size is nonzero"),
+            id_lease_refill_threshold: DEFAULT_LEASE_REFILL_THRESHOLD,
             slate: SlateRuntimeConfig::new(),
             cache: CacheConfig::default(),
             secondary_index_lifecycle: SecondaryIndexLifecycleTuning::default(),
@@ -310,6 +317,11 @@ impl DbConfig {
     /// Number of IDs to lease at a time for automatic ID allocation.
     pub const fn id_lease_size(&self) -> u64 {
         self.id_lease_size.get()
+    }
+
+    /// Remaining durable IDs at which a proactive lease refill begins.
+    pub const fn id_lease_refill_threshold(&self) -> u64 {
+        self.id_lease_refill_threshold
     }
 
     /// SlateDB runtime settings.
@@ -418,7 +430,7 @@ impl DbConfig {
     /// Higher values reduce storage operations but may "waste" IDs when
     /// the database is closed before the lease is exhausted.
     ///
-    /// Default: 1000
+    /// Default: 10,000
     pub fn with_id_lease_size(mut self, size: NonZeroU64) -> Self {
         self.id_lease_size = size;
         self
@@ -429,6 +441,17 @@ impl DbConfig {
         self.id_lease_size = NonZeroU64::new(size)
             .ok_or_else(|| ConfigError::new("id lease size must be nonzero"))?;
         Ok(self)
+    }
+
+    /// Set the absolute remaining-ID threshold for proactive lease refill.
+    ///
+    /// A threshold of zero starts renewal after the final ID in the current
+    /// lease is claimed. Thresholds larger than the lease size are supported;
+    /// the allocator reserves enough whole lease chunks to restore the
+    /// requested headroom.
+    pub fn with_id_lease_refill_threshold(mut self, remaining_ids: u64) -> Self {
+        self.id_lease_refill_threshold = remaining_ids;
+        self
     }
 }
 

--- a/crates/db/src/config/db.rs
+++ b/crates/db/src/config/db.rs
@@ -193,6 +193,8 @@ pub struct DbConfig {
     /// Number of IDs to lease at a time for automatic ID allocation
     ///
     /// Higher values reduce storage operations but may "waste" IDs on restart.
+    /// The configured size is applied independently to both node and edge ID
+    /// allocators whenever a writer is opened.
     /// Default: 10,000
     id_lease_size: NonZeroU64,
 
@@ -429,6 +431,8 @@ impl DbConfig {
     ///
     /// Higher values reduce storage operations but may "waste" IDs when
     /// the database is closed before the lease is exhausted.
+    /// The configured size is applied independently to both node and edge ID
+    /// allocators whenever a writer is opened.
     ///
     /// Default: 10,000
     pub fn with_id_lease_size(mut self, size: NonZeroU64) -> Self {

--- a/crates/db/src/config/tests.rs
+++ b/crates/db/src/config/tests.rs
@@ -146,6 +146,7 @@ fn db_config_builders_preserve_checked_runtime_contracts() {
         .expect("legacy adaptive policy byte is valid")
         .try_with_id_lease_size(42)
         .expect("positive lease size is valid")
+        .with_id_lease_refill_threshold(21)
         .with_wal(false)
         .with_adaptive_updates(2048)
         .with_cache(cache.clone())
@@ -170,6 +171,7 @@ fn db_config_builders_preserve_checked_runtime_contracts() {
         EdgeUpdatePolicy::Adaptive.as_u8()
     );
     assert_eq!(config.id_lease_size(), 42);
+    assert_eq!(config.id_lease_refill_threshold(), 21);
     assert!(!config.enable_wal);
     assert_eq!(config.high_degree_threshold, 2048);
     assert_eq!(config.cache(), &cache);
@@ -204,6 +206,12 @@ fn db_and_helix_config_defaults_and_builders_expose_runtime_contracts() {
         DbConfig::default().id_lease_size(),
         crate::id_allocator::DEFAULT_LEASE_SIZE
     );
+    assert_eq!(DbConfig::default().id_lease_size(), 10_000);
+    assert_eq!(
+        DbConfig::default().id_lease_refill_threshold(),
+        crate::id_allocator::DEFAULT_LEASE_REFILL_THRESHOLD
+    );
+    assert_eq!(DbConfig::default().id_lease_refill_threshold(), 5_000);
     assert_eq!(
         super::SlateRuntimeConfig::default()
             .to_reader_options(None)
@@ -227,6 +235,10 @@ fn db_and_helix_config_defaults_and_builders_expose_runtime_contracts() {
     assert_eq!(
         default.id_lease_size(),
         crate::id_allocator::DEFAULT_LEASE_SIZE
+    );
+    assert_eq!(
+        default.id_lease_refill_threshold(),
+        crate::id_allocator::DEFAULT_LEASE_REFILL_THRESHOLD
     );
     assert!(matches!(default.cache().mode(), CacheMode::Memory { .. }));
     assert_eq!(

--- a/crates/db/src/id_allocator.rs
+++ b/crates/db/src/id_allocator.rs
@@ -253,7 +253,9 @@ impl IdAllocator {
     /// Persist enough whole lease chunks to cover claims and refill headroom.
     ///
     /// The caller must hold `extend_lock` and provide the greatest currently
-    /// durable watermark observed under that lock.
+    /// durable watermark observed under that lock. Extending the exclusive
+    /// watermark never changes `next_id`, so unused IDs in the current lease
+    /// remain the next IDs returned after a proactive refill.
     async fn persist_lease_extension(&self, current_lease_end: u64) -> Result<()> {
         let next = self.next_id.load(Ordering::Acquire);
         let new_lease_end = Self::extension_target(
@@ -1112,6 +1114,28 @@ mod tests {
             RefillLifecycle::load(&alloc.refill_lifecycle),
             RefillLifecycle::Closed
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn proactive_refill_preserves_the_next_contiguous_id() {
+        let db = test_db().await;
+        let key = Bytes::from_static(b"proactive-contiguous");
+        let alloc = IdAllocator::new_with_refill_threshold(Arc::clone(&db), key.clone(), 10, 5);
+
+        assert_eq!(alloc.allocate_batch(4).await.unwrap(), 0..4);
+        let extension_guard = alloc.extend_lock.lock().await;
+        assert_eq!(alloc.allocate().await.unwrap(), 4);
+        wait_for_refill_lifecycle(&alloc, RefillLifecycle::InFlight).await;
+        assert_eq!(alloc.next_id.load(Ordering::Acquire), 5);
+        assert_eq!(read_stored_hwm(&db, &key).await, 10);
+
+        drop(extension_guard);
+        wait_for_refill_lifecycle(&alloc, RefillLifecycle::Idle).await;
+        assert_eq!(read_stored_hwm(&db, &key).await, 20);
+        assert_eq!(alloc.next_id.load(Ordering::Acquire), 5);
+        assert_eq!(alloc.allocate_batch(5).await.unwrap(), 5..10);
+
+        alloc.shutdown().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/db/src/id_allocator.rs
+++ b/crates/db/src/id_allocator.rs
@@ -5,21 +5,79 @@
 //! - First allocation (read persisted counter, write new lease)
 //! - Lease exhausted (write extended lease)
 //!
-//! Fast path is lock-free (atomic fetch_add). Lock only protects lease extension.
+//! Fast path is lock-free. Lease extension is serialized, and proactive
+//! extension runs in one background task per allocator.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 
 use bytes::Bytes;
 use slatedb::Db;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 use super::error::Result;
 use crate::encoding::v2::keys::metadata;
 use crate::encoding::v2::values::id_allocation::IdAllocationWatermarkValue;
 
-/// Default number of IDs to lease at a time
-pub const DEFAULT_LEASE_SIZE: u64 = 1000;
+/// Default number of IDs to lease at a time.
+pub const DEFAULT_LEASE_SIZE: u64 = 10_000;
+
+/// Default remaining-ID threshold for starting a proactive lease refill.
+pub const DEFAULT_LEASE_REFILL_THRESHOLD: u64 = 5_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum RefillLifecycle {
+    Idle,
+    InFlight,
+    ClosingInFlight,
+    Closed,
+}
+
+impl RefillLifecycle {
+    fn load(state: &AtomicU8) -> Self {
+        match state.load(Ordering::Acquire) {
+            value if value == Self::Idle as u8 => Self::Idle,
+            value if value == Self::InFlight as u8 => Self::InFlight,
+            value if value == Self::ClosingInFlight as u8 => Self::ClosingInFlight,
+            value if value == Self::Closed as u8 => Self::Closed,
+            value => unreachable!("invalid ID allocator refill lifecycle {value}"),
+        }
+    }
+}
+
+struct RefillCompletion {
+    lifecycle: Arc<AtomicU8>,
+    finished: Arc<Notify>,
+}
+
+impl Drop for RefillCompletion {
+    fn drop(&mut self) {
+        loop {
+            let lifecycle = RefillLifecycle::load(&self.lifecycle);
+            let completed = match lifecycle {
+                RefillLifecycle::InFlight => RefillLifecycle::Idle,
+                RefillLifecycle::ClosingInFlight => RefillLifecycle::Closed,
+                RefillLifecycle::Idle | RefillLifecycle::Closed => {
+                    unreachable!("completed ID allocator refill was not in flight")
+                }
+            };
+            if self
+                .lifecycle
+                .compare_exchange(
+                    lifecycle as u8,
+                    completed as u8,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                self.finished.notify_waiters();
+                return;
+            }
+        }
+    }
+}
 
 /// Lease-based ID allocator
 ///
@@ -27,15 +85,19 @@ pub const DEFAULT_LEASE_SIZE: u64 = 1000;
 /// - `lease_end == 0`: Uninitialized (must read from storage)
 /// - `lease_end > 0`: Initialized, can allocate IDs in range `[0, lease_end)`
 /// - `next_id`: Counter for next ID to allocate (may exceed lease_end temporarily)
+#[derive(Clone)]
 pub struct IdAllocator {
     /// Next ID to hand out. May temporarily exceed lease_end during extension.
-    next_id: AtomicU64,
+    next_id: Arc<AtomicU64>,
 
     /// Upper bound of current lease (exclusive). Zero means uninitialized.
-    lease_end: AtomicU64,
+    lease_end: Arc<AtomicU64>,
 
     /// How many IDs to acquire per lease extension.
     lease_size: u64,
+
+    /// Remaining durable IDs at which a proactive refill should begin.
+    refill_threshold: u64,
 
     /// Storage backend for persisting the high watermark.
     db: Arc<Db>,
@@ -44,18 +106,42 @@ pub struct IdAllocator {
     watermark_key: Bytes,
 
     /// Lock protecting lease extension. Only held during storage I/O.
-    extend_lock: Mutex<()>,
+    extend_lock: Arc<Mutex<()>>,
+
+    /// Lock-free lifecycle gate for the single proactive refill task.
+    refill_lifecycle: Arc<AtomicU8>,
+
+    /// Wakes database close after an in-flight refill finishes.
+    refill_finished: Arc<Notify>,
 }
 
 impl IdAllocator {
     pub fn new(db: Arc<Db>, watermark_key: Bytes, lease_size: u64) -> Self {
-        Self {
-            next_id: AtomicU64::new(0),
-            lease_end: AtomicU64::new(0),
-            lease_size,
+        Self::new_with_refill_threshold(
             db,
             watermark_key,
-            extend_lock: Mutex::new(()),
+            lease_size,
+            DEFAULT_LEASE_REFILL_THRESHOLD,
+        )
+    }
+
+    pub(crate) fn new_with_refill_threshold(
+        db: Arc<Db>,
+        watermark_key: Bytes,
+        lease_size: u64,
+        refill_threshold: u64,
+    ) -> Self {
+        assert_ne!(lease_size, 0, "ID allocator lease size must be nonzero");
+        Self {
+            next_id: Arc::new(AtomicU64::new(0)),
+            lease_end: Arc::new(AtomicU64::new(0)),
+            lease_size,
+            refill_threshold,
+            db,
+            watermark_key,
+            extend_lock: Arc::new(Mutex::new(())),
+            refill_lifecycle: Arc::new(AtomicU8::new(RefillLifecycle::Idle as u8)),
+            refill_finished: Arc::new(Notify::new()),
         }
     }
 
@@ -64,22 +150,17 @@ impl IdAllocator {
     /// Fast path (99.9% of calls): Single atomic increment, no I/O.
     /// Slow path: Lock + storage write when lease exhausted.
     pub async fn allocate(&self) -> Result<u64> {
-        // Check if initialized
-        if self.lease_end.load(Ordering::Acquire) == 0 {
-            return self.initialize_and_allocate(1).await.map(|r| r.start);
-        }
-
-        // Fast path: atomically claim an ID
-        let id = self.next_id.fetch_add(1, Ordering::AcqRel);
-
-        // Check if claimed ID is within our lease
-        if id < self.lease_end.load(Ordering::Acquire) {
-            return Ok(id);
-        }
-
-        // Claimed past lease boundary - extend to cover it
-        self.ensure_lease_covers_claimed_ids().await?;
-        Ok(id)
+        let range = if self.lease_end.load(Ordering::Acquire) == 0 {
+            self.initialize_and_allocate(1).await?
+        } else {
+            let range = self.claim_ids(1)?;
+            if range.end > self.lease_end.load(Ordering::Acquire) {
+                self.ensure_lease_covers_claimed_ids().await?;
+            }
+            range
+        };
+        self.start_refill_if_needed();
+        Ok(range.start)
     }
 
     /// Allocate a contiguous batch of IDs.
@@ -90,23 +171,17 @@ impl IdAllocator {
             return Ok(0..0);
         }
 
-        // Check if initialized
-        if self.lease_end.load(Ordering::Acquire) == 0 {
-            return self.initialize_and_allocate(count).await;
-        }
-
-        // Fast path: atomically claim a range
-        let start = self.next_id.fetch_add(count, Ordering::AcqRel);
-        let end = start + count;
-
-        // Check if entire range is within our lease
-        if end <= self.lease_end.load(Ordering::Acquire) {
-            return Ok(start..end);
-        }
-
-        // Claimed past lease boundary - extend to cover it
-        self.ensure_lease_covers_claimed_ids().await?;
-        Ok(start..end)
+        let range = if self.lease_end.load(Ordering::Acquire) == 0 {
+            self.initialize_and_allocate(count).await?
+        } else {
+            let range = self.claim_ids(count)?;
+            if range.end > self.lease_end.load(Ordering::Acquire) {
+                self.ensure_lease_covers_claimed_ids().await?;
+            }
+            range
+        };
+        self.start_refill_if_needed();
+        Ok(range)
     }
 
     /// Ensure no future allocation returns an ID below `next_id`.
@@ -116,11 +191,12 @@ impl IdAllocator {
         let current_next = self.next_id.load(Ordering::Acquire);
         let target = persisted_counter.max(current_next).max(next_id);
 
-        if self.next_id.load(Ordering::Acquire) < target {
-            self.next_id.store(target, Ordering::Release);
-        }
-        if self.lease_end.load(Ordering::Acquire) < target || persisted_counter < target {
-            self.persist_lease_extension().await?;
+        self.next_id.fetch_max(target, Ordering::AcqRel);
+        let current_lease_end = self.lease_end.load(Ordering::Acquire);
+        let durable_lease_end = current_lease_end.max(persisted_counter);
+        let next = self.next_id.load(Ordering::Acquire);
+        if current_lease_end < next || persisted_counter < next {
+            self.persist_lease_extension(durable_lease_end).await?;
         }
 
         Ok(())
@@ -137,14 +213,13 @@ impl IdAllocator {
         let lease_end = self.lease_end.load(Ordering::Acquire);
         if lease_end > 0 {
             // Already initialized - do normal allocation under lock
-            let start = self.next_id.fetch_add(count, Ordering::AcqRel);
-            let end = start + count;
-            if end <= lease_end {
-                return Ok(start..end);
+            let range = self.claim_ids(count)?;
+            if range.end <= lease_end {
+                return Ok(range);
             }
             // Still need to extend
-            self.persist_lease_extension().await?;
-            return Ok(start..end);
+            self.persist_lease_extension(lease_end).await?;
+            return Ok(range);
         }
 
         // We're the initializing thread - read persisted counter
@@ -152,10 +227,10 @@ impl IdAllocator {
         self.next_id.store(persisted_counter, Ordering::Release);
 
         // Claim IDs and extend lease to cover them
-        let start = self.next_id.fetch_add(count, Ordering::AcqRel);
-        self.persist_lease_extension().await?;
+        let range = self.claim_ids(count)?;
+        self.persist_lease_extension(persisted_counter).await?;
 
-        Ok(start..start + count)
+        Ok(range)
     }
 
     /// Ensure lease covers all claimed IDs.
@@ -172,13 +247,24 @@ impl IdAllocator {
             return Ok(()); // Already covered
         }
 
-        self.persist_lease_extension().await
+        self.persist_lease_extension(lease_end).await
     }
 
-    /// Write extended lease to storage. Caller must hold extend_lock.
-    async fn persist_lease_extension(&self) -> Result<()> {
+    /// Persist enough whole lease chunks to cover claims and refill headroom.
+    ///
+    /// The caller must hold `extend_lock` and provide the greatest currently
+    /// durable watermark observed under that lock.
+    async fn persist_lease_extension(&self, current_lease_end: u64) -> Result<()> {
         let next = self.next_id.load(Ordering::Acquire);
-        let new_lease_end = Self::round_up_to_multiple(next, self.lease_size);
+        let new_lease_end = Self::extension_target(
+            current_lease_end,
+            next,
+            self.lease_size,
+            self.refill_threshold,
+        );
+        if new_lease_end == current_lease_end {
+            return Ok(());
+        }
 
         // Persist new high watermark to storage
         let encoded = IdAllocationWatermarkValue::new(new_lease_end).encode();
@@ -206,9 +292,126 @@ impl IdAllocator {
         Ok(value)
     }
 
-    /// Round up to the next multiple of `multiple`.
-    fn round_up_to_multiple(value: u64, multiple: u64) -> u64 {
-        value.div_ceil(multiple) * multiple
+    /// Compute the next exclusive watermark without overflowing the ID space.
+    fn extension_target(
+        current_lease_end: u64,
+        next_id: u64,
+        lease_size: u64,
+        refill_threshold: u64,
+    ) -> u64 {
+        let desired_lease_end = next_id.saturating_add(refill_threshold);
+        if desired_lease_end < current_lease_end {
+            return current_lease_end;
+        }
+
+        let missing = desired_lease_end - current_lease_end;
+        let chunks = if missing == 0 {
+            1
+        } else {
+            missing.div_ceil(lease_size)
+        };
+        current_lease_end
+            .saturating_add(chunks.saturating_mul(lease_size))
+            .max(desired_lease_end)
+    }
+
+    /// Claim a range without allowing the atomic counter to wrap.
+    fn claim_ids(&self, count: u64) -> Result<std::ops::Range<u64>> {
+        let start = self
+            .next_id
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |next| {
+                next.checked_add(count)
+            })
+            .map_err(|_| {
+                crate::HelixDbError::InvariantViolation(
+                    "ID allocator exhausted the u64 ID space".to_string(),
+                )
+            })?;
+        Ok(start..start + count)
+    }
+
+    /// Start one best-effort refill without delaying the successful claim.
+    fn start_refill_if_needed(&self) {
+        if self.remaining_in_lease() > self.refill_threshold
+            || self
+                .refill_lifecycle
+                .compare_exchange(
+                    RefillLifecycle::Idle as u8,
+                    RefillLifecycle::InFlight as u8,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_err()
+        {
+            return;
+        }
+
+        let allocator = self.clone();
+        let completion = RefillCompletion {
+            lifecycle: Arc::clone(&allocator.refill_lifecycle),
+            finished: Arc::clone(&allocator.refill_finished),
+        };
+        tokio::spawn(async move {
+            let _completion = completion;
+            if let Err(error) = allocator.refill_if_needed().await {
+                tracing::warn!(
+                    error = %error,
+                    "proactive ID allocator lease refill failed"
+                );
+            }
+        });
+    }
+
+    /// Recheck the low-water mark under the extension lock and refill it.
+    async fn refill_if_needed(&self) -> Result<()> {
+        let _guard = self.extend_lock.lock().await;
+        let next = self.next_id.load(Ordering::Acquire);
+        let lease_end = self.lease_end.load(Ordering::Acquire);
+        if lease_end.saturating_sub(next) > self.refill_threshold {
+            return Ok(());
+        }
+        self.persist_lease_extension(lease_end).await
+    }
+
+    /// Prevent new refills and wait for the current background write to finish.
+    pub(crate) async fn shutdown(&self) {
+        loop {
+            match RefillLifecycle::load(&self.refill_lifecycle) {
+                RefillLifecycle::Idle => {
+                    if self
+                        .refill_lifecycle
+                        .compare_exchange(
+                            RefillLifecycle::Idle as u8,
+                            RefillLifecycle::Closed as u8,
+                            Ordering::AcqRel,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        return;
+                    }
+                }
+                RefillLifecycle::InFlight => {
+                    let _ = self.refill_lifecycle.compare_exchange(
+                        RefillLifecycle::InFlight as u8,
+                        RefillLifecycle::ClosingInFlight as u8,
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    );
+                }
+                RefillLifecycle::ClosingInFlight => {
+                    let notified = self.refill_finished.notified();
+                    tokio::pin!(notified);
+                    notified.as_mut().enable();
+                    if RefillLifecycle::load(&self.refill_lifecycle)
+                        == RefillLifecycle::ClosingInFlight
+                    {
+                        notified.await;
+                    }
+                }
+                RefillLifecycle::Closed => return,
+            }
+        }
     }
 
     /// Get remaining IDs in current lease.
@@ -224,10 +427,19 @@ pub struct NodeIdAllocator(IdAllocator);
 
 impl NodeIdAllocator {
     pub fn new(db: Arc<Db>, lease_size: u64) -> Self {
-        Self(IdAllocator::new(
+        Self::new_with_refill_threshold(db, lease_size, DEFAULT_LEASE_REFILL_THRESHOLD)
+    }
+
+    pub(crate) fn new_with_refill_threshold(
+        db: Arc<Db>,
+        lease_size: u64,
+        refill_threshold: u64,
+    ) -> Self {
+        Self(IdAllocator::new_with_refill_threshold(
             db,
             metadata::MetadataKey::next_node_id_key().to_bytes(),
             lease_size,
+            refill_threshold,
         ))
     }
 
@@ -245,6 +457,10 @@ impl NodeIdAllocator {
 
     pub fn remaining_in_lease(&self) -> u64 {
         self.0.remaining_in_lease()
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        self.0.shutdown().await;
     }
 }
 
@@ -253,10 +469,19 @@ pub struct EdgeIdAllocator(IdAllocator);
 
 impl EdgeIdAllocator {
     pub fn new(db: Arc<Db>, lease_size: u64) -> Self {
-        Self(IdAllocator::new(
+        Self::new_with_refill_threshold(db, lease_size, DEFAULT_LEASE_REFILL_THRESHOLD)
+    }
+
+    pub(crate) fn new_with_refill_threshold(
+        db: Arc<Db>,
+        lease_size: u64,
+        refill_threshold: u64,
+    ) -> Self {
+        Self(IdAllocator::new_with_refill_threshold(
             db,
             metadata::MetadataKey::next_edge_id_key().to_bytes(),
             lease_size,
+            refill_threshold,
         ))
     }
 
@@ -274,6 +499,10 @@ impl EdgeIdAllocator {
 
     pub fn remaining_in_lease(&self) -> u64 {
         self.0.remaining_in_lease()
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        self.0.shutdown().await;
     }
 }
 
@@ -293,6 +522,24 @@ mod tests {
         )
     }
 
+    fn test_allocator(db: Arc<Db>, key: Bytes, lease_size: u64) -> IdAllocator {
+        let allocator = IdAllocator::new_with_refill_threshold(db, key, lease_size, 0);
+        allocator
+            .refill_lifecycle
+            .store(RefillLifecycle::Closed as u8, Ordering::Release);
+        allocator
+    }
+
+    async fn wait_for_refill_lifecycle(allocator: &IdAllocator, expected: RefillLifecycle) {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while RefillLifecycle::load(&allocator.refill_lifecycle) != expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("allocator reaches the expected refill lifecycle");
+    }
+
     /// Read the persisted HWM(High Water Mark) directly from storage
     async fn read_stored_hwm(db: &Db, key: &Bytes) -> u64 {
         db.get(key)
@@ -308,7 +555,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_sequential_allocation() {
-        let alloc = IdAllocator::new(test_db().await, Bytes::from_static(b"test"), 100);
+        let alloc = test_allocator(test_db().await, Bytes::from_static(b"test"), 100);
 
         assert_eq!(alloc.allocate().await.unwrap(), 0);
         assert_eq!(alloc.allocate().await.unwrap(), 1);
@@ -317,7 +564,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_batch_allocation() {
-        let alloc = IdAllocator::new(test_db().await, Bytes::from_static(b"test"), 100);
+        let alloc = test_allocator(test_db().await, Bytes::from_static(b"test"), 100);
 
         assert_eq!(alloc.allocate_batch(5).await.unwrap(), 0..5);
         assert_eq!(alloc.allocate_batch(10).await.unwrap(), 5..15);
@@ -326,7 +573,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_batch() {
-        let alloc = IdAllocator::new(test_db().await, Bytes::from_static(b"test"), 100);
+        let alloc = test_allocator(test_db().await, Bytes::from_static(b"test"), 100);
 
         assert_eq!(alloc.allocate_batch(0).await.unwrap(), 0..0);
         assert_eq!(alloc.allocate().await.unwrap(), 0);
@@ -338,7 +585,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_lease_extension() {
-        let alloc = IdAllocator::new(test_db().await, Bytes::from_static(b"test"), 10);
+        let alloc = test_allocator(test_db().await, Bytes::from_static(b"test"), 10);
 
         // Exhaust first lease
         for i in 0..10 {
@@ -352,7 +599,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_large_batch_extends_lease() {
-        let alloc = IdAllocator::new(test_db().await, Bytes::from_static(b"test"), 10);
+        let alloc = test_allocator(test_db().await, Bytes::from_static(b"test"), 10);
 
         assert_eq!(alloc.allocate_batch(25).await.unwrap(), 0..25);
         // Lease extended to 30 (rounded up)
@@ -361,7 +608,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_initialized_batch_extends_existing_lease() {
-        let alloc = IdAllocator::new(test_db().await, Bytes::from_static(b"test"), 5);
+        let alloc = test_allocator(test_db().await, Bytes::from_static(b"test"), 5);
 
         assert_eq!(alloc.allocate_batch(3).await.unwrap(), 0..3);
         assert_eq!(alloc.allocate_batch(4).await.unwrap(), 3..7);
@@ -371,8 +618,8 @@ mod tests {
     #[tokio::test]
     async fn typed_allocators_delegate_all_public_operations() {
         let db = test_db().await;
-        let nodes = NodeIdAllocator::new(Arc::clone(&db), 5);
-        let edges = EdgeIdAllocator::new(db, 5);
+        let nodes = NodeIdAllocator::new_with_refill_threshold(Arc::clone(&db), 5, 0);
+        let edges = EdgeIdAllocator::new_with_refill_threshold(db, 5, 0);
 
         assert_eq!(nodes.allocate().await.unwrap(), 0);
         assert_eq!(nodes.allocate_batch(2).await.unwrap(), 1..3);
@@ -387,7 +634,7 @@ mod tests {
     async fn test_hwm_is_minimal_after_extension() {
         let db = test_db().await;
         let key = Bytes::from_static(b"test");
-        let alloc = IdAllocator::new(Arc::clone(&db), key.clone(), 10);
+        let alloc = test_allocator(Arc::clone(&db), key.clone(), 10);
 
         // Allocate 15 IDs (exhausts first lease of 10, extends to 20)
         for _ in 0..15 {
@@ -409,14 +656,14 @@ mod tests {
         let key = Bytes::from_static(b"test");
 
         {
-            let alloc = IdAllocator::new(Arc::clone(&db), key.clone(), 100);
+            let alloc = test_allocator(Arc::clone(&db), key.clone(), 100);
             for _ in 0..50 {
                 alloc.allocate().await.unwrap();
             }
         }
 
         // New allocator continues from persisted HWM
-        let alloc = IdAllocator::new(db, key, 100);
+        let alloc = test_allocator(db, key, 100);
         assert_eq!(alloc.allocate().await.unwrap(), 100);
     }
 
@@ -426,7 +673,7 @@ mod tests {
         let key = Bytes::from_static(b"test");
 
         {
-            let alloc = IdAllocator::new(Arc::clone(&db), key.clone(), 10);
+            let alloc = test_allocator(Arc::clone(&db), key.clone(), 10);
             // Allocate 35 IDs, causing 4 lease extensions (10, 20, 30, 40)
             for _ in 0..35 {
                 alloc.allocate().await.unwrap();
@@ -436,7 +683,7 @@ mod tests {
         let hwm = read_stored_hwm(&db, &key).await;
         assert_eq!(hwm, 40);
 
-        let alloc = IdAllocator::new(db, key, 10);
+        let alloc = test_allocator(db, key, 10);
         assert_eq!(alloc.allocate().await.unwrap(), 40);
     }
 
@@ -446,7 +693,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_concurrent_allocation() {
-        let alloc = Arc::new(IdAllocator::new(
+        let alloc = Arc::new(test_allocator(
             test_db().await,
             Bytes::from_static(b"test"),
             1000,
@@ -477,7 +724,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_concurrent_batch_allocation() {
-        let alloc = Arc::new(IdAllocator::new(
+        let alloc = Arc::new(test_allocator(
             test_db().await,
             Bytes::from_static(b"test"),
             100,
@@ -508,7 +755,7 @@ mod tests {
     async fn test_racing_initialization_single_extend() {
         let db = test_db().await;
         let key = Bytes::from_static(b"test");
-        let alloc = Arc::new(IdAllocator::new(Arc::clone(&db), key.clone(), 100));
+        let alloc = Arc::new(test_allocator(Arc::clone(&db), key.clone(), 100));
 
         let num_tasks = 20;
         let barrier = Arc::new(Barrier::new(num_tasks));
@@ -547,7 +794,7 @@ mod tests {
     async fn test_racing_initialization_batch_single_extend() {
         let db = test_db().await;
         let key = Bytes::from_static(b"test");
-        let alloc = Arc::new(IdAllocator::new(Arc::clone(&db), key.clone(), 100));
+        let alloc = Arc::new(test_allocator(Arc::clone(&db), key.clone(), 100));
 
         let num_tasks = 10;
         let batch_size = 5u64;
@@ -587,7 +834,7 @@ mod tests {
     async fn test_racing_extension_single_extend() {
         let db = test_db().await;
         let key = Bytes::from_static(b"test");
-        let alloc = Arc::new(IdAllocator::new(Arc::clone(&db), key.clone(), 10));
+        let alloc = Arc::new(test_allocator(Arc::clone(&db), key.clone(), 10));
 
         // First, allocate 9 IDs (one away from lease boundary)
         for _ in 0..9 {
@@ -628,7 +875,7 @@ mod tests {
     async fn test_racing_extension_with_small_lease() {
         let db = test_db().await;
         let key = Bytes::from_static(b"test");
-        let alloc = Arc::new(IdAllocator::new(Arc::clone(&db), key.clone(), 5));
+        let alloc = Arc::new(test_allocator(Arc::clone(&db), key.clone(), 5));
 
         let num_tasks = 50;
         let barrier = Arc::new(Barrier::new(num_tasks));
@@ -671,7 +918,7 @@ mod tests {
     impl CountingAllocator {
         fn new(db: Arc<Db>, key: Bytes, lease_size: u64) -> Self {
             Self {
-                inner: IdAllocator::new(db, key, lease_size),
+                inner: IdAllocator::new_with_refill_threshold(db, key, lease_size, 0),
                 extend_count: AtomicUsize::new(0),
             }
         }
@@ -714,7 +961,8 @@ mod tests {
 
         async fn counted_persist(&self) -> Result<()> {
             self.extend_count.fetch_add(1, Ordering::SeqCst);
-            self.inner.persist_lease_extension().await
+            let lease_end = self.inner.lease_end.load(Ordering::Acquire);
+            self.inner.persist_lease_extension(lease_end).await
         }
 
         fn extend_count(&self) -> usize {
@@ -809,12 +1057,231 @@ mod tests {
     }
 
     // =========================================================================
+    // Proactive Refill
+    // =========================================================================
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exact_threshold_starts_one_nonblocking_refill() {
+        let db = test_db().await;
+        let key = Bytes::from_static(b"proactive");
+        let alloc = Arc::new(IdAllocator::new_with_refill_threshold(
+            Arc::clone(&db),
+            key.clone(),
+            10,
+            5,
+        ));
+
+        assert_eq!(alloc.allocate().await.unwrap(), 0);
+        for expected in 1..4 {
+            assert_eq!(alloc.allocate().await.unwrap(), expected);
+        }
+        assert_eq!(alloc.remaining_in_lease(), 6);
+
+        let extension_guard = alloc.extend_lock.lock().await;
+        let threshold_allocation =
+            tokio::time::timeout(std::time::Duration::from_secs(1), alloc.allocate())
+                .await
+                .expect("threshold allocation must not wait for the extension lock")
+                .unwrap();
+        assert_eq!(threshold_allocation, 4);
+        wait_for_refill_lifecycle(&alloc, RefillLifecycle::InFlight).await;
+        assert_eq!(read_stored_hwm(&db, &key).await, 10);
+
+        let concurrent = (0..5)
+            .map(|_| {
+                let alloc = Arc::clone(&alloc);
+                tokio::spawn(async move { alloc.allocate().await.unwrap() })
+            })
+            .collect::<Vec<_>>();
+        let mut concurrent_ids = futures::future::join_all(concurrent)
+            .await
+            .into_iter()
+            .map(|result| result.unwrap())
+            .collect::<Vec<_>>();
+        concurrent_ids.sort_unstable();
+        assert_eq!(concurrent_ids, (5..10).collect::<Vec<_>>());
+        assert_eq!(
+            RefillLifecycle::load(&alloc.refill_lifecycle),
+            RefillLifecycle::InFlight
+        );
+
+        drop(extension_guard);
+        alloc.shutdown().await;
+        assert_eq!(read_stored_hwm(&db, &key).await, 20);
+        assert_eq!(
+            RefillLifecycle::load(&alloc.refill_lifecycle),
+            RefillLifecycle::Closed
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn batch_can_skip_past_threshold_without_waiting() {
+        let db = test_db().await;
+        let key = Bytes::from_static(b"batch-proactive");
+        let alloc = IdAllocator::new_with_refill_threshold(Arc::clone(&db), key.clone(), 10, 5);
+
+        assert_eq!(alloc.allocate_batch(4).await.unwrap(), 0..4);
+        let extension_guard = alloc.extend_lock.lock().await;
+        assert_eq!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), alloc.allocate_batch(3),)
+                .await
+                .expect("in-lease batch must not wait for proactive refill")
+                .unwrap(),
+            4..7
+        );
+        wait_for_refill_lifecycle(&alloc, RefillLifecycle::InFlight).await;
+
+        drop(extension_guard);
+        alloc.shutdown().await;
+        assert_eq!(read_stored_hwm(&db, &key).await, 20);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn allocation_past_durable_boundary_waits_for_refill() {
+        let db = test_db().await;
+        let key = Bytes::from_static(b"blocking-fallback");
+        let alloc = Arc::new(IdAllocator::new_with_refill_threshold(
+            Arc::clone(&db),
+            key.clone(),
+            10,
+            5,
+        ));
+
+        assert_eq!(alloc.allocate_batch(4).await.unwrap(), 0..4);
+        let extension_guard = alloc.extend_lock.lock().await;
+        assert_eq!(alloc.allocate_batch(6).await.unwrap(), 4..10);
+        wait_for_refill_lifecycle(&alloc, RefillLifecycle::InFlight).await;
+
+        let waiting = {
+            let alloc = Arc::clone(&alloc);
+            tokio::spawn(async move { alloc.allocate().await })
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while alloc.next_id.load(Ordering::Acquire) != 11 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("boundary allocation claims its ID before waiting");
+        assert!(!waiting.is_finished());
+
+        drop(extension_guard);
+        assert_eq!(waiting.await.unwrap().unwrap(), 10);
+        alloc.shutdown().await;
+        assert_eq!(read_stored_hwm(&db, &key).await, 20);
+    }
+
+    #[tokio::test]
+    async fn zero_and_large_thresholds_have_defined_headroom() {
+        let db = test_db().await;
+        let zero_key = Bytes::from_static(b"zero-threshold");
+        let zero = IdAllocator::new_with_refill_threshold(Arc::clone(&db), zero_key.clone(), 3, 0);
+        assert_eq!(zero.allocate_batch(3).await.unwrap(), 0..3);
+        zero.shutdown().await;
+        assert_eq!(read_stored_hwm(&db, &zero_key).await, 6);
+
+        let large_key = Bytes::from_static(b"large-threshold");
+        let large =
+            IdAllocator::new_with_refill_threshold(Arc::clone(&db), large_key.clone(), 10, 25);
+        assert_eq!(large.allocate().await.unwrap(), 0);
+        assert_eq!(large.remaining_in_lease(), 29);
+        assert_eq!(large.allocate_batch(4).await.unwrap(), 1..5);
+        large.shutdown().await;
+        assert_eq!(read_stored_hwm(&db, &large_key).await, 40);
+    }
+
+    #[tokio::test]
+    async fn reopening_can_change_lease_and_threshold_tuning() {
+        let db = test_db().await;
+        let key = Bytes::from_static(b"retuned");
+        let first = IdAllocator::new_with_refill_threshold(Arc::clone(&db), key.clone(), 10, 5);
+        assert_eq!(first.allocate().await.unwrap(), 0);
+        first.shutdown().await;
+        assert_eq!(read_stored_hwm(&db, &key).await, 10);
+
+        let second = IdAllocator::new_with_refill_threshold(Arc::clone(&db), key.clone(), 6, 3);
+        assert_eq!(second.allocate().await.unwrap(), 10);
+        second.shutdown().await;
+        assert_eq!(read_stored_hwm(&db, &key).await, 16);
+    }
+
+    #[tokio::test]
+    async fn failed_background_refill_retries_and_exhaustion_fails_closed() {
+        let db = test_db().await;
+        let alloc = IdAllocator::new_with_refill_threshold(
+            Arc::clone(&db),
+            Bytes::from_static(b"closed-db"),
+            4,
+            2,
+        );
+        assert_eq!(alloc.allocate().await.unwrap(), 0);
+        db.close().await.unwrap();
+
+        assert_eq!(alloc.allocate().await.unwrap(), 1);
+        wait_for_refill_lifecycle(&alloc, RefillLifecycle::Idle).await;
+        assert_eq!(alloc.allocate().await.unwrap(), 2);
+        wait_for_refill_lifecycle(&alloc, RefillLifecycle::Idle).await;
+        assert_eq!(alloc.allocate().await.unwrap(), 3);
+        wait_for_refill_lifecycle(&alloc, RefillLifecycle::Idle).await;
+        assert!(alloc.allocate().await.is_err());
+        alloc.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reserve_and_allocate_concurrently_preserve_monotonic_ids() {
+        let db = test_db().await;
+        let alloc = Arc::new(IdAllocator::new_with_refill_threshold(
+            db,
+            Bytes::from_static(b"concurrent-reserve"),
+            10,
+            5,
+        ));
+        assert_eq!(alloc.allocate().await.unwrap(), 0);
+
+        let reservation = {
+            let alloc = Arc::clone(&alloc);
+            tokio::spawn(async move { alloc.reserve_at_least(50).await })
+        };
+        let allocation = {
+            let alloc = Arc::clone(&alloc);
+            tokio::spawn(async move { alloc.allocate_batch(3).await })
+        };
+        reservation.await.unwrap().unwrap();
+        let allocated = allocation.await.unwrap().unwrap();
+        let next = alloc.allocate().await.unwrap();
+        assert!(allocated.end <= 50 || allocated.start >= 50);
+        assert!(next >= 50);
+        alloc.shutdown().await;
+    }
+
+    #[test]
+    fn extension_target_clamps_at_the_end_of_the_id_space() {
+        assert_eq!(IdAllocator::extension_target(10, 5, 10, 5), 20);
+        assert_eq!(IdAllocator::extension_target(0, 1, 10, 25), 30);
+        assert_eq!(
+            IdAllocator::extension_target(u64::MAX - 5, u64::MAX - 1, 10, 5),
+            u64::MAX
+        );
+    }
+
+    #[tokio::test]
+    async fn allocator_exhaustion_does_not_wrap() {
+        let alloc = test_allocator(test_db().await, Bytes::from_static(b"exhaustion"), 10);
+        alloc.next_id.store(u64::MAX - 1, Ordering::Release);
+        alloc.lease_end.store(u64::MAX, Ordering::Release);
+
+        assert_eq!(alloc.allocate().await.unwrap(), u64::MAX - 1);
+        assert!(alloc.allocate().await.is_err());
+        assert_eq!(alloc.next_id.load(Ordering::Acquire), u64::MAX);
+    }
+
+    // =========================================================================
     // Edge Cases
     // =========================================================================
 
     #[tokio::test]
     async fn test_lease_size_one() {
-        let alloc = IdAllocator::new(test_db().await, Bytes::from_static(b"test"), 1);
+        let alloc = test_allocator(test_db().await, Bytes::from_static(b"test"), 1);
 
         // Every allocation triggers an extension
         for i in 0..10 {
@@ -826,7 +1293,7 @@ mod tests {
     async fn test_batch_larger_than_lease() {
         let db = test_db().await;
         let key = Bytes::from_static(b"test");
-        let alloc = IdAllocator::new(Arc::clone(&db), key.clone(), 10);
+        let alloc = test_allocator(Arc::clone(&db), key.clone(), 10);
 
         // Batch of 100 with lease_size=10
         let range = alloc.allocate_batch(100).await.unwrap();
@@ -839,7 +1306,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mixed_single_and_batch() {
-        let alloc = IdAllocator::new(test_db().await, Bytes::from_static(b"test"), 20);
+        let alloc = test_allocator(test_db().await, Bytes::from_static(b"test"), 20);
 
         assert_eq!(alloc.allocate().await.unwrap(), 0);
         assert_eq!(alloc.allocate_batch(5).await.unwrap(), 1..6);
@@ -856,7 +1323,7 @@ mod tests {
     async fn test_stress_many_extensions() {
         let db = test_db().await;
         let key = Bytes::from_static(b"test");
-        let alloc = Arc::new(IdAllocator::new(Arc::clone(&db), key.clone(), 3));
+        let alloc = Arc::new(test_allocator(Arc::clone(&db), key.clone(), 3));
 
         let num_tasks = 100;
         let barrier = Arc::new(Barrier::new(num_tasks));
@@ -888,7 +1355,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_stress_mixed_operations() {
-        let alloc = Arc::new(IdAllocator::new(
+        let alloc = Arc::new(test_allocator(
             test_db().await,
             Bytes::from_static(b"test"),
             7,

--- a/crates/db/src/id_allocator.rs
+++ b/crates/db/src/id_allocator.rs
@@ -1139,6 +1139,45 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn writer_open_error_drains_an_inflight_refill_before_closing_storage() {
+        let db = test_db().await;
+        let writer = Arc::new(crate::HelixWriter::new(Arc::clone(&db), 4, 2));
+
+        assert_eq!(writer.node_ids().allocate().await.unwrap(), 0);
+        let extension_guard = writer.node_ids().0.extend_lock.lock().await;
+        assert_eq!(writer.node_ids().allocate().await.unwrap(), 1);
+        wait_for_refill_lifecycle(&writer.node_ids().0, RefillLifecycle::InFlight).await;
+
+        let closing = {
+            let writer = Arc::clone(&writer);
+            tokio::spawn(async move {
+                let result: crate::Result<()> = Err(crate::HelixDbError::Config(
+                    "injected writer open failure".to_string(),
+                ));
+                writer.close_on_open_error(result).await
+            })
+        };
+        wait_for_refill_lifecycle(&writer.node_ids().0, RefillLifecycle::ClosingInFlight).await;
+        assert!(!closing.is_finished());
+
+        drop(extension_guard);
+        let error = closing.await.unwrap().unwrap_err();
+        assert!(matches!(
+            error,
+            crate::HelixDbError::Config(reason) if reason == "injected writer open failure"
+        ));
+        assert_eq!(
+            RefillLifecycle::load(&writer.node_ids().0.refill_lifecycle),
+            RefillLifecycle::Closed
+        );
+        assert_eq!(
+            RefillLifecycle::load(&writer.edge_ids().0.refill_lifecycle),
+            RefillLifecycle::Closed
+        );
+        assert!(db.get(b"closed-after-open-error").await.is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn batch_can_skip_past_threshold_without_waiting() {
         let db = test_db().await;
         let key = Bytes::from_static(b"batch-proactive");

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -448,11 +448,19 @@ pub(crate) struct HelixWriter {
 }
 
 impl HelixWriter {
-    pub(crate) fn new(db: Arc<Db>, lease_size: u64) -> Self {
+    pub(crate) fn new(db: Arc<Db>, lease_size: u64, refill_threshold: u64) -> Self {
         Self {
             db: Arc::clone(&db),
-            node_ids: Arc::new(NodeIdAllocator::new(Arc::clone(&db), lease_size)),
-            edge_ids: Arc::new(EdgeIdAllocator::new(db, lease_size)),
+            node_ids: Arc::new(NodeIdAllocator::new_with_refill_threshold(
+                Arc::clone(&db),
+                lease_size,
+                refill_threshold,
+            )),
+            edge_ids: Arc::new(EdgeIdAllocator::new_with_refill_threshold(
+                db,
+                lease_size,
+                refill_threshold,
+            )),
         }
     }
 
@@ -466,6 +474,12 @@ impl HelixWriter {
 
     pub(crate) fn edge_ids(&self) -> &EdgeIdAllocator {
         self.edge_ids.as_ref()
+    }
+
+    async fn close(&self) -> Result<()> {
+        tokio::join!(self.node_ids.shutdown(), self.edge_ids.shutdown());
+        self.db.close().await?;
+        Ok(())
     }
 }
 
@@ -889,6 +903,26 @@ impl HelixDB {
     }
 
     /// Open a read/write database handle with explicit tuning config.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// use std::num::NonZeroU64;
+    /// use db::{DbConfig, HelixDB, HelixDbSource};
+    ///
+    /// let config = DbConfig::new()
+    ///     .with_id_lease_size(NonZeroU64::new(20_000).unwrap())
+    ///     .with_id_lease_refill_threshold(8_000);
+    /// let db = HelixDB::open_with_config(
+    ///     HelixDbSource::InMemory {
+    ///         database: "custom-id-leasing".to_string(),
+    ///     },
+    ///     config,
+    /// ).await.unwrap();
+    /// db.close().await.unwrap();
+    /// # });
+    /// ```
     pub async fn open_with_config(source: HelixDbSource, config: DbConfig) -> Result<Self> {
         let (path, object_store) = source.into_parts()?;
         let db = Self::open_writer_inner(path, object_store, config).await?;
@@ -1104,7 +1138,11 @@ impl HelixDB {
             }
         }
         log_stage("storage_contract_validation", stage_started);
-        let writer = HelixWriter::new(Arc::clone(&db), config.id_lease_size());
+        let writer = HelixWriter::new(
+            Arc::clone(&db),
+            config.id_lease_size(),
+            config.id_lease_refill_threshold(),
+        );
         let stage_started = Instant::now();
         let migration_authorized = matches!(
             &open_mode,

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -481,6 +481,23 @@ impl HelixWriter {
         self.db.close().await?;
         Ok(())
     }
+
+    /// Preserve a writer-open error after draining allocators and closing storage.
+    pub(crate) async fn close_on_open_error<T>(&self, result: Result<T>) -> Result<T> {
+        match result {
+            Ok(value) => Ok(value),
+            Err(open_error) => {
+                if let Err(close_error) = self.close().await {
+                    tracing::warn!(
+                        error = %close_error,
+                        original_error = %open_error,
+                        "failed to close SlateDB after writer open failed"
+                    );
+                }
+                Err(open_error)
+            }
+        }
+    }
 }
 
 impl std::ops::Deref for HelixWriter {
@@ -867,6 +884,23 @@ enum CloseState {
 }
 
 impl HelixDB {
+    /// Preserve a runtime-open error after stopping tasks and closing storage.
+    async fn close_on_open_error<T>(&self, result: Result<T>) -> Result<T> {
+        match result {
+            Ok(value) => Ok(value),
+            Err(open_error) => {
+                if let Err(close_error) = self.close().await {
+                    tracing::warn!(
+                        error = %close_error,
+                        original_error = %open_error,
+                        "failed to close database runtime after writer open failed"
+                    );
+                }
+                Err(open_error)
+            }
+        }
+    }
+
     /// Open a read/write database handle.
     pub async fn open(source: HelixDbSource) -> Result<Self> {
         let config = source.embedded_default_config();
@@ -1002,11 +1036,18 @@ impl HelixDB {
                 .await?,
         );
         let writer = migrations::startup::prepare_writer(Arc::clone(&db), &config).await?;
-        let loaded_catalog =
-            index_lifecycle::repository::load_scope_catalog(db.as_ref(), DataScope::LegacyUnscoped)
-                .await?;
+        let runtime_inputs: Result<_> = async {
+            let loaded_catalog = index_lifecycle::repository::load_scope_catalog(
+                db.as_ref(),
+                DataScope::LegacyUnscoped,
+            )
+            .await?;
+            let fts_cache = build_fts_cache(&path, &object_store, &config)?;
+            Ok((loaded_catalog, fts_cache))
+        }
+        .await;
+        let (loaded_catalog, fts_cache) = writer.close_on_open_error(runtime_inputs).await?;
         let storage = HelixStorage::Writer(Arc::new(writer));
-        let fts_cache = build_fts_cache(&path, &object_store, &config)?;
         let db = Self::from_storage(
             HelixStorageParts::new(path, object_store, storage),
             HelixConfig::new(config),
@@ -1015,7 +1056,8 @@ impl HelixDB {
             fts_cache,
             index_lifecycle::repository::ReaderStorageCompatibility::Current,
         );
-        migrations::startup::finish_writer(&db).await?;
+        let finish_result = migrations::startup::finish_writer(&db).await;
+        db.close_on_open_error(finish_result).await?;
         db.start_background_migration_worker().await;
         Ok(db)
     }
@@ -1143,45 +1185,53 @@ impl HelixDB {
             config.id_lease_size(),
             config.id_lease_refill_threshold(),
         );
-        let stage_started = Instant::now();
-        let migration_authorized = matches!(
-            &open_mode,
-            WriterOpenMode::Embedded
-                | WriterOpenMode::Managed {
-                    intent: ManagedWriterOpenIntent::ControlledMigration(_),
-                    ..
-                }
-        );
-        if migration_authorized {
-            migrations::run_blocking_startup_migration(&writer, config.migrations()).await?;
-            index_lifecycle::outbox::reconcile_legacy_reader_coordination_operations(
-                &db,
+        let runtime_inputs: Result<_> = async {
+            let stage_started = Instant::now();
+            let migration_authorized = matches!(
+                &open_mode,
+                WriterOpenMode::Embedded
+                    | WriterOpenMode::Managed {
+                        intent: ManagedWriterOpenIntent::ControlledMigration(_),
+                        ..
+                    }
+            );
+            if migration_authorized {
+                migrations::run_blocking_startup_migration(&writer, config.migrations()).await?;
+                index_lifecycle::outbox::reconcile_legacy_reader_coordination_operations(
+                    &db,
+                    DataScope::LegacyUnscoped,
+                )
+                .await?;
+            }
+            tracing::info!(
+                stage = "startup_migration",
+                open_intent,
+                writer_epoch,
+                migration_authorized,
+                elapsed_ms = u64::try_from(stage_started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                total_elapsed_ms =
+                    u64::try_from(open_started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                "HelixDB writer open stage completed"
+            );
+            let stage_started = Instant::now();
+            index_lifecycle::outbox::reconcile_operation_queue(&db).await?;
+            log_stage("operation_queue_reconciliation", stage_started);
+            let stage_started = Instant::now();
+            let loaded_catalog = index_lifecycle::repository::load_scope_catalog(
+                db.as_ref(),
                 DataScope::LegacyUnscoped,
             )
             .await?;
+            log_stage("catalog_load", stage_started);
+            let stage_started = Instant::now();
+            let fts_cache = build_fts_cache(&path, &object_store, &config)?;
+            log_stage("fts_cache_construction", stage_started);
+            Ok((migration_authorized, loaded_catalog, fts_cache))
         }
-        tracing::info!(
-            stage = "startup_migration",
-            open_intent,
-            writer_epoch,
-            migration_authorized,
-            elapsed_ms = u64::try_from(stage_started.elapsed().as_millis()).unwrap_or(u64::MAX),
-            total_elapsed_ms =
-                u64::try_from(open_started.elapsed().as_millis()).unwrap_or(u64::MAX),
-            "HelixDB writer open stage completed"
-        );
-        let stage_started = Instant::now();
-        index_lifecycle::outbox::reconcile_operation_queue(&db).await?;
-        log_stage("operation_queue_reconciliation", stage_started);
-        let stage_started = Instant::now();
-        let loaded_catalog =
-            index_lifecycle::repository::load_scope_catalog(db.as_ref(), DataScope::LegacyUnscoped)
-                .await?;
-        log_stage("catalog_load", stage_started);
+        .await;
+        let (migration_authorized, loaded_catalog, fts_cache) =
+            writer.close_on_open_error(runtime_inputs).await?;
         let storage = HelixStorage::Writer(Arc::new(writer));
-        let stage_started = Instant::now();
-        let fts_cache = build_fts_cache(&path, &object_store, &config)?;
-        log_stage("fts_cache_construction", stage_started);
         let stage_started = Instant::now();
         let db = Self::from_storage_with_index_scheduling(
             HelixStorageParts::new(path, object_store, storage),
@@ -1193,21 +1243,25 @@ impl HelixDB {
             index_lifecycle::repository::ReaderStorageCompatibility::Current,
         );
         log_stage("runtime_construction", stage_started);
-        let stage_started = Instant::now();
-        if migration_authorized && let Err(error) = migrations::startup::finish_writer(&db).await {
-            let _ = db.close().await;
-            return Err(error);
+        let finish_result: Result<()> = async {
+            let stage_started = Instant::now();
+            if migration_authorized {
+                migrations::startup::finish_writer(&db).await?;
+            }
+            log_stage("legacy_migration_cleanup", stage_started);
+            let allow_blocking_warm = matches!(&open_mode, WriterOpenMode::Embedded);
+            let stage_started = Instant::now();
+            db.run_configured_startup_cache_warm(allow_blocking_warm)
+                .await?;
+            log_stage("startup_cache_warm", stage_started);
+            let stage_started = Instant::now();
+            db.run_configured_vector_memory_warm(vector_memory_settings, allow_blocking_warm)
+                .await?;
+            log_stage("vector_memory_warm", stage_started);
+            Ok(())
         }
-        log_stage("legacy_migration_cleanup", stage_started);
-        let allow_blocking_warm = matches!(&open_mode, WriterOpenMode::Embedded);
-        let stage_started = Instant::now();
-        db.run_configured_startup_cache_warm(allow_blocking_warm)
-            .await?;
-        log_stage("startup_cache_warm", stage_started);
-        let stage_started = Instant::now();
-        db.run_configured_vector_memory_warm(vector_memory_settings, allow_blocking_warm)
-            .await?;
-        log_stage("vector_memory_warm", stage_started);
+        .await;
+        db.close_on_open_error(finish_result).await?;
         if migration_authorized {
             db.start_background_migration_worker().await;
         }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -908,11 +908,11 @@ impl HelixDB {
     ///
     /// ```
     /// # tokio_test::block_on(async {
-    /// use std::num::NonZeroU64;
     /// use db::{DbConfig, HelixDB, HelixDbSource};
     ///
     /// let config = DbConfig::new()
-    ///     .with_id_lease_size(NonZeroU64::new(20_000).unwrap())
+    ///     .try_with_id_lease_size(20_000)
+    ///     .unwrap()
     ///     .with_id_lease_refill_threshold(8_000);
     /// let db = HelixDB::open_with_config(
     ///     HelixDbSource::InMemory {
@@ -4464,6 +4464,32 @@ mod tests {
             Some(&serde_json::json!(0))
         );
         assert!(db.query_json(b"not-json").await.is_err());
+        db.close().await.expect("writer closes");
+    }
+
+    #[tokio::test]
+    async fn open_with_config_applies_lease_size_to_both_id_allocators() {
+        let config = DbConfig::new()
+            .try_with_id_lease_size(7)
+            .expect("nonzero lease size is valid")
+            .with_id_lease_refill_threshold(3);
+        let db = HelixDB::open_with_config(
+            HelixDbSource::InMemory {
+                database: "configured-id-lease-size".to_string(),
+            },
+            config,
+        )
+        .await
+        .expect("writer opens with custom ID leasing");
+        let HelixStorage::Writer(writer) = db.storage() else {
+            panic!("writer handle expected")
+        };
+
+        assert_eq!(writer.node_ids().allocate().await.unwrap(), 0);
+        assert_eq!(writer.edge_ids().allocate().await.unwrap(), 0);
+        assert_eq!(writer.node_ids().remaining_in_lease(), 6);
+        assert_eq!(writer.edge_ids().remaining_in_lease(), 6);
+
         db.close().await.expect("writer closes");
     }
 

--- a/crates/db/src/migrations/background/worker.rs
+++ b/crates/db/src/migrations/background/worker.rs
@@ -133,7 +133,7 @@ mod tests {
                 .await
                 .expect("migration worker test database opens"),
         );
-        let writer = Arc::new(HelixWriter::new(Arc::clone(&db), 64));
+        let writer = Arc::new(HelixWriter::new(Arc::clone(&db), 64, 32));
         (db, writer)
     }
 

--- a/crates/db/src/migrations/mod.rs
+++ b/crates/db/src/migrations/mod.rs
@@ -7981,7 +7981,11 @@ pub(crate) mod production_contracts {
     ) -> MigrationJob {
         let raw = Arc::new(raw(database, store).await);
         let config = one_row_config();
-        let writer = crate::HelixWriter::new(Arc::clone(&raw), config.id_lease_size());
+        let writer = crate::HelixWriter::new(
+            Arc::clone(&raw),
+            config.id_lease_size(),
+            config.id_lease_refill_threshold(),
+        );
         let target = recovery_stage.migration_stage();
         let target_rank = recovery_stage
             .stage_rank(target)

--- a/crates/db/src/migrations/startup/pipeline.rs
+++ b/crates/db/src/migrations/startup/pipeline.rs
@@ -22,13 +22,18 @@ pub(crate) async fn prepare_writer(db: Arc<Db>, config: &DbConfig) -> Result<Hel
         config.id_lease_size(),
         config.id_lease_refill_threshold(),
     );
-    super::super::run_blocking_startup_migration(&writer, config.migrations()).await?;
-    crate::index_lifecycle::outbox::reconcile_legacy_reader_coordination_operations(
-        writer.db(),
-        DataScope::LegacyUnscoped,
-    )
-    .await?;
-    crate::index_lifecycle::outbox::reconcile_operation_queue(writer.db()).await?;
+    let prepare_result: Result<()> = async {
+        super::super::run_blocking_startup_migration(&writer, config.migrations()).await?;
+        crate::index_lifecycle::outbox::reconcile_legacy_reader_coordination_operations(
+            writer.db(),
+            DataScope::LegacyUnscoped,
+        )
+        .await?;
+        crate::index_lifecycle::outbox::reconcile_operation_queue(writer.db()).await?;
+        Ok(())
+    }
+    .await;
+    writer.close_on_open_error(prepare_result).await?;
     Ok(writer)
 }
 

--- a/crates/db/src/migrations/startup/pipeline.rs
+++ b/crates/db/src/migrations/startup/pipeline.rs
@@ -17,7 +17,11 @@ use crate::{HelixDB, Result};
 pub(crate) async fn prepare_writer(db: Arc<Db>, config: &DbConfig) -> Result<HelixWriter> {
     super::bootstrap_writer(&db).await?;
     super::super::preflight_legacy_vector_reservations(&db).await?;
-    let writer = HelixWriter::new(db, config.id_lease_size());
+    let writer = HelixWriter::new(
+        db,
+        config.id_lease_size(),
+        config.id_lease_refill_threshold(),
+    );
     super::super::run_blocking_startup_migration(&writer, config.migrations()).await?;
     crate::index_lifecycle::outbox::reconcile_legacy_reader_coordination_operations(
         writer.db(),

--- a/crates/db/src/migrations/vector_scale.rs
+++ b/crates/db/src/migrations/vector_scale.rs
@@ -295,7 +295,12 @@ async fn run_inner(entity_count: u64) -> Result<VectorMigrationScaleReport> {
             .await?,
     );
     crate::migrations::startup::bootstrap_writer(db.as_ref()).await?;
-    let writer = crate::HelixWriter::new(Arc::clone(&db), config::DbConfig::new().id_lease_size());
+    let config = config::DbConfig::new();
+    let writer = crate::HelixWriter::new(
+        Arc::clone(&db),
+        config.id_lease_size(),
+        config.id_lease_refill_threshold(),
+    );
     let scope = DataScope::LegacyUnscoped;
     let definition: ValidatedDynamicIndexDefinition = config::VectorIndexDefinition::new_node(
         "MigrationScaleDocument",

--- a/crates/db/tests/unit/migrations_contracts.rs
+++ b/crates/db/tests/unit/migrations_contracts.rs
@@ -557,7 +557,11 @@ async fn empty_migration_controller_executes_every_stage_and_catalog_family_to_c
         .unwrap(),
     );
     let config = crate::config::DbConfig::default();
-    let writer = crate::HelixWriter::new(Arc::clone(&raw), config.id_lease_size());
+    let writer = crate::HelixWriter::new(
+        Arc::clone(&raw),
+        config.id_lease_size(),
+        config.id_lease_refill_threshold(),
+    );
     let scope = DataScope::LegacyUnscoped;
 
     assert!(

--- a/scripts/db-production-coverage-baselines.json
+++ b/scripts/db-production-coverage-baselines.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "uncovered_non_vector_source_lines": {
-    "count": 10489,
-    "sha256": "06d2c8030c33e7865dd03cc79ddd43a0c101cd9fbce227254588df627f736d31",
+    "count": 10490,
+    "sha256": "24be47528559ff848f9ca3fb8a5b384f6f29853786889ed854e1e9690978f8a1",
     "classification": "test-required",
     "reason": "Every uncovered production source line outside vector search and its stochastic vector key/value codecs remains in the explicit production-linked test backlog. The digest makes additions, removals, and newly covered lines require a reviewed baseline update; vector code remains enforced by the whole-DB and dedicated vector thresholds plus finer named-test, architecture, invariant, and platform classifications."
   },

--- a/scripts/db-production-coverage-baselines.json
+++ b/scripts/db-production-coverage-baselines.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "uncovered_non_vector_source_lines": {
-    "count": 10429,
-    "sha256": "300955ba60656464b30beee515bc3662ec0f3d2adf968118feac3df1d005781d",
+    "count": 10489,
+    "sha256": "06d2c8030c33e7865dd03cc79ddd43a0c101cd9fbce227254588df627f736d31",
     "classification": "test-required",
     "reason": "Every uncovered production source line outside vector search and its stochastic vector key/value codecs remains in the explicit production-linked test backlog. The digest makes additions, removals, and newly covered lines require a reviewed baseline update; vector code remains enforced by the whole-DB and dedicated vector thresholds plus finer named-test, architecture, invariant, and platform classifications."
   },


### PR DESCRIPTION
## Summary

- increase the default ID lease size from 1,000 to 10,000
- add a configurable absolute refill threshold, defaulting to 5,000 remaining IDs
- renew node and edge leases in one background task per allocator while preserving synchronous exhaustion safety
- keep initial leasing lazy and synchronous, retry failed background renewals, check arithmetic, and drain renewal tasks before closing SlateDB
- expose both lease size and refill threshold through DbConfig and document open_with_config usage
- preserve contiguous allocation: renewal advances only the durable exclusive watermark and never advances next_id or skips unused IDs

## Verification

- cargo test -p db --lib: 1,514 passed before the focused follow-up
- cargo test -p db --lib id_allocator: 35 passed, including configurability and no-gap renewal regressions
- cargo test -p db --doc: 29 passed
- cargo clippy --workspace -- -D warnings
- cargo fmt --all -- --check
- focused allocator coverage: 95.94% lines and 96% regions before the additional no-gap regression test

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds configurable proactive node and edge ID-lease renewal, increases the default lease size, checks allocator arithmetic, and drains refills during normal database shutdown. One startup error path still bypasses the new refill shutdown protocol.

- Adds a single background refill lifecycle per allocator while preserving synchronous exhaustion handling.
- Propagates lease size and refill threshold through writer configuration and documents `open_with_config`.
- Extends allocator tests for concurrency, contiguous allocation, retry behavior, shutdown, and exhaustion.
- Needs cleanup of refill-capable allocators when writer initialization fails before the runtime owns them.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/id_allocator.rs | Implements checked contiguous allocation, proactive refill lifecycle coordination, retry behavior, and allocator shutdown. |
| crates/db/src/lib.rs | Propagates lease tuning and drains refills on normal close, but pre-runtime writer-open failures can bypass that cleanup. |
| crates/db/src/config/db.rs | Exposes validated lease-size configuration and an absolute refill-threshold builder with documented defaults. |
| crates/db/src/migrations/mod.rs | Updates migration writer construction and contains the startup edge-allocation path capable of triggering proactive refill. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant O as Writer open
    participant A as ID allocator
    participant M as Startup migration
    participant R as Refill task
    participant S as SlateDB
    O->>A: Construct refill-capable allocator
    O->>M: Run blocking migration
    M->>A: Allocate IDs
    A-->>R: Spawn threshold refill
    R->>S: Persist exclusive watermark
    M-->>O: Later migration error
    O--xA: Drop writer without shutdown
    O-->>O: Return open error
    R->>S: Refill may finish after failure
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(db): verify configurable contiguous..."](https://github.com/helixdb/helix-db/commit/2db0aac2c6d9d6f9b4b5981cd4c045cd5eccbf5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60427474)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Database engine](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/database-engine.md)

<!-- /greptile_comment -->