### PR TITLE
fix(sdk/go): add nil check guard to getAPIKey method

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -226,6 +226,9 @@ func (c *Client) setAPIKey(apiKey string) {
 }
 
 func (c *Client) getAPIKey() string {
+	if c == nil {
+		return ""
+	}
 	c.apiKeyMu.RLock()
 	apiKey := c.apiKey
 	c.apiKeyMu.RUnlock()


### PR DESCRIPTION
This PR adds a nil check guard to getAPIKey in the Go SDK client, ensuring it aligns with the nil checks implemented across other Client methods to prevent potential nil pointer dereference.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR defensively updates the Go SDK's API-key accessor to return an empty key for a nil client receiver.
- Prevents direct nil-receiver access from dereferencing `apiKeyMu`.
- Preserves locking and API-key behavior for initialized clients.
- The added branch currently lacks direct regression coverage.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdks/go/client.go | Adds a safe nil-receiver return to `getAPIKey`; implementation is straightforward, but its new branch is not covered by a test. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sdk/go): add nil check guard to getA..."](https://github.com/helixdb/helix-db/commit/7f51ca56ffd784619741fdb8e9ea5010246aab59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60721591)</sub>

**Context used:**

- Knowledge Base — [Go, Python, and TypeScript SDKs](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/language-client-sdks.md)

<!-- /greptile_comment -->