### PR TITLE
Fix permanent index cleanup failures and validation diagnostics

### DIFF
--- a/crates/db/src/index_lifecycle/outbox.rs
+++ b/crates/db/src/index_lifecycle/outbox.rs
@@ -988,9 +988,15 @@ pub(crate) async fn execute_claimed_step_with_evidence(
         ));
     }
 
-    let prepared = driver
+    let prepared = match driver
         .prepare_step(db, claimed.scope, &claimed.record, limits)
-        .await?;
+        .await
+    {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            return record_driver_failure(db, claimed, error, now_unix_millis, started).await
+        }
+    };
     if prepared.family() != driver.family() {
         prepared.discard().await?;
         return Err(corruption(
@@ -998,6 +1004,7 @@ pub(crate) async fn execute_claimed_step_with_evidence(
         ));
     }
 
+    let mut driver_failed = false;
     let staged: Result<Option<StagedOperationStep>> = async {
         let transaction = db.begin(IsolationLevel::SerializableSnapshot).await?;
         failpoints::trip(IndexOutboxFailpoint::BatchReadBefore)?;
@@ -1019,17 +1026,11 @@ pub(crate) async fn execute_claimed_step_with_evidence(
             .stage(driver, db, &transaction, claimed.scope, &operation, limits)
             .await;
         failpoints::trip(IndexOutboxFailpoint::PhysicalStagingAfter)?;
-        let execution = match step {
-            Ok(execution) => execution,
-            Err(error) => {
-                tracing::warn!(
-                    operation_id = %operation.operation_id().as_uuid(),
-                    error = %error,
-                    "index operation driver returned a transient failure"
-                );
-                return Ok(None);
-            }
-        };
+        // An error can follow staged physical writes. Drop this transaction before
+        // recording a blocker or releasing the claim; never commit a partial step.
+        let execution = step.inspect_err(|_| {
+            driver_failed = true;
+        })?;
         let IndexOperationStepExecution {
             result: step,
             resources,
@@ -1177,6 +1178,9 @@ pub(crate) async fn execute_claimed_step_with_evidence(
         Ok(staged) => staged,
         Err(error) => {
             prepared.discard().await?;
+            if driver_failed {
+                return record_driver_failure(db, claimed, error, now_unix_millis, started).await;
+            }
             return Err(error);
         }
     })
@@ -1212,6 +1216,74 @@ pub(crate) async fn execute_claimed_step_with_evidence(
         before_stage,
         after_stage,
         resources,
+        elapsed_micros: elapsed_micros(started),
+    })
+}
+
+/// Records failures only after failed preparation and staging have been discarded.
+/// The exact claim is rechecked in a fresh serializable transaction so a stale
+/// worker cannot block an operation that another writer or an abort has advanced.
+async fn record_driver_failure(
+    db: &Db,
+    claimed: &ClaimedOperation,
+    error: HelixDbError,
+    now_unix_millis: u64,
+    started: Instant,
+) -> Result<CommittedOperationStepEvidence> {
+    if matches!(
+        error,
+        HelixDbError::DatabaseClosed | HelixDbError::WriterFencedCommitOutcomeUnknown
+    ) || matches!(&error, HelixDbError::Storage(storage) if matches!(storage.kind(), slatedb::ErrorKind::Closed(_)))
+    {
+        return Err(error);
+    }
+    let retryable = error.is_transaction_conflict()
+        || matches!(&error, HelixDbError::Storage(storage) if storage.kind() == slatedb::ErrorKind::Unavailable)
+        || matches!(error, HelixDbError::ObjectStore(_));
+    let status = IndexOperationStatus::from_record(&claimed.record);
+    tracing::warn!(
+        operation_id = %claimed.record.operation_id().as_uuid(),
+        index_id = claimed.record.index_id().get(),
+        generation = claimed.record.generation().get(),
+        stage = ?status.common().stage,
+        error = %error,
+        retryable,
+        "index operation driver failed"
+    );
+    let outcome = if retryable {
+        release_transient_claim(db, claimed, now_unix_millis).await?;
+        CommittedOperationStep::TransientFailure
+    } else {
+        let transaction = db.begin(IsolationLevel::SerializableSnapshot).await?;
+        let Some((index, operation, _)) =
+            load_exact_link(&transaction, claimed.scope, claimed.record.operation_id()).await?
+        else {
+            return Err(corruption("failed operation disappeared before blocking"));
+        };
+        if operation.operation_revision() != claimed.record.operation_revision()
+            || operation.execution_state() != claimed.record.execution_state()
+        {
+            return Err(HelixDbError::TransactionConflict(
+                "failed index claim has advanced".into(),
+            ));
+        }
+        let next = operation
+            .block(IndexOperationBlocker::InvariantViolation)
+            .map_err(operation_model_error)?;
+        validate_link(claimed.scope, &index, &next, None)?;
+        transaction.put(
+            scoped_operation_key(claimed.scope, next.operation_id()),
+            encode_operation_record(&next),
+        )?;
+        transaction.delete(global_operation_key(next.operation_id()))?;
+        transaction.commit().await?;
+        CommittedOperationStep::Blocked
+    };
+    Ok(CommittedOperationStepEvidence {
+        outcome,
+        before_stage: status.common().stage,
+        after_stage: status.common().stage,
+        resources: StepResourceUsage::default(),
         elapsed_micros: elapsed_micros(started),
     })
 }
@@ -1843,6 +1915,263 @@ mod tests {
         ) -> Result<IndexOperationStepExecution> {
             Ok(IndexOperationStepExecution::new(self.0.clone()))
         }
+    }
+
+    #[derive(Clone, Copy)]
+    enum FailureMode {
+        PrepareCorruption,
+        StageCorruption,
+        StageInvariant,
+        Conflict,
+        ObjectStore,
+    }
+
+    struct FailingDriver {
+        mode: FailureMode,
+        probe_key: Bytes,
+    }
+
+    #[async_trait]
+    impl IndexOperationDriver for FailingDriver {
+        fn family(&self) -> IndexOperationFamily {
+            IndexOperationFamily::Secondary
+        }
+
+        async fn acquire_step_permit(
+            &self,
+            _scope: DataScope,
+            _operation: &IndexOperationRecord,
+        ) -> Result<Box<dyn IndexOperationStepPermit>> {
+            if matches!(self.mode, FailureMode::PrepareCorruption) {
+                return Err(corruption("prepare fixture"));
+            }
+            Ok(Box::new(()))
+        }
+
+        async fn step(
+            &self,
+            _db: &Db,
+            transaction: &DbTransaction,
+            _scope: DataScope,
+            _operation: &IndexOperationRecord,
+            _limits: SearchIndexBatchLimits,
+        ) -> Result<IndexOperationStepExecution> {
+            transaction.delete(self.probe_key.clone())?;
+            Err(match self.mode {
+                FailureMode::PrepareCorruption | FailureMode::StageCorruption => {
+                    corruption("stage fixture")
+                }
+                FailureMode::StageInvariant => {
+                    HelixDbError::InvariantViolation("stage fixture".into())
+                }
+                FailureMode::Conflict => HelixDbError::TransactionConflict("stage fixture".into()),
+                FailureMode::ObjectStore => {
+                    HelixDbError::ObjectStore(slatedb::object_store::Error::Generic {
+                        store: "fixture",
+                        source: std::io::Error::other("temporarily unavailable").into(),
+                    })
+                }
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn driver_errors_discard_partial_writes_and_preserve_retry_classification() {
+        for (mode, expected) in [
+            (
+                FailureMode::PrepareCorruption,
+                CommittedOperationStep::Blocked,
+            ),
+            (
+                FailureMode::StageCorruption,
+                CommittedOperationStep::Blocked,
+            ),
+            (FailureMode::StageInvariant, CommittedOperationStep::Blocked),
+            (
+                FailureMode::Conflict,
+                CommittedOperationStep::TransientFailure,
+            ),
+            (
+                FailureMode::ObjectStore,
+                CommittedOperationStep::TransientFailure,
+            ),
+        ] {
+            let db = db("outbox-driver-error").await;
+            let (index, operation) = fixture(70);
+            let scope = DataScope::LegacyUnscoped;
+            enqueue_operation(
+                &db,
+                scope,
+                ExpectedCanonicalRevision::Absent,
+                &index,
+                &operation,
+            )
+            .await
+            .unwrap();
+            abort_operation(&db, scope, operation.operation_id())
+                .await
+                .unwrap();
+            let epoch = WriterEpoch::from_bytes([71; 16]).unwrap();
+            let OperationPointerObservation::Eligible(eligible) =
+                observe_operation_pointer(&db, operation.operation_id(), epoch, 0)
+                    .await
+                    .unwrap()
+            else {
+                panic!("queued operation is eligible");
+            };
+            let claimed = claim_operation(
+                &db,
+                &eligible,
+                epoch,
+                ClaimSequence::new(1).unwrap(),
+                0,
+                ClaimPermission::Normal,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            let probe_key = scoped_index_key(scope, &index);
+            let before = db.get(&probe_key).await.unwrap();
+            let result = execute_claimed_step(
+                &db,
+                &claimed,
+                &FailingDriver {
+                    mode,
+                    probe_key: probe_key.clone(),
+                },
+                SearchIndexBackfillLimits::default().batch(),
+                0,
+            )
+            .await
+            .unwrap();
+            assert_eq!(result, expected);
+            assert_eq!(
+                db.get(probe_key).await.unwrap(),
+                before,
+                "failed physical staging must roll back"
+            );
+            let value = db
+                .get(scoped_operation_key(scope, operation.operation_id()))
+                .await
+                .unwrap()
+                .unwrap();
+            let retained = decode_operation_record(&value).unwrap();
+            assert_eq!(retained.progress(), claimed.record.progress());
+            assert_eq!(retained.attempt(), claimed.record.attempt());
+            let pointer = db
+                .get(global_operation_key(operation.operation_id()))
+                .await
+                .unwrap();
+            match expected {
+                CommittedOperationStep::Blocked => {
+                    assert!(matches!(
+                        retained.execution_state(),
+                        IndexOperationExecutionState::Blocked(
+                            IndexOperationBlocker::InvariantViolation
+                        )
+                    ));
+                    assert!(pointer.is_none());
+                    let retried = retry_operation(&db, scope, operation.operation_id())
+                        .await
+                        .unwrap();
+                    assert_eq!(retried.progress(), retained.progress());
+                }
+                CommittedOperationStep::TransientFailure => {
+                    assert!(
+                        matches!(retained.execution_state(), IndexOperationExecutionState::Queued { not_before_unix_millis: Some(deadline) } if *deadline > 0)
+                    );
+                    assert!(pointer.is_some());
+                }
+                CommittedOperationStep::Progressed | CommittedOperationStep::Completed => {
+                    unreachable!()
+                }
+            }
+            db.close().await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn stale_and_unknown_claims_cannot_become_durable_blockers() {
+        let db = db("outbox-stale-failure").await;
+        let (index, operation) = fixture(72);
+        let scope = DataScope::LegacyUnscoped;
+        enqueue_operation(
+            &db,
+            scope,
+            ExpectedCanonicalRevision::Absent,
+            &index,
+            &operation,
+        )
+        .await
+        .unwrap();
+        let epoch = WriterEpoch::from_bytes([73; 16]).unwrap();
+        let OperationPointerObservation::Eligible(eligible) =
+            observe_operation_pointer(&db, operation.operation_id(), epoch, 0)
+                .await
+                .unwrap()
+        else {
+            panic!("queued operation is eligible");
+        };
+        let claimed = claim_operation(
+            &db,
+            &eligible,
+            epoch,
+            ClaimSequence::new(1).unwrap(),
+            0,
+            ClaimPermission::Normal,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let before = db
+            .get(scoped_operation_key(scope, operation.operation_id()))
+            .await
+            .unwrap();
+        assert!(matches!(
+            record_driver_failure(
+                &db,
+                &claimed,
+                HelixDbError::WriterFencedCommitOutcomeUnknown,
+                0,
+                Instant::now()
+            )
+            .await,
+            Err(HelixDbError::WriterFencedCommitOutcomeUnknown)
+        ));
+        assert_eq!(
+            db.get(scoped_operation_key(scope, operation.operation_id()))
+                .await
+                .unwrap(),
+            before
+        );
+        release_transient_claim(&db, &claimed, 0).await.unwrap();
+        let advanced = db
+            .get(scoped_operation_key(scope, operation.operation_id()))
+            .await
+            .unwrap();
+        assert!(matches!(
+            record_driver_failure(
+                &db,
+                &claimed,
+                corruption("stale failure"),
+                0,
+                Instant::now()
+            )
+            .await,
+            Err(HelixDbError::TransactionConflict(_))
+        ));
+        assert_eq!(
+            db.get(scoped_operation_key(scope, operation.operation_id()))
+                .await
+                .unwrap(),
+            advanced
+        );
+        assert!(db
+            .get(global_operation_key(operation.operation_id()))
+            .await
+            .unwrap()
+            .is_some());
+        db.close().await.unwrap();
     }
 
     fn fixture(id_byte: u8) -> (IndexRecordV2, IndexOperationRecord) {

--- a/crates/db/src/index_lifecycle/outbox.rs
+++ b/crates/db/src/index_lifecycle/outbox.rs
@@ -1920,6 +1920,9 @@ mod tests {
     #[derive(Clone, Copy)]
     enum FailureMode {
         PrepareCorruption,
+        PrepareObjectStore,
+        StorageUnavailable,
+        StorageCorruption,
         StageCorruption,
         StageInvariant,
         Conflict,
@@ -1945,6 +1948,14 @@ mod tests {
             if matches!(self.mode, FailureMode::PrepareCorruption) {
                 return Err(corruption("prepare fixture"));
             }
+            if matches!(self.mode, FailureMode::PrepareObjectStore) {
+                return Err(HelixDbError::ObjectStore(
+                    slatedb::object_store::Error::Generic {
+                        store: "fixture",
+                        source: std::io::Error::other("temporarily unavailable").into(),
+                    },
+                ));
+            }
             Ok(Box::new(()))
         }
 
@@ -1965,7 +1976,13 @@ mod tests {
                     HelixDbError::InvariantViolation("stage fixture".into())
                 }
                 FailureMode::Conflict => HelixDbError::TransactionConflict("stage fixture".into()),
-                FailureMode::ObjectStore => {
+                FailureMode::StorageUnavailable => {
+                    HelixDbError::Storage(slatedb::Error::unavailable("fixture".into()))
+                }
+                FailureMode::StorageCorruption => {
+                    HelixDbError::Storage(slatedb::Error::data("fixture".into()))
+                }
+                FailureMode::PrepareObjectStore | FailureMode::ObjectStore => {
                     HelixDbError::ObjectStore(slatedb::object_store::Error::Generic {
                         store: "fixture",
                         source: std::io::Error::other("temporarily unavailable").into(),
@@ -1978,6 +1995,18 @@ mod tests {
     #[tokio::test]
     async fn driver_errors_discard_partial_writes_and_preserve_retry_classification() {
         for (mode, expected) in [
+            (
+                FailureMode::PrepareObjectStore,
+                CommittedOperationStep::TransientFailure,
+            ),
+            (
+                FailureMode::StorageUnavailable,
+                CommittedOperationStep::TransientFailure,
+            ),
+            (
+                FailureMode::StorageCorruption,
+                CommittedOperationStep::Blocked,
+            ),
             (
                 FailureMode::PrepareCorruption,
                 CommittedOperationStep::Blocked,
@@ -2127,23 +2156,26 @@ mod tests {
             .get(scoped_operation_key(scope, operation.operation_id()))
             .await
             .unwrap();
-        assert!(matches!(
-            record_driver_failure(
-                &db,
-                &claimed,
-                HelixDbError::WriterFencedCommitOutcomeUnknown,
-                0,
-                Instant::now()
-            )
-            .await,
-            Err(HelixDbError::WriterFencedCommitOutcomeUnknown)
-        ));
-        assert_eq!(
-            db.get(scoped_operation_key(scope, operation.operation_id()))
-                .await
-                .unwrap(),
-            before
-        );
+        for error in [
+            HelixDbError::WriterFencedCommitOutcomeUnknown,
+            HelixDbError::DatabaseClosed,
+            HelixDbError::Storage(slatedb::Error::closed(
+                "fixture".into(),
+                slatedb::CloseReason::Fenced,
+            )),
+        ] {
+            assert!(
+                record_driver_failure(&db, &claimed, error, 0, Instant::now())
+                    .await
+                    .is_err()
+            );
+            assert_eq!(
+                db.get(scoped_operation_key(scope, operation.operation_id()))
+                    .await
+                    .unwrap(),
+                before
+            );
+        }
         release_transient_claim(&db, &claimed, 0).await.unwrap();
         let advanced = db
             .get(scoped_operation_key(scope, operation.operation_id()))

--- a/crates/db/src/index_lifecycle/text/driver.rs
+++ b/crates/db/src/index_lifecycle/text/driver.rs
@@ -1145,11 +1145,7 @@ async fn prepare_build_upload(
     let next_progress =
         IndexOperationProgress::TextBuild(TextBuildProgress::Constructing(next_stage));
     let uploaded =
-        crate::search::text::upload_blob(&runtime.object_store, &runtime.db_path, &payload)
-            .await
-            .map_err(|error| {
-                HelixDbError::InvariantViolation(format!("text split upload failed: {error}"))
-            })?;
+        crate::search::text::upload_blob(&runtime.object_store, &runtime.db_path, &payload).await?;
     if uploaded.sha256 != *split.blob().hash() || uploaded.size_bytes != split.blob().size() {
         return Err(corruption(
             "text split upload returned metadata for different content",
@@ -1439,11 +1435,7 @@ async fn prepare_compaction_step(
     let next_progress =
         IndexOperationProgress::TextBuild(TextBuildProgress::Constructing(next_stage));
     let uploaded =
-        crate::search::text::upload_blob(&runtime.object_store, &runtime.db_path, &payload)
-            .await
-            .map_err(|error| {
-                HelixDbError::InvariantViolation(format!("text compaction upload failed: {error}"))
-            })?;
+        crate::search::text::upload_blob(&runtime.object_store, &runtime.db_path, &payload).await?;
     if uploaded.sha256 != *split.blob().hash() || uploaded.size_bytes != split.blob().size() {
         return Err(corruption(
             "text compaction upload returned metadata for different content",

--- a/crates/db/src/index_lifecycle/text/validation.rs
+++ b/crates/db/src/index_lifecycle/text/validation.rs
@@ -33,9 +33,30 @@ use crate::index_lifecycle::{
 /// One prepared validation decision that needs no external blob authority.
 #[derive(Debug)]
 pub(crate) struct PreparedDatabaseValidation {
+    diagnostic: ValidationDiagnostic,
     ranges: Vec<PreparedValidationRange>,
     observations: Vec<RowObservation>,
     result: IndexOperationStepResult,
+}
+
+/// Disposable failure context; never serialized into index metadata.
+#[derive(Debug)]
+struct ValidationDiagnostic {
+    operation_id: uuid::Uuid,
+    index_id: u64,
+    generation: u64,
+    check: Option<&'static str>,
+}
+
+impl ValidationDiagnostic {
+    fn new(operation: &IndexOperationRecord) -> Self {
+        Self {
+            operation_id: operation.operation_id().as_uuid(),
+            index_id: operation.index_id().get(),
+            generation: operation.generation().get(),
+            check: None,
+        }
+    }
 }
 
 impl PreparedDatabaseValidation {
@@ -53,6 +74,15 @@ impl PreparedDatabaseValidation {
             if transaction.get(&observation.key).await? != observation.value {
                 return Ok(IndexOperationStepResult::TransientFailure);
             }
+        }
+        if matches!(self.result, IndexOperationStepResult::Blocked(_)) {
+            tracing::warn!(
+                operation_id = %self.diagnostic.operation_id,
+                index_id = self.diagnostic.index_id,
+                generation = self.diagnostic.generation,
+                check = self.diagnostic.check.unwrap_or("manifest_limit"),
+                "text manifest validation failed after snapshot revalidation"
+            );
         }
         Ok(self.result.clone())
     }
@@ -84,6 +114,12 @@ impl PreparedPageValidation {
         mut self,
         result: IndexOperationStepResult,
     ) -> PreparedDatabaseValidation {
+        if matches!(
+            result,
+            IndexOperationStepResult::Blocked(IndexOperationBlocker::InvariantViolation)
+        ) {
+            self.database.diagnostic.check = Some("blob_missing_or_size_mismatch");
+        }
         self.database.result = result;
         self.database
     }
@@ -175,6 +211,7 @@ pub(super) async fn select(
     let (delta_range, delta) = select_one(transaction, delta_prefix, None).await?;
     if delta.is_some() {
         return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+            diagnostic: ValidationDiagnostic::new(operation),
             ranges: vec![delta_range],
             observations: Vec::new(),
             result: progressed(TextBuildStage::CatchUp(PrefixScanProgress {
@@ -230,6 +267,7 @@ async fn select_page(
             ))
         };
         return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+            diagnostic: ValidationDiagnostic::new(operation),
             ranges: vec![scan.range_through(0)],
             observations: Vec::new(),
             result,
@@ -250,11 +288,21 @@ async fn select_page(
                 ..
             }) => key,
             Ok(ManagedIndexKey::Data { .. } | ManagedIndexKey::Global { .. }) | Err(_) => {
-                return Ok(blocked_database(range(), observations));
+                return Ok(blocked_database(
+                    operation,
+                    "page_key_encoding",
+                    range(),
+                    observations,
+                ));
             }
         };
         let Ok(page) = index_values::decode_manifest_page(row_value) else {
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "page_value_encoding",
+                range(),
+                observations,
+            ));
         };
         let root_key = scoped_key(
             scope,
@@ -267,11 +315,21 @@ async fn select_page(
         }];
         let Some(root_value) = root_value.as_ref() else {
             observations.extend(row_observations);
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "page_root_missing",
+                range(),
+                observations,
+            ));
         };
         let Ok(root) = index_values::decode_manifest_root(root_value) else {
             observations.extend(row_observations);
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "page_root_encoding",
+                range(),
+                observations,
+            ));
         };
 
         let minimum_revision = u64::from(root.page_count()).saturating_add(1);
@@ -291,7 +349,12 @@ async fn select_page(
             || page_key.page >= root.page_count()
         {
             observations.extend(row_observations);
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "page_root_identity_or_revision",
+                range(),
+                observations,
+            ));
         }
 
         let observed_before = match next_partition.as_ref() {
@@ -307,7 +370,12 @@ async fn select_page(
             None if page_key.page == 0 => 0,
             Some(_) | None => {
                 observations.extend(row_observations);
-                return Ok(blocked_database(range(), observations));
+                return Ok(blocked_database(
+                    operation,
+                    "page_sequence",
+                    range(),
+                    observations,
+                ));
             }
         };
         let page_split_count =
@@ -317,7 +385,12 @@ async fn select_page(
         let candidate_partition = if next_page == root.page_count() {
             if observed_split_count != root.split_count() {
                 observations.extend(row_observations);
-                return Ok(blocked_database(range(), observations));
+                return Ok(blocked_database(
+                    operation,
+                    "partition_split_count",
+                    range(),
+                    observations,
+                ));
             }
             None
         } else {
@@ -330,7 +403,12 @@ async fn select_page(
                 observed_split_count,
             ) else {
                 observations.extend(row_observations);
-                return Ok(blocked_database(range(), observations));
+                return Ok(blocked_database(
+                    operation,
+                    "partition_progress",
+                    range(),
+                    observations,
+                ));
             };
             Some(partition)
         };
@@ -347,7 +425,12 @@ async fn select_page(
             ) || !page_distinct_blobs.insert(blob)
             {
                 observations.extend(row_observations);
-                return Ok(blocked_database(range(), observations));
+                return Ok(blocked_database(
+                    operation,
+                    "split_layout_or_duplicate_blob",
+                    range(),
+                    observations,
+                ));
             }
             page_blobs.push(blob);
         }
@@ -360,6 +443,7 @@ async fn select_page(
         if admitted_rows == 0 && row_input_bytes > limits.max_input_bytes().get() {
             observations.extend(row_observations);
             return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+                diagnostic: ValidationDiagnostic::new(operation),
                 ranges: range(),
                 observations,
                 result: IndexOperationStepResult::Blocked(IndexOperationBlocker::ManifestLimit {
@@ -399,6 +483,7 @@ async fn select_page(
         .map_err(|error| HelixDbError::InvariantViolation(error.to_string()))?;
     Ok(ValidationSelection::Page(PreparedPageValidation {
         database: PreparedDatabaseValidation {
+            diagnostic: ValidationDiagnostic::new(operation),
             ranges: vec![scan.range_through(admitted_rows)],
             observations,
             result: progressed(TextBuildStage::ValidateManifests(
@@ -429,6 +514,7 @@ async fn select_root(
     .await?;
     if scan.rows.is_empty() {
         return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+            diagnostic: ValidationDiagnostic::new(operation),
             ranges: vec![scan.range_through(0)],
             observations: Vec::new(),
             result: progressed(TextBuildStage::ValidateManifests(
@@ -451,11 +537,21 @@ async fn select_root(
                 ..
             }) => key,
             Ok(ManagedIndexKey::Data { .. } | ManagedIndexKey::Global { .. }) | Err(_) => {
-                return Ok(blocked_database(range(), observations));
+                return Ok(blocked_database(
+                    operation,
+                    "root_key_encoding",
+                    range(),
+                    observations,
+                ));
             }
         };
         let Ok(root) = index_values::decode_manifest_root(row_value) else {
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "root_value_encoding",
+                range(),
+                observations,
+            ));
         };
         let partition_mode_is_valid = match (definition.tenant_property(), root.partition()) {
             (None, TextPartition::Unpartitioned) | (Some(_), TextPartition::TenantValue(_)) => true,
@@ -477,7 +573,12 @@ async fn select_root(
             || !partition_mode_is_valid
             || !revision_is_valid
         {
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "root_identity_partition_or_revision",
+                range(),
+                observations,
+            ));
         }
 
         let corpus_key = super::statistics::corpus_key(
@@ -501,7 +602,12 @@ async fn select_root(
         .is_err()
         {
             observations.extend(row_observations);
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "root_corpus_statistics",
+                range(),
+                observations,
+            ));
         }
         if root.page_count() != 0 {
             let page_key = scoped_key(
@@ -526,7 +632,12 @@ async fn select_root(
             });
             if !exact_page_zero {
                 observations.extend(row_observations);
-                return Ok(blocked_database(range(), observations));
+                return Ok(blocked_database(
+                    operation,
+                    "root_page_zero",
+                    range(),
+                    observations,
+                ));
             }
         }
         let row_input_bytes = row_bytes(row_key, Some(row_value)).saturating_add(
@@ -537,6 +648,7 @@ async fn select_root(
         if admitted_rows == 0 && row_input_bytes > limits.max_input_bytes().get() {
             observations.extend(row_observations);
             return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+                diagnostic: ValidationDiagnostic::new(operation),
                 ranges: range(),
                 observations,
                 result: IndexOperationStepResult::Blocked(IndexOperationBlocker::ManifestLimit {
@@ -562,6 +674,7 @@ async fn select_root(
         ..progress.counters
     };
     Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+        diagnostic: ValidationDiagnostic::new(operation),
         ranges: vec![scan.range_through(admitted_rows)],
         observations,
         result: progressed(TextBuildStage::ValidateManifests(
@@ -615,11 +728,21 @@ async fn select_entity_state(
                 ..
             }) => key,
             Ok(ManagedIndexKey::Data { .. } | ManagedIndexKey::Global { .. }) | Err(_) => {
-                return Ok(blocked_database(range(), observations));
+                return Ok(blocked_database(
+                    operation,
+                    "entity_key_encoding",
+                    range(),
+                    observations,
+                ));
             }
         };
         let Ok(state) = index_values::decode_text_entity_state(row_value) else {
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "entity_value_encoding",
+                range(),
+                observations,
+            ));
         };
         let root_key = scoped_key(
             scope,
@@ -632,11 +755,21 @@ async fn select_entity_state(
         }];
         let Some(root_value) = root_value.as_ref() else {
             observations.extend(row_observations);
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "entity_root_missing",
+                range(),
+                observations,
+            ));
         };
         let Ok(root) = index_values::decode_manifest_root(root_value) else {
             observations.extend(row_observations);
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "entity_root_encoding",
+                range(),
+                observations,
+            ));
         };
         if state_key.root.index_id != operation.index_id()
             || state_key.root.generation != operation.generation()
@@ -652,7 +785,12 @@ async fn select_entity_state(
             || (state.live && root.page_count() == 0)
         {
             observations.extend(row_observations);
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "entity_root_identity_or_version",
+                range(),
+                observations,
+            ));
         }
         let marker_key = scoped_key(
             scope,
@@ -669,11 +807,21 @@ async fn select_entity_state(
         });
         let Some(marker_value) = marker_value.as_ref() else {
             observations.extend(row_observations);
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "entity_statistics_missing",
+                range(),
+                observations,
+            ));
         };
         let Ok(marker) = index_values::decode_statistics_entity(marker_value) else {
             observations.extend(row_observations);
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "entity_statistics_encoding",
+                range(),
+                observations,
+            ));
         };
         if marker.index_id != operation.index_id()
             || marker.generation != operation.generation()
@@ -681,7 +829,12 @@ async fn select_entity_state(
             || marker.entity_id != state_key.entity.id
         {
             observations.extend(row_observations);
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "entity_statistics_identity",
+                range(),
+                observations,
+            ));
         }
         let marker_matches = match (&marker.contribution, state.live) {
             (work::TextStatisticsContribution::Present { partition, .. }, true) => {
@@ -724,7 +877,12 @@ async fn select_entity_state(
         };
         if !marker_matches {
             observations.extend(row_observations);
-            return Ok(blocked_database(range(), observations));
+            return Ok(blocked_database(
+                operation,
+                "entity_statistics_contribution",
+                range(),
+                observations,
+            ));
         }
         let row_input_bytes = row_bytes(row_key, Some(row_value)).saturating_add(
             row_observations.iter().fold(0_u64, |bytes, observation| {
@@ -734,6 +892,7 @@ async fn select_entity_state(
         if admitted_rows == 0 && row_input_bytes > limits.max_input_bytes().get() {
             observations.extend(row_observations);
             return Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+                diagnostic: ValidationDiagnostic::new(operation),
                 ranges: range(),
                 observations,
                 result: IndexOperationStepResult::Blocked(IndexOperationBlocker::ManifestLimit {
@@ -764,6 +923,7 @@ async fn select_entity_state(
         ..progress.counters
     };
     Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+        diagnostic: ValidationDiagnostic::new(operation),
         ranges: vec![scan.range_through(admitted_rows)],
         observations,
         result: progressed(TextBuildStage::ValidateManifests(
@@ -804,6 +964,10 @@ async fn select_activation_prerequisites(
         ))
     };
     Ok(ValidationSelection::Database(PreparedDatabaseValidation {
+        diagnostic: ValidationDiagnostic {
+            check: Some("build_artifact_remaining"),
+            ..ValidationDiagnostic::new(operation)
+        },
         ranges: vec![entity_state_range, delta_range, artifact_range],
         observations: Vec::new(),
         result,
@@ -895,10 +1059,16 @@ fn validation_start(prefix: &Bytes, cursor: Option<&IndexCursor>) -> Result<Boun
 
 /// Constructs a range-fenced durable invariant blocker.
 fn blocked_database(
+    operation: &IndexOperationRecord,
+    check: &'static str,
     ranges: Vec<PreparedValidationRange>,
     observations: Vec<RowObservation>,
 ) -> ValidationSelection {
     ValidationSelection::Database(PreparedDatabaseValidation {
+        diagnostic: ValidationDiagnostic {
+            check: Some(check),
+            ..ValidationDiagnostic::new(operation)
+        },
         ranges,
         observations,
         result: IndexOperationStepResult::Blocked(IndexOperationBlocker::InvariantViolation),
@@ -1198,6 +1368,16 @@ mod tests {
         let blocked = page.into_database_with_result(IndexOperationStepResult::Blocked(
             IndexOperationBlocker::InvariantViolation,
         ));
+        assert_eq!(
+            blocked.diagnostic.operation_id,
+            operation.operation_id().as_uuid()
+        );
+        assert_eq!(blocked.diagnostic.index_id, operation.index_id().get());
+        assert_eq!(blocked.diagnostic.generation, operation.generation().get());
+        assert_eq!(
+            blocked.diagnostic.check,
+            Some("blob_missing_or_size_mismatch")
+        );
         assert!(matches!(
             blocked.stage(&transaction).await.unwrap(),
             IndexOperationStepResult::Blocked(IndexOperationBlocker::InvariantViolation)

--- a/crates/db/src/search/vector/spaces/simple_neon.rs
+++ b/crates/db/src/search/vector/spaces/simple_neon.rs
@@ -145,7 +145,7 @@ mod tests {
         use crate::search::vector::unaligned_vector::UnalignedVector;
 
         if std::arch::is_aarch64_feature_detected!("neon") {
-            let mut rng = TestRng(0x2026_09_04);
+            let mut rng = TestRng(0x2026_0904);
             for dimension in AGREEMENT_DIMENSIONS {
                 let left_values = rng.vector(dimension);
                 let right_values = rng.vector(dimension);

--- a/crates/db/tests/unit/index_lifecycle_text_driver_prepared.rs
+++ b/crates/db/tests/unit/index_lifecycle_text_driver_prepared.rs
@@ -96,6 +96,7 @@ struct HeadState {
     peak: usize,
     released: bool,
     transient: HashSet<Path>,
+    fail_put: bool,
 }
 
 #[derive(Debug, Default)]
@@ -167,6 +168,12 @@ impl ObjectStore for ControlledHeadStore {
         payload: PutPayload,
         options: PutOptions,
     ) -> ObjectStoreResult<PutResult> {
+        if self.state.lock().unwrap().fail_put {
+            return Err(slatedb::object_store::Error::Generic {
+                store: "fixture",
+                source: std::io::Error::other("temporary upload failure").into(),
+            });
+        }
         self.inner.put_opts(location, payload, options).await
     }
 
@@ -844,9 +851,9 @@ async fn build_upload_classifies_limits_and_encodes_partition_and_catch_up_resum
     let unclaimed_operation = operation();
     let operation = claimed_operation();
     let definition = definition();
-    let object_store = Arc::new(InMemory::new());
+    let object_store = Arc::new(ControlledHeadStore::default());
     let runtime = TextStorageRuntime {
-        object_store,
+        object_store: object_store.clone(),
         db_path: "text-driver-build-upload-contracts".to_string(),
         compaction_limits: crate::config::SearchIndexBackfillLimits::default().text_compaction(),
     };
@@ -950,6 +957,23 @@ async fn build_upload_classifies_limits_and_encodes_partition_and_catch_up_resum
         IndexOperationProgress::TextBuild(TextBuildProgress::Constructing(
             TextBuildStage::CatchUp(_)
         ))
+    ));
+
+    object_store.state.lock().unwrap().fail_put = true;
+    assert!(matches!(
+        prepare_build_upload(
+            &operation,
+            DataScope::LegacyUnscoped,
+            &definition,
+            limits(u64::MAX),
+            &runtime,
+            split_input(
+                OperationCounters::default(),
+                PreparedTextUploadSource::CatchUp
+            ),
+        )
+        .await,
+        Err(HelixDbError::ObjectStore(_))
     ));
 
     assert!(prepare_build_upload(
@@ -1620,8 +1644,9 @@ async fn compaction_preparation_requires_a_claim_and_exhaustion_advances_exactly
             sequence: ClaimSequence::new(1).unwrap(),
         })
         .unwrap();
+    let object_store = Arc::new(ControlledHeadStore::default());
     let runtime = TextStorageRuntime {
-        object_store: Arc::new(InMemory::new()),
+        object_store: object_store.clone(),
         db_path: "text-driver-empty-compaction".to_string(),
         compaction_limits: crate::config::SearchIndexBackfillLimits::default().text_compaction(),
     };
@@ -1824,6 +1849,12 @@ async fn compaction_preparation_requires_a_claim_and_exhaustion_advances_exactly
     )
     .await
     .unwrap();
+    object_store.state.lock().unwrap().fail_put = true;
+    assert!(matches!(
+        prepare_compaction_step(&db, scope, &claimed, &progress, limits(u64::MAX), &runtime).await,
+        Err(HelixDbError::ObjectStore(_))
+    ));
+    object_store.state.lock().unwrap().fail_put = false;
     let PreparedTextOperationStep::CompactionUpload(prepared) =
         prepare_compaction_step(&db, scope, &claimed, &progress, limits(u64::MAX), &runtime)
             .await

--- a/crates/db/tests/unit/index_lifecycle_text_validation.rs
+++ b/crates/db/tests/unit/index_lifecycle_text_validation.rs
@@ -815,6 +815,10 @@ async fn live_state_with_absent_marker_catches_up_only_when_a_delta_explains_it(
     .unwrap() else {
         panic!("entity-state validation is database-only")
     };
+    assert_eq!(
+        unexplained.diagnostic.check,
+        Some("entity_statistics_contribution")
+    );
     assert!(matches!(
         unexplained.stage(&transaction).await.unwrap(),
         IndexOperationStepResult::Blocked(IndexOperationBlocker::InvariantViolation)
@@ -962,6 +966,7 @@ async fn prepared_database_revalidation_rejects_missing_changed_and_appended_row
         .put(second_key.clone(), second_value.clone())
         .unwrap();
     let prepared = PreparedDatabaseValidation {
+        diagnostic: ValidationDiagnostic::new(&test_support::operation()),
         ranges: vec![PreparedValidationRange {
             prefix,
             start: Bound::Unbounded,
@@ -1035,6 +1040,7 @@ async fn page_validation_rejects_malformed_missing_mismatched_and_duplicate_inpu
     .unwrap() else {
         panic!("malformed page is database-blocked");
     };
+    assert_eq!(invalid_page.diagnostic.check, Some("page_value_encoding"));
     assert!(matches!(
         invalid_page.stage(&transaction).await.unwrap(),
         IndexOperationStepResult::Blocked(_)
@@ -1063,6 +1069,7 @@ async fn page_validation_rejects_malformed_missing_mismatched_and_duplicate_inpu
     .unwrap() else {
         panic!("missing root is database-blocked");
     };
+    assert_eq!(missing_root.diagnostic.check, Some("page_root_missing"));
     assert!(matches!(
         missing_root.stage(&transaction).await.unwrap(),
         IndexOperationStepResult::Blocked(_)
@@ -1083,6 +1090,7 @@ async fn page_validation_rejects_malformed_missing_mismatched_and_duplicate_inpu
     .unwrap() else {
         panic!("malformed root is database-blocked");
     };
+    assert_eq!(invalid_root.diagnostic.check, Some("page_root_encoding"));
     assert!(matches!(
         invalid_root.stage(&transaction).await.unwrap(),
         IndexOperationStepResult::Blocked(_)


### PR DESCRIPTION
Permanent index-driver failures were treated as transient and could keep abort cleanup queued indefinitely. Discard failed preparation/staged writes, recheck the exact claim, and persist the existing invariant blocker for permanent failures. Temporary I/O and transaction conflicts retain backoff; closed/fenced storage errors propagate.

```text
driver failure -> discard staged writes -> check exact claim
  temporary I/O/conflict -> queued with backoff
  permanent failure     -> blocked; queue pointer removed
  closed/fenced writer  -> propagate error
```

Text split and compaction uploads preserve their I/O error type. Manifest validation logs the failed check with operation, index, and generation after revalidation. Storage encodings are unchanged. A test-seed grouping typo is also corrected for strict Clippy.

Validation: 1,507 DB unit tests passed under LLVM coverage (5 existing ignored); 272 lifecycle tests and 18 focused outbox tests passed. Strict workspace/all-target Clippy and formatting pass. ARM64 image runtime smoke covers memory, persistence/reopen, deletion, concurrent membership, and shutdown.

Cloud integration: https://github.com/HelixDB/helix-hyperscale/pull/308 uses the same production patch backported onto its existing engine pin at `1402bd27980a722d8d740cfe1aa87a5358a0523c`.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes index-driver failure handling so failed preparation and staging are discarded before the exact claim is rechecked, preserves object-store upload errors, and adds detailed text-manifest validation diagnostics.

- Permanent non-I/O driver failures now durably block the operation and remove its queue pointer.
- Transaction conflicts and unavailable storage retain transient backoff behavior.
- Text validation records the operation, index, generation, and failed check after snapshot revalidation.
- Tests cover driver failure classification, stale claims, upload errors, and validation labels.
- One classification gap still treats every object-store error as transient, and one validation path emits the wrong check label.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/index_lifecycle/outbox.rs | Adds centralized driver-failure recording and exact-claim revalidation, but classifies all object-store errors as transient. |
| crates/db/src/index_lifecycle/text/driver.rs | Preserves object-store error types for text split and compaction uploads, exposing them to outbox retry classification. |
| crates/db/src/index_lifecycle/text/validation.rs | Adds detailed validation diagnostics, with one missing-page invariant path incorrectly falling back to the manifest-limit label. |
| crates/db/tests/unit/index_lifecycle_text_driver_prepared.rs | Extends controlled object-store fixtures and verifies that upload failures retain their error type. |
| crates/db/tests/unit/index_lifecycle_text_validation.rs | Adds assertions for several newly introduced validation diagnostic labels. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Driver preparation or staging] --> B{Error returned?}
    B -->|No| C[Commit validated step]
    B -->|Yes| D[Discard staged transaction or preparation]
    D --> E{Closed or fenced?}
    E -->|Yes| F[Propagate error]
    E -->|No| G{Retryable?}
    G -->|Conflict or temporary I/O| H[Release claim and queue with backoff]
    G -->|Permanent| I[Recheck exact claim]
    I --> J[Persist invariant blocker]
    J --> K[Remove queue pointer]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Cover storage failure and closed writer ..."](https://github.com/helixdb/helix-db/commit/56c0bc79f019cd81b42bdff35bd8729360e86058) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60757076)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Index lifecycle and search](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/index-lifecycle-and-search.md)

<!-- /greptile_comment -->