### PR TITLE
fix(sdk): reject non-RFC3339 timestamps

### DIFF
--- a/sdks/python/src/helixdb/dsl.py
+++ b/sdks/python/src/helixdb/dsl.py
@@ -211,7 +211,12 @@ class DateTime:
 
     @classmethod
     def parse_rfc3339(cls, value: str) -> "DateTime":
-        text = value[:-1] + "+00:00" if value.endswith("Z") else value
+        if re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})",
+            value,
+        ) is None:
+            raise TypeError(f"invalid RFC3339 datetime: {value}")
+        text = value[:-1] + "+00:00" if value.endswith(("Z", "z")) else value
         try:
             return cls.from_datetime(datetime.fromisoformat(text))
         except ValueError as exc:

--- a/sdks/python/tests/test_dsl.py
+++ b/sdks/python/tests/test_dsl.py
@@ -242,6 +242,13 @@ class DslAstTests(unittest.TestCase):
             DateTime.parse_rfc3339("1969-12-31T23:59:59.999-00:00").to_rfc3339(),
             "1969-12-31T23:59:59.999Z",
         )
+        self.assertEqual(
+            DateTime.parse_rfc3339("2026-04-05t12:34:56z").to_rfc3339(),
+            "2026-04-05T12:34:56.000Z",
+        )
+        for value in ["2026-04-05", "2026-04-05T12:34:56"]:
+            with self.assertRaisesRegex(TypeError, "invalid RFC3339 datetime"):
+                DateTime.parse_rfc3339(value)
 
         self.assertEqual(
             parsed(Expr.prop("a").add(Expr.val(1)).neg()),

--- a/sdks/typescript/src/dsl.ts
+++ b/sdks/typescript/src/dsl.ts
@@ -231,6 +231,8 @@ export type EdgeId = number | bigint;
 export type ParamValue = PropertyValue;
 export type ParamObject = Record<string, PropertyValue | PropertyValueInput>;
 
+const rfc3339Pattern = /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})$/;
+
 function intToJson(value: number | bigint): number | bigint {
   if (typeof value === "bigint") return value;
   if (!Number.isInteger(value)) throw new TypeError(`expected integer, got ${value}`);
@@ -250,6 +252,22 @@ export class DateTime {
   }
 
   static parseRfc3339(input: string): DateTime {
+    const match = rfc3339Pattern.exec(input);
+    if (match === null) throw new TypeError(`invalid RFC3339 datetime: ${input}`);
+    const [year, month, day, hour, minute, second] = match.slice(1).map(Number);
+    const date = new Date(0);
+    date.setUTCFullYear(year, month - 1, day);
+    date.setUTCHours(hour, minute, second, 0);
+    if (
+      date.getUTCFullYear() !== year ||
+      date.getUTCMonth() !== month - 1 ||
+      date.getUTCDate() !== day ||
+      date.getUTCHours() !== hour ||
+      date.getUTCMinutes() !== minute ||
+      date.getUTCSeconds() !== second
+    ) {
+      throw new TypeError(`invalid RFC3339 datetime: ${input}`);
+    }
     const parsed = Date.parse(input);
     if (Number.isNaN(parsed)) throw new TypeError(`invalid RFC3339 datetime: ${input}`);
     return DateTime.fromMillis(parsed);

--- a/sdks/typescript/test/basic.test.ts
+++ b/sdks/typescript/test/basic.test.ts
@@ -118,6 +118,10 @@ assert.equal(Object.isFrozen(writeBatch()), true);
 assert.equal(PropertyValue.string("x").asStr(), "x");
 assert.equal(PropertyValue.i64(1n).asI64(), 1n);
 assert.equal(DateTime.parseRfc3339("1969-12-31T23:59:59.999-00:00").toRfc3339(), "1969-12-31T23:59:59.999Z");
+assert.equal(DateTime.parseRfc3339("2026-04-05t12:34:56z").toRfc3339(), "2026-04-05T12:34:56.000Z");
+for (const value of ["2026-04-05", "2026-04-05T12:34:56", "2026-02-30T12:00:00Z", "2026-01-01T24:00:00Z"]) {
+  assert.throws(() => DateTime.parseRfc3339(value), TypeError);
+}
 
 assert.deepEqual(parsed(Expr.prop("a").add(Expr.val(1)).neg()), {
   neg: { expr: { add: { left: { property: "a" }, right: { constant: { i64: 1 } } } } },


### PR DESCRIPTION
Python's `DateTime.parse_rfc3339` and TypeScript's `DateTime.parseRfc3339` delegated directly to platform parsers, which accept date-only and timezone-less values outside the RFC3339 timestamp format. TypeScript also interprets timezone-less values using the local machine timezone.

Require a complete date-time with either `Z` or a numeric timezone offset before passing it to the native parser. Valid UTC and numeric-offset timestamps keep their existing behavior.

Added Python and TypeScript regression coverage for date-only and timezone-less inputs.

Checked locally: 53 Python tests (2 configured gateway cases skipped), TypeScript compile and test files, ESLint, Prettier, Python compilation, and `git diff --check`.

Closes #1089


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63363470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a></h2>

The PR is not yet safe to merge because the TypeScript parser rejects valid RFC3339 inputs and still silently normalizes invalid timestamps.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Valid lowercase timestamps rejected** <a href="https://github.com/HelixDB/helix-db/pull/1095#discussion_r3995109029">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Invalid timestamps silently normalized** <a href="https://github.com/HelixDB/helix-db/pull/1095#discussion_r3995109030">▶</a>

<h3>Summary</h3>

- Python now requires a complete timestamp with `Z` or a numeric offset before calling `datetime.fromisoformat`.
- TypeScript applies an equivalent pattern before calling `Date.parse`.
- Regression coverage verifies rejection of date-only and timezone-less values.
- The TypeScript validation remains incomplete for semantic date ranges and newly rejects valid lowercase RFC3339 separators.

<sub>Reviews (1) · Last reviewed commit: ["fix(sdk): reject non-RFC3339 timestamps"](https://github.com/helixdb/helix-db/commit/bad01f7c43257a393a12d437fd3ed539f5d8750a)</sub>

<!-- /greptile_comment -->