### PR TITLE
fix(cli): handle EOF and invalid email input in metrics full

### DIFF
--- a/crates/cli/src/commands/metrics.rs
+++ b/crates/cli/src/commands/metrics.rs
@@ -5,7 +5,7 @@ use crate::{
     output, MetricsAction,
 };
 use color_eyre::owo_colors::OwoColorize;
-use eyre::Result;
+use eyre::{eyre, Result};
 use regex::Regex;
 
 pub async fn run(action: MetricsAction) -> Result<()> {
@@ -20,7 +20,7 @@ pub async fn run(action: MetricsAction) -> Result<()> {
 async fn enable_full_metrics() -> Result<()> {
     output::info("Enabling metrics collection");
 
-    let email = ask_for_email();
+    let email = ask_for_email()?;
     let mut config = load_metrics_config().unwrap_or_default();
     config.level = MetricsLevel::Full;
     config.email = Some(email);
@@ -109,22 +109,38 @@ fn format_age(seconds: u64) -> String {
 static EMAIL_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$").unwrap());
 
-fn ask_for_email() -> String {
-    println!("Please enter your email address:");
-    let mut email = String::new();
-    io::stdin().read_line(&mut email).unwrap();
-    let email = email.trim().to_string();
-    // validate email
-    if !EMAIL_REGEX.is_match(&email) {
-        println!("Invalid email address");
-        return ask_for_email();
+fn is_valid_email(email: &str) -> bool {
+    EMAIL_REGEX.is_match(email)
+}
+
+fn ask_for_email() -> Result<String> {
+    read_email_from(&mut io::stdin().lock())
+}
+
+fn read_email_from<R: io::BufRead>(reader: &mut R) -> Result<String> {
+    loop {
+        println!("Please enter your email address:");
+        let mut email = String::new();
+        let bytes = reader.read_line(&mut email)?;
+        if bytes == 0 {
+            return Err(eyre!(
+                "email input ended before an address was provided; run `helix metrics full` from an interactive terminal"
+            ));
+        }
+        let email = email.trim();
+        if email.is_empty() || !is_valid_email(email) {
+            println!("Invalid email address");
+            continue;
+        }
+        return Ok(email.to_string());
     }
-    email
 }
 
 #[cfg(test)]
 mod tests {
-    use super::format_age;
+    use std::io::Cursor;
+
+    use super::{format_age, is_valid_email, read_email_from};
 
     #[test]
     fn formats_age_for_status_output() {
@@ -133,5 +149,31 @@ mod tests {
         assert_eq!(format_age(60), "1m ago");
         assert_eq!(format_age(3_600), "1h ago");
         assert_eq!(format_age(172_800), "2d ago");
+    }
+
+    #[test]
+    fn validates_email_addresses() {
+        assert!(is_valid_email("user@example.com"));
+        assert!(!is_valid_email(""));
+        assert!(!is_valid_email("not-an-email"));
+        assert!(!is_valid_email("@example.com"));
+    }
+
+    #[test]
+    fn read_email_from_rejects_eof_before_valid_input() {
+        let mut reader = Cursor::new(Vec::new());
+        let error = read_email_from(&mut reader)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("email input ended"));
+    }
+
+    #[test]
+    fn read_email_from_skips_invalid_lines_before_accepting_valid_email() {
+        let mut reader = Cursor::new(b"not-an-email\nuser@example.com\n");
+        assert_eq!(
+            read_email_from(&mut reader).unwrap(),
+            "user@example.com".to_string()
+        );
     }
 }


### PR DESCRIPTION
## Problem

`helix metrics full` prompts for an email via `ask_for_email()`. When stdin closes before a valid address is entered (for example piping empty input or running non-interactively), the old implementation:

1. Called `read_line().unwrap()`, which can panic on I/O errors.
2. Recursively called itself on invalid/empty input, causing stack overflow on EOF because `read_line` returns `Ok(0)` with an empty string.

## Root cause

`ask_for_email` used unbounded recursion and did not treat EOF as a terminal error.

## Solution

- Read email addresses through a `read_email_from` helper that operates on any `BufRead` (stdin in production).
- Loop until a valid address is entered instead of recursing.
- Return a clear error when input ends before a valid email is provided.
- Propagate `read_line` I/O errors with `?`.

## Testing

- `cargo test -p helix-cli --lib metrics::tests` — 4 passed
- `cargo clippy -p helix-cli --lib -- -D warnings` — clean

## Issue

Independently discovered through code analysis and reproduction (`helix metrics full` with closed stdin). No existing GitHub issue or open PR was found for this bug.

## Note

This PR is a single-file CLI fix. If GitHub shows extra commits, sync the fork `main` branch with upstream before merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces recursive, panic-prone email prompting in `helix metrics full` with an iterative, testable reader implementation.
- Propagates stdin I/O failures instead of unwrapping them.
- Treats EOF before a valid address as a terminal, actionable error.
- Preserves the metrics configuration unless a valid email is obtained.
- Adds coverage for validation, EOF, and retrying invalid input.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/cli/src/commands/metrics.rs | Reworks email input into an error-propagating loop over `BufRead` and adds focused validation and EOF tests. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): handle EOF and invalid email i..."](https://github.com/helixdb/helix-db/commit/62824f743499bcea025bfbdaa06c5ce073a26573) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61494433)</sub>

**Context used:**

- Knowledge Base — [CLI and operations](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/cli-and-operations.md)
- Knowledge Base — [CLI command workflows](https://app.greptile.com/helixdb/-/custom-context/knowledge-base/helixdb/helix-db/-/docs/cli-command-workflows.md)

<!-- /greptile_comment -->