### PR TITLE
test(db): check the x86 simd kernels against the scalar reference too

### DIFF
--- a/crates/db/src/search/vector/spaces/mod.rs
+++ b/crates/db/src/search/vector/spaces/mod.rs
@@ -52,7 +52,11 @@ pub(super) mod kernel_agreement {
 
     /// Dimensions covering the main loop and the trailing remainder of every
     /// kernel, including the 32 wide AVX stride.
-    pub const AGREEMENT_DIMENSIONS: [usize; 5] = [17, 33, 64, 384, 1536];
+    ///
+    /// The 16 wide kernels see remainders of 1, 14, 15 and 0, and the 32 wide
+    /// ones see 1, 15, 17, 30 and 0. 17 and 30 also leave the main loop with
+    /// nothing to do on a 32 wide stride, so the remainder path runs alone.
+    pub const AGREEMENT_DIMENSIONS: [usize; 7] = [17, 30, 33, 47, 64, 384, 1536];
 
     /// Assert a kernel matches the scalar reference to within the tolerance.
     ///

--- a/crates/db/src/search/vector/spaces/simple_avx.rs
+++ b/crates/db/src/search/vector/spaces/simple_avx.rs
@@ -291,4 +291,76 @@ mod tests {
             println!("avx test skipped");
         }
     }
+
+    /// The fixed vectors above are small integers, so every intermediate is
+    /// exactly representable and no kernel here can disagree with the scalar
+    /// reference no matter how it rounds. FMA is the sharpest case: the fused
+    /// kernels round once per term where the reference rounds twice, so integer
+    /// input is precisely where the two cannot be told apart.
+    ///
+    /// The non-FMA kernels also have no other coverage. The test above picks the
+    /// FMA variant whenever the CPU reports FMA, which every x86 part since 2013
+    /// does, so `euclid_similarity_avx` and `dot_similarity_avx` are otherwise
+    /// never executed. Both pairs run here.
+    ///
+    /// Seeded identically to the NEON and SSE agreement tests, so a divergence
+    /// on one architecture and not another is a real difference in the kernel
+    /// rather than a different input.
+    #[test]
+    fn avx_kernels_agree_with_scalar_on_rounding_sensitive_input() {
+        use super::*;
+        use crate::search::vector::spaces::kernel_agreement::{
+            assert_agrees, dot_scale, TestRng, AGREEMENT_DIMENSIONS,
+        };
+
+        if !is_x86_feature_detected!("avx") {
+            return;
+        }
+        let has_fma = is_x86_feature_detected!("fma");
+
+        let mut rng = TestRng(0x2026_0904);
+        for dimension in AGREEMENT_DIMENSIONS {
+            let left_values = rng.vector(dimension);
+            let right_values = rng.vector(dimension);
+            let left = UnalignedVector::from_slice(&left_values[..]);
+            let right = UnalignedVector::from_slice(&right_values[..]);
+            let pair = SameDimensionPair::try_new(&left, &right).unwrap();
+
+            let euclid_scalar = euclidean_distance_non_optimized(&left, &right);
+            let dot_scalar = dot_product_non_optimized(&left, &right);
+            let scale = dot_scale(&left_values, &right_values);
+
+            assert_agrees(
+                unsafe { euclid_similarity_avx(pair) },
+                euclid_scalar,
+                euclid_scalar,
+                "euclidean avx",
+                dimension,
+            );
+            assert_agrees(
+                unsafe { dot_similarity_avx(pair) },
+                dot_scalar,
+                scale,
+                "dot avx",
+                dimension,
+            );
+
+            if has_fma {
+                assert_agrees(
+                    unsafe { euclid_similarity_avx_fma(pair) },
+                    euclid_scalar,
+                    euclid_scalar,
+                    "euclidean avx+fma",
+                    dimension,
+                );
+                assert_agrees(
+                    unsafe { dot_similarity_avx_fma(pair) },
+                    dot_scalar,
+                    scale,
+                    "dot avx+fma",
+                    dimension,
+                );
+            }
+        }
+    }
 }

--- a/crates/db/src/search/vector/spaces/simple_sse.rs
+++ b/crates/db/src/search/vector/spaces/simple_sse.rs
@@ -166,4 +166,50 @@ mod tests {
             println!("sse test skipped");
         }
     }
