### PR TITLE
Fix workspace CI race and refresh coverage fingerprint

### DIFF
--- a/crates/db/src/index_lifecycle/secondary.rs
+++ b/crates/db/src/index_lifecycle/secondary.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 use std::num::NonZeroU64;
 use std::ops::Bound;
 #[cfg(any(test, feature = "production-coverage"))]
-use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+use std::sync::atomic::{self, Ordering as AtomicOrdering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -99,14 +99,14 @@ pub(crate) use exact::{
     lookup_active_equality_literal_batch, lookup_active_equality_point_literal,
 };
 
-#[cfg(any(test, feature = "production-coverage"))]
-static BENCHMARK_POINT_READS: AtomicU64 = AtomicU64::new(0);
-#[cfg(any(test, feature = "production-coverage"))]
-static BENCHMARK_MULTI_GETS: AtomicU64 = AtomicU64::new(0);
-#[cfg(any(test, feature = "production-coverage"))]
-static BENCHMARK_SCANS: AtomicU64 = AtomicU64::new(0);
-#[cfg(any(test, feature = "production-coverage"))]
-static BENCHMARK_GRAPH_READS: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(not(test), feature = "production-coverage"))]
+static BENCHMARK_POINT_READS: atomic::AtomicU64 = atomic::AtomicU64::new(0);
+#[cfg(all(not(test), feature = "production-coverage"))]
+static BENCHMARK_MULTI_GETS: atomic::AtomicU64 = atomic::AtomicU64::new(0);
+#[cfg(all(not(test), feature = "production-coverage"))]
+static BENCHMARK_SCANS: atomic::AtomicU64 = atomic::AtomicU64::new(0);
+#[cfg(all(not(test), feature = "production-coverage"))]
+static BENCHMARK_GRAPH_READS: atomic::AtomicU64 = atomic::AtomicU64::new(0);
 
 /// Exact storage operations issued by managed equality serving while the
 /// production-coverage benchmark is measuring it.
@@ -7618,3 +7618,12 @@ pub(crate) use exact::RangeScanCounters;
 
 #[cfg(test)]
 mod ordered_tests;
+
+#[cfg(test)]
+mod test_read_counters;
+
+#[cfg(test)]
+use test_read_counters::{
+    ThreadLocalCounter, BENCHMARK_GRAPH_READS, BENCHMARK_MULTI_GETS, BENCHMARK_POINT_READS,
+    BENCHMARK_SCANS,
+};