+
+    /// The fixed vectors above are small integers, so every intermediate is
+    /// exactly representable and the kernel cannot disagree with the scalar
+    /// reference no matter how it rounds. This covers the inputs that can.
+    ///
+    /// Seeded identically to the NEON and AVX agreement tests, so a divergence
+    /// on one architecture and not another is a real difference in the kernel
+    /// rather than a different input.
+    #[test]
+    fn sse_kernels_agree_with_scalar_on_rounding_sensitive_input() {
+        use super::*;
+        use crate::search::vector::spaces::kernel_agreement::{
+            assert_agrees, dot_scale, TestRng, AGREEMENT_DIMENSIONS,
+        };
+
+        if !is_x86_feature_detected!("sse") {
+            return;
+        }
+
+        let mut rng = TestRng(0x2026_0904);
+        for dimension in AGREEMENT_DIMENSIONS {
+            let left_values = rng.vector(dimension);
+            let right_values = rng.vector(dimension);
+            let left = UnalignedVector::from_slice(&left_values[..]);
+            let right = UnalignedVector::from_slice(&right_values[..]);
+            let pair = SameDimensionPair::try_new(&left, &right).unwrap();
+
+            let euclid_scalar = euclidean_distance_non_optimized(&left, &right);
+            assert_agrees(
+                unsafe { euclid_similarity_sse(pair) },
+                euclid_scalar,
+                euclid_scalar,
+                "euclidean sse",
+                dimension,
+            );
+
+            let dot_scalar = dot_product_non_optimized(&left, &right);
+            assert_agrees(
+                unsafe { dot_similarity_sse(pair) },
+                dot_scalar,
+                dot_scale(&left_values, &right_values),
+                "dot sse",
+                dimension,
+            );
+        }
+    }
 }


### PR DESCRIPTION
Follow-up to #1075, which added the agreement harness and wired it to NEON only.

SSE and AVX still compare against the scalar reference with assert_eq! on vectors of small integers. Every intermediate is exactly representable, so the kernel and the reference cannot differ however either one rounds. Those tests pass whether or not the kernels are correct.

AVX has a second gap. It has four kernels and the test picks the FMA variant whenever the CPU reports FMA, so euclid_similarity_avx and dot_similarity_avx never run at all. Integer input hides FMA best of all, since it rounds once per term where the reference rounds twice.

This puts both files through the existing kernel_agreement helpers, with the same seed the NEON test uses so all three architectures see identical input. The AVX one runs the non-FMA pair unconditionally and the FMA pair when the CPU has it.

It also widens AGREEMENT_DIMENSIONS to [17, 30, 33, 47, 64, 384, 1536]. The old set left the 16 wide kernels with a trailing remainder of only 1 or 0, so the leftover loop for 2 to 15 elements had nothing looking at it. That was true for NEON as well.

Checked locally: fmt, clippy --all-targets -D warnings cross-compiled for x86_64, workspace clippy, and the NEON tests at the wider dimensions. I have no x86 machine, so CI here is what actually exercises the x86 kernels, not me.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands scalar-agreement testing for the x86 SSE, AVX, and AVX+FMA vector kernels and broadens the shared dimension set to cover additional SIMD remainder lengths.

- Adds deterministic, rounding-sensitive agreement tests for SSE kernels.
- Exercises both non-FMA and FMA AVX kernel pairs when supported.
- Adds dimensions covering standalone and mixed SIMD remainder paths.
- Contains one overly broad architecture-support claim in test documentation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/search/vector/spaces/mod.rs | Expands the shared agreement dimensions to exercise more 16-wide and 32-wide remainder cases. |
| crates/db/src/search/vector/spaces/simple_avx.rs | Adds scalar-agreement coverage for all AVX kernel variants; the implementation is sound, but one explanatory CPU-support claim is inaccurate. |
| crates/db/src/search/vector/spaces/simple_sse.rs | Adds feature-gated scalar-agreement tests for the SSE Euclidean and dot-product kernels. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(db): widen the agreement dimensions..."](https://github.com/helixdb/helix-db/commit/45d5a1cf76ea33043e5ef106ba9fb67083d5d3e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61088575)</sub>

<!-- /greptile_comment -->