--- a/crates/db/src/index_lifecycle/secondary/test_read_counters.rs
+++ b/crates/db/src/index_lifecycle/secondary/test_read_counters.rs
@@ -1,0 +1,123 @@
+//! Unit-test measurements belong to one libtest thread and its current-thread
+//! Tokio runtime, including tasks spawned on that runtime. Reject multi-thread
+//! measurement runtimes instead of silently losing worker-thread reads.
+//! Production-coverage binaries retain the process-wide atomic counters for
+//! concurrent benchmarks; this module is compiled only for unit tests.
+
+use std::thread;
+
+use super::atomic;
+
+thread_local! {
+    pub(super) static BENCHMARK_POINT_READS: atomic::AtomicU64 = const { atomic::AtomicU64::new(0) };
+    pub(super) static BENCHMARK_MULTI_GETS: atomic::AtomicU64 = const { atomic::AtomicU64::new(0) };
+    pub(super) static BENCHMARK_SCANS: atomic::AtomicU64 = const { atomic::AtomicU64::new(0) };
+    pub(super) static BENCHMARK_GRAPH_READS: atomic::AtomicU64 = const { atomic::AtomicU64::new(0) };
+}
+
+/// Keeps instrumentation call sites identical to the benchmark atomics while
+/// isolating unit-test reads and resets on their owning test thread.
+pub(super) trait ThreadLocalCounter {
+    fn store(&'static self, value: u64, ordering: atomic::Ordering);
+    fn load(&'static self, ordering: atomic::Ordering) -> u64;
+    fn fetch_add(&'static self, value: u64, ordering: atomic::Ordering) -> u64;
+}
+
+impl ThreadLocalCounter for thread::LocalKey<atomic::AtomicU64> {
+    fn store(&'static self, value: u64, ordering: atomic::Ordering) {
+        assert!(
+            tokio::runtime::Handle::try_current().map_or(true, |handle| matches!(
+                handle.runtime_flavor(),
+                tokio::runtime::RuntimeFlavor::CurrentThread
+            )),
+            "equality read metric unit tests require a current-thread runtime"
+        );
+        self.with(|counter| counter.store(value, ordering));
+    }
+
+    fn load(&'static self, ordering: atomic::Ordering) -> u64 {
+        self.with(|counter| counter.load(ordering))
+    }
+
+    fn fetch_add(&'static self, value: u64, ordering: atomic::Ordering) -> u64 {
+        self.with(|counter| counter.fetch_add(value, ordering))
+    }
+}
+
+#[test]
+fn equality_read_metrics_isolate_parallel_test_reads_and_resets() {
+    let barrier = std::sync::Barrier::new(2);
+    let measurements = std::thread::scope(|scope| {
+        let workers = (1..=2)
+            .map(|reads| {
+                let barrier = &barrier;
+                scope.spawn(move || {
+                    super::reset_equality_read_metrics();
+                    barrier.wait();
+                    for _ in 0..reads {
+                        super::record_equality_point_read();
+                        super::record_equality_graph_read();
+                        super::BENCHMARK_MULTI_GETS.fetch_add(1, super::AtomicOrdering::Relaxed);
+                        super::BENCHMARK_SCANS.fetch_add(1, super::AtomicOrdering::Relaxed);
+                    }
+                    barrier.wait();
+                    let measured = super::equality_read_metrics();
+                    barrier.wait();
+                    if reads == 1 {
+                        super::reset_equality_read_metrics();
+                    }
+                    barrier.wait();
+                    (reads, measured, super::equality_read_metrics())
+                })
+            })
+            .collect::<Vec<_>>();
+        workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect::<Vec<_>>()
+    });
+
+    for (reads, measured, after_reset) in measurements {
+        let expected = super::SecondaryEqualityReadMetrics {
+            point_reads: reads,
+            multi_get_calls: reads,
+            scans: reads,
+            graph_reads: reads,
+        };
+        assert_eq!(measured, expected);
+        assert_eq!(
+            after_reset,
+            if reads == 1 {
+                Default::default()
+            } else {
+                expected
+            }
+        );
+    }
+}
+
+#[tokio::test]
+async fn equality_read_metrics_include_spawned_current_thread_work() {
+    super::reset_equality_read_metrics();
+    tokio::spawn(async {
+        super::record_equality_point_read();
+        tokio::task::yield_now().await;
+        super::record_equality_graph_read();
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        super::equality_read_metrics(),
+        super::SecondaryEqualityReadMetrics {
+            point_reads: 1,
+            graph_reads: 1,
+            ..Default::default()
+        }
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[should_panic(expected = "equality read metric unit tests require a current-thread runtime")]
+async fn equality_read_metrics_reject_multi_thread_unit_test_runtimes() {
+    super::reset_equality_read_metrics();
+}

--- a/crates/db/src/search/vector/spaces/simple_neon.rs
+++ b/crates/db/src/search/vector/spaces/simple_neon.rs
@@ -145,7 +145,7 @@ mod tests {
         use crate::search::vector::unaligned_vector::UnalignedVector;
 
         if std::arch::is_aarch64_feature_detected!("neon") {
-            let mut rng = TestRng(0x2026_09_04);
+            let mut rng = TestRng(0x2026_0904);
             for dimension in AGREEMENT_DIMENSIONS {
                 let left_values = rng.vector(dimension);
                 let right_values = rng.vector(dimension);

--- a/docs/WORKSPACE_CI_VALIDATION.md
+++ b/docs/WORKSPACE_CI_VALIDATION.md
@@ -1,0 +1,33 @@
+# Workspace CI validation
+
+The workspace failure on `main` came from process-global equality read counters:
+parallel unit tests could increment or reset another test's measurement.
+Unit-test counters now belong to the test thread and its current-thread Tokio
+runtime. Production-coverage builds retain their global atomics.
+
+The barrier regression fails with the original counters and passes with isolated
+counters. Workspace tests, doctests, strict workspace and DB test-target Clippy,
+formatting, and the multithreaded production equality contract passed locally.
+Focused LLVM coverage reached 100% of lines, regions, and functions in the new
+counter module.
+
+## Production coverage fingerprint
+
+The final coverage gate also failed before this PR. Compare the complete JSON
+summaries emitted by these two independent Linux ARM64 CI jobs:
+
+- [Merged PR #1090, commit c834d51e](https://github.com/HelixDB/helix-db/actions/runs/34374965998/job/102545436242)
+- [PR #1092, commit 1b382834](https://github.com/HelixDB/helix-db/actions/runs/34398741639/job/102625359451)
+
+The DB sources and coverage scripts at `c834d51e` match its merge into `main`
+at `1ffadba6`. The two parsed CI summaries are identical: all 187 integration
+tests passed, every scope threshold passed, and vector coverage was 97.3473%
+functions, 97.1564% source lines, and 94.5472% regions.
+
+Both runs report 10,497 uncovered non-vector source lines with SHA-256
+`6d29b946f78eab3f28136bca75e6d0e9fa6bc3b23fc925e8fe0f4329425a5143`.
+The stored fingerprint still described 10,424 lines from an earlier revision.
+Refreshing only its count and digest records the existing `main` backlog;
+those lines retain their `test-required` classification. Scope thresholds,
+vector thresholds, exclusions, dispositions, and exact fingerprint enforcement
+remain unchanged. This refresh does not claim those uncovered lines are tested.

--- a/scripts/db-production-coverage-baselines.json
+++ b/scripts/db-production-coverage-baselines.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "uncovered_non_vector_source_lines": {
-    "count": 10424,
-    "sha256": "7343bd9430f31b4ac627ccf2c98aee62b62023270172b089c516718d5c1733b2",
+    "count": 10497,
+    "sha256": "6d29b946f78eab3f28136bca75e6d0e9fa6bc3b23fc925e8fe0f4329425a5143",
     "classification": "test-required",
     "reason": "Every uncovered production source line outside vector search and its stochastic vector key/value codecs remains in the explicit production-linked test backlog. The digest makes additions, removals, and newly covered lines require a reviewed baseline update; vector code remains enforced by the whole-DB and dedicated vector thresholds plus finer named-test, architecture, invariant, and platform classifications."
   },


### PR DESCRIPTION
The `main` [workspace test run](https://github.com/HelixDB/helix-db/actions/runs/34375289966/job/102546438477) failed because `exact_unique_row_access_verifies_present_missing_and_corrupt_owners` observed four point reads instead of two. Equality I/O counters were process-global, so parallel unit tests could add to or reset another test's measurement.

Use thread-local counters in unit-test builds, including work spawned on the test's current-thread Tokio runtime. Reject measurement resets from a multithreaded unit-test runtime explicitly. Production-coverage binaries retain their process-global atomics for concurrent benchmarks.

Add a barrier-based regression covering interference from both reads and resets, plus tests for spawned current-thread work and the runtime guard. The barrier regression failed with the original counters and passes with the fix. Also normalize an existing ARM test seed's hexadecimal digit grouping so strict test-target Clippy passes; its numeric value is unchanged.

The production coverage gate also had a stale uncovered-line fingerprint on merged `main`. [The pre-merge main run](https://github.com/HelixDB/helix-db/actions/runs/34374965998/job/102545436242) and [this PR's run](https://github.com/HelixDB/helix-db/actions/runs/34398741639/job/102625359451) produced identical complete summaries, including all coverage metrics and the 10,497-line fingerprint. Refresh the stored count and SHA-256 to that shared evidence. The uncovered lines remain classified as `test-required`; coverage thresholds, exclusions, dispositions, and exact fingerprint enforcement are unchanged. Record the comparison in `docs/WORKSPACE_CI_VALIDATION.md`.

Validation:
- `cargo test --locked --workspace --all-targets` passed with the isolated counters.
- Workspace doctests passed; the server doctest needed a rerun with localhost socket access outside the sandbox.
- `cargo test --locked -p db --features production-coverage --test production_secondary_equality_hot_path_contracts` passed on its multithreaded runtime.
- `cargo clippy --locked --workspace -- -D warnings` and `cargo clippy --locked -p db --lib --tests -- -D warnings` passed.
- Workspace formatting and edition-2024 rustfmt checks passed.
- Compared the two independent CI summaries and verified that both satisfy every unchanged threshold and the refreshed exact fingerprint; reran workspace Clippy and formatting successfully.
- Focused LLVM coverage: 100% of lines, regions, and functions in the new counter module.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR isolates equality-read instrumentation by execution context while preserving process-global counters for production-coverage benchmarks.
- Unit-test builds now use thread-local counters, preventing parallel tests from resetting or incrementing one another’s measurements.
- Production-coverage builds retain atomic process-wide aggregation for concurrent benchmark tasks.
- Regression coverage verifies parallel read/reset isolation, spawned work on a current-thread Tokio runtime, and explicit rejection of multithreaded unit-test resets.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/db/src/index_lifecycle/secondary.rs | Splits equality-read counter storage by compilation mode and wires the unit-test implementation into existing instrumentation call sites. |
| crates/db/src/index_lifecycle/secondary/test_read_counters.rs | Implements thread-local unit-test counters and regression tests for isolation, current-thread task accounting, and runtime guarding. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  C{Compilation mode}
  C -->|Unit test| T[Thread-local atomic counters]
  T --> I[Isolated per libtest thread]
  T --> R[Require current-thread Tokio runtime for reset]
  C -->|Production coverage| P[Process-global atomic counters]
  P --> B[Aggregate concurrent benchmark reads]
  C -->|Ordinary production| N[Instrumentation compiled out]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(db): isolate equality read metrics a..."](https://github.com/helixdb/helix-db/commit/8b71d712872880788ed3b93e8fb811811b95431b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62286641)</sub>

<!-- /greptile_comment -